### PR TITLE
TDD + DDD-lite 셋업: Jacoco / 4-layer 패키지 구조 / 샘플 테스트

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -143,31 +143,58 @@ springdoc-openapi (Swagger)
 - 호출 timeout 설정 누락 (기본값에 의존하면 위험)
 - 외부 응답을 그대로 사용자에게 노출하지 않는가 (정보 누출)
 
-### 3.11 테스트 전략
+### 3.11 테스트 전략 (TDD)
 
-- 핵심 영역(결제, 거래 상태 전이, 포인트 동시성, JWT 검증, 토큰 Rotation) **단위 테스트 누락 시 Critical**
-- Slice 테스트(`@WebMvcTest`, `@DataJpaTest`) 가능한데 `@SpringBootTest` 남발하는가
-- Testcontainers(MySQL, MongoDB) 대신 로컬 인스턴스 의존 — 재현성 떨어짐
-- 테스트 메서드명: `대상메서드_상황_기대결과` 패턴 준수
+**RED → GREEN → REFACTOR 사이클 준수 여부 검토.**
+
+영역별 강도:
+| 영역 | 강도 | 위반 시 |
+|---|---|---|
+| 보안 / 결제 / 포인트 / 거래 상태 전이 / JWT / 토큰 Rotation / 동시성 | 🔒 **테스트 먼저 필수** | **Critical** — 리뷰 거부, 구현 전 RED 요구 |
+| 일반 도메인 (Aggregate, DomainService, ApplicationService, ValueObject) | TDD 권장 | Warning |
+| 트리비얼 어댑터 (Controller 라우팅, JPA Repository, DTO) | 통합 테스트로 갈음 OK | — |
+
+체크 항목:
+- 핵심 영역에 단위 테스트 누락 — **Critical**
+- `domain/` layer 테스트가 Spring 컨텍스트 띄우는지 — 순수 단위로 가능해야 함
+- Slice 테스트(`@WebMvcTest`, `@DataJpaTest`) 가능한데 `@SpringBootTest` 남발 — 느림 + TDD 사이클 깨짐
+- Testcontainers(MySQL, MongoDB) 대신 로컬 인스턴스 의존 — 재현성 ↓
+- 테스트 메서드명: `대상_상황_기대결과` (예: `차감_잔액부족_예외발생`)
 - 동시성 테스트: 여러 스레드/CompletableFuture로 race 시나리오 재현되는가
+- Jacoco 커버리지 리포트 확인 (CI artifact `jacoco-report`) — 보안·결제·포인트 패키지가 비어 있으면 Critical
 
-## 4. 코딩 컨벤션 (검토 시 적용)
+## 4. 코딩 컨벤션 (검토 시 적용) — DDD-lite
 
 ### 4.1 패키지 / 명명
 - 패키지: 소문자, 단수형 (`item` ✅ / `items` ❌)
-- DTO: `Request`, `Response` 접미사
-- Entity = 테이블명 단수 PascalCase
+- DTO: `Request`, `Response` 접미사 (Presentation), `Command`/`Query`/`Result` (Application 내부)
+- Entity = 테이블명 단수 PascalCase, Aggregate Root는 도메인 명사
+- ValueObject는 불변 + 자가 검증 (`Money`, `Email`, `Phone`, `PointBalance`)
 - 테스트 메서드: `대상_상황_기대결과`
 
-### 4.2 레이어 분리
-- Controller → Service → Repository (역방향 호출 X)
-- Service 간 호출은 다른 도메인 Service를 통해 (Repository 직접 X)
-- Entity Setter X → 비즈니스 메서드로 상태 변경
-- Service에 HttpServletRequest 받지 않기
+### 4.2 패키지 구조 (4-layer)
+```
+domain/{도메인}/
+├── application/        # UseCase, ApplicationService (트랜잭션 경계), dto/
+├── domain/             # Aggregate, ValueObject, DomainService,
+│                       # Repository(인터페이스), DomainEvent (event/)
+├── infrastructure/     # JPA RepositoryImpl (persistence/), 외부 어댑터
+└── presentation/       # Controller, Request/Response DTO (dto/)
+```
 
-### 4.3 트랜잭션
-- `@Transactional`: Service에만
+### 4.3 레이어 분리 (의존 방향: presentation → application → domain ← infrastructure)
+- Presentation은 ApplicationService만 호출 (Repository / Entity 직접 X)
+- ApplicationService 간 호출은 다른 도메인의 ApplicationService를 통해 (Repository 직접 X)
+- **Domain layer는 Spring/JPA/Web 어노테이션 의존 금지** (`@Service`, `@Transactional`, `@Entity` 제외하고 순수 POJO)
+- Repository = 도메인 인터페이스, JPA 구현은 `infrastructure/persistence/`
+- Aggregate 자식 Entity는 외부에서 직접 조작 금지 (반드시 Root 메서드 통해)
+- Entity Setter X → 비즈니스 메서드(상태 전이 의도)
+- Application/Domain Service에 HttpServletRequest 받지 않기
+
+### 4.4 트랜잭션
+- `@Transactional`: **ApplicationService에만**
 - 조회 전용: `@Transactional(readOnly = true)`
+- DomainService는 트랜잭션을 모름 — 호출자가 책임
 
 ## 5. 리뷰 출력 형식
 
@@ -225,6 +252,9 @@ springdoc-openapi (Swagger)
 - ❌ 트랜잭션 없이 다중 쓰기
 - ❌ 토스 결제 금액 백엔드 재검증 누락
 - ❌ 멱등성 키 없는 결제 처리
+- ❌ Domain layer가 Spring/JPA/Web 어노테이션 의존 (DDD 위반)
+- ❌ Aggregate 자식 Entity 외부 직접 조작 (Root 우회)
+- ❌ 보안/결제/포인트 코드 테스트 없이 작성 (TDD 강제 영역)
 
 ## 9. Claude Code와의 협업
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,10 @@ EC2 + Docker Compose 배포 / Let's Encrypt
 
 ## 3. 코딩 컨벤션 (강제)
 
-### 3.1 패키지 구조 (도메인 중심)
+### 3.1 패키지 구조 (DDD-lite)
+
+> 1인 9일 일정 + DDD 핵심(Aggregate / VO / Domain Event / Repository 인터페이스 분리)
+
 ```
 com.sseulang
 ├── global/        config, security, exception, common, infra
@@ -36,7 +39,31 @@ com.sseulang
                    delivery, chat, notification, report, review,
                    notice, banner, admin, category
 ```
-각 도메인 하위: `controller / service / repository / entity / dto / event`
+
+각 도메인 하위 4-layer:
+```
+domain/{도메인}/
+├── application/        # UseCase, ApplicationService (트랜잭션 경계)
+│   └── dto/            # Command, Query, Result (계층 내부 DTO)
+├── domain/             # Aggregate Root, Entity, ValueObject,
+│   │                   # DomainService, Repository(인터페이스), DomainEvent
+│   └── event/
+├── infrastructure/     # JPA RepositoryImpl, 외부 시스템 어댑터
+│   └── persistence/
+└── presentation/       # Controller, Request/Response DTO
+    └── dto/
+```
+
+#### DDD-lite 원칙
+- **Aggregate Root**만 Repository로 직접 접근. 자식 Entity는 root 통해 조작
+- **Value Object** 적극 활용 — `Money`, `Email`, `Phone`, `PointBalance`, `Address` (불변 + 자가 검증)
+- **Repository 인터페이스는 `domain/`에**, JPA 구현은 `infrastructure/persistence/`에
+- **DomainEvent**는 `domain/event/`에 정의, 발행은 Aggregate Root가, 처리는 ApplicationService 또는 별도 EventListener
+- **외부 시스템(토스/카카오/S3)** = `domain/`에 인터페이스만, 어댑터는 `infrastructure/` (anti-corruption)
+- **ApplicationService = 트랜잭션 경계 + 흐름 조율**, **DomainService = 여러 Aggregate에 걸친 도메인 규칙**
+
+#### 도입 안 함 (over-engineering)
+- 헥사고날 별도 모듈 분리, CQRS, Event Sourcing, 도메인 이벤트 비동기 분산 처리
 
 ### 3.2 명명 규칙
 - 패키지: 소문자, 단수형 (`item`, `user` ✅ / `items`, `users` ❌)
@@ -48,17 +75,26 @@ com.sseulang
 - 테스트: `대상메서드_상황_기대결과` (예: `signup_이메일중복시_예외발생`)
 
 ### 3.3 레이어 룰 (절대 금지)
-- ❌ Controller가 Repository 직접 호출
-- ❌ Service가 다른 도메인 Repository 직접 호출 → **다른 도메인 Service를 통해**
-- ❌ Entity를 Controller까지 노출 → 무조건 DTO 변환
-- ❌ Service에서 HttpServletRequest 받기 → Controller에서 추출해 전달
-- ❌ Entity 안에 Setter 사용 → 비즈니스 메서드로 상태 변경
-- ✅ Entity 생성/수정은 정적 팩토리 메서드 또는 도메인 메서드로
+
+**의존 방향**: `presentation → application → domain ← infrastructure`
+(domain은 어디에도 의존하지 않는다)
+
+- ❌ Presentation(Controller)이 Repository / domain entity 직접 호출 → ApplicationService 경유
+- ❌ ApplicationService가 다른 도메인 Repository 직접 호출 → **다른 도메인의 ApplicationService 통해**
+- ❌ Domain layer가 Spring/JPA/Web 어노테이션에 의존 (`@Service`, `@Transactional`, `@RestController` 등) → 순수 POJO
+- ❌ Aggregate 자식 Entity를 외부에서 직접 조작 → 반드시 Aggregate Root 메서드 통해
+- ❌ Entity / Aggregate를 Presentation까지 노출 → Response DTO로 변환
+- ❌ Application/Domain Service에서 `HttpServletRequest` 받기 → Controller에서 추출해 전달
+- ❌ Entity 안 Setter 사용 → 비즈니스 메서드(상태 전이 의도가 이름에 드러남)로 변경
+- ❌ Repository 구현체를 직접 import → 인터페이스만 의존 (구현은 `infrastructure/persistence/`)
+- ✅ Entity / Aggregate 생성은 정적 팩토리 메서드 또는 도메인 메서드로
+- ✅ ValueObject는 불변 + 생성자에서 자가 검증
 
 ### 3.4 트랜잭션
-- `@Transactional`은 **Service에만** (Controller, Repository에 X)
+- `@Transactional`은 **ApplicationService에만** (Controller, Repository, Domain Layer에 X)
 - 조회 전용은 `@Transactional(readOnly = true)`
 - 클래스 단위 readOnly 기본 + 쓰기 메서드만 `@Transactional` 오버라이드 패턴 권장
+- DomainService는 트랜잭션을 모름 — 호출하는 ApplicationService가 경계 책임
 
 ### 3.5 예외 처리
 - 비즈니스 예외: `BusinessException(ErrorCode)` 사용
@@ -179,17 +215,43 @@ WHERE id = ? AND point_balance + ? >= 0
 - 응답은 `PageResponse<T>`로 변환
 - 채팅 메시지는 **커서 페이징** (`?before={messageId}&size=30`)
 
-## 7. 테스트 전략
+## 7. 테스트 전략 (TDD)
 
-### 7.1 우선순위
-- **단위 테스트 필수**: 결제, 거래 상태 전이, 포인트 동시성, JWT 검증, 토큰 Rotation
-- **통합 테스트**: Controller 레벨 핵심 플로우 (회원가입, 로그인, 물품 등록, 결제)
-- CRUD: Swagger 수동 테스트로 갈음 OK
+### 7.1 흐름 — RED → GREEN → REFACTOR
+1. **RED**: 의도를 표현하는 **실패하는 테스트**부터 작성. 컴파일 에러도 RED.
+2. **GREEN**: 테스트를 통과시키는 **최소 구현**. 우아함보다 통과가 우선.
+3. **REFACTOR**: 통과 상태 유지하며 중복 제거 / 이름 정리 / 구조 개선.
 
-### 7.2 도구
+### 7.2 강도 (영역별 차등)
+
+| 영역 | 강도 | 위반 시 |
+|---|---|---|
+| 보안 / 결제 / 포인트 / 거래 상태 전이 / JWT / 토큰 Rotation / 동시성 | 🔒 **테스트 먼저 필수** (구현 전 RED) | PR 리젝, Codex 리뷰 거부 |
+| 일반 도메인 로직 (Aggregate 메서드, DomainService, ApplicationService, ValueObject) | TDD 권장 (RED-GREEN-REFACTOR 기본) | 리뷰에서 지적 |
+| 트리비얼 어댑터 (Controller 라우팅, JPA Repository, DTO 변환) | 통합 테스트로 갈음 OK | — |
+
+### 7.3 테스트 종류와 적용 범위
+- **순수 단위 테스트** (`domain/` layer): Spring 컨텍스트 X, Mockito 거의 X — domain은 외부 의존 0이라 가능
+- **단위 테스트 + Mockito** (`application/` layer): 도메인 Repository / 다른 ApplicationService를 mock
+- **Slice 테스트**: `@WebMvcTest` (Controller), `@DataJpaTest` (Repository 실제 동작), `@JsonTest` (DTO 직렬화)
+- **통합 테스트**: `@SpringBootTest` + Testcontainers — 핵심 플로우(회원가입, 로그인, 결제 end-to-end)에만 한정
+- `@SpringBootTest` 남발 금지 — 느림 + TDD 사이클 깨짐
+
+### 7.4 커버리지 (Jacoco)
+- 리포트는 항상 생성 (`./gradlew test jacocoTestReport`)
+- 임계 강제는 도메인 30% 이상 작성 시 활성화 (build.gradle TODO 참조)
+- 점진 상향: 1단계 라인 50% / 보안·결제·포인트 80% → 2단계 70% / 90%
+
+### 7.5 도구
 - JUnit 5 + Mockito + AssertJ
+- spring-security-test (`@WithMockUser` 등)
 - Testcontainers (MySQL, MongoDB)
-- `@SpringBootTest` 무분별 사용 X — 가능하면 Slice 테스트(`@WebMvcTest`, `@DataJpaTest`)
+- 테스트 메서드명: `대상_상황_기대결과` (예: `차감_잔액부족_예외발생`)
+
+### 7.6 동시성 테스트 (필수)
+- 잔액 변경 코드는 반드시 동시 실행 시나리오 테스트
+- `CompletableFuture` + `CountDownLatch` 또는 `ExecutorService`로 race 재현
+- 락/원자 연산이 정상 작동하는지 검증
 
 ## 8. Git 컨벤션
 
@@ -263,6 +325,9 @@ WHERE id = ? AND point_balance + ? >= 0
 - ❌ 잔액 변경을 비원자 연산으로 처리
 - ❌ Entity 직접 직렬화하여 응답
 - ❌ 사용자 입력을 그대로 SQL 조립 (QueryDSL/JPQL 파라미터 바인딩 사용)
+- ❌ Domain layer에 Spring/JPA 어노테이션 의존 (DDD 위반)
+- ❌ Aggregate 자식 Entity 외부 직접 조작 (반드시 Root 통해)
+- ❌ 보안/결제/포인트 코드를 테스트 없이 작성 (TDD §7.2 강제 영역)
 
 ## 12. 참고 문서
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,11 +11,14 @@
 <!-- close #이슈번호 -->
 
 ## 체크리스트
-- [ ] 로컬 빌드 통과 (`./gradlew build`)
-- [ ] 신규/변경 로직에 단위 테스트 추가
+- [ ] 로컬 빌드 + 테스트 통과 (`./gradlew build`)
+- [ ] **TDD**: 실패하는 테스트(RED)를 먼저 작성한 뒤 구현(GREEN)했는가? *(보안/결제/포인트는 필수)*
+- [ ] **DDD**: 패키지 구조(application/domain/infrastructure/presentation) 준수, domain layer는 Spring/JPA 어노테이션 무의존
+- [ ] Aggregate 자식 Entity는 Root 통해서만 조작
 - [ ] 응답 포맷 `ApiResponse<T>` / 페이징 `PageResponse<T>` 준수
 - [ ] 시크릿/민감정보 커밋 없음
 - [ ] N+1 쿼리 점검 (필요 시 fetch join)
+- [ ] Jacoco 리포트 확인 — 보안·결제·포인트 패키지에 테스트 누락 없음
 
 ## 보안 민감 영역 변경 여부
 - [ ] `global/security/**`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,5 +36,19 @@ jobs:
       - name: Build with Gradle (no tests requiring infra)
         run: ./gradlew clean build -x test --no-daemon
 
-      - name: Run unit tests
-        run: ./gradlew test --no-daemon
+      - name: Run unit tests + Jacoco report
+        run: ./gradlew test jacocoTestReport --no-daemon
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/reports/tests/test/
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.6'
 }
@@ -65,7 +66,63 @@ dependencies {
     testRuntimeOnly  'org.junit.platform:junit-platform-launcher'
 }
 
-test { useJUnitPlatform() }
+test {
+    useJUnitPlatform()
+    failFast = true
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+        showStandardStreams = false
+        exceptionFormat = 'full'
+    }
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = '0.8.12'
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+    // QueryDSL Q-class 등 자동 생성 코드 제외
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                '**/Q*.class',
+                'com/sseulang/SseulangApplication.class',
+                '**/dto/**',
+                '**/config/**'
+            ])
+        }))
+    }
+}
+
+// 커버리지 임계 검증 — 도메인 코드가 차오르면 단계적으로 활성화
+// TODO(도메인 30% 이상 작성 시): enabled = true 로 전환, 임계 점진 상향
+//   - 1단계: 라인 50% / 보안·결제·포인트 패키지 80%
+//   - 2단계: 라인 70% / 보안·결제·포인트 패키지 90%
+jacocoTestCoverageVerification {
+    enabled = false
+    violationRules {
+        rule {
+            element = 'BUNDLE'
+            limit { counter = 'LINE'; minimum = 0.50 }
+        }
+        rule {
+            element = 'PACKAGE'
+            includes = [
+                'com.sseulang.global.security.*',
+                'com.sseulang.domain.auth.*',
+                'com.sseulang.domain.payment.*',
+                'com.sseulang.domain.point.*'
+            ]
+            limit { counter = 'LINE'; minimum = 0.80 }
+        }
+    }
+}
 
 // QueryDSL Q-class 생성 위치
 def querydslSrcDir = 'build/generated/querydsl'

--- a/src/test/java/com/sseulang/global/common/ApiResponseTest.java
+++ b/src/test/java/com/sseulang/global/common/ApiResponseTest.java
@@ -1,0 +1,51 @@
+package com.sseulang.global.common;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ApiResponse")
+class ApiResponseTest {
+
+    @Nested
+    @DisplayName("ok(data)")
+    class Ok {
+
+        @Test
+        void 생성_데이터있을때_success_true와_data만_채운다() {
+            ApiResponse<String> response = ApiResponse.ok("hello");
+
+            assertThat(response.success()).isTrue();
+            assertThat(response.data()).isEqualTo("hello");
+            assertThat(response.error()).isNull();
+        }
+
+        @Test
+        void 생성_데이터없을때_success_true에_data와_error가_null() {
+            ApiResponse<Void> response = ApiResponse.ok();
+
+            assertThat(response.success()).isTrue();
+            assertThat(response.data()).isNull();
+            assertThat(response.error()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("fail(code, message, traceId)")
+    class Fail {
+
+        @Test
+        void 생성_실패응답_success_false와_error_채운다() {
+            ApiResponse<Void> response = ApiResponse.fail("AUTH_LOGIN_FAILED", "로그인 실패", "trace-123");
+
+            assertThat(response.success()).isFalse();
+            assertThat(response.data()).isNull();
+            assertThat(response.error()).isNotNull();
+            assertThat(response.error().code()).isEqualTo("AUTH_LOGIN_FAILED");
+            assertThat(response.error().message()).isEqualTo("로그인 실패");
+            assertThat(response.error().traceId()).isEqualTo("trace-123");
+        }
+    }
+}

--- a/src/test/java/com/sseulang/global/exception/BusinessExceptionTest.java
+++ b/src/test/java/com/sseulang/global/exception/BusinessExceptionTest.java
@@ -1,0 +1,38 @@
+package com.sseulang.global.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("BusinessException")
+class BusinessExceptionTest {
+
+    @Test
+    void 생성_ErrorCode만_전달시_defaultMessage가_적용된다() {
+        BusinessException exception = new BusinessException(ErrorCode.USER_NOT_FOUND);
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.USER_NOT_FOUND.getDefaultMessage());
+        assertThat(exception.getCause()).isNull();
+    }
+
+    @Test
+    void 생성_커스텀메시지_전달시_message가_오버라이드된다() {
+        BusinessException exception = new BusinessException(ErrorCode.INVALID_REQUEST, "id는 양수여야 합니다");
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("id는 양수여야 합니다");
+    }
+
+    @Test
+    void 생성_원인예외_전달시_cause가_보존된다() {
+        IllegalStateException cause = new IllegalStateException("DB down");
+
+        BusinessException exception = new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, cause);
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+        assertThat(exception.getCause()).isSameAs(cause);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR.getDefaultMessage());
+    }
+}


### PR DESCRIPTION
## 변경 요약
1인 9일 일정에 맞춘 **TDD + DDD-lite** 작업 환경을 한 번에 셋업합니다. 인프라(Jacoco/CI), 컨벤션(CLAUDE/AGENTS/PR 템플릿), 샘플 테스트 3축으로 분리 커밋.

## 변경 유형
- [x] chore (인프라)
- [x] docs (컨벤션)
- [x] test (샘플)

## 커밋 분리
1. `5acc6fc` chore: Jacoco + CI 리포트 업로드
2. `c5e0db9` docs: TDD + DDD-lite 컨벤션
3. `9d63a67` test: 샘플 단위 테스트 (ApiResponse, BusinessException)

## 핵심 결정
### TDD 강도 (CLAUDE.md §7.2)
| 영역 | 강도 |
|---|---|
| 보안 / 결제 / 포인트 / 거래 상태 / JWT / 동시성 | 🔒 테스트 먼저 필수 |
| 일반 도메인 (Aggregate, DomainService, AppService, VO) | TDD 권장 |
| 트리비얼 어댑터 (Controller, JPA Repo, DTO) | 통합 테스트로 갈음 OK |

### DDD 깊이 — DDD-lite (헥사고날·CQRS·ES 도입 안 함)
4-layer 패키지 구조:
```
domain/{도메인}/
├── application/   # UseCase, AppService (트랜잭션 경계)
├── domain/        # Aggregate, VO, DomainService, Repository(인터페이스), DomainEvent
├── infrastructure/ # JPA RepositoryImpl, 외부 어댑터
└── presentation/   # Controller, Request/Response DTO
```

### Jacoco 임계값
- **시작은 OFF, 리포트만 생성** — 골격만 있어 측정 무의미
- 도메인 30% 이상 차오르면 활성화 (`build.gradle` TODO):
  - 1단계: 라인 50% / 보안·결제·포인트 80%
  - 2단계: 라인 70% / 90%

## 보안 민감 영역 변경 여부
- [ ] global/security/** — (변경 없음)
- [ ] domain/auth/** — (변경 없음)
- [ ] domain/payment/** / point/** — (변경 없음)
- [ ] 결제 웹훅 / OAuth 콜백 / WebSocket 인증 — (변경 없음)
- [ ] 동시성/잔액 처리 — (변경 없음)

→ Codex 리뷰 의무 영역 아님. 단, 컨벤션 자체에 대한 의견은 환영.

## 테스트 방법
- 로컬: `./gradlew clean build` → BUILD SUCCESSFUL (테스트 6개 PASSED)
- CI: build.yml에서 `test jacocoTestReport` 후 artifact `test-results`, `jacoco-report` 업로드 — PR Files 탭 우측에서 다운로드 가능

## 체크리스트
- [x] 로컬 빌드 + 테스트 통과
- [x] TDD 샘플 테스트 (ApiResponse, BusinessException)
- [x] 응답 포맷 / 페이징 컨벤션 변경 없음
- [x] 시크릿 커밋 없음
- [x] N+1 해당 없음
- [x] Jacoco 리포트 정상 생성

## 다음 단계 (이 PR 머지 후)
- 외부 의존성 검증 (토스 테스트 키, OAuth 콘솔, S3) — 내일
- `feature/auth-jwt` 착수 시 새 패키지 구조 + TDD 적용 시작