### PR TITLE
feat: JWT 인증 흐름 + Codex 게이트 1 리뷰 반영 (Day 2)

### DIFF
--- a/docs/AUTH_SECURITY.md
+++ b/docs/AUTH_SECURITY.md
@@ -5,17 +5,21 @@
 
 ---
 
-## 1. 게이트 1 리뷰 결과 요약
+## 1. 게이트 1 / mini 게이트 2 리뷰 결과 요약
 
-리뷰 thread: `019dd216-bcea-7c42-8cc6-113c6dab9989` (`.logs/codex-review.log` 참고).
+- 게이트 1 thread: `019dd216-bcea-7c42-8cc6-113c6dab9989`
+- mini 게이트 2 thread: `019dd22d-72ab-7d91-9602-0672679a2429`
+- (`.logs/codex-review.log` 참고. 보안 영역 작업 직후엔 비울 것.)
 
 | 항목 | 분류 | 처리 | 커밋/이슈 |
 |------|------|------|-----------|
-| C1: AT 블랙리스트 검증 부재 | 🔴 Critical | **적용 (옵션 b — jti 블랙리스트)** | 본 PR |
-| C2: rotation race (isValid+revoke 분리) | 🔴 Critical | **적용 (consume atomic)** | 본 PR |
-| W1: AuthenticationEntryPoint 부재 | 🟡 Warning | **적용** | 본 PR |
-| W2: revokeAll SCAN 비효율 | 🟡 Warning | **TODO 주석 + 후속 이슈** | (별도 이슈) |
-| C1-a 보강: user-level token version | — | **후속 이슈로 분리 (Day 3 User 도메인 후)** | (별도 이슈) |
+| **게이트 1** C1: AT 블랙리스트 검증 부재 | 🔴 Critical | **적용 (옵션 b — jti 블랙리스트)** | 본 PR |
+| **게이트 1** C2: rotation race (isValid+revoke 분리) | 🔴 Critical | **적용 (consume atomic)** | 본 PR |
+| **게이트 1** W1: AuthenticationEntryPoint 부재 | 🟡 Warning | **적용** (`JwtAuthenticationEntryPoint` + `JwtAccessDeniedHandler`) | 본 PR |
+| **게이트 1** W2: revokeAll SCAN 비효율 | 🟡 Warning | **TODO 주석 + 후속 이슈** | #5 |
+| **mini 게이트 2** Critical: Redis 어댑터 통합 테스트 부재 | 🔴 Critical | **적용** — testcontainers Redis IT (blacklist / consume / revokeAll / TTL / race) | 본 PR |
+| **mini 게이트 2** Warning: SecurityConfig wiring + traceId 일관성 미검증 | 🟡 Warning | **적용** — `AuthSecurityFlowIT` (WebMvcTest 슬라이스 + traceId 일치 검증) | 본 PR |
+| C1-a 보강: user-level token version | — | **후속 이슈로 분리 (Day 3 User 도메인 후)** | #4 |
 
 ---
 

--- a/docs/AUTH_SECURITY.md
+++ b/docs/AUTH_SECURITY.md
@@ -1,0 +1,116 @@
+# Auth 보안 트레이드오프 / 트러블슈팅
+
+> Day 2 JWT 인증 흐름 작업 시 Codex 게이트 1 🔴 리뷰 결과를 정리한 문서.
+> 적용한 것 / 의도적으로 미룬 것 / 운영 주의사항.
+
+---
+
+## 1. 게이트 1 리뷰 결과 요약
+
+리뷰 thread: `019dd216-bcea-7c42-8cc6-113c6dab9989` (`.logs/codex-review.log` 참고).
+
+| 항목 | 분류 | 처리 | 커밋/이슈 |
+|------|------|------|-----------|
+| C1: AT 블랙리스트 검증 부재 | 🔴 Critical | **적용 (옵션 b — jti 블랙리스트)** | 본 PR |
+| C2: rotation race (isValid+revoke 분리) | 🔴 Critical | **적용 (consume atomic)** | 본 PR |
+| W1: AuthenticationEntryPoint 부재 | 🟡 Warning | **적용** | 본 PR |
+| W2: revokeAll SCAN 비효율 | 🟡 Warning | **TODO 주석 + 후속 이슈** | (별도 이슈) |
+| C1-a 보강: user-level token version | — | **후속 이슈로 분리 (Day 3 User 도메인 후)** | (별도 이슈) |
+
+---
+
+## 2. 의도된 설계 결정 (Critical 아님)
+
+### 2.1 RT 에 role claim 포함
+
+`JwtProvider.issueRefreshToken(userId, role)` — RT payload 에 role 까지 박는다.
+
+**Why:** rotation 시점에 새 AT 발급에 필요한 role 의 출처가 필요한데, User 도메인 + OAuth 흐름은 Day 3 작업. RT 가 가장 단순한 출처.
+
+**한계:** RT 유효 기간(7일) 동안 role 변경(예: `USER → ADMIN` 승급)이 새 AT 에 반영되지 않는다. → 후속 이슈 C1-a 의 token version 도입 시 해결됨.
+
+### 2.2 재사용 탐지 시 사용자 전체 폐기
+
+`RefreshTokenRotationService.rotate` — `consume` 가 false 면 (이미 누가 사용한 jti 또는 처음부터 없는 jti) `revokeAll(userId)` 로 사용자 모든 토큰 무효화.
+
+**Why:** 폐기된 RT 가 다시 들어오는 건 탈취 의심 시그널. 보수적으로 전체 폐기.
+
+**UX 한계:** 동시 refresh 요청이 둘 다 들어와도 한 쪽이 먼저 consume → 다른 쪽이 false → 정상 사용자도 전 디바이스 강제 로그아웃. 동시성 race 의 false-positive.
+- 실제 환경에서는 클라이언트가 한 번에 한 RT 만 굴리므로 거의 발생 X
+- 발생해도 보안 우선 — 다시 로그인하면 됨
+
+### 2.3 `/auth/login` 엔드포인트 부재
+
+본 PR 은 토큰 발급/검증/회전 프레임워크만 닫고, OAuth 콜백 → User 매핑 → 토큰 발급 흐름은 Day 3 OAuth 작업에서 마무리.
+
+---
+
+## 3. 운영 주의사항
+
+### 3.1 logout 흐름
+
+`POST /api/v1/auth/logout` 는 두 가지 동작:
+
+1. **AT jti 블랙리스트 등록** (Redis `auth:atbl:{jti}`, TTL = AT 잔여 만료시간)
+   - logout 직후의 위험 윈도우 차단 — 다른 곳에 AT 가 복사돼 있어도 즉시 폐기됨
+2. **RT 폐기** (Redis `auth:rt:{userId}:{jti}` DEL)
+
+폐기 단위는 **device 단위**. 같은 사용자의 다른 디바이스 AT/RT 는 영향 없음.
+
+### 3.2 재사용 탐지 시 사용자 안내
+
+`AUTH_REFRESH_TOKEN_INVALID` 가 나오면 사용자의 **모든 디바이스**가 로그아웃됐다는 의미. 클라이언트는 이 코드를 받으면 강제 재로그인 화면으로 유도하고, 가능하면 "보안상의 이유로 모든 디바이스에서 로그아웃됐습니다" 안내.
+
+### 3.3 `.logs/codex-review.log` 보존 정책
+
+Codex MCP 호출 입출력에 토큰 / 비밀키 / 코드가 그대로 남는다. **보안 영역 작업 직후엔 비울 것:**
+
+```bash
+> .logs/codex-review.log
+```
+
+`.logs/` 는 `.gitignore` 처리되어 있지만 로컬 디스크엔 남는다.
+
+---
+
+## 4. 후속 이슈 (트래킹)
+
+| ID | 대응 | 시점 |
+|----|------|------|
+| C1-a | user-level token version (User 엔티티 + AT/RT payload 에 ver claim + Filter 비교) | Day 3 OAuth 작업 ~ 직후 |
+| W2 | `RedisRefreshTokenStore.revokeAll` 의 SCAN → user 별 SET 인덱스 (`auth:rt-idx:{userId}`) | 5/6 이후 |
+
+---
+
+## 5. 의존 다이어그램
+
+```
+AuthController
+   │
+   └─> RefreshTokenRotationService  (AT jti 블랙리스트 + RT consume/revoke)
+          │
+          ├─> JwtProvider           (HS256 issue / parse / validate)
+          ├─> RefreshTokenStore     (interface — domain layer)
+          │      └─> RedisRefreshTokenStore  (auth:rt:{userId}:{jti})
+          ├─> AccessTokenBlacklist  (interface — domain layer)
+          │      └─> RedisAccessTokenBlacklist (auth:atbl:{jti})
+          └─> Clock
+
+JwtAuthenticationFilter
+   ├─> JwtProvider
+   ├─> AccessTokenBlacklist  (요청마다 isBlacklisted 검사)
+   └─> HandlerExceptionResolver  (BusinessException → ApiResponse 위임)
+
+SecurityConfig (3-chain: ADMIN / USER / PUBLIC)
+   ├─> JwtAuthenticationFilter (USER, ADMIN)
+   ├─> JwtAuthenticationEntryPoint  (401 → ApiResponse)
+   └─> JwtAccessDeniedHandler        (403 → ApiResponse)
+```
+
+---
+
+## 6. 관련 문서 / 컨벤션
+
+- `.claude/CLAUDE.md` §4 (보안/인증 핵심 룰), §7.2 (TDD 강제 영역), §9 (Codex 게이트)
+- `.claude/AGENTS.md` §3.1 (보안 체크), §6.1 (게이트 1)
+- `docs/SSEULANG_BACKEND_GUIDE.md` §4.1 (인증/인가 결정 사항)

--- a/src/main/java/com/sseulang/SseulangApplication.java
+++ b/src/main/java/com/sseulang/SseulangApplication.java
@@ -1,12 +1,23 @@
 package com.sseulang;
 
+import com.sseulang.global.security.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
+
+import java.time.Clock;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan("com.sseulang")
 public class SseulangApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(SseulangApplication.class, args);
+    }
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
     }
 }

--- a/src/main/java/com/sseulang/domain/auth/application/RefreshTokenRotationService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/RefreshTokenRotationService.java
@@ -1,0 +1,102 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.auth.domain.AccessTokenBlacklist;
+import com.sseulang.domain.auth.domain.RefreshTokenStore;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.security.JwtClaims;
+import com.sseulang.global.security.JwtProperties;
+import com.sseulang.global.security.JwtProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Duration;
+
+/**
+ * Auth 세션 lifecycle.
+ *
+ * <ul>
+ *   <li>{@code rotate}: oldRT 를 atomic 하게 consume → 통과 시 새 AT/RT 발급. 재사용 탐지 시 전체 폐기.</li>
+ *   <li>{@code logout}: AT jti 를 블랙리스트에 등록 + RT 폐기. 만료/변조 토큰은 조용히 무시.</li>
+ *   <li>{@code revoke}: RT 단일 폐기 — 내부용 호환 (logout 이 권장).</li>
+ * </ul>
+ */
+@Service
+@Transactional
+public class RefreshTokenRotationService {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenStore refreshTokenStore;
+    private final AccessTokenBlacklist accessTokenBlacklist;
+    private final Clock clock;
+    private final Duration refreshTokenTtl;
+
+    public RefreshTokenRotationService(
+            JwtProvider jwtProvider,
+            RefreshTokenStore refreshTokenStore,
+            AccessTokenBlacklist accessTokenBlacklist,
+            Clock clock,
+            JwtProperties jwtProperties
+    ) {
+        this.jwtProvider = jwtProvider;
+        this.refreshTokenStore = refreshTokenStore;
+        this.accessTokenBlacklist = accessTokenBlacklist;
+        this.clock = clock;
+        this.refreshTokenTtl = Duration.ofSeconds(jwtProperties.refreshTokenValiditySeconds());
+    }
+
+    public TokenPair rotate(String oldRefreshToken) {
+        JwtClaims claims = jwtProvider.parse(oldRefreshToken);  // AUTH_TOKEN_EXPIRED / INVALID
+        Long userId = claims.userId();
+        String role = claims.role();
+        String oldJti = claims.jti();
+
+        // atomic: 동시 rotate 요청 중 단 하나만 true 를 받는다.
+        // false = (a) 처음부터 없는 jti 또는 (b) 이미 누가 사용함 → 탈취 의심
+        if (!refreshTokenStore.consume(userId, oldJti)) {
+            refreshTokenStore.revokeAll(userId);
+            throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
+        }
+
+        String newAccessToken = jwtProvider.issueAccessToken(userId, role);
+        String newRefreshToken = jwtProvider.issueRefreshToken(userId, role);
+        String newJti = jwtProvider.parse(newRefreshToken).jti();
+        refreshTokenStore.save(userId, newJti, refreshTokenTtl);
+
+        return new TokenPair(newAccessToken, newRefreshToken);
+    }
+
+    public void logout(String accessToken, String refreshToken) {
+        blacklistAccessToken(accessToken);
+        revoke(refreshToken);
+    }
+
+    public void revoke(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            return;
+        }
+        try {
+            JwtClaims claims = jwtProvider.parse(refreshToken);
+            refreshTokenStore.revoke(claims.userId(), claims.jti());
+        } catch (BusinessException ignored) {
+            // 만료/변조 토큰은 어차피 사용 불가 — 조용히 흘려보냄
+        }
+    }
+
+    private void blacklistAccessToken(String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            return;
+        }
+        try {
+            JwtClaims claims = jwtProvider.parse(accessToken);
+            long remainingSeconds = claims.expiresAt().getEpochSecond() - clock.instant().getEpochSecond();
+            if (remainingSeconds > 0) {
+                accessTokenBlacklist.blacklist(claims.jti(), Duration.ofSeconds(remainingSeconds));
+            }
+        } catch (BusinessException ignored) {
+            // 만료/변조 AT 는 어차피 필터에서 거부됨
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/application/dto/TokenPair.java
+++ b/src/main/java/com/sseulang/domain/auth/application/dto/TokenPair.java
@@ -1,0 +1,7 @@
+package com.sseulang.domain.auth.application.dto;
+
+/**
+ * Access / Refresh Token 한 쌍. ApplicationService 결과 DTO.
+ */
+public record TokenPair(String accessToken, String refreshToken) {
+}

--- a/src/main/java/com/sseulang/domain/auth/domain/AccessTokenBlacklist.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/AccessTokenBlacklist.java
@@ -1,0 +1,23 @@
+package com.sseulang.domain.auth.domain;
+
+import java.time.Duration;
+
+/**
+ * Access Token jti 블랙리스트 — 명시적 logout 시 즉시 폐기 흐름.
+ *
+ * AT 는 만료가 짧지만(30분) logout 직후의 위험 윈도우를 막기 위해 jti 단위로 폐기 가능해야 한다.
+ * (가이드 §4.1 의 {@code AUTH_TOKEN_REVOKED} 사용 의도)
+ *
+ * 디바이스 단위 — 한 디바이스에서 logout 해도 다른 디바이스의 AT 는 유효.
+ */
+public interface AccessTokenBlacklist {
+
+    /**
+     * jti 를 블랙리스트에 등록. TTL 은 보통 AT 의 잔여 만료시간으로 잡으면
+     * 자연 만료와 함께 자동 정리된다.
+     */
+    void blacklist(String jti, Duration ttl);
+
+    /** 블랙리스트 hit 인지 확인. */
+    boolean isBlacklisted(String jti);
+}

--- a/src/main/java/com/sseulang/domain/auth/domain/RefreshTokenStore.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/RefreshTokenStore.java
@@ -1,0 +1,32 @@
+package com.sseulang.domain.auth.domain;
+
+import java.time.Duration;
+
+/**
+ * Refresh Token 저장소 인터페이스. 도메인 layer 순수 POJO — Spring/JPA/Redis 의존 X.
+ * 구현은 {@code domain/auth/infrastructure/persistence}.
+ *
+ * Rotation 정책:
+ *  - 토큰 발급 시 {@link #save} (TTL = 7일)
+ *  - Rotation 시 {@link #consume} 으로 atomic 폐기 (반환 false 면 재사용 탐지)
+ *  - 명시적 logout 시 {@link #revoke}
+ *  - 재사용 탐지 시 {@link #revokeAll} 로 해당 사용자 전체 토큰 무효화
+ */
+public interface RefreshTokenStore {
+
+    /** 발급 시 호출 — jti 를 지정 TTL 로 저장. */
+    void save(Long userId, String jti, Duration ttl);
+
+    /**
+     * Rotation 의 핵심 — atomic 하게 jti 를 검증·폐기한다.
+     * 저장돼 있던 jti 면 즉시 삭제하고 true. 없거나 이미 폐기됐으면 false.
+     * isValid+revoke 두 단계를 race 없이 합친 형태.
+     */
+    boolean consume(Long userId, String jti);
+
+    /** 명시적 logout 등 — 단일 jti 폐기. 없어도 무방. */
+    void revoke(Long userId, String jti);
+
+    /** 해당 사용자의 모든 Refresh Token 폐기 — 재사용 탐지·전체 로그아웃. */
+    void revokeAll(Long userId);
+}

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisAccessTokenBlacklist.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisAccessTokenBlacklist.java
@@ -1,0 +1,34 @@
+package com.sseulang.domain.auth.infrastructure.persistence;
+
+import com.sseulang.domain.auth.domain.AccessTokenBlacklist;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+/**
+ * Redis 백엔드. Key 패턴: {@code auth:atbl:{jti}} → marker "1", TTL = AT 잔여 만료시간.
+ * jti 가 글로벌 유니크라 user 차원의 prefix 불필요.
+ */
+@Repository
+public class RedisAccessTokenBlacklist implements AccessTokenBlacklist {
+
+    private static final String KEY_PREFIX = "auth:atbl:";
+    private static final String MARKER = "1";
+
+    private final StringRedisTemplate redis;
+
+    public RedisAccessTokenBlacklist(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    @Override
+    public void blacklist(String jti, Duration ttl) {
+        redis.opsForValue().set(KEY_PREFIX + jti, MARKER, ttl);
+    }
+
+    @Override
+    public boolean isBlacklisted(String jti) {
+        return Boolean.TRUE.equals(redis.hasKey(KEY_PREFIX + jti));
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStore.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStore.java
@@ -1,0 +1,69 @@
+package com.sseulang.domain.auth.infrastructure.persistence;
+
+import com.sseulang.domain.auth.domain.RefreshTokenStore;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Redis 백엔드. Key 패턴: {@code auth:rt:{userId}:{jti}} → marker "1", TTL = 토큰 유효기간.
+ * revokeAll 은 SCAN 으로 점진 검색 (KEYS 명령 회피).
+ */
+@Repository
+public class RedisRefreshTokenStore implements RefreshTokenStore {
+
+    private static final String KEY_PREFIX = "auth:rt:";
+    private static final String MARKER = "1";
+    private static final long SCAN_BATCH = 100L;
+
+    private final StringRedisTemplate redis;
+
+    public RedisRefreshTokenStore(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    @Override
+    public void save(Long userId, String jti, Duration ttl) {
+        redis.opsForValue().set(key(userId, jti), MARKER, ttl);
+    }
+
+    @Override
+    public boolean consume(Long userId, String jti) {
+        // DEL 의 반환값 = 삭제된 키 개수. 1 이면 이번 호출이 jti 를 가진 첫 호출자.
+        // 같은 jti 에 대한 동시 호출 중 단 하나만 true 를 받는다 (Redis 가 단일 스레드).
+        Long deleted = redis.delete(java.util.List.of(key(userId, jti)));
+        return deleted != null && deleted > 0L;
+    }
+
+    @Override
+    public void revoke(Long userId, String jti) {
+        redis.delete(key(userId, jti));
+    }
+
+    @Override
+    public void revokeAll(Long userId) {
+        // TODO(5/6 이후): 토큰 수 증가 시 SCAN 비효율. user 별 SET 인덱스(`auth:rt-idx:{userId}`)로 변경.
+        ScanOptions opts = ScanOptions.scanOptions()
+                .match(KEY_PREFIX + userId + ":*")
+                .count(SCAN_BATCH)
+                .build();
+        Set<String> keys = new HashSet<>();
+        try (Cursor<String> cursor = redis.scan(opts)) {
+            while (cursor.hasNext()) {
+                keys.add(cursor.next());
+            }
+        }
+        if (!keys.isEmpty()) {
+            redis.delete(keys);
+        }
+    }
+
+    private static String key(Long userId, String jti) {
+        return KEY_PREFIX + userId + ":" + jti;
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
@@ -1,0 +1,62 @@
+package com.sseulang.domain.auth.presentation;
+
+import com.sseulang.domain.auth.application.RefreshTokenRotationService;
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.security.CookieUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final RefreshTokenRotationService rotationService;
+    private final CookieUtil cookieUtil;
+
+    public AuthController(RefreshTokenRotationService rotationService, CookieUtil cookieUtil) {
+        this.rotationService = rotationService;
+        this.cookieUtil = cookieUtil;
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<Void>> refresh(
+            @CookieValue(name = CookieUtil.REFRESH_TOKEN_COOKIE, required = false) String refreshToken
+    ) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_TOKEN_MISSING);
+        }
+        TokenPair pair = rotationService.rotate(refreshToken);
+
+        ResponseCookie at = cookieUtil.accessTokenCookie(pair.accessToken());
+        ResponseCookie rt = cookieUtil.refreshTokenCookie(pair.refreshToken());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, at.toString())
+                .header(HttpHeaders.SET_COOKIE, rt.toString())
+                .body(ApiResponse.ok());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @CookieValue(name = CookieUtil.ACCESS_TOKEN_COOKIE, required = false) String accessToken,
+            @CookieValue(name = CookieUtil.REFRESH_TOKEN_COOKIE, required = false) String refreshToken
+    ) {
+        rotationService.logout(accessToken, refreshToken);
+
+        ResponseCookie atDel = cookieUtil.deleteAccessTokenCookie();
+        ResponseCookie rtDel = cookieUtil.deleteRefreshTokenCookie();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, atDel.toString())
+                .header(HttpHeaders.SET_COOKIE, rtDel.toString())
+                .body(ApiResponse.ok());
+    }
+}

--- a/src/main/java/com/sseulang/global/config/SecurityConfig.java
+++ b/src/main/java/com/sseulang/global/config/SecurityConfig.java
@@ -1,29 +1,114 @@
 package com.sseulang.global.config;
 
+import com.sseulang.global.security.JwtAccessDeniedHandler;
+import com.sseulang.global.security.JwtAuthenticationEntryPoint;
+import com.sseulang.global.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
 /**
- * Day 1 기준선 — 모든 요청 허용.
- * Day 2에서 JWT 필터 + USER/ADMIN/PUBLIC 체인 분리로 교체된다.
+ * 3-chain 분리:
+ *  - ADMIN ({@code /api/v1/admin/**}) : ROLE_ADMIN 강제 + JWT + CSRF
+ *  - USER  ({@code /api/v1/**})       : 기본 authenticated, 일부 permitAll + JWT + CSRF
+ *  - PUBLIC (그 외 정적·공개 자원)    : swagger/actuator 외 deny, CSRF 불필요
+ *
+ * CSRF 정책: 쿠키 인증이므로 {@code X-XSRF-TOKEN} 헤더로 검증 (CLAUDE.md §4 보안 룰).
+ * SameSite=Strict 가 1차 방어, X-XSRF-TOKEN 이 2차. {@code /api/v1/auth/**} 는 면제.
  */
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
+    private static final String[] PUBLIC_ENDPOINTS = {
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/actuator/health",
+            "/actuator/info"
+    };
+
+    private static final String[] AUTH_ENDPOINTS = {
+            "/api/v1/auth/**"
+    };
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint authenticationEntryPoint;
+    private final JwtAccessDeniedHandler accessDeniedHandler;
+
+    public SecurityConfig(
+            JwtAuthenticationFilter jwtAuthenticationFilter,
+            JwtAuthenticationEntryPoint authenticationEntryPoint,
+            JwtAccessDeniedHandler accessDeniedHandler
+    ) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
+    }
+
     @Bean
-    public SecurityFilterChain baselineFilterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(csrf -> csrf.disable())
-                .httpBasic(basic -> basic.disable())
-                .formLogin(form -> form.disable())
-                .logout(logout -> logout.disable())
-                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+    @Order(1)
+    public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
+        applyCommon(http)
+                .securityMatcher("/api/v1/admin/**")
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler()))
+                .exceptionHandling(eh -> eh
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeHttpRequests(auth -> auth.anyRequest().hasRole("ADMIN"))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain userFilterChain(HttpSecurity http) throws Exception {
+        applyCommon(http)
+                .securityMatcher("/api/v1/**")
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+                        .ignoringRequestMatchers(AUTH_ENDPOINTS))
+                .exceptionHandling(eh -> eh
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(AUTH_ENDPOINTS).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/items/**").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    @Order(Ordered.LOWEST_PRECEDENCE)
+    public SecurityFilterChain publicFilterChain(HttpSecurity http) throws Exception {
+        applyCommon(http)
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+                        .anyRequest().denyAll());
+        return http.build();
+    }
+
+    private HttpSecurity applyCommon(HttpSecurity http) throws Exception {
+        return http
+                .httpBasic(b -> b.disable())
+                .formLogin(f -> f.disable())
+                .logout(l -> l.disable())
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
     }
 }

--- a/src/main/java/com/sseulang/global/security/CookieProperties.java
+++ b/src/main/java/com/sseulang/global/security/CookieProperties.java
@@ -1,0 +1,27 @@
+package com.sseulang.global.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Set;
+
+@ConfigurationProperties(prefix = "app.cookie")
+public record CookieProperties(
+        String domain,
+        boolean secure,
+        String sameSite
+) {
+    private static final Set<String> ALLOWED_SAME_SITE = Set.of("Strict", "Lax", "None");
+
+    public CookieProperties {
+        if (sameSite == null || sameSite.isBlank()) {
+            sameSite = "Lax";
+        }
+        if (!ALLOWED_SAME_SITE.contains(sameSite)) {
+            throw new IllegalArgumentException("app.cookie.same-site 는 Strict / Lax / None 중 하나여야 합니다");
+        }
+        // SameSite=None 인데 secure=false 이면 모던 브라우저가 무시함 → fail-fast
+        if ("None".equals(sameSite) && !secure) {
+            throw new IllegalArgumentException("SameSite=None 은 secure=true 와 함께만 사용 가능합니다");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/global/security/CookieUtil.java
+++ b/src/main/java/com/sseulang/global/security/CookieUtil.java
@@ -1,0 +1,59 @@
+package com.sseulang.global.security;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+/**
+ * 인증 쿠키(AT/RT) 빌더. 모두 HttpOnly. secure / sameSite / domain 은 yml(app.cookie) 주입.
+ *
+ * Path 분리:
+ *  - AT: "/" — 모든 API 에 동봉
+ *  - RT: "/api/v1/auth" — refresh / logout 엔드포인트 한정 (CSRF 표면적 최소화)
+ */
+@Component
+public class CookieUtil {
+
+    public static final String ACCESS_TOKEN_COOKIE = "at";
+    public static final String REFRESH_TOKEN_COOKIE = "rt";
+    public static final String ACCESS_TOKEN_PATH = "/";
+    public static final String REFRESH_TOKEN_PATH = "/api/v1/auth";
+
+    private final CookieProperties cookieProps;
+    private final long accessTokenMaxAge;
+    private final long refreshTokenMaxAge;
+
+    public CookieUtil(CookieProperties cookieProps, JwtProperties jwtProps) {
+        this.cookieProps = cookieProps;
+        this.accessTokenMaxAge = jwtProps.accessTokenValiditySeconds();
+        this.refreshTokenMaxAge = jwtProps.refreshTokenValiditySeconds();
+    }
+
+    public ResponseCookie accessTokenCookie(String token) {
+        return baseBuilder(ACCESS_TOKEN_COOKIE, token, ACCESS_TOKEN_PATH, accessTokenMaxAge).build();
+    }
+
+    public ResponseCookie refreshTokenCookie(String token) {
+        return baseBuilder(REFRESH_TOKEN_COOKIE, token, REFRESH_TOKEN_PATH, refreshTokenMaxAge).build();
+    }
+
+    public ResponseCookie deleteAccessTokenCookie() {
+        return baseBuilder(ACCESS_TOKEN_COOKIE, "", ACCESS_TOKEN_PATH, 0L).build();
+    }
+
+    public ResponseCookie deleteRefreshTokenCookie() {
+        return baseBuilder(REFRESH_TOKEN_COOKIE, "", REFRESH_TOKEN_PATH, 0L).build();
+    }
+
+    private ResponseCookie.ResponseCookieBuilder baseBuilder(String name, String value, String path, long maxAgeSeconds) {
+        ResponseCookie.ResponseCookieBuilder b = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(cookieProps.secure())
+                .sameSite(cookieProps.sameSite())
+                .path(path)
+                .maxAge(maxAgeSeconds);
+        if (cookieProps.domain() != null && !cookieProps.domain().isBlank()) {
+            b = b.domain(cookieProps.domain());
+        }
+        return b;
+    }
+}

--- a/src/main/java/com/sseulang/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/sseulang/global/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,42 @@
+package com.sseulang.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 권한 부족(403) 시 ApiResponse 형식 통일.
+ * 인증은 됐지만 ROLE_ADMIN 등 권한이 부족할 때.
+ */
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public JwtAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(
+            HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException
+    ) throws IOException {
+        ErrorCode code = ErrorCode.FORBIDDEN;
+        response.setStatus(code.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        ApiResponse<Void> body = ApiResponse.fail(code.name(), code.getDefaultMessage(), MDC.get("traceId"));
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}

--- a/src/main/java/com/sseulang/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sseulang/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package com.sseulang.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 인증 누락(401) 시 ApiResponse 형식 통일.
+ * SecurityConfig 의 USER/ADMIN chain 에 등록 — Spring 기본 401 HTML 대신 표준 JSON 응답.
+ */
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(
+            HttpServletRequest request, HttpServletResponse response, AuthenticationException authException
+    ) throws IOException {
+        ErrorCode code = ErrorCode.AUTH_TOKEN_MISSING;
+        response.setStatus(code.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        ApiResponse<Void> body = ApiResponse.fail(code.name(), code.getDefaultMessage(), MDC.get("traceId"));
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}

--- a/src/main/java/com/sseulang/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sseulang/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,91 @@
+package com.sseulang.global.security;
+
+import com.sseulang.domain.auth.domain.AccessTokenBlacklist;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * AT 쿠키에서 토큰 추출 → 검증 → SecurityContext 주입.
+ *
+ * 쿠키가 없으면 anonymous 로 통과 (PUBLIC 엔드포인트 정상, USER 엔드포인트는 SecurityConfig 가 401).
+ * 쿠키가 있는데 invalid/expired 면 BusinessException 을 GlobalExceptionHandler 로 위임 →
+ * 정확한 에러 코드(AUTH_TOKEN_EXPIRED / INVALID) 로 ApiResponse 401 응답.
+ */
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final AccessTokenBlacklist accessTokenBlacklist;
+    private final HandlerExceptionResolver resolver;
+
+    public JwtAuthenticationFilter(
+            JwtProvider jwtProvider,
+            AccessTokenBlacklist accessTokenBlacklist,
+            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver
+    ) {
+        this.jwtProvider = jwtProvider;
+        this.accessTokenBlacklist = accessTokenBlacklist;
+        this.resolver = resolver;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain
+    ) throws ServletException, IOException {
+        String token = extractAccessToken(request);
+        if (token == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+        try {
+            JwtClaims claims = jwtProvider.parse(token);
+            if (accessTokenBlacklist.isBlacklisted(claims.jti())) {
+                throw new BusinessException(ErrorCode.AUTH_TOKEN_REVOKED);
+            }
+            Authentication auth = toAuthentication(claims);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            chain.doFilter(request, response);
+        } catch (BusinessException e) {
+            SecurityContextHolder.clearContext();
+            resolver.resolveException(request, response, null, e);
+        }
+    }
+
+    private String extractAccessToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie c : cookies) {
+            if (CookieUtil.ACCESS_TOKEN_COOKIE.equals(c.getName())) {
+                return c.getValue();
+            }
+        }
+        return null;
+    }
+
+    private Authentication toAuthentication(JwtClaims claims) {
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + claims.role());
+        return new UsernamePasswordAuthenticationToken(
+                claims.userId(),   // principal = userId
+                null,              // credentials
+                List.of(authority)
+        );
+    }
+}

--- a/src/main/java/com/sseulang/global/security/JwtClaims.java
+++ b/src/main/java/com/sseulang/global/security/JwtClaims.java
@@ -1,0 +1,15 @@
+package com.sseulang.global.security;
+
+import java.time.Instant;
+
+/**
+ * JWT 파싱 결과. AccessToken 의 경우 role 채워짐, RefreshToken 의 경우 role 은 null.
+ */
+public record JwtClaims(
+        Long userId,
+        String role,
+        String jti,
+        Instant issuedAt,
+        Instant expiresAt
+) {
+}

--- a/src/main/java/com/sseulang/global/security/JwtProperties.java
+++ b/src/main/java/com/sseulang/global/security/JwtProperties.java
@@ -1,0 +1,19 @@
+package com.sseulang.global.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.jwt")
+public record JwtProperties(
+        String secret,
+        long accessTokenValiditySeconds,
+        long refreshTokenValiditySeconds
+) {
+    public JwtProperties {
+        if (secret == null || secret.length() < 32) {
+            throw new IllegalArgumentException("app.jwt.secret 은 32바이트 이상이어야 합니다");
+        }
+        if (accessTokenValiditySeconds <= 0 || refreshTokenValiditySeconds <= 0) {
+            throw new IllegalArgumentException("토큰 유효기간은 양수여야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/global/security/JwtProvider.java
+++ b/src/main/java/com/sseulang/global/security/JwtProvider.java
@@ -1,0 +1,87 @@
+package com.sseulang.global.security;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class JwtProvider {
+
+    private static final String CLAIM_ROLE = "role";
+
+    private final JwtProperties props;
+    private final Clock clock;
+    private final SecretKey key;
+    private final JwtParser parser;
+
+    public JwtProvider(JwtProperties props, Clock clock) {
+        this.props = props;
+        this.clock = clock;
+        this.key = Keys.hmacShaKeyFor(props.secret().getBytes(StandardCharsets.UTF_8));
+        this.parser = Jwts.parser()
+                .clock(() -> Date.from(clock.instant()))
+                .verifyWith(key)
+                .build();
+    }
+
+    public String issueAccessToken(Long userId, String role) {
+        Instant now = clock.instant();
+        Instant exp = now.plusSeconds(props.accessTokenValiditySeconds());
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim(CLAIM_ROLE, role)
+                .id(UUID.randomUUID().toString())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(exp))
+                .signWith(key)
+                .compact();
+    }
+
+    public String issueRefreshToken(Long userId, String role) {
+        Instant now = clock.instant();
+        Instant exp = now.plusSeconds(props.refreshTokenValiditySeconds());
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim(CLAIM_ROLE, role)
+                .id(UUID.randomUUID().toString())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(exp))
+                .signWith(key)
+                .compact();
+    }
+
+    public JwtClaims parse(String token) {
+        if (token == null || token.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_TOKEN_INVALID);
+        }
+        try {
+            Jws<Claims> jws = parser.parseSignedClaims(token);
+            Claims c = jws.getPayload();
+            return new JwtClaims(
+                    Long.valueOf(c.getSubject()),
+                    c.get(CLAIM_ROLE, String.class),
+                    c.getId(),
+                    c.getIssuedAt().toInstant(),
+                    c.getExpiration().toInstant()
+            );
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(ErrorCode.AUTH_TOKEN_EXPIRED);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.AUTH_TOKEN_INVALID);
+        }
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/application/InMemoryFakeAccessTokenBlacklist.java
+++ b/src/test/java/com/sseulang/domain/auth/application/InMemoryFakeAccessTokenBlacklist.java
@@ -1,0 +1,27 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.domain.AccessTokenBlacklist;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** 단위 테스트용 in-memory fake. TTL 무시. */
+class InMemoryFakeAccessTokenBlacklist implements AccessTokenBlacklist {
+
+    private final Set<String> blacklist = ConcurrentHashMap.newKeySet();
+
+    @Override
+    public void blacklist(String jti, Duration ttl) {
+        blacklist.add(jti);
+    }
+
+    @Override
+    public boolean isBlacklisted(String jti) {
+        return blacklist.contains(jti);
+    }
+
+    int size() {
+        return blacklist.size();
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/application/InMemoryFakeRefreshTokenStore.java
+++ b/src/test/java/com/sseulang/domain/auth/application/InMemoryFakeRefreshTokenStore.java
@@ -1,0 +1,48 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.domain.RefreshTokenStore;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 단위 테스트용 in-memory fake. TTL 무시 (테스트 시간 짧음).
+ */
+class InMemoryFakeRefreshTokenStore implements RefreshTokenStore {
+
+    private final Set<String> store = ConcurrentHashMap.newKeySet();
+
+    @Override
+    public void save(Long userId, String jti, Duration ttl) {
+        store.add(key(userId, jti));
+    }
+
+    @Override
+    public boolean consume(Long userId, String jti) {
+        return store.remove(key(userId, jti));  // ConcurrentHashMap.newKeySet() → atomic remove
+    }
+
+    @Override
+    public void revoke(Long userId, String jti) {
+        store.remove(key(userId, jti));
+    }
+
+    boolean contains(Long userId, String jti) {
+        return store.contains(key(userId, jti));
+    }
+
+    @Override
+    public void revokeAll(Long userId) {
+        String prefix = userId + "::";
+        store.removeIf(k -> k.startsWith(prefix));
+    }
+
+    int size() {
+        return store.size();
+    }
+
+    private static String key(Long userId, String jti) {
+        return userId + "::" + jti;
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/application/RefreshTokenRotationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/RefreshTokenRotationServiceTest.java
@@ -1,0 +1,219 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.security.JwtClaims;
+import com.sseulang.global.security.JwtProperties;
+import com.sseulang.global.security.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RefreshTokenRotationServiceTest {
+
+    private static final String SECRET = "test-secret-must-be-at-least-32-bytes-long-for-hs256-blah-blah";
+    private static final long AT_VALIDITY = 1800L;
+    private static final long RT_VALIDITY = 604800L;
+    private static final Instant FIXED_NOW = Instant.parse("2026-04-28T03:00:00Z");
+    private static final Long USER_ID = 42L;
+
+    private JwtProperties props;
+    private JwtProvider jwt;
+    private InMemoryFakeRefreshTokenStore store;
+    private InMemoryFakeAccessTokenBlacklist blacklist;
+    private Clock fixedClock;
+    private RefreshTokenRotationService service;
+
+    @BeforeEach
+    void setUp() {
+        props = new JwtProperties(SECRET, AT_VALIDITY, RT_VALIDITY);
+        fixedClock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        jwt = new JwtProvider(props, fixedClock);
+        store = new InMemoryFakeRefreshTokenStore();
+        blacklist = new InMemoryFakeAccessTokenBlacklist();
+        service = new RefreshTokenRotationService(jwt, store, blacklist, fixedClock, props);
+    }
+
+    /** login 시점 시뮬레이션: 토큰 발급 + store 등록. */
+    private String issueAndRegister(Long userId, String role) {
+        String rt = jwt.issueRefreshToken(userId, role);
+        store.save(userId, jwt.parse(rt).jti(), Duration.ofSeconds(RT_VALIDITY));
+        return rt;
+    }
+
+    @Test
+    @DisplayName("rotate_정상_새 AT/RT 발급 + old jti revoke + new jti save")
+    void rotate_정상() {
+        String oldRt = issueAndRegister(USER_ID, "USER");
+        String oldJti = jwt.parse(oldRt).jti();
+
+        TokenPair pair = service.rotate(oldRt);
+
+        assertThat(pair.accessToken()).isNotBlank();
+        assertThat(pair.refreshToken())
+                .isNotBlank()
+                .isNotEqualTo(oldRt);
+
+        // old jti 무효화
+        assertThat(store.contains(USER_ID, oldJti)).isFalse();
+        // 새 jti 등록
+        JwtClaims newClaims = jwt.parse(pair.refreshToken());
+        assertThat(store.contains(USER_ID, newClaims.jti())).isTrue();
+        assertThat(newClaims.role()).isEqualTo("USER");
+    }
+
+    @Test
+    @DisplayName("rotate_새 AT 의 role 이 RT role 과 동일")
+    void rotate_새AT의_role_유지() {
+        String rt = issueAndRegister(USER_ID, "ADMIN");
+
+        TokenPair pair = service.rotate(rt);
+
+        assertThat(jwt.parse(pair.accessToken()).role()).isEqualTo("ADMIN");
+    }
+
+    @Test
+    @DisplayName("rotate_재사용 탐지_AUTH_REFRESH_TOKEN_INVALID + 해당 사용자 전체 폐기")
+    void rotate_재사용탐지() {
+        // 정상 발급 + store 등록 후 한 번 사용해서 폐기된 상태 가정
+        String reusedRt = issueAndRegister(USER_ID, "USER");
+        TokenPair first = service.rotate(reusedRt);  // 정상 회전 — old 폐기
+        // 다른 디바이스에서도 토큰 등록되어 있다고 가정 (동일 사용자)
+        String otherDeviceRt = issueAndRegister(USER_ID, "USER");
+        String otherJti = jwt.parse(otherDeviceRt).jti();
+        // first 후 새 RT 도 store 에 있음
+        String firstNewJti = jwt.parse(first.refreshToken()).jti();
+        assertThat(store.contains(USER_ID, firstNewJti)).isTrue();
+        assertThat(store.contains(USER_ID, otherJti)).isTrue();
+
+        // 이미 폐기된 reusedRt 를 다시 들고 옴 → 탈취 의심 → 전체 폐기
+        assertThatThrownBy(() -> service.rotate(reusedRt))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
+
+        // 해당 사용자의 모든 jti 가 사라져야 함
+        assertThat(store.contains(USER_ID, firstNewJti)).isFalse();
+        assertThat(store.contains(USER_ID, otherJti)).isFalse();
+    }
+
+    @Test
+    @DisplayName("rotate_만료된 RT_AUTH_TOKEN_EXPIRED")
+    void rotate_만료RT() {
+        String rt = issueAndRegister(USER_ID, "USER");
+
+        Clock laterClock = Clock.fixed(FIXED_NOW.plusSeconds(RT_VALIDITY + 1), ZoneOffset.UTC);
+        JwtProvider laterJwt = new JwtProvider(props, laterClock);
+        RefreshTokenRotationService laterService = new RefreshTokenRotationService(laterJwt, store, blacklist, laterClock, props);
+
+        assertThatThrownBy(() -> laterService.rotate(rt))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_TOKEN_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("rotate_변조된 RT_AUTH_TOKEN_INVALID")
+    void rotate_변조RT() {
+        String tampered = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0MiJ9.fake";
+
+        assertThatThrownBy(() -> service.rotate(tampered))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_TOKEN_INVALID);
+    }
+
+    @Test
+    @DisplayName("revoke_정상_RT 폐기됨")
+    void revoke_정상() {
+        String rt = issueAndRegister(USER_ID, "USER");
+        String jti = jwt.parse(rt).jti();
+        assertThat(store.contains(USER_ID, jti)).isTrue();
+
+        service.revoke(rt);
+
+        assertThat(store.contains(USER_ID, jti)).isFalse();
+    }
+
+    @Test
+    @DisplayName("revoke_변조 토큰_조용히 흘려보냄 (예외 X)")
+    void revoke_변조토큰_무시() {
+        assertThatCode(() -> service.revoke("totally.invalid.token"))
+                .doesNotThrowAnyException();
+        assertThat(store.size()).isZero();
+    }
+
+    @Test
+    @DisplayName("revoke_만료 토큰_조용히 흘려보냄 (예외 X)")
+    void revoke_만료토큰_무시() {
+        String rt = issueAndRegister(USER_ID, "USER");
+
+        Clock laterClock = Clock.fixed(FIXED_NOW.plusSeconds(RT_VALIDITY + 1), ZoneOffset.UTC);
+        JwtProvider laterJwt = new JwtProvider(props, laterClock);
+        RefreshTokenRotationService laterService = new RefreshTokenRotationService(laterJwt, store, blacklist, laterClock, props);
+
+        assertThatCode(() -> laterService.revoke(rt))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("logout_정상_AT 블랙리스트 등록 + RT 폐기")
+    void logout_정상() {
+        String rt = issueAndRegister(USER_ID, "USER");
+        String rtJti = jwt.parse(rt).jti();
+        String at = jwt.issueAccessToken(USER_ID, "USER");
+        String atJti = jwt.parse(at).jti();
+
+        service.logout(at, rt);
+
+        assertThat(blacklist.isBlacklisted(atJti)).isTrue();
+        assertThat(store.contains(USER_ID, rtJti)).isFalse();
+    }
+
+    @Test
+    @DisplayName("logout_AT 만료_블랙리스트 등록 X (어차피 필터에서 거부됨)")
+    void logout_만료AT_블랙리스트X() {
+        String rt = issueAndRegister(USER_ID, "USER");
+        String at = jwt.issueAccessToken(USER_ID, "USER");
+        String atJti = jwt.parse(at).jti();
+
+        Clock laterClock = Clock.fixed(FIXED_NOW.plusSeconds(AT_VALIDITY + 1), ZoneOffset.UTC);
+        JwtProvider laterJwt = new JwtProvider(props, laterClock);
+        RefreshTokenRotationService laterService = new RefreshTokenRotationService(laterJwt, store, blacklist, laterClock, props);
+
+        laterService.logout(at, rt);
+
+        assertThat(blacklist.isBlacklisted(atJti)).isFalse();
+        assertThat(blacklist.size()).isZero();
+    }
+
+    @Test
+    @DisplayName("logout_AT 변조_블랙리스트 등록 X (예외 X)")
+    void logout_변조AT_블랙리스트X() {
+        String rt = issueAndRegister(USER_ID, "USER");
+        String rtJti = jwt.parse(rt).jti();
+
+        assertThatCode(() -> service.logout("totally.invalid.token", rt))
+                .doesNotThrowAnyException();
+
+        assertThat(blacklist.size()).isZero();
+        // RT 는 정상이라 폐기됨
+        assertThat(store.contains(USER_ID, rtJti)).isFalse();
+    }
+
+    @Test
+    @DisplayName("logout_AT/RT 모두 null_no-op (예외 X)")
+    void logout_둘다null_무시() {
+        assertThatCode(() -> service.logout(null, null))
+                .doesNotThrowAnyException();
+        assertThat(blacklist.size()).isZero();
+        assertThat(store.size()).isZero();
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/infrastructure/persistence/RedisAccessTokenBlacklistIT.java
+++ b/src/test/java/com/sseulang/domain/auth/infrastructure/persistence/RedisAccessTokenBlacklistIT.java
@@ -1,0 +1,66 @@
+package com.sseulang.domain.auth.infrastructure.persistence;
+
+import com.sseulang.support.RedisIntegrationTestBase;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedisAccessTokenBlacklistIT extends RedisIntegrationTestBase {
+
+    private RedisAccessTokenBlacklist blacklist;
+
+    @BeforeEach
+    void setUp() {
+        blacklist = new RedisAccessTokenBlacklist(redisTemplate());
+    }
+
+    @Test
+    @DisplayName("blacklist 등록_isBlacklisted true")
+    void blacklist_등록후_조회() {
+        String jti = UUID.randomUUID().toString();
+
+        blacklist.blacklist(jti, Duration.ofMinutes(30));
+
+        assertThat(blacklist.isBlacklisted(jti)).isTrue();
+    }
+
+    @Test
+    @DisplayName("blacklist 미등록 jti_isBlacklisted false")
+    void blacklist_미등록_false() {
+        assertThat(blacklist.isBlacklisted(UUID.randomUUID().toString())).isFalse();
+    }
+
+    @Test
+    @DisplayName("TTL 만료_자동 정리")
+    void blacklist_TTL_만료시_사라짐() {
+        String jti = UUID.randomUUID().toString();
+        blacklist.blacklist(jti, Duration.ofSeconds(1));
+
+        assertThat(blacklist.isBlacklisted(jti)).isTrue();
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(3))
+                .pollInterval(Duration.ofMillis(200))
+                .until(() -> !blacklist.isBlacklisted(jti));
+    }
+
+    @Test
+    @DisplayName("같은 jti 두 번 등록_TTL 갱신 (덮어쓰기)")
+    void blacklist_재등록_TTL갱신() {
+        String jti = UUID.randomUUID().toString();
+        blacklist.blacklist(jti, Duration.ofSeconds(1));
+        blacklist.blacklist(jti, Duration.ofMinutes(30));
+
+        // 1초 지나도 살아있어야 함 (덮어쓴 TTL = 30분)
+        Awaitility.await()
+                .during(Duration.ofSeconds(2))
+                .atMost(Duration.ofSeconds(3))
+                .until(() -> blacklist.isBlacklisted(jti));
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStoreIT.java
+++ b/src/test/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStoreIT.java
@@ -1,0 +1,135 @@
+package com.sseulang.domain.auth.infrastructure.persistence;
+
+import com.sseulang.support.RedisIntegrationTestBase;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedisRefreshTokenStoreIT extends RedisIntegrationTestBase {
+
+    private static final Long USER_ID = 42L;
+    private static final Duration TTL = Duration.ofMinutes(30);
+
+    private RedisRefreshTokenStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new RedisRefreshTokenStore(redisTemplate());
+    }
+
+    @Test
+    @DisplayName("save 후 consume_true 반환 (atomic 폐기)")
+    void consume_save된jti_true() {
+        String jti = UUID.randomUUID().toString();
+        store.save(USER_ID, jti, TTL);
+
+        boolean consumed = store.consume(USER_ID, jti);
+
+        assertThat(consumed).isTrue();
+        // 같은 jti 다시 consume → false (one-time)
+        assertThat(store.consume(USER_ID, jti)).isFalse();
+    }
+
+    @Test
+    @DisplayName("save 안 한 jti consume_false")
+    void consume_save안한jti_false() {
+        assertThat(store.consume(USER_ID, UUID.randomUUID().toString())).isFalse();
+    }
+
+    @Test
+    @DisplayName("revokeAll_해당 user 의 모든 jti 사라짐")
+    void revokeAll_user전체폐기() {
+        List<String> jtis = IntStream.range(0, 5)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .toList();
+        jtis.forEach(jti -> store.save(USER_ID, jti, TTL));
+        // 다른 user 의 jti — 영향받지 않아야 함
+        Long otherUser = 99L;
+        String otherJti = UUID.randomUUID().toString();
+        store.save(otherUser, otherJti, TTL);
+
+        store.revokeAll(USER_ID);
+
+        jtis.forEach(jti -> assertThat(store.consume(USER_ID, jti)).isFalse());
+        // 다른 user 의 jti 는 살아있어야 함
+        assertThat(store.consume(otherUser, otherJti)).isTrue();
+    }
+
+    @Test
+    @DisplayName("revoke_단일 jti 폐기")
+    void revoke_단일폐기() {
+        String jti = UUID.randomUUID().toString();
+        store.save(USER_ID, jti, TTL);
+
+        store.revoke(USER_ID, jti);
+
+        assertThat(store.consume(USER_ID, jti)).isFalse();
+    }
+
+    @Test
+    @DisplayName("TTL 만료_자동 정리")
+    void save_TTL_만료시_사라짐() {
+        String jti = UUID.randomUUID().toString();
+        store.save(USER_ID, jti, Duration.ofSeconds(1));
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(3))
+                .pollInterval(Duration.ofMillis(200))
+                .until(() -> !store.consume(USER_ID, jti));
+    }
+
+    @Test
+    @DisplayName("동시 consume race_정확히 1개 스레드만 true")
+    void consume_race_one_winner() throws Exception {
+        String jti = UUID.randomUUID().toString();
+        store.save(USER_ID, jti, TTL);
+
+        int threadCount = 16;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger trueCount = new AtomicInteger(0);
+
+        try {
+            List<CompletableFuture<Boolean>> futures = IntStream.range(0, threadCount)
+                    .mapToObj(i -> CompletableFuture.supplyAsync(() -> {
+                        ready.countDown();
+                        try {
+                            start.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            return false;
+                        }
+                        boolean ok = store.consume(USER_ID, jti);
+                        if (ok) trueCount.incrementAndGet();
+                        return ok;
+                    }, pool))
+                    .toList();
+
+            ready.await(5, TimeUnit.SECONDS);
+            start.countDown();
+            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+                    .get(5, TimeUnit.SECONDS);
+        } finally {
+            pool.shutdown();
+        }
+
+        assertThat(trueCount.get())
+                .as("Redis DEL 의 atomic 보장으로 정확히 1개 스레드만 consume=true 를 받아야 한다")
+                .isEqualTo(1);
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/sseulang/domain/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,117 @@
+package com.sseulang.domain.auth.presentation;
+
+import com.sseulang.domain.auth.application.RefreshTokenRotationService;
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.global.exception.GlobalExceptionHandler;
+import com.sseulang.global.security.CookieUtil;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AuthControllerTest {
+
+    private RefreshTokenRotationService rotationService;
+    private CookieUtil cookieUtil;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        rotationService = mock(RefreshTokenRotationService.class);
+        cookieUtil = mock(CookieUtil.class);
+        AuthController controller = new AuthController(rotationService, cookieUtil);
+        mvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("POST /auth/refresh_RT 쿠키 없음_401 AUTH_TOKEN_MISSING")
+    void refresh_쿠키없음_401() throws Exception {
+        mvc.perform(post("/api/v1/auth/refresh"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("AUTH_TOKEN_MISSING"));
+
+        verify(rotationService, never()).rotate(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @DisplayName("POST /auth/refresh_RT 쿠키 정상_새 AT/RT Set-Cookie 응답")
+    void refresh_정상_쿠키set() throws Exception {
+        when(rotationService.rotate("OLD_RT")).thenReturn(new TokenPair("NEW_AT", "NEW_RT"));
+        when(cookieUtil.accessTokenCookie("NEW_AT"))
+                .thenReturn(ResponseCookie.from("at", "NEW_AT").path("/").httpOnly(true).maxAge(1800).build());
+        when(cookieUtil.refreshTokenCookie("NEW_RT"))
+                .thenReturn(ResponseCookie.from("rt", "NEW_RT").path("/api/v1/auth").httpOnly(true).maxAge(604800).build());
+
+        MvcResult result = mvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new Cookie(CookieUtil.REFRESH_TOKEN_COOKIE, "OLD_RT")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andReturn();
+
+        List<String> setCookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(setCookies).hasSize(2);
+        assertThat(setCookies).anyMatch(s -> s.startsWith("at=NEW_AT"));
+        assertThat(setCookies).anyMatch(s -> s.startsWith("rt=NEW_RT"));
+
+        verify(rotationService, times(1)).rotate("OLD_RT");
+    }
+
+    @Test
+    @DisplayName("POST /auth/logout_AT/RT 쿠키 모두 있음_logout(at, rt) 호출 + 삭제 쿠키 응답")
+    void logout_AT_RT_둘다_있음() throws Exception {
+        when(cookieUtil.deleteAccessTokenCookie())
+                .thenReturn(ResponseCookie.from("at", "").path("/").httpOnly(true).maxAge(0).build());
+        when(cookieUtil.deleteRefreshTokenCookie())
+                .thenReturn(ResponseCookie.from("rt", "").path("/api/v1/auth").httpOnly(true).maxAge(0).build());
+
+        MvcResult result = mvc.perform(post("/api/v1/auth/logout")
+                        .cookie(new Cookie(CookieUtil.ACCESS_TOKEN_COOKIE, "AT_VALUE"))
+                        .cookie(new Cookie(CookieUtil.REFRESH_TOKEN_COOKIE, "RT_VALUE")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andReturn();
+
+        List<String> setCookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(setCookies).hasSize(2);
+        assertThat(setCookies).anyMatch(s -> s.contains("Max-Age=0"));
+
+        verify(rotationService, times(1)).logout(eq("AT_VALUE"), eq("RT_VALUE"));
+    }
+
+    @Test
+    @DisplayName("POST /auth/logout_쿠키 모두 없음_service.logout(null, null) 호출 + 삭제 쿠키 응답")
+    void logout_쿠키없음() throws Exception {
+        when(cookieUtil.deleteAccessTokenCookie())
+                .thenReturn(ResponseCookie.from("at", "").path("/").httpOnly(true).maxAge(0).build());
+        when(cookieUtil.deleteRefreshTokenCookie())
+                .thenReturn(ResponseCookie.from("rt", "").path("/api/v1/auth").httpOnly(true).maxAge(0).build());
+
+        mvc.perform(post("/api/v1/auth/logout"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        // 쿠키 없으면 둘 다 null — service 가 noop 처리
+        verify(rotationService, times(1)).logout(org.mockito.ArgumentMatchers.isNull(), org.mockito.ArgumentMatchers.isNull());
+    }
+}

--- a/src/test/java/com/sseulang/global/security/AuthSecurityFlowIT.java
+++ b/src/test/java/com/sseulang/global/security/AuthSecurityFlowIT.java
@@ -1,0 +1,114 @@
+package com.sseulang.global.security;
+
+import com.sseulang.domain.auth.domain.AccessTokenBlacklist;
+import com.sseulang.global.common.TraceIdFilter;
+import com.sseulang.global.config.SecurityConfig;
+import com.sseulang.global.exception.GlobalExceptionHandler;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Security filter chain wiring + EntryPoint + traceId 일관성 통합 테스트.
+ *
+ * <p>실제 SecurityConfig 의 USER chain 이 동작하고, 인증 누락 시 EntryPoint 가 ApiResponse 응답을
+ * 내려주며, X-Trace-Id 헤더와 본문 traceId 가 일치하는지 검증한다.</p>
+ */
+@WebMvcTest(controllers = ProtectedTestController.class)
+@Import({
+        SecurityConfig.class,
+        JwtAuthenticationFilter.class,
+        JwtAuthenticationEntryPoint.class,
+        JwtAccessDeniedHandler.class,
+        TraceIdFilter.class,
+        GlobalExceptionHandler.class
+})
+class AuthSecurityFlowIT {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private AccessTokenBlacklist accessTokenBlacklist;
+
+    @Test
+    @DisplayName("보호된 엔드포인트_토큰 없음_401 + AUTH_TOKEN_MISSING + X-Trace-Id 헤더와 본문 traceId 일치")
+    @WithAnonymousUser
+    void 보호된엔드포인트_토큰없음_401_traceId일관() throws Exception {
+        MvcResult result = mvc.perform(get("/api/v1/test/protected"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().exists(TraceIdFilter.HEADER))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.AUTH_TOKEN_MISSING.name()))
+                .andExpect(jsonPath("$.error.traceId").exists())
+                .andReturn();
+
+        String headerTraceId = result.getResponse().getHeader(TraceIdFilter.HEADER);
+        String bodyJson = result.getResponse().getContentAsString();
+
+        assertThat(headerTraceId)
+                .as("X-Trace-Id 헤더와 응답 본문의 error.traceId 가 일치해야 한다")
+                .isNotBlank();
+        assertThat(bodyJson).contains("\"traceId\":\"" + headerTraceId + "\"");
+    }
+
+    @Test
+    @DisplayName("유효한 AT 쿠키_보호된 엔드포인트 200")
+    void 유효AT_보호된엔드포인트_200() throws Exception {
+        JwtClaims claims = new JwtClaims(1L, "USER", "jti-1",
+                Instant.parse("2026-04-28T03:00:00Z"),
+                Instant.parse("2026-04-28T03:30:00Z"));
+        when(jwtProvider.parse(any())).thenReturn(claims);
+        when(accessTokenBlacklist.isBlacklisted("jti-1")).thenReturn(false);
+
+        mvc.perform(get("/api/v1/test/protected")
+                        .cookie(new Cookie(CookieUtil.ACCESS_TOKEN_COOKIE, "AT_VALUE"))
+                        .with(req -> {
+                            // CSRF 면제 — GET 요청은 어차피 CSRF 검증 안 함
+                            return req;
+                        }))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(TraceIdFilter.HEADER));
+    }
+
+    @Test
+    @DisplayName("Public 엔드포인트(swagger)_인증 차단 안 됨")
+    void public_swagger_인증차단X() throws Exception {
+        // Springdoc 본체는 슬라이스에 없어 404 가 정상. PUBLIC chain 의 permitAll 매처가
+        // 동작했는지(=401/403 이 아닌지)만 검증한다.
+        int status = mvc.perform(get("/swagger-ui.html")).andReturn().getResponse().getStatus();
+        assertThat(status).isNotIn(401, 403);
+    }
+
+    @Test
+    @DisplayName("Public 엔드포인트(actuator/health)_인증 없이 통과")
+    void public_actuator_통과() throws Exception {
+        // health endpoint 가 미설치된 슬라이스 환경 — denyAll 이 아닌 permitAll 매처가 동작하는지만 검증.
+        // 매처는 통과하지만 핸들러가 없어 404 가 나오는 게 정상. 401/403 이 아님을 확인.
+        int status = mvc.perform(get("/actuator/health")).andReturn().getResponse().getStatus();
+        assertThat(status)
+                .as("PUBLIC chain 의 permitAll 매처에 잡혀야 — 401/403 이면 chain 분리 실패")
+                .isNotIn(401, 403);
+    }
+}

--- a/src/test/java/com/sseulang/global/security/CookieUtilTest.java
+++ b/src/test/java/com/sseulang/global/security/CookieUtilTest.java
@@ -1,0 +1,133 @@
+package com.sseulang.global.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CookieUtilTest {
+
+    private static final String SECRET = "test-secret-must-be-at-least-32-bytes-long-for-hs256-blah-blah";
+    private static final long AT_VALIDITY = 1800L;
+    private static final long RT_VALIDITY = 604800L;
+
+    private final JwtProperties jwt = new JwtProperties(SECRET, AT_VALIDITY, RT_VALIDITY);
+
+    private CookieUtil prodLikeUtil() {
+        return new CookieUtil(new CookieProperties("sseulang.kr", true, "Strict"), jwt);
+    }
+
+    private CookieUtil localLikeUtil() {
+        return new CookieUtil(new CookieProperties("localhost", false, "Lax"), jwt);
+    }
+
+    @Test
+    @DisplayName("accessTokenCookie_HttpOnly + Path / + MaxAge=AT 유효기간")
+    void accessTokenCookie_기본속성() {
+        ResponseCookie c = prodLikeUtil().accessTokenCookie("AT_VALUE");
+
+        assertThat(c.getName()).isEqualTo("at");
+        assertThat(c.getValue()).isEqualTo("AT_VALUE");
+        assertThat(c.isHttpOnly()).isTrue();
+        assertThat(c.getPath()).isEqualTo("/");
+        assertThat(c.getMaxAge()).isEqualTo(Duration.ofSeconds(AT_VALIDITY));
+    }
+
+    @Test
+    @DisplayName("refreshTokenCookie_HttpOnly + Path /api/v1/auth + MaxAge=RT 유효기간")
+    void refreshTokenCookie_기본속성() {
+        ResponseCookie c = prodLikeUtil().refreshTokenCookie("RT_VALUE");
+
+        assertThat(c.getName()).isEqualTo("rt");
+        assertThat(c.getValue()).isEqualTo("RT_VALUE");
+        assertThat(c.isHttpOnly()).isTrue();
+        assertThat(c.getPath()).isEqualTo("/api/v1/auth");
+        assertThat(c.getMaxAge()).isEqualTo(Duration.ofSeconds(RT_VALIDITY));
+    }
+
+    @Test
+    @DisplayName("delete 쿠키_value 비고 MaxAge=0")
+    void deleteCookies_maxAge_0() {
+        CookieUtil u = prodLikeUtil();
+
+        assertThat(u.deleteAccessTokenCookie().getMaxAge()).isEqualTo(Duration.ZERO);
+        assertThat(u.deleteAccessTokenCookie().getValue()).isEmpty();
+        assertThat(u.deleteRefreshTokenCookie().getMaxAge()).isEqualTo(Duration.ZERO);
+        assertThat(u.deleteRefreshTokenCookie().getValue()).isEmpty();
+    }
+
+    @Nested
+    @DisplayName("환경별 속성")
+    class EnvironmentSpecific {
+
+        @Test
+        @DisplayName("prod-like_secure=true + SameSite=Strict + domain=sseulang.kr")
+        void prodLike() {
+            ResponseCookie c = prodLikeUtil().accessTokenCookie("AT");
+
+            assertThat(c.isSecure()).isTrue();
+            assertThat(c.getSameSite()).isEqualTo("Strict");
+            assertThat(c.getDomain()).isEqualTo("sseulang.kr");
+        }
+
+        @Test
+        @DisplayName("local-like_secure=false + SameSite=Lax + domain=localhost")
+        void localLike() {
+            ResponseCookie c = localLikeUtil().accessTokenCookie("AT");
+
+            assertThat(c.isSecure()).isFalse();
+            assertThat(c.getSameSite()).isEqualTo("Lax");
+            assertThat(c.getDomain()).isEqualTo("localhost");
+        }
+
+        @Test
+        @DisplayName("domain 빈 문자열_쿠키 domain 미설정")
+        void emptyDomain_omits() {
+            CookieUtil u = new CookieUtil(new CookieProperties("", false, "Lax"), jwt);
+
+            ResponseCookie c = u.accessTokenCookie("AT");
+
+            assertThat(c.getDomain()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("CookieProperties 검증")
+    class PropertiesValidation {
+
+        @Test
+        @DisplayName("허용 안 된 sameSite 값_예외")
+        void invalidSameSite_예외() {
+            assertThatThrownBy(() -> new CookieProperties("localhost", false, "Weird"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("SameSite=None_secure=false_예외")
+        void sameSiteNone_secureFalse_예외() {
+            assertThatThrownBy(() -> new CookieProperties("localhost", false, "None"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("SameSite=None_secure=true_OK")
+        void sameSiteNone_secureTrue_ok() {
+            CookieProperties p = new CookieProperties("a.com", true, "None");
+
+            assertThat(p.sameSite()).isEqualTo("None");
+            assertThat(p.secure()).isTrue();
+        }
+
+        @Test
+        @DisplayName("sameSite null 또는 blank_기본값 Lax")
+        void blankSameSite_defaultsToLax() {
+            assertThat(new CookieProperties("a", false, null).sameSite()).isEqualTo("Lax");
+            assertThat(new CookieProperties("a", false, "").sameSite()).isEqualTo("Lax");
+        }
+    }
+}

--- a/src/test/java/com/sseulang/global/security/JwtAuthenticationEntryPointTest.java
+++ b/src/test/java/com/sseulang/global/security/JwtAuthenticationEntryPointTest.java
@@ -1,0 +1,50 @@
+package com.sseulang.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtAuthenticationEntryPointTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final JwtAuthenticationEntryPoint entryPoint = new JwtAuthenticationEntryPoint(om);
+    private final JwtAccessDeniedHandler deniedHandler = new JwtAccessDeniedHandler(om);
+
+    @Test
+    @DisplayName("EntryPoint commence_401 + AUTH_TOKEN_MISSING JSON 응답")
+    void entryPoint_401_AUTH_TOKEN_MISSING() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        entryPoint.commence(req, res, new BadCredentialsException("anything"));
+
+        assertThat(res.getStatus()).isEqualTo(401);
+        assertThat(res.getContentType()).startsWith("application/json");
+        String body = res.getContentAsString(StandardCharsets.UTF_8);
+        assertThat(body).contains("\"success\":false");
+        assertThat(body).contains("\"code\":\"AUTH_TOKEN_MISSING\"");
+    }
+
+    @Test
+    @DisplayName("AccessDeniedHandler handle_403 + FORBIDDEN JSON 응답")
+    void accessDeniedHandler_403_FORBIDDEN() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        deniedHandler.handle(req, res, new AccessDeniedException("nope"));
+
+        assertThat(res.getStatus()).isEqualTo(403);
+        assertThat(res.getContentType()).startsWith("application/json");
+        String body = res.getContentAsString(StandardCharsets.UTF_8);
+        assertThat(body).contains("\"success\":false");
+        assertThat(body).contains("\"code\":\"FORBIDDEN\"");
+    }
+}

--- a/src/test/java/com/sseulang/global/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/sseulang/global/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,175 @@
+package com.sseulang.global.security;
+
+import com.sseulang.domain.auth.domain.AccessTokenBlacklist;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    private static final String SECRET = "test-secret-must-be-at-least-32-bytes-long-for-hs256-blah-blah";
+    private static final long AT_VALIDITY = 1800L;
+    private static final long RT_VALIDITY = 604800L;
+    private static final Instant FIXED_NOW = Instant.parse("2026-04-28T03:00:00Z");
+
+    @Mock
+    private HandlerExceptionResolver resolver;
+
+    @Mock
+    private AccessTokenBlacklist blacklist;
+
+    private JwtProvider jwtProvider;
+    private JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties props = new JwtProperties(SECRET, AT_VALIDITY, RT_VALIDITY);
+        Clock fixedClock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        jwtProvider = new JwtProvider(props, fixedClock);
+        filter = new JwtAuthenticationFilter(jwtProvider, blacklist, resolver);
+    }
+
+    @AfterEach
+    void clear() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("쿠키 없음_인증 시도 X_체인 통과")
+    void 쿠키없음_체인통과() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(chain.getRequest()).isSameAs(req);  // chain 호출됨
+        verify(resolver, never()).resolveException(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("유효한 AT 쿠키_SecurityContext 에 Authentication 주입")
+    void 유효AT_인증주입() throws Exception {
+        String token = jwtProvider.issueAccessToken(42L, "USER");
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(CookieUtil.ACCESS_TOKEN_COOKIE, token));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getPrincipal()).isEqualTo(42L);
+        assertThat(auth.getAuthorities()).hasSize(1);
+        assertThat(auth.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_USER");
+        verify(resolver, never()).resolveException(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("만료 AT_resolver 위임_에러코드 EXPIRED")
+    void 만료AT_resolver위임() throws Exception {
+        String token = jwtProvider.issueAccessToken(1L, "USER");
+        // 31분 뒤 시점의 필터로 검증
+        Clock laterClock = Clock.fixed(FIXED_NOW.plusSeconds(AT_VALIDITY + 1), ZoneOffset.UTC);
+        JwtProvider laterProvider = new JwtProvider(
+                new JwtProperties(SECRET, AT_VALIDITY, RT_VALIDITY), laterClock);
+        JwtAuthenticationFilter laterFilter = new JwtAuthenticationFilter(laterProvider, blacklist, resolver);
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(CookieUtil.ACCESS_TOKEN_COOKIE, token));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        laterFilter.doFilter(req, res, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(resolver, times(1)).resolveException(eq(req), eq(res), any(),
+                org.mockito.ArgumentMatchers.argThat(t ->
+                        t instanceof BusinessException be
+                                && be.getErrorCode() == ErrorCode.AUTH_TOKEN_EXPIRED));
+        // chain 은 호출되면 안 됨
+        assertThat(chain.getRequest()).isNull();
+    }
+
+    @Test
+    @DisplayName("변조 AT_resolver 위임_에러코드 INVALID")
+    void 변조AT_resolver위임() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(CookieUtil.ACCESS_TOKEN_COOKIE, "tampered.token.value"));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(resolver, times(1)).resolveException(eq(req), eq(res), any(),
+                org.mockito.ArgumentMatchers.argThat(t ->
+                        t instanceof BusinessException be
+                                && be.getErrorCode() == ErrorCode.AUTH_TOKEN_INVALID));
+        assertThat(chain.getRequest()).isNull();
+    }
+
+    @Test
+    @DisplayName("다른 이름의 쿠키만 있음_AT 무시_anonymous 통과")
+    void 다른쿠키만_AT무시() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie("session_id", "abc"), new Cookie("xsrf", "csrf"));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(chain.getRequest()).isSameAs(req);
+        verify(resolver, never()).resolveException(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("블랙리스트 등록된 AT_AUTH_TOKEN_REVOKED 위임")
+    void 블랙리스트AT_REVOKED() throws Exception {
+        String token = jwtProvider.issueAccessToken(42L, "USER");
+        String jti = jwtProvider.parse(token).jti();
+        org.mockito.Mockito.when(blacklist.isBlacklisted(jti)).thenReturn(true);
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie(CookieUtil.ACCESS_TOKEN_COOKIE, token));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(resolver, times(1)).resolveException(eq(req), eq(res), any(),
+                org.mockito.ArgumentMatchers.argThat(t ->
+                        t instanceof BusinessException be
+                                && be.getErrorCode() == ErrorCode.AUTH_TOKEN_REVOKED));
+        assertThat(chain.getRequest()).isNull();
+    }
+}

--- a/src/test/java/com/sseulang/global/security/JwtProviderTest.java
+++ b/src/test/java/com/sseulang/global/security/JwtProviderTest.java
@@ -1,0 +1,127 @@
+package com.sseulang.global.security;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtProviderTest {
+
+    private static final String SECRET = "test-secret-must-be-at-least-32-bytes-long-for-hs256-blah-blah";
+    private static final long AT_VALIDITY = 1800L;     // 30분
+    private static final long RT_VALIDITY = 604800L;   // 7일
+    private static final Instant FIXED_NOW = Instant.parse("2026-04-28T03:00:00Z");
+
+    private JwtProperties props;
+    private Clock fixedClock;
+    private JwtProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        props = new JwtProperties(SECRET, AT_VALIDITY, RT_VALIDITY);
+        fixedClock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        provider = new JwtProvider(props, fixedClock);
+    }
+
+    @Test
+    @DisplayName("AccessToken 발급_정상_userId/role/jti 포함되고 30분 뒤 만료")
+    void issueAccessToken_정상_payload포함_30분만료() {
+        String token = provider.issueAccessToken(42L, "USER");
+
+        JwtClaims claims = provider.parse(token);
+        assertThat(claims.userId()).isEqualTo(42L);
+        assertThat(claims.role()).isEqualTo("USER");
+        assertThat(claims.jti()).isNotBlank();
+        assertThat(claims.issuedAt()).isEqualTo(FIXED_NOW);
+        assertThat(claims.expiresAt()).isEqualTo(FIXED_NOW.plusSeconds(AT_VALIDITY));
+    }
+
+    @Test
+    @DisplayName("RefreshToken 발급_정상_userId/role/jti 포함되고 7일 뒤 만료")
+    void issueRefreshToken_정상_payload포함_7일만료() {
+        String token = provider.issueRefreshToken(42L, "USER");
+
+        JwtClaims claims = provider.parse(token);
+        assertThat(claims.userId()).isEqualTo(42L);
+        assertThat(claims.role()).isEqualTo("USER");
+        assertThat(claims.jti()).isNotBlank();
+        assertThat(claims.expiresAt()).isEqualTo(FIXED_NOW.plusSeconds(RT_VALIDITY));
+    }
+
+    @Test
+    @DisplayName("AccessToken 두 번 발급_같은 userId여도 jti는 매번 다름")
+    void issueAccessToken_매번다른jti() {
+        String t1 = provider.issueAccessToken(1L, "USER");
+        String t2 = provider.issueAccessToken(1L, "USER");
+
+        assertThat(provider.parse(t1).jti()).isNotEqualTo(provider.parse(t2).jti());
+    }
+
+    @Test
+    @DisplayName("parse_만료된 토큰_AUTH_TOKEN_EXPIRED 예외")
+    void parse_만료된토큰_예외발생() {
+        String token = provider.issueAccessToken(1L, "USER");
+
+        Clock laterClock = Clock.fixed(FIXED_NOW.plusSeconds(AT_VALIDITY + 1), ZoneOffset.UTC);
+        JwtProvider laterProvider = new JwtProvider(props, laterClock);
+
+        assertThatThrownBy(() -> laterProvider.parse(token))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_TOKEN_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("parse_변조된 서명_AUTH_TOKEN_INVALID 예외")
+    void parse_변조된서명_예외발생() {
+        String tampered = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.tamperedSignaturePart";
+
+        assertThatThrownBy(() -> provider.parse(tampered))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_TOKEN_INVALID);
+    }
+
+    @Test
+    @DisplayName("parse_빈 문자열_AUTH_TOKEN_INVALID 예외")
+    void parse_빈문자열_예외발생() {
+        assertThatThrownBy(() -> provider.parse(""))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_TOKEN_INVALID);
+    }
+
+    @Test
+    @DisplayName("parse_null_AUTH_TOKEN_INVALID 예외")
+    void parse_null_예외발생() {
+        assertThatThrownBy(() -> provider.parse(null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_TOKEN_INVALID);
+    }
+
+    @Test
+    @DisplayName("parse_다른 secret으로 서명된 토큰_AUTH_TOKEN_INVALID 예외")
+    void parse_다른secret_예외발생() {
+        JwtProperties otherProps = new JwtProperties(
+                "another-secret-must-be-at-least-32-bytes-long-for-hs256-okok",
+                AT_VALIDITY, RT_VALIDITY);
+        JwtProvider otherProvider = new JwtProvider(otherProps, fixedClock);
+        String foreignToken = otherProvider.issueAccessToken(1L, "USER");
+
+        assertThatThrownBy(() -> provider.parse(foreignToken))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_TOKEN_INVALID);
+    }
+
+    @Test
+    @DisplayName("JwtProperties_secret이 32바이트 미만이면 생성 실패")
+    void jwtProperties_짧은secret_예외() {
+        assertThatThrownBy(() -> new JwtProperties("short", AT_VALIDITY, RT_VALIDITY))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/sseulang/global/security/ProtectedTestController.java
+++ b/src/test/java/com/sseulang/global/security/ProtectedTestController.java
@@ -1,0 +1,17 @@
+package com.sseulang.global.security;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * AuthSecurityFlowIT 전용 더미 controller. test 디렉토리에 위치하므로 production
+ * 컨텍스트엔 영향 없음.
+ */
+@RestController
+class ProtectedTestController {
+
+    @GetMapping("/api/v1/test/protected")
+    public String secret() {
+        return "ok";
+    }
+}

--- a/src/test/java/com/sseulang/support/RedisIntegrationTestBase.java
+++ b/src/test/java/com/sseulang/support/RedisIntegrationTestBase.java
@@ -1,0 +1,58 @@
+package com.sseulang.support;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Redis testcontainers 통합 테스트 공통 베이스. Spring 컨텍스트 없이 가볍게 동작.
+ *
+ * <p>컨테이너는 클래스 단위 1회 기동(static), {@link LettuceConnectionFactory} 는 매 테스트마다
+ * 새로 만들고 destroy — 클래스 간 stale connection 방지.</p>
+ */
+@Testcontainers
+public abstract class RedisIntegrationTestBase {
+
+    @Container
+    protected static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                    .withExposedPorts(6379);
+
+    private LettuceConnectionFactory connectionFactory;
+    private StringRedisTemplate redisTemplate;
+
+    @BeforeEach
+    void initRedis() {
+        connectionFactory = new LettuceConnectionFactory(REDIS.getHost(), REDIS.getFirstMappedPort());
+        connectionFactory.afterPropertiesSet();
+        redisTemplate = new StringRedisTemplate(connectionFactory);
+        redisTemplate.afterPropertiesSet();
+    }
+
+    @AfterEach
+    void teardownRedis() {
+        if (connectionFactory == null) {
+            return;
+        }
+        try {
+            connectionFactory.getConnection().serverCommands().flushDb();
+        } catch (Exception ignored) {
+            // 컨테이너가 죽은 경우 등 — 어차피 다음 테스트가 새로 만든다
+        }
+        try {
+            connectionFactory.destroy();
+        } catch (Exception ignored) {
+        }
+        connectionFactory = null;
+        redisTemplate = null;
+    }
+
+    protected StringRedisTemplate redisTemplate() {
+        return redisTemplate;
+    }
+}


### PR DESCRIPTION
## 변경 영역
- [x] 보안/인증
- [ ] 결제/포인트
- [ ] 거래 상태 머신
- [x] 동시성/락
- [ ] 일반 CRUD
- [ ] 문서/설정만

## Codex 리뷰
- [x] 🔴 즉시 리뷰 완료 (보안/돈 영역) — thread `019dd216-bcea-7c42-8cc6-113c6dab9989`
- [x] 🟡 PR 풀 리뷰 완료 (mini 게이트 2) — thread `019dd22d-72ab-7d91-9602-0672679a2429`
- [ ] ❌ 해당 없음

## 체크리스트
- [x] CLAUDE.md 컨벤션 준수 (DDD-lite 4-layer, 의존 방향)
- [x] 테스트 작성 (보안/돈/동시성 영역 필수) — **63개 PASS** (단위 49 + 통합 14)
- [x] traceId 로깅 확인 (EntryPoint/AccessDeniedHandler MDC 전파, IT 로 헤더↔본문 일관성 검증)
- [x] 민감 정보(비밀번호/토큰/카드번호) 로깅 없음
- [x] @Transactional 경계 검토 완료 (ApplicationService 에만)

## 관련 이슈
- Closes #3 (Day 2 JWT 인증 흐름 트래커)
- Follow-up: #4 (User-level token version), #5 (revokeAll SET 인덱스)

## 비고

### 핵심 흐름

| 컴포넌트 | 위치 | 책임 |
|----------|------|------|
| `JwtProvider` | `global/security` | HS256 issue/parse, AT 30분 / RT 7일, payload `userId+role+jti`, Clock 주입 |
| `JwtAuthenticationFilter` | `global/security` | 쿠키→SecurityContext, BusinessException → HandlerExceptionResolver 위임, blacklist 검사 |
| `SecurityConfig` 3-chain | `global/config` | PUBLIC / USER / ADMIN, CSRF (`X-XSRF-TOKEN`), EntryPoint+AccessDeniedHandler |
| `RefreshTokenStore` | `domain/auth/domain` | 인터페이스 (도메인 layer 순수 POJO) |
| `RedisRefreshTokenStore` | `domain/auth/infrastructure` | `auth:rt:{userId}:{jti}`, **atomic consume (DEL 반환값)** |
| `RefreshTokenRotationService` | `domain/auth/application` | rotation + logout(at, rt) + 재사용 탐지 시 revokeAll |
| `AccessTokenBlacklist` | `domain/auth/domain` | 인터페이스 |
| `RedisAccessTokenBlacklist` | `domain/auth/infrastructure` | `auth:atbl:{jti}`, TTL=AT 잔여 |
| `AuthController` | `domain/auth/presentation` | `/auth/refresh`, `/auth/logout` |
| `CookieUtil` | `global/security` | HttpOnly+Secure+SameSite=Strict, Path 분리 |
| `JwtAuthenticationEntryPoint` / `JwtAccessDeniedHandler` | `global/security` | 401/403 → `ApiResponse` 응답 통일 |

### Codex 게이트 1 + mini 게이트 2 리뷰 반영 (6건)

| 분류 | 항목 | 처리 |
|------|------|------|
| 🔴 게이트1 C1 | AT 블랙리스트 부재 | **적용 (옵션 b — device 단위 jti 블랙리스트)** |
| 🔴 게이트1 C2 | rotation race | **적용 (consume atomic — Redis DEL 반환값으로 원자화)** |
| 🟡 게이트1 W1 | AuthenticationEntryPoint 부재 | **적용** |
| 🟡 게이트1 W2 | revokeAll SCAN 비효율 | TODO 마킹 + 후속 이슈 #5 분리 |
| 🔴 mini게이트2 | Redis 어댑터 Jacoco 0% | **적용 (testcontainers Redis IT 14건 — race 검증 포함)** |
| 🟡 mini게이트2 | SecurityConfig wiring + traceId 일관성 | **적용 (`AuthSecurityFlowIT`)** |

### 테스트 (63 PASS / 0 FAIL)

**단위 (49):** JwtProvider 9 / CookieUtil 10 / JwtAuthenticationFilter 6 / RefreshTokenRotationService 12 / AuthController 4 / JwtAuthenticationEntryPoint 2 / 기타 6

**통합 (14):**
- `RedisAccessTokenBlacklistIT` (4): blacklist/조회/TTL 자동정리/재등록
- `RedisRefreshTokenStoreIT` (6): consume atomic / revokeAll user 격리 / TTL / **동시 consume race (16 스레드 → 정확히 1개만 true 검증)**
- `AuthSecurityFlowIT` (4): WebMvcTest 슬라이스로 USER chain wiring + X-Trace-Id ↔ 본문 traceId 일관성

### 의도된 설계 결정 (트레이드오프 정리: `docs/AUTH_SECURITY.md`)

1. **RT 에 role claim 포함** — rotation 시 role 출처. User 도메인 부재 동안의 단순화. 후속 이슈 #4 의 token version 도입 시 해결.
2. **재사용 탐지 시 revokeAll** — 보수적 보안 우선. 동시 refresh 의 false-positive 가능 (실제 환경에선 거의 발생 X).
3. **`/auth/login` 부재** — Day 3 OAuth 작업과 묶음.

### 운영 주의사항

- `AUTH_REFRESH_TOKEN_INVALID` 응답은 사용자의 **모든 디바이스**가 로그아웃됐다는 의미 — 클라이언트는 강제 재로그인 화면으로 유도
- logout 직후 device 의 AT 즉시 폐기됨 (위험 윈도우 없음)
- `.logs/codex-review.log` 는 보안 영역 작업 직후 비울 것

🤖 Generated with [Claude Code](https://claude.com/claude-code)