### PR TITLE
feat: OAuth (카카오/구글) + User 도메인 + 게이트 1 반영 (Day 3)

### DIFF
--- a/docs/AUTH_SECURITY.md
+++ b/docs/AUTH_SECURITY.md
@@ -13,6 +13,7 @@
 
 ### Day 3 (OAuth + User 도메인)
 - 게이트 1 thread: `019dd299-d74b-7ec0-99b5-90d6922df8d4`
+- mini 게이트 2 thread: `019dd2af-c49e-7621-b486-2b541121fe0f`
 
 `.logs/codex-review.log` 참고. 보안 영역 작업 직후엔 비울 것.
 
@@ -30,6 +31,9 @@
 | **Day 3 게이트 1** Warning: Google `email_verified=null` 통과 | 🟡 | **적용** — `!Boolean.TRUE.equals` 로 null/false 모두 거부 | (Day 3 PR) |
 | **Day 3 게이트 1** Warning: 외부 호출 실패 원인 분리 X | 🟡 | **적용** — `ExternalApiException` 도입 (가이드 §3.10), provider 에서 wrap, service 가 `AUTH_OAUTH_FAILED` 변환 | (Day 3 PR) |
 | **Day 3 게이트 1** Suggestion: Email 정규화 부재 | 🟢 | **적용** — Email VO compact constructor 에서 trim + lowercase | (Day 3 PR) |
+| **Day 3 mini 게이트 2** Warning: race catch 광범위 | 🟡 | **적용** — UNIQUE race 만 보정, 그 외 제약 위반(닉네임 등) 은 원본 예외 그대로 throw | (Day 3 PR) |
+| **Day 3 mini 게이트 2** Warning: oauth2 엔드포인트 traceId 통합 검증 부재 | 🟡 | **적용** — `AuthOAuthFlowIT` (TraceIdFilter + X-Trace-Id 헤더 ↔ 본문 traceId 일관성, header relay 검증) | (Day 3 PR) |
+| **Day 3 mini 게이트 2** Suggestion: OAuthProvider javadoc | 🟢 | **적용** — 예외 계약(ExternalApiException + BusinessException) 명시 | (Day 3 PR) |
 
 ---
 

--- a/docs/AUTH_SECURITY.md
+++ b/docs/AUTH_SECURITY.md
@@ -5,11 +5,16 @@
 
 ---
 
-## 1. 게이트 1 / mini 게이트 2 리뷰 결과 요약
+## 1. 게이트 리뷰 결과 요약
 
+### Day 2 (JWT 인증 흐름)
 - 게이트 1 thread: `019dd216-bcea-7c42-8cc6-113c6dab9989`
 - mini 게이트 2 thread: `019dd22d-72ab-7d91-9602-0672679a2429`
-- (`.logs/codex-review.log` 참고. 보안 영역 작업 직후엔 비울 것.)
+
+### Day 3 (OAuth + User 도메인)
+- 게이트 1 thread: `019dd299-d74b-7ec0-99b5-90d6922df8d4`
+
+`.logs/codex-review.log` 참고. 보안 영역 작업 직후엔 비울 것.
 
 | 항목 | 분류 | 처리 | 커밋/이슈 |
 |------|------|------|-----------|
@@ -18,8 +23,13 @@
 | **게이트 1** W1: AuthenticationEntryPoint 부재 | 🟡 Warning | **적용** (`JwtAuthenticationEntryPoint` + `JwtAccessDeniedHandler`) | 본 PR |
 | **게이트 1** W2: revokeAll SCAN 비효율 | 🟡 Warning | **TODO 주석 + 후속 이슈** | #5 |
 | **mini 게이트 2** Critical: Redis 어댑터 통합 테스트 부재 | 🔴 Critical | **적용** — testcontainers Redis IT (blacklist / consume / revokeAll / TTL / race) | 본 PR |
-| **mini 게이트 2** Warning: SecurityConfig wiring + traceId 일관성 미검증 | 🟡 Warning | **적용** — `AuthSecurityFlowIT` (WebMvcTest 슬라이스 + traceId 일치 검증) | 본 PR |
+| **mini 게이트 2** Warning: SecurityConfig wiring + traceId 일관성 미검증 | 🟡 Warning | **적용** — `AuthSecurityFlowIT` (WebMvcTest 슬라이스 + traceId 일치 검증) | (Day 2 PR) |
 | C1-a 보강: user-level token version | — | **후속 이슈로 분리 (Day 3 User 도메인 후)** | #4 |
+| **Day 3 게이트 1** Critical: `findOrCreateBySocial` race | 🔴 | **적용** — `DataIntegrityViolationException` catch + race winner 재조회 | (Day 3 PR) |
+| **Day 3 게이트 1** Warning: 외부 OAuth 호출이 트랜잭션 안에서 일어남 | 🟡 | **적용** — `OAuthLoginService` 클래스 `@Transactional` 제거 (가이드 §3.10) | (Day 3 PR) |
+| **Day 3 게이트 1** Warning: Google `email_verified=null` 통과 | 🟡 | **적용** — `!Boolean.TRUE.equals` 로 null/false 모두 거부 | (Day 3 PR) |
+| **Day 3 게이트 1** Warning: 외부 호출 실패 원인 분리 X | 🟡 | **적용** — `ExternalApiException` 도입 (가이드 §3.10), provider 에서 wrap, service 가 `AUTH_OAUTH_FAILED` 변환 | (Day 3 PR) |
+| **Day 3 게이트 1** Suggestion: Email 정규화 부재 | 🟢 | **적용** — Email VO compact constructor 에서 trim + lowercase | (Day 3 PR) |
 
 ---
 

--- a/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
@@ -1,0 +1,96 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.auth.domain.OAuthProvider;
+import com.sseulang.domain.auth.domain.OAuthUserInfo;
+import com.sseulang.domain.auth.domain.RefreshTokenStore;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.exception.ExternalApiException;
+import com.sseulang.global.security.JwtProperties;
+import com.sseulang.global.security.JwtProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 소셜 로그인 흐름 — provider 검증 → user 조회/생성 → JWT 발급 + RT 저장.
+ *
+ * <p>본 PR 범위에선 role 은 항상 "USER" (일반 사용자). 관리자는 별도 admins 테이블로 관리.</p>
+ */
+/**
+ * 클래스 단위 {@code @Transactional} 의도적으로 미적용 — 가이드 §3.10 "외부 API 호출은 트랜잭션
+ * 밖에서". UserApplicationService 가 자체 트랜잭션을 가지며, RefreshTokenStore.save 는 Redis 라
+ * JPA 트랜잭션 밖. AT 발급은 stateless.
+ */
+@Slf4j
+@Service
+public class OAuthLoginService {
+
+    private static final String DEFAULT_ROLE = "USER";
+
+    private final Map<SocialProvider, OAuthProvider> providersByType;
+    private final UserApplicationService userService;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenStore refreshTokenStore;
+    private final Duration refreshTokenTtl;
+
+    public OAuthLoginService(
+            List<OAuthProvider> providers,
+            UserApplicationService userService,
+            JwtProvider jwtProvider,
+            RefreshTokenStore refreshTokenStore,
+            JwtProperties jwtProperties
+    ) {
+        this.providersByType = providers.stream()
+                .collect(Collectors.toMap(OAuthProvider::supports, Function.identity()));
+        this.userService = userService;
+        this.jwtProvider = jwtProvider;
+        this.refreshTokenStore = refreshTokenStore;
+        this.refreshTokenTtl = Duration.ofSeconds(jwtProperties.refreshTokenValiditySeconds());
+    }
+
+    public TokenPair login(SocialProvider provider, String accessToken) {
+        OAuthProvider impl = providersByType.get(provider);
+        if (impl == null) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+
+        OAuthUserInfo info;
+        try {
+            info = impl.verifyAndFetch(accessToken);
+        } catch (ExternalApiException e) {
+            // 외부 인프라 예외 → 사용자 응답은 AUTH_OAUTH_FAILED 통일.
+            // 원인은 cause 에 보존 + 운영용 로그.
+            log.warn("OAuth provider {} 호출 실패: {}", provider, e.getExternalServiceName(), e);
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+
+        User user = userService.findOrCreateBySocial(
+                info.provider(),
+                info.providerId(),
+                info.email(),
+                info.nickname(),
+                info.profileImage()
+        );
+
+        if (user.isBlocked() || user.isDeleted()) {
+            throw new BusinessException(ErrorCode.USER_BLOCKED);
+        }
+
+        String at = jwtProvider.issueAccessToken(user.getId(), DEFAULT_ROLE);
+        String rt = jwtProvider.issueRefreshToken(user.getId(), DEFAULT_ROLE);
+        String rtJti = jwtProvider.parse(rt).jti();
+        refreshTokenStore.save(user.getId(), rtJti, refreshTokenTtl);
+
+        return new TokenPair(at, rt);
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/domain/OAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/OAuthProvider.java
@@ -6,8 +6,14 @@ import com.sseulang.domain.user.domain.SocialProvider;
  * 소셜 로그인 provider 추상화. 도메인 layer 인터페이스 — Spring/HTTP 의존 X.
  * 각 provider 별 구현(KAKAO/GOOGLE)은 {@code domain/auth/infrastructure/oauth} 에 위치.
  *
- * <p>토큰 검증 실패 / 네트워크 오류 / 응답 파싱 실패 모두
- * {@code BusinessException(AUTH_OAUTH_FAILED)} 으로 통일.</p>
+ * <h2>예외 계약</h2>
+ * <ul>
+ *   <li>외부 API 호출 자체 실패 (network / 5xx / parse 등 인프라성) →
+ *       {@link com.sseulang.global.exception.ExternalApiException} (가이드 §3.10 anti-corruption).
+ *       호출자(ApplicationService 등)가 정책에 맞춰 BusinessException 으로 변환.</li>
+ *   <li>토큰 무효 / 동의 항목 누락 / 검증 안 된 이메일 / 응답 비정상 →
+ *       {@code BusinessException(ErrorCode.AUTH_OAUTH_FAILED)}.</li>
+ * </ul>
  */
 public interface OAuthProvider {
 

--- a/src/main/java/com/sseulang/domain/auth/domain/OAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/OAuthProvider.java
@@ -1,0 +1,17 @@
+package com.sseulang.domain.auth.domain;
+
+import com.sseulang.domain.user.domain.SocialProvider;
+
+/**
+ * 소셜 로그인 provider 추상화. 도메인 layer 인터페이스 — Spring/HTTP 의존 X.
+ * 각 provider 별 구현(KAKAO/GOOGLE)은 {@code domain/auth/infrastructure/oauth} 에 위치.
+ *
+ * <p>토큰 검증 실패 / 네트워크 오류 / 응답 파싱 실패 모두
+ * {@code BusinessException(AUTH_OAUTH_FAILED)} 으로 통일.</p>
+ */
+public interface OAuthProvider {
+
+    SocialProvider supports();
+
+    OAuthUserInfo verifyAndFetch(String accessToken);
+}

--- a/src/main/java/com/sseulang/domain/auth/domain/OAuthUserInfo.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/OAuthUserInfo.java
@@ -1,0 +1,30 @@
+package com.sseulang.domain.auth.domain;
+
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+
+/**
+ * Provider API 가 돌려준 사용자 정보의 도메인 표현. profileImage 는 nullable.
+ */
+public record OAuthUserInfo(
+        SocialProvider provider,
+        String providerId,
+        Email email,
+        String nickname,
+        String profileImage
+) {
+    public OAuthUserInfo {
+        if (provider == null || provider == SocialProvider.LOCAL) {
+            throw new IllegalArgumentException("provider 는 KAKAO/GOOGLE 만 허용");
+        }
+        if (providerId == null || providerId.isBlank()) {
+            throw new IllegalArgumentException("providerId 는 필수");
+        }
+        if (email == null) {
+            throw new IllegalArgumentException("email 은 필수");
+        }
+        if (nickname == null || nickname.isBlank()) {
+            throw new IllegalArgumentException("nickname 은 필수");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/GoogleOAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/GoogleOAuthProvider.java
@@ -1,0 +1,85 @@
+package com.sseulang.domain.auth.infrastructure.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sseulang.domain.auth.domain.OAuthProvider;
+import com.sseulang.domain.auth.domain.OAuthUserInfo;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.exception.ExternalApiException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * 구글 access_token 검증 + 사용자 정보 조회.
+ *
+ * <p>API: {@code GET https://www.googleapis.com/oauth2/v3/userinfo} with Bearer token.
+ * 응답: {@code sub} (providerId), {@code email}, {@code email_verified}, {@code name}, {@code picture}.</p>
+ *
+ * <p>{@code email_verified=false} 이면 보안상 인증 실패 처리.</p>
+ */
+@Component
+public class GoogleOAuthProvider implements OAuthProvider {
+
+    private static final String USER_INFO_URI = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+    private final RestClient restClient;
+
+    public GoogleOAuthProvider(RestClient.Builder builder) {
+        this.restClient = builder.build();
+    }
+
+    @Override
+    public SocialProvider supports() {
+        return SocialProvider.GOOGLE;
+    }
+
+    @Override
+    public OAuthUserInfo verifyAndFetch(String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+        GoogleUserResponse res;
+        try {
+            res = restClient.get()
+                    .uri(USER_INFO_URI)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .body(GoogleUserResponse.class);
+        } catch (RestClientException e) {
+            throw new ExternalApiException("google-oauth", e);
+        }
+
+        if (res == null || res.sub() == null || res.email() == null || res.name() == null) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+
+        // 검증된 이메일만 허용 — null/missing/false 모두 거부 (도용 위험)
+        if (!Boolean.TRUE.equals(res.emailVerified())) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+
+        try {
+            return new OAuthUserInfo(
+                    SocialProvider.GOOGLE,
+                    res.sub(),
+                    new Email(res.email()),
+                    res.name(),
+                    res.picture()
+            );
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+    }
+
+    record GoogleUserResponse(
+            String sub,
+            String email,
+            @JsonProperty("email_verified") Boolean emailVerified,
+            String name,
+            String picture
+    ) {}
+}

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/KakaoOAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/KakaoOAuthProvider.java
@@ -1,0 +1,97 @@
+package com.sseulang.domain.auth.infrastructure.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sseulang.domain.auth.domain.OAuthProvider;
+import com.sseulang.domain.auth.domain.OAuthUserInfo;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.exception.ExternalApiException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * 카카오 access_token 검증 + 사용자 정보 조회.
+ *
+ * <p>API: {@code GET https://kapi.kakao.com/v2/user/me} with Bearer token.
+ * 응답에서 {@code id} (providerId), {@code kakao_account.email}, {@code kakao_account.profile.nickname/profile_image_url}
+ * 추출.</p>
+ *
+ * <p>모든 실패(토큰 무효 / 네트워크 / 응답 파싱 / 동의 항목 누락)는 {@code AUTH_OAUTH_FAILED} 로 통일.</p>
+ */
+@Component
+public class KakaoOAuthProvider implements OAuthProvider {
+
+    private static final String USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+
+    private final RestClient restClient;
+
+    public KakaoOAuthProvider(RestClient.Builder builder) {
+        this.restClient = builder.build();
+    }
+
+    @Override
+    public SocialProvider supports() {
+        return SocialProvider.KAKAO;
+    }
+
+    @Override
+    public OAuthUserInfo verifyAndFetch(String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+        KakaoUserResponse res;
+        try {
+            res = restClient.get()
+                    .uri(USER_INFO_URI)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .body(KakaoUserResponse.class);
+        } catch (RestClientException e) {
+            // 외부 인프라 예외 — anti-corruption wrap. 호출자가 정책에 맞춰 변환.
+            throw new ExternalApiException("kakao-oauth", e);
+        }
+
+        if (res == null || res.id() == null) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+
+        String email = res.kakaoAccount() != null ? res.kakaoAccount().email() : null;
+        KakaoProfile profile = res.kakaoAccount() != null ? res.kakaoAccount().profile() : null;
+        String nickname = profile != null ? profile.nickname() : null;
+        String profileImage = profile != null ? profile.profileImageUrl() : null;
+
+        if (email == null || nickname == null) {
+            // 동의 항목 누락 — 사용자가 약관에서 거부했거나 개발자 콘솔 권한 미설정
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+
+        try {
+            return new OAuthUserInfo(
+                    SocialProvider.KAKAO,
+                    String.valueOf(res.id()),
+                    new Email(email),
+                    nickname,
+                    profileImage
+            );
+        } catch (IllegalArgumentException e) {
+            // 잘못된 이메일 형식 등 — provider 가 비정상 응답
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+    }
+
+    record KakaoUserResponse(
+            Long id,
+            @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+    ) {}
+
+    record KakaoAccount(String email, KakaoProfile profile) {}
+
+    record KakaoProfile(
+            String nickname,
+            @JsonProperty("profile_image_url") String profileImageUrl
+    ) {}
+}

--- a/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
@@ -1,16 +1,22 @@
 package com.sseulang.domain.auth.presentation;
 
+import com.sseulang.domain.auth.application.OAuthLoginService;
 import com.sseulang.domain.auth.application.RefreshTokenRotationService;
 import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.auth.presentation.dto.OAuthLoginRequest;
+import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import com.sseulang.global.security.CookieUtil;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,11 +25,45 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final RefreshTokenRotationService rotationService;
+    private final OAuthLoginService oauthLoginService;
     private final CookieUtil cookieUtil;
 
-    public AuthController(RefreshTokenRotationService rotationService, CookieUtil cookieUtil) {
+    public AuthController(
+            RefreshTokenRotationService rotationService,
+            OAuthLoginService oauthLoginService,
+            CookieUtil cookieUtil
+    ) {
         this.rotationService = rotationService;
+        this.oauthLoginService = oauthLoginService;
         this.cookieUtil = cookieUtil;
+    }
+
+    @PostMapping("/oauth2/{provider}")
+    public ResponseEntity<ApiResponse<Void>> oauth2(
+            @PathVariable("provider") String provider,
+            @Valid @RequestBody OAuthLoginRequest request
+    ) {
+        SocialProvider socialProvider = parseProvider(provider);
+        TokenPair pair = oauthLoginService.login(socialProvider, request.accessToken());
+
+        ResponseCookie at = cookieUtil.accessTokenCookie(pair.accessToken());
+        ResponseCookie rt = cookieUtil.refreshTokenCookie(pair.refreshToken());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, at.toString())
+                .header(HttpHeaders.SET_COOKIE, rt.toString())
+                .body(ApiResponse.ok());
+    }
+
+    private SocialProvider parseProvider(String pathParam) {
+        if (pathParam == null) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+        return switch (pathParam.toLowerCase()) {
+            case "kakao" -> SocialProvider.KAKAO;
+            case "google" -> SocialProvider.GOOGLE;
+            default -> throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        };
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/OAuthLoginRequest.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.auth.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 소셜 로그인 요청 본문.
+ *
+ * <p>가이드 §4.4 "프론트가 카카오/구글 SDK로 access_token 획득 → 백엔드로 전달".</p>
+ */
+public record OAuthLoginRequest(
+        @NotBlank(message = "accessToken 은 필수입니다")
+        String accessToken
+) {
+}

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -10,6 +10,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @Transactional(readOnly = true)
 public class UserApplicationService {
@@ -51,10 +53,25 @@ public class UserApplicationService {
         try {
             return userRepository.save(newUser);
         } catch (DataIntegrityViolationException race) {
-            // 동시 호출 race — DB UNIQUE 제약(email 또는 social_provider+social_id)에 걸림.
-            // race winner 가 같은 (provider, providerId) 면 그것을 반환, 아니면 email 충돌.
-            return userRepository.findBySocial(provider, providerId)
-                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED));
+            // 본 catch 는 UNIQUE 충돌 race 만 보정. 다른 제약(닉네임 길이 등) 은 그대로 던져
+            // 시스템 에러로 처리한다 — 사용자에게 잘못된 USER_EMAIL_DUPLICATED 응답 방지.
+            return resolveRaceOrRethrow(provider, providerId, email, race);
         }
+    }
+
+    private User resolveRaceOrRethrow(
+            SocialProvider provider, String providerId, Email email, DataIntegrityViolationException race
+    ) {
+        // race winner 가 같은 (provider, providerId) 면 그것을 반환
+        Optional<User> raceWinner = userRepository.findBySocial(provider, providerId);
+        if (raceWinner.isPresent()) {
+            return raceWinner.get();
+        }
+        // 다른 user 가 같은 email 로 가입한 경우만 USER_EMAIL_DUPLICATED 로 변환
+        if (userRepository.findByEmail(email).isPresent()) {
+            throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);
+        }
+        // UNIQUE 충돌이 아닌 다른 제약 위반 — 시스템 에러로 그대로 노출
+        throw race;
     }
 }

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -1,0 +1,60 @@
+package com.sseulang.domain.user.application;
+
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserRepository;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UserApplicationService {
+
+    private final UserRepository userRepository;
+
+    public UserApplicationService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 소셜 가입 흐름 — (provider, providerId) 로 기존 user 조회, 없으면 신규 가입.
+     *
+     * <p>주의: 같은 email 이 다른 provider 로 이미 가입돼 있으면 {@code USER_EMAIL_DUPLICATED}.
+     * 이 정책은 가이드 §12 의 미결정 영역 — 추후 PM 협의로 "동일 이메일 다중 provider 연결" 허용 시 변경.</p>
+     */
+    @Transactional
+    public User findOrCreateBySocial(
+            SocialProvider provider,
+            String providerId,
+            Email email,
+            String nickname,
+            String profileImage
+    ) {
+        return userRepository.findBySocial(provider, providerId)
+                .orElseGet(() -> create(provider, providerId, email, nickname, profileImage));
+    }
+
+    public User getById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private User create(SocialProvider provider, String providerId, Email email, String nickname, String profileImage) {
+        userRepository.findByEmail(email).ifPresent(existing -> {
+            throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);
+        });
+        User newUser = User.createSocialUser(provider, providerId, email, nickname, profileImage);
+        try {
+            return userRepository.save(newUser);
+        } catch (DataIntegrityViolationException race) {
+            // 동시 호출 race — DB UNIQUE 제약(email 또는 social_provider+social_id)에 걸림.
+            // race winner 가 같은 (provider, providerId) 면 그것을 반환, 아니면 email 충돌.
+            return userRepository.findBySocial(provider, providerId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED));
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/domain/Email.java
+++ b/src/main/java/com/sseulang/domain/user/domain/Email.java
@@ -1,0 +1,30 @@
+package com.sseulang.domain.user.domain;
+
+import java.util.regex.Pattern;
+
+/**
+ * 이메일 VO. 불변 + 자가 검증.
+ *
+ * <p>JPA 매핑은 {@link User} 의 {@code String email} 컬럼이 책임지고, 도메인 layer 는
+ * 의미적 wrapper 로 본 record 만 사용한다.</p>
+ */
+public record Email(String value) {
+
+    private static final int MAX_LENGTH = 100;
+    private static final Pattern PATTERN =
+            Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
+
+    public Email {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("이메일은 필수입니다");
+        }
+        // 정규화: provider 별 대소문자 차이로 인한 중복 판단 흔들림 방지
+        value = value.trim().toLowerCase();
+        if (value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("이메일은 100자 이하여야 합니다");
+        }
+        if (!PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/domain/SocialProvider.java
+++ b/src/main/java/com/sseulang/domain/user/domain/SocialProvider.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.user.domain;
+
+/**
+ * 사용자 가입 출처. V1 스키마의 {@code users.social_provider} 컬럼과 1:1 매핑.
+ * <ul>
+ *   <li>{@link #LOCAL} — 이메일/비밀번호 가입 (5/6 이후 영역)</li>
+ *   <li>{@link #KAKAO} / {@link #GOOGLE} — 소셜 가입 (Day 3 본 PR 범위)</li>
+ * </ul>
+ */
+public enum SocialProvider {
+    LOCAL,
+    KAKAO,
+    GOOGLE;
+}

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -1,0 +1,96 @@
+package com.sseulang.domain.user.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * User Aggregate Root. V1 스키마 {@code users} 매핑.
+ *
+ * <p>본 PR(Day 3 OAuth) 범위에서 다루는 필드만 매핑. 나머지(point_balance / trust_score /
+ * password / address ...) 는 후속 도메인 작업에서 필요 시 추가. JPA validate 는 entity 가 가진
+ * 컬럼이 DB 에 있는지만 검사하므로 선택 매핑 가능.</p>
+ *
+ * <p>Setter 없음. 상태 변경은 명시된 비즈니스 메서드로만.</p>
+ */
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", nullable = false, length = 100, unique = true)
+    private String email;
+
+    @Column(name = "nickname", nullable = false, length = 50)
+    private String nickname;
+
+    @Column(name = "phone", length = 20)
+    private String phone;
+
+    @Column(name = "profile_image", length = 500)
+    private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_provider", length = 20)
+    private SocialProvider socialProvider;
+
+    @Column(name = "social_id", length = 100)
+    private String socialId;
+
+    @Column(name = "is_blocked", nullable = false)
+    private boolean blocked;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean deleted;
+
+    /**
+     * 소셜 가입 흐름의 정적 팩토리. (provider, providerId) 가 비어있을 수 없으며 LOCAL 은 거부.
+     * 일반 회원가입 흐름은 별도 팩토리(예: {@code createLocalUser})로 분리.
+     */
+    public static User createSocialUser(
+            SocialProvider provider,
+            String providerId,
+            Email email,
+            String nickname,
+            String profileImage
+    ) {
+        if (provider == null || provider == SocialProvider.LOCAL) {
+            throw new IllegalArgumentException("소셜 provider 는 LOCAL 외여야 합니다");
+        }
+        if (providerId == null || providerId.isBlank()) {
+            throw new IllegalArgumentException("providerId 는 필수입니다");
+        }
+        if (nickname == null || nickname.isBlank()) {
+            throw new IllegalArgumentException("nickname 은 필수입니다");
+        }
+
+        User u = new User();
+        u.email = email.value();
+        u.nickname = nickname;
+        u.profileImage = profileImage;
+        u.socialProvider = provider;
+        u.socialId = providerId;
+        u.blocked = false;
+        u.deleted = false;
+        return u;
+    }
+
+    /** 도메인 layer 외부에서 raw String 대신 VO 로 다루도록 의미적 wrapper. */
+    public Email email() {
+        return new Email(email);
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.user.domain;
+
+import java.util.Optional;
+
+/**
+ * User Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
+ * 구현은 {@code domain/user/infrastructure/persistence}.
+ */
+public interface UserRepository {
+
+    Optional<User> findById(Long id);
+
+    Optional<User> findBySocial(SocialProvider provider, String socialId);
+
+    Optional<User> findByEmail(Email email);
+
+    User save(User user);
+}

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -1,0 +1,15 @@
+package com.sseulang.domain.user.infrastructure.persistence;
+
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/** Spring Data JPA — {@link UserRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
+interface UserJpaRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findBySocialProviderAndSocialId(SocialProvider provider, String socialId);
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.sseulang.domain.user.infrastructure.persistence;
+
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository jpa;
+
+    public UserRepositoryImpl(UserJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Optional<User> findBySocial(SocialProvider provider, String socialId) {
+        return jpa.findBySocialProviderAndSocialId(provider, socialId);
+    }
+
+    @Override
+    public Optional<User> findByEmail(Email email) {
+        return jpa.findByEmail(email.value());
+    }
+
+    @Override
+    public User save(User user) {
+        return jpa.save(user);
+    }
+}

--- a/src/main/java/com/sseulang/global/config/RestClientConfig.java
+++ b/src/main/java/com/sseulang/global/config/RestClientConfig.java
@@ -1,0 +1,29 @@
+package com.sseulang.global.config;
+
+import org.springframework.boot.web.client.RestClientCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+
+import java.time.Duration;
+
+/**
+ * 외부 HTTP 호출용 RestClient 공통 설정. timeout 명시 — 외부 API 가 hang 되면
+ * thread 점유로 인한 cascading failure 방지.
+ */
+@Configuration
+public class RestClientConfig {
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
+
+    @Bean
+    public RestClientCustomizer restClientCustomizer() {
+        return builder -> {
+            SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+            factory.setConnectTimeout((int) CONNECT_TIMEOUT.toMillis());
+            factory.setReadTimeout((int) READ_TIMEOUT.toMillis());
+            builder.requestFactory(factory);
+        };
+    }
+}

--- a/src/main/java/com/sseulang/global/exception/ExternalApiException.java
+++ b/src/main/java/com/sseulang/global/exception/ExternalApiException.java
@@ -1,0 +1,22 @@
+package com.sseulang.global.exception;
+
+import lombok.Getter;
+
+/**
+ * 외부 API 호출 실패. 가이드 §3.10 — anti-corruption boundary 에서 raw 예외(SocketTimeout,
+ * RestClientException 등)를 이 타입으로 wrap 하여 도메인 레이어가 외부 인프라 예외에
+ * 직접 의존하지 않도록 한다.
+ *
+ * <p>호출자(ApplicationService 등)는 본 예외를 잡아 상황에 맞는 BusinessException 으로
+ * 변환한다 (예: OAuth 흐름 → {@code AUTH_OAUTH_FAILED}).</p>
+ */
+@Getter
+public class ExternalApiException extends RuntimeException {
+
+    private final String externalServiceName;
+
+    public ExternalApiException(String externalServiceName, Throwable cause) {
+        super("외부 API 호출 실패: " + externalServiceName, cause);
+        this.externalServiceName = externalServiceName;
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/application/OAuthLoginServiceTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/OAuthLoginServiceTest.java
@@ -1,0 +1,196 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.auth.domain.OAuthProvider;
+import com.sseulang.domain.auth.domain.OAuthUserInfo;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.security.JwtClaims;
+import com.sseulang.global.security.JwtProperties;
+import com.sseulang.global.security.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OAuthLoginServiceTest {
+
+    private static final String SECRET = "test-secret-must-be-at-least-32-bytes-long-for-hs256-blah-blah";
+    private static final long AT_VALIDITY = 1800L;
+    private static final long RT_VALIDITY = 604800L;
+    private static final Email EMAIL = new Email("user@kakao.com");
+    private static final String PROVIDER_ID = "kakao-12345";
+    private static final Long USER_ID = 7L;
+    private static final OAuthUserInfo INFO =
+            new OAuthUserInfo(SocialProvider.KAKAO, PROVIDER_ID, EMAIL, "쓸랭이", "https://img/u.png");
+
+    private OAuthProvider kakaoProvider;
+    private OAuthProvider googleProvider;
+    private UserApplicationService userService;
+    private JwtProvider jwtProvider;
+    private InMemoryFakeRefreshTokenStore store;
+    private OAuthLoginService service;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties props = new JwtProperties(SECRET, AT_VALIDITY, RT_VALIDITY);
+        Clock clock = Clock.fixed(Instant.parse("2026-04-28T03:00:00Z"), ZoneOffset.UTC);
+        jwtProvider = new JwtProvider(props, clock);
+
+        kakaoProvider = mock(OAuthProvider.class);
+        when(kakaoProvider.supports()).thenReturn(SocialProvider.KAKAO);
+
+        googleProvider = mock(OAuthProvider.class);
+        when(googleProvider.supports()).thenReturn(SocialProvider.GOOGLE);
+
+        userService = mock(UserApplicationService.class);
+        store = new InMemoryFakeRefreshTokenStore();
+
+        service = new OAuthLoginService(
+                List.of(kakaoProvider, googleProvider),
+                userService,
+                jwtProvider,
+                store,
+                props
+        );
+    }
+
+    private User userWithId(Long id, boolean blocked, boolean deleted) {
+        User u = mock(User.class);
+        when(u.getId()).thenReturn(id);
+        when(u.isBlocked()).thenReturn(blocked);
+        when(u.isDeleted()).thenReturn(deleted);
+        return u;
+    }
+
+    @Test
+    @DisplayName("login 정상_provider 호출 + user 생성/조회 + AT/RT 발급 + RT store 저장")
+    void login_정상() {
+        when(kakaoProvider.verifyAndFetch("KAKAO_TOKEN")).thenReturn(INFO);
+        User u = userWithId(USER_ID, false, false);
+        when(userService.findOrCreateBySocial(
+                eq(SocialProvider.KAKAO), eq(PROVIDER_ID), eq(EMAIL), eq("쓸랭이"), eq("https://img/u.png")))
+                .thenReturn(u);
+
+        TokenPair pair = service.login(SocialProvider.KAKAO, "KAKAO_TOKEN");
+
+        assertThat(pair.accessToken()).isNotBlank();
+        assertThat(pair.refreshToken()).isNotBlank();
+
+        // 발급된 AT 의 sub = USER_ID, role = USER
+        JwtClaims atClaims = jwtProvider.parse(pair.accessToken());
+        assertThat(atClaims.userId()).isEqualTo(USER_ID);
+        assertThat(atClaims.role()).isEqualTo("USER");
+
+        // RT jti 가 store 에 저장됨
+        String rtJti = jwtProvider.parse(pair.refreshToken()).jti();
+        assertThat(store.contains(USER_ID, rtJti)).isTrue();
+
+        // 다른 provider 호출 X
+        verify(googleProvider, never()).verifyAndFetch(any());
+    }
+
+    @Test
+    @DisplayName("login_미지원 provider_AUTH_OAUTH_FAILED")
+    void login_미지원provider() {
+        // 본 service 에 KAKAO/GOOGLE 만 등록 → LOCAL 호출 시 실패
+        assertThatThrownBy(() -> service.login(SocialProvider.LOCAL, "T"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
+
+        verify(kakaoProvider, never()).verifyAndFetch(any());
+        verify(googleProvider, never()).verifyAndFetch(any());
+        verify(userService, never()).findOrCreateBySocial(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("login_provider 토큰 검증 실패_BusinessException 그대로 전파")
+    void login_provider_검증실패() {
+        when(kakaoProvider.verifyAndFetch("BAD")).thenThrow(new BusinessException(ErrorCode.AUTH_OAUTH_FAILED));
+
+        assertThatThrownBy(() -> service.login(SocialProvider.KAKAO, "BAD"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
+
+        verify(userService, never()).findOrCreateBySocial(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("login_외부 API 호출 실패(ExternalApiException)_AUTH_OAUTH_FAILED 변환 + user 조회 X")
+    void login_externalApi_실패() {
+        when(kakaoProvider.verifyAndFetch("T"))
+                .thenThrow(new com.sseulang.global.exception.ExternalApiException(
+                        "kakao-oauth", new RuntimeException("network")));
+
+        assertThatThrownBy(() -> service.login(SocialProvider.KAKAO, "T"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
+
+        verify(userService, never()).findOrCreateBySocial(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("login_blocked user_USER_BLOCKED + JWT 발급 X")
+    void login_blocked() {
+        when(kakaoProvider.verifyAndFetch("T")).thenReturn(INFO);
+        User u = userWithId(USER_ID, true, false);
+        when(userService.findOrCreateBySocial(any(), any(), any(), any(), any())).thenReturn(u);
+
+        assertThatThrownBy(() -> service.login(SocialProvider.KAKAO, "T"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_BLOCKED);
+
+        assertThat(store.size()).isZero();
+    }
+
+    @Test
+    @DisplayName("login_deleted user_USER_BLOCKED")
+    void login_deleted() {
+        when(kakaoProvider.verifyAndFetch("T")).thenReturn(INFO);
+        User u = userWithId(USER_ID, false, true);
+        when(userService.findOrCreateBySocial(any(), any(), any(), any(), any())).thenReturn(u);
+
+        assertThatThrownBy(() -> service.login(SocialProvider.KAKAO, "T"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_BLOCKED);
+    }
+
+    @Test
+    @DisplayName("login_연속 호출_매번 새 jti store 저장 (누적 X 정책 X — Day3 단순화)")
+    void login_연속() {
+        when(kakaoProvider.verifyAndFetch(any())).thenReturn(INFO);
+        User u = userWithId(USER_ID, false, false);
+        when(userService.findOrCreateBySocial(any(), any(), any(), any(), any())).thenReturn(u);
+
+        TokenPair p1 = service.login(SocialProvider.KAKAO, "T1");
+        TokenPair p2 = service.login(SocialProvider.KAKAO, "T2");
+
+        // 둘 다 store 에 등록 — 디바이스 동시 로그인 허용
+        String j1 = jwtProvider.parse(p1.refreshToken()).jti();
+        String j2 = jwtProvider.parse(p2.refreshToken()).jti();
+        assertThat(j1).isNotEqualTo(j2);
+        assertThat(store.contains(USER_ID, j1)).isTrue();
+        assertThat(store.contains(USER_ID, j2)).isTrue();
+
+        verify(userService, times(2)).findOrCreateBySocial(any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/domain/OAuthUserInfoTest.java
+++ b/src/test/java/com/sseulang/domain/auth/domain/OAuthUserInfoTest.java
@@ -1,0 +1,53 @@
+package com.sseulang.domain.auth.domain;
+
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OAuthUserInfoTest {
+
+    private static final Email EMAIL = new Email("foo@example.com");
+
+    @Test
+    @DisplayName("정상 생성_필드 보존")
+    void 정상생성() {
+        OAuthUserInfo info = new OAuthUserInfo(SocialProvider.KAKAO, "k-1", EMAIL, "쓸랭이", "https://img/x.png");
+        assertThat(info.provider()).isEqualTo(SocialProvider.KAKAO);
+        assertThat(info.providerId()).isEqualTo("k-1");
+        assertThat(info.email()).isEqualTo(EMAIL);
+        assertThat(info.nickname()).isEqualTo("쓸랭이");
+        assertThat(info.profileImage()).isEqualTo("https://img/x.png");
+    }
+
+    @Test
+    @DisplayName("profileImage null_허용")
+    void profileImage_nullable() {
+        OAuthUserInfo info = new OAuthUserInfo(SocialProvider.GOOGLE, "g-1", EMAIL, "n", null);
+        assertThat(info.profileImage()).isNull();
+    }
+
+    @Test
+    @DisplayName("LOCAL provider_거부")
+    void local_거부() {
+        assertThatThrownBy(() ->
+                new OAuthUserInfo(SocialProvider.LOCAL, "id", EMAIL, "n", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("필수 필드 누락_거부")
+    void 필수누락_거부() {
+        assertThatThrownBy(() -> new OAuthUserInfo(null, "id", EMAIL, "n", null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new OAuthUserInfo(SocialProvider.KAKAO, "", EMAIL, "n", null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new OAuthUserInfo(SocialProvider.KAKAO, "id", null, "n", null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new OAuthUserInfo(SocialProvider.KAKAO, "id", EMAIL, "", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/infrastructure/oauth/OAuthProviderGuardTest.java
+++ b/src/test/java/com/sseulang/domain/auth/infrastructure/oauth/OAuthProviderGuardTest.java
@@ -1,0 +1,62 @@
+package com.sseulang.domain.auth.infrastructure.oauth;
+
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Provider 진입 가드(null/blank token) 단위 테스트. 외부 API 호출 자체는 트리비얼 어댑터로 통합 테스트 영역.
+ */
+class OAuthProviderGuardTest {
+
+    private final RestClient.Builder builder = RestClient.builder();
+
+    @Test
+    @DisplayName("Kakao supports_KAKAO")
+    void kakao_supports() {
+        KakaoOAuthProvider p = new KakaoOAuthProvider(builder);
+        assertThat(p.supports()).isEqualTo(SocialProvider.KAKAO);
+    }
+
+    @Test
+    @DisplayName("Google supports_GOOGLE")
+    void google_supports() {
+        GoogleOAuthProvider p = new GoogleOAuthProvider(builder);
+        assertThat(p.supports()).isEqualTo(SocialProvider.GOOGLE);
+    }
+
+    @Test
+    @DisplayName("Kakao verifyAndFetch null/blank 토큰_AUTH_OAUTH_FAILED")
+    void kakao_blank_token() {
+        KakaoOAuthProvider p = new KakaoOAuthProvider(builder);
+
+        assertThatThrownBy(() -> p.verifyAndFetch(null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
+        assertThatThrownBy(() -> p.verifyAndFetch(""))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
+        assertThatThrownBy(() -> p.verifyAndFetch("   "))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
+    }
+
+    @Test
+    @DisplayName("Google verifyAndFetch null/blank 토큰_AUTH_OAUTH_FAILED")
+    void google_blank_token() {
+        GoogleOAuthProvider p = new GoogleOAuthProvider(builder);
+
+        assertThatThrownBy(() -> p.verifyAndFetch(null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
+        assertThatThrownBy(() -> p.verifyAndFetch(""))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/infrastructure/oauth/OAuthProviderJsonTest.java
+++ b/src/test/java/com/sseulang/domain/auth/infrastructure/oauth/OAuthProviderJsonTest.java
@@ -1,0 +1,101 @@
+package com.sseulang.domain.auth.infrastructure.oauth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Provider 응답 JSON ↔ record 매핑 검증. 외부 API 호출 부분은 트리비얼 어댑터(가이드 §7.3)
+ * 라 통합 테스트로 갈음하지만, 응답 스키마 매핑만큼은 단위로 닫는다.
+ */
+@JsonTest
+class OAuthProviderJsonTest {
+
+    @Autowired
+    private ObjectMapper om;
+
+    @Test
+    @DisplayName("Kakao /v2/user/me 응답 파싱_id/email/nickname/profile_image_url")
+    void kakao_응답_파싱() throws Exception {
+        String json = """
+                {
+                  "id": 1234567890,
+                  "kakao_account": {
+                    "email": "user@kakao.com",
+                    "profile": {
+                      "nickname": "쓸랭이",
+                      "profile_image_url": "https://img.kakao/u.png"
+                    }
+                  }
+                }
+                """;
+
+        KakaoOAuthProvider.KakaoUserResponse res =
+                om.readValue(json, KakaoOAuthProvider.KakaoUserResponse.class);
+
+        assertThat(res.id()).isEqualTo(1234567890L);
+        assertThat(res.kakaoAccount().email()).isEqualTo("user@kakao.com");
+        assertThat(res.kakaoAccount().profile().nickname()).isEqualTo("쓸랭이");
+        assertThat(res.kakaoAccount().profile().profileImageUrl()).isEqualTo("https://img.kakao/u.png");
+    }
+
+    @Test
+    @DisplayName("Kakao 응답_kakao_account 부재_null 매핑")
+    void kakao_응답_kakao_account_부재() throws Exception {
+        String json = """
+                { "id": 9999 }
+                """;
+
+        KakaoOAuthProvider.KakaoUserResponse res =
+                om.readValue(json, KakaoOAuthProvider.KakaoUserResponse.class);
+
+        assertThat(res.id()).isEqualTo(9999L);
+        assertThat(res.kakaoAccount()).isNull();
+    }
+
+    @Test
+    @DisplayName("Google /oauth2/v3/userinfo 응답 파싱_sub/email/email_verified/name/picture")
+    void google_응답_파싱() throws Exception {
+        String json = """
+                {
+                  "sub": "1234567890",
+                  "name": "쓸랭이",
+                  "email": "user@gmail.com",
+                  "email_verified": true,
+                  "picture": "https://lh3.googleusercontent.com/x.jpg"
+                }
+                """;
+
+        GoogleOAuthProvider.GoogleUserResponse res =
+                om.readValue(json, GoogleOAuthProvider.GoogleUserResponse.class);
+
+        assertThat(res.sub()).isEqualTo("1234567890");
+        assertThat(res.name()).isEqualTo("쓸랭이");
+        assertThat(res.email()).isEqualTo("user@gmail.com");
+        assertThat(res.emailVerified()).isTrue();
+        assertThat(res.picture()).isEqualTo("https://lh3.googleusercontent.com/x.jpg");
+    }
+
+    @Test
+    @DisplayName("Google 응답_email_verified=false_매핑")
+    void google_응답_email_verified_false() throws Exception {
+        String json = """
+                {
+                  "sub": "1",
+                  "name": "n",
+                  "email": "x@y.com",
+                  "email_verified": false
+                }
+                """;
+
+        GoogleOAuthProvider.GoogleUserResponse res =
+                om.readValue(json, GoogleOAuthProvider.GoogleUserResponse.class);
+
+        assertThat(res.emailVerified()).isFalse();
+        assertThat(res.picture()).isNull();
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/sseulang/domain/auth/presentation/AuthControllerTest.java
@@ -1,7 +1,11 @@
 package com.sseulang.domain.auth.presentation;
 
+import com.sseulang.domain.auth.application.OAuthLoginService;
 import com.sseulang.domain.auth.application.RefreshTokenRotationService;
 import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
 import com.sseulang.global.exception.GlobalExceptionHandler;
 import com.sseulang.global.security.CookieUtil;
 import jakarta.servlet.http.Cookie;
@@ -9,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -30,14 +35,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class AuthControllerTest {
 
     private RefreshTokenRotationService rotationService;
+    private OAuthLoginService oauthLoginService;
     private CookieUtil cookieUtil;
     private MockMvc mvc;
 
     @BeforeEach
     void setUp() {
         rotationService = mock(RefreshTokenRotationService.class);
+        oauthLoginService = mock(OAuthLoginService.class);
         cookieUtil = mock(CookieUtil.class);
-        AuthController controller = new AuthController(rotationService, cookieUtil);
+        AuthController controller = new AuthController(rotationService, oauthLoginService, cookieUtil);
         mvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
@@ -113,5 +120,92 @@ class AuthControllerTest {
 
         // 쿠키 없으면 둘 다 null — service 가 noop 처리
         verify(rotationService, times(1)).logout(org.mockito.ArgumentMatchers.isNull(), org.mockito.ArgumentMatchers.isNull());
+    }
+
+    @Test
+    @DisplayName("POST /auth/oauth2/kakao_정상_KAKAO 매핑 + AT/RT 쿠키 응답")
+    void oauth2_kakao_정상() throws Exception {
+        when(oauthLoginService.login(eq(SocialProvider.KAKAO), eq("KAKAO_AT")))
+                .thenReturn(new TokenPair("NEW_AT", "NEW_RT"));
+        when(cookieUtil.accessTokenCookie("NEW_AT"))
+                .thenReturn(ResponseCookie.from("at", "NEW_AT").path("/").httpOnly(true).maxAge(1800).build());
+        when(cookieUtil.refreshTokenCookie("NEW_RT"))
+                .thenReturn(ResponseCookie.from("rt", "NEW_RT").path("/api/v1/auth").httpOnly(true).maxAge(604800).build());
+
+        MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accessToken\":\"KAKAO_AT\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andReturn();
+
+        List<String> setCookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(setCookies).hasSize(2);
+        assertThat(setCookies).anyMatch(s -> s.startsWith("at=NEW_AT"));
+        assertThat(setCookies).anyMatch(s -> s.startsWith("rt=NEW_RT"));
+
+        verify(oauthLoginService, times(1)).login(SocialProvider.KAKAO, "KAKAO_AT");
+    }
+
+    @Test
+    @DisplayName("POST /auth/oauth2/google_정상_GOOGLE 매핑")
+    void oauth2_google_정상() throws Exception {
+        when(oauthLoginService.login(eq(SocialProvider.GOOGLE), eq("G_AT")))
+                .thenReturn(new TokenPair("AT", "RT"));
+        when(cookieUtil.accessTokenCookie("AT"))
+                .thenReturn(ResponseCookie.from("at", "AT").path("/").build());
+        when(cookieUtil.refreshTokenCookie("RT"))
+                .thenReturn(ResponseCookie.from("rt", "RT").path("/api/v1/auth").build());
+
+        mvc.perform(post("/api/v1/auth/oauth2/google")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accessToken\":\"G_AT\"}"))
+                .andExpect(status().isOk());
+
+        verify(oauthLoginService, times(1)).login(SocialProvider.GOOGLE, "G_AT");
+    }
+
+    @Test
+    @DisplayName("POST /auth/oauth2/unknown_path 미지원 provider_AUTH_OAUTH_FAILED + service 호출 X")
+    void oauth2_unknown_provider() throws Exception {
+        mvc.perform(post("/api/v1/auth/oauth2/twitter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accessToken\":\"T\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.AUTH_OAUTH_FAILED.name()));
+
+        verify(oauthLoginService, never()).login(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("POST /auth/oauth2/kakao_provider 검증 실패_AUTH_OAUTH_FAILED 전파")
+    void oauth2_provider_검증실패_전파() throws Exception {
+        when(oauthLoginService.login(eq(SocialProvider.KAKAO), eq("BAD")))
+                .thenThrow(new BusinessException(ErrorCode.AUTH_OAUTH_FAILED));
+
+        mvc.perform(post("/api/v1/auth/oauth2/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accessToken\":\"BAD\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.AUTH_OAUTH_FAILED.name()));
+    }
+
+    @Test
+    @DisplayName("POST /auth/oauth2/KAKAO (대문자)_path 대소문자 무시")
+    void oauth2_path_대소문자() throws Exception {
+        when(oauthLoginService.login(eq(SocialProvider.KAKAO), eq("T")))
+                .thenReturn(new TokenPair("AT", "RT"));
+        when(cookieUtil.accessTokenCookie("AT"))
+                .thenReturn(ResponseCookie.from("at", "AT").path("/").build());
+        when(cookieUtil.refreshTokenCookie("RT"))
+                .thenReturn(ResponseCookie.from("rt", "RT").path("/api/v1/auth").build());
+
+        mvc.perform(post("/api/v1/auth/oauth2/KAKAO")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accessToken\":\"T\"}"))
+                .andExpect(status().isOk());
+
+        verify(oauthLoginService, times(1)).login(SocialProvider.KAKAO, "T");
     }
 }

--- a/src/test/java/com/sseulang/domain/auth/presentation/AuthOAuthFlowIT.java
+++ b/src/test/java/com/sseulang/domain/auth/presentation/AuthOAuthFlowIT.java
@@ -1,0 +1,113 @@
+package com.sseulang.domain.auth.presentation;
+
+import com.sseulang.domain.auth.application.OAuthLoginService;
+import com.sseulang.domain.auth.application.RefreshTokenRotationService;
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.global.common.TraceIdFilter;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.exception.GlobalExceptionHandler;
+import com.sseulang.global.security.CookieUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * /api/v1/auth/oauth2/* 의 통합 흐름 검증 — TraceIdFilter / X-Trace-Id 헤더 / 응답 본문
+ * traceId 일관성. (Day 2 의 AuthSecurityFlowIT 가 SecurityConfig chain wiring 을, 본 IT 는
+ * AuthController + filter + advice 의 응답 일관성을 닫는다.)
+ */
+class AuthOAuthFlowIT {
+
+    private OAuthLoginService oauthLoginService;
+    private RefreshTokenRotationService rotationService;
+    private CookieUtil cookieUtil;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        oauthLoginService = mock(OAuthLoginService.class);
+        rotationService = mock(RefreshTokenRotationService.class);
+        cookieUtil = mock(CookieUtil.class);
+        AuthController controller = new AuthController(rotationService, oauthLoginService, cookieUtil);
+
+        mvc = MockMvcBuilders.standaloneSetup(controller)
+                .addFilter(new TraceIdFilter())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("oauth2/kakao 정상_200 + X-Trace-Id 헤더 + Set-Cookie 2 + ApiResponse")
+    void oauth2_kakao_정상_traceId_헤더() throws Exception {
+        when(oauthLoginService.login(eq(SocialProvider.KAKAO), eq("KAKAO_AT")))
+                .thenReturn(new TokenPair("AT", "RT"));
+        when(cookieUtil.accessTokenCookie("AT"))
+                .thenReturn(ResponseCookie.from("at", "AT").path("/").httpOnly(true).build());
+        when(cookieUtil.refreshTokenCookie("RT"))
+                .thenReturn(ResponseCookie.from("rt", "RT").path("/api/v1/auth").httpOnly(true).build());
+
+        MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accessToken\":\"KAKAO_AT\"}"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(TraceIdFilter.HEADER))
+                .andExpect(jsonPath("$.success").value(true))
+                .andReturn();
+
+        assertThat(result.getResponse().getHeaders(HttpHeaders.SET_COOKIE)).hasSize(2);
+        assertThat(result.getResponse().getHeader(TraceIdFilter.HEADER)).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("oauth2/unknown 미지원 provider_401 + X-Trace-Id 헤더 ↔ 본문 error.traceId 일치")
+    void oauth2_unknown_traceId_일관성() throws Exception {
+        MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/twitter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accessToken\":\"T\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().exists(TraceIdFilter.HEADER))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.AUTH_OAUTH_FAILED.name()))
+                .andExpect(jsonPath("$.error.traceId").exists())
+                .andReturn();
+
+        String headerTraceId = result.getResponse().getHeader(TraceIdFilter.HEADER);
+        String body = result.getResponse().getContentAsString();
+
+        assertThat(headerTraceId).isNotBlank();
+        assertThat(body).contains("\"traceId\":\"" + headerTraceId + "\"");
+    }
+
+    @Test
+    @DisplayName("oauth2 헤더의 X-Trace-Id 가 들어오면 그대로 사용 (relay)")
+    void oauth2_traceId_relay() throws Exception {
+        String incoming = "client-trace-12345";
+
+        MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/twitter")
+                        .header(TraceIdFilter.HEADER, incoming)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accessToken\":\"T\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().string(TraceIdFilter.HEADER, incoming))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("\"traceId\":\"" + incoming + "\"");
+    }
+}

--- a/src/test/java/com/sseulang/domain/user/application/UserApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/user/application/UserApplicationServiceTest.java
@@ -116,17 +116,39 @@ class UserApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("findOrCreateBySocial_save 시 DB UNIQUE 충돌_재조회 실패시 USER_EMAIL_DUPLICATED")
+    @DisplayName("findOrCreateBySocial_save 시 DB UNIQUE 충돌_재조회 후 email 다른 user 가 점유_USER_EMAIL_DUPLICATED")
     void findOrCreateBySocial_race_email충돌() {
-        when(userRepository.findBySocial(SocialProvider.KAKAO, "k-1")).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+        User other = User.createSocialUser(SocialProvider.KAKAO, "k-other", EMAIL, "n", null);
+        when(userRepository.findBySocial(SocialProvider.KAKAO, "k-1"))
+                .thenReturn(Optional.empty())   // 첫 호출 — 신규
+                .thenReturn(Optional.empty());  // race 후 재조회 — race winner 도 다른 사용자
+        // save 직전엔 비어있었지만 race winner 가 같은 email 로 먼저 가입함
+        when(userRepository.findByEmail(EMAIL))
+                .thenReturn(Optional.empty())   // 첫 사전 체크
+                .thenReturn(Optional.of(other)); // race 후 재조회
         when(userRepository.save(any(User.class)))
                 .thenThrow(new DataIntegrityViolationException("UNIQUE 위반"));
 
-        // race winner 가 다른 (provider, providerId) 였거나 아예 다른 사용자 → 재조회 fail
         assertThatThrownBy(() ->
                 service.findOrCreateBySocial(SocialProvider.KAKAO, "k-1", EMAIL, "n", null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.USER_EMAIL_DUPLICATED);
+    }
+
+    @Test
+    @DisplayName("findOrCreateBySocial_UNIQUE 외 다른 제약 위반_원본 예외 그대로 throw")
+    void findOrCreateBySocial_다른제약위반_원본throw() {
+        when(userRepository.findBySocial(SocialProvider.KAKAO, "k-1")).thenReturn(Optional.empty());
+        // 사전 findByEmail 도 비어있음 + race 시점 재조회도 둘 다 비어있음 → 진짜 다른 제약 위반
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+
+        DataIntegrityViolationException nicknameTooLong =
+                new DataIntegrityViolationException("nickname too long");
+        when(userRepository.save(any(User.class))).thenThrow(nicknameTooLong);
+
+        // USER_EMAIL_DUPLICATED 로 오분류되지 않고 원본 예외 그대로 노출되어야 한다
+        assertThatThrownBy(() ->
+                service.findOrCreateBySocial(SocialProvider.KAKAO, "k-1", EMAIL, "n", null))
+                .isSameAs(nicknameTooLong);
     }
 }

--- a/src/test/java/com/sseulang/domain/user/application/UserApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/user/application/UserApplicationServiceTest.java
@@ -1,0 +1,132 @@
+package com.sseulang.domain.user.application;
+
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserRepository;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserApplicationServiceTest {
+
+    private static final Email EMAIL = new Email("foo@example.com");
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserApplicationService service;
+
+    @Test
+    @DisplayName("findOrCreateBySocial_기존 user 있음_save 호출 X")
+    void findOrCreateBySocial_기존user() {
+        User existing = User.createSocialUser(SocialProvider.KAKAO, "k-1", EMAIL, "n", null);
+        when(userRepository.findBySocial(SocialProvider.KAKAO, "k-1")).thenReturn(Optional.of(existing));
+
+        User result = service.findOrCreateBySocial(SocialProvider.KAKAO, "k-1", EMAIL, "ignored", null);
+
+        assertThat(result).isSameAs(existing);
+        verify(userRepository, never()).save(any());
+        verify(userRepository, never()).findByEmail(any());
+    }
+
+    @Test
+    @DisplayName("findOrCreateBySocial_신규 + email 중복 없음_save 호출")
+    void findOrCreateBySocial_신규() {
+        when(userRepository.findBySocial(SocialProvider.GOOGLE, "g-1")).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        User result = service.findOrCreateBySocial(SocialProvider.GOOGLE, "g-1", EMAIL, "쓸랭이", "https://img/u.png");
+
+        assertThat(result.getSocialProvider()).isEqualTo(SocialProvider.GOOGLE);
+        assertThat(result.getSocialId()).isEqualTo("g-1");
+        assertThat(result.getNickname()).isEqualTo("쓸랭이");
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("findOrCreateBySocial_신규인데 email 이미 다른 provider 로 가입됨_USER_EMAIL_DUPLICATED")
+    void findOrCreateBySocial_email중복() {
+        User other = User.createSocialUser(SocialProvider.KAKAO, "k-other", EMAIL, "n", null);
+        when(userRepository.findBySocial(SocialProvider.GOOGLE, "g-1")).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(other));
+
+        assertThatThrownBy(() ->
+                service.findOrCreateBySocial(SocialProvider.GOOGLE, "g-1", EMAIL, "n", null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_EMAIL_DUPLICATED);
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("getById_존재_user 반환")
+    void getById_존재() {
+        User u = User.createSocialUser(SocialProvider.KAKAO, "k-1", EMAIL, "n", null);
+        when(userRepository.findById(7L)).thenReturn(Optional.of(u));
+
+        assertThat(service.getById(7L)).isSameAs(u);
+    }
+
+    @Test
+    @DisplayName("getById_없음_USER_NOT_FOUND")
+    void getById_없음() {
+        when(userRepository.findById(7L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getById(7L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("findOrCreateBySocial_save 시 DB UNIQUE 충돌_race winner 재조회 성공")
+    void findOrCreateBySocial_race_winner_재조회() {
+        // findBySocial: 처음엔 없음 → save 시 race winner 가 먼저 만들었음
+        when(userRepository.findBySocial(SocialProvider.KAKAO, "k-1"))
+                .thenReturn(Optional.empty())                                  // 첫 호출
+                .thenReturn(Optional.of(                                       // race winner 가 만든 user
+                        User.createSocialUser(SocialProvider.KAKAO, "k-1", EMAIL, "n", null)));
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class)))
+                .thenThrow(new DataIntegrityViolationException("UNIQUE 위반"));
+
+        User result = service.findOrCreateBySocial(SocialProvider.KAKAO, "k-1", EMAIL, "n", null);
+
+        assertThat(result.getSocialId()).isEqualTo("k-1");
+        verify(userRepository, times(2)).findBySocial(SocialProvider.KAKAO, "k-1");
+    }
+
+    @Test
+    @DisplayName("findOrCreateBySocial_save 시 DB UNIQUE 충돌_재조회 실패시 USER_EMAIL_DUPLICATED")
+    void findOrCreateBySocial_race_email충돌() {
+        when(userRepository.findBySocial(SocialProvider.KAKAO, "k-1")).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class)))
+                .thenThrow(new DataIntegrityViolationException("UNIQUE 위반"));
+
+        // race winner 가 다른 (provider, providerId) 였거나 아예 다른 사용자 → 재조회 fail
+        assertThatThrownBy(() ->
+                service.findOrCreateBySocial(SocialProvider.KAKAO, "k-1", EMAIL, "n", null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_EMAIL_DUPLICATED);
+    }
+}

--- a/src/test/java/com/sseulang/domain/user/domain/EmailTest.java
+++ b/src/test/java/com/sseulang/domain/user/domain/EmailTest.java
@@ -1,0 +1,60 @@
+package com.sseulang.domain.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EmailTest {
+
+    @Test
+    @DisplayName("Email 정상값_생성")
+    void 정상값_생성() {
+        Email e = new Email("foo@example.com");
+        assertThat(e.value()).isEqualTo("foo@example.com");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"plain", "@nope.com", "no@domain", "no@.com", "spaces in@x.com"})
+    @DisplayName("Email 잘못된 형식_예외")
+    void 잘못된_형식_예외(String invalid) {
+        assertThatThrownBy(() -> new Email(invalid))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("Email null/blank_예외")
+    void null_blank_예외() {
+        assertThatThrownBy(() -> new Email(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new Email("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new Email("   ")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("Email 100자 초과_예외")
+    void 길이초과_예외() {
+        String longLocal = "a".repeat(95);
+        String over = longLocal + "@x.com";  // 95+6 = 101
+        assertThatThrownBy(() -> new Email(over))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("Email 대소문자 차이_정규화로 동일 취급")
+    void 대소문자_정규화() {
+        Email lower = new Email("user@example.com");
+        Email mixed = new Email("User@Example.COM");
+        assertThat(mixed).isEqualTo(lower);
+        assertThat(mixed.value()).isEqualTo("user@example.com");
+    }
+
+    @Test
+    @DisplayName("Email 양쪽 공백_trim")
+    void 공백_trim() {
+        Email e = new Email("  user@example.com  ");
+        assertThat(e.value()).isEqualTo("user@example.com");
+    }
+}

--- a/src/test/java/com/sseulang/domain/user/domain/UserTest.java
+++ b/src/test/java/com/sseulang/domain/user/domain/UserTest.java
@@ -1,0 +1,65 @@
+package com.sseulang.domain.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserTest {
+
+    private static final Email EMAIL = new Email("foo@example.com");
+
+    @Test
+    @DisplayName("createSocialUser 정상_필드 채워지고 blocked/deleted=false")
+    void createSocialUser_정상() {
+        User u = User.createSocialUser(SocialProvider.KAKAO, "kakao-12345", EMAIL, "쓸랭이", "https://img.kakao/u.png");
+
+        assertThat(u.email()).isEqualTo(EMAIL);
+        assertThat(u.getNickname()).isEqualTo("쓸랭이");
+        assertThat(u.getProfileImage()).isEqualTo("https://img.kakao/u.png");
+        assertThat(u.getSocialProvider()).isEqualTo(SocialProvider.KAKAO);
+        assertThat(u.getSocialId()).isEqualTo("kakao-12345");
+        assertThat(u.isBlocked()).isFalse();
+        assertThat(u.isDeleted()).isFalse();
+        assertThat(u.getPhone()).isNull();
+    }
+
+    @Test
+    @DisplayName("createSocialUser LOCAL_provider 거부")
+    void createSocialUser_LOCAL_거부() {
+        assertThatThrownBy(() ->
+                User.createSocialUser(SocialProvider.LOCAL, "id", EMAIL, "n", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("createSocialUser null provider_거부")
+    void createSocialUser_null_provider_거부() {
+        assertThatThrownBy(() ->
+                User.createSocialUser(null, "id", EMAIL, "n", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("createSocialUser 빈 providerId_거부")
+    void createSocialUser_빈_providerId_거부() {
+        assertThatThrownBy(() ->
+                User.createSocialUser(SocialProvider.GOOGLE, "", EMAIL, "n", null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                User.createSocialUser(SocialProvider.GOOGLE, null, EMAIL, "n", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("createSocialUser 빈 nickname_거부")
+    void createSocialUser_빈_nickname_거부() {
+        assertThatThrownBy(() ->
+                User.createSocialUser(SocialProvider.GOOGLE, "id", EMAIL, "", null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                User.createSocialUser(SocialProvider.GOOGLE, "id", EMAIL, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## 변경 영역
- [x] 보안/인증
- [ ] 결제/포인트
- [ ] 거래 상태 머신
- [x] 동시성/락
- [ ] 일반 CRUD
- [ ] 문서/설정만

## Codex 리뷰
- [x] 🔴 즉시 리뷰 완료 (보안/돈 영역) — thread `019dd299-d74b-7ec0-99b5-90d6922df8d4`
- [x] 🟡 PR 풀 리뷰 완료 (mini 게이트 2) — thread `019dd2af-c49e-7621-b486-2b541121fe0f`
- [ ] ❌ 해당 없음

## 체크리스트
- [x] CLAUDE.md 컨벤션 준수 (DDD-lite 4-layer, 의존 방향)
- [x] 테스트 작성 — **113개 PASS** (단위 109 + 통합 4)
- [x] traceId 로깅 확인 (oauth2 엔드포인트도 X-Trace-Id ↔ 본문 traceId 일관성 IT 로 검증)
- [x] 민감 정보(비밀번호/토큰/카드번호) 로깅 없음
- [x] @Transactional 경계 검토 완료 — OAuthLoginService 는 의도적으로 클래스 @Transactional 미적용 (외부 API 호출 트랜잭션 밖)

## 관련 이슈
- Closes #7 (Day 3 — OAuth + User 도메인 트래커)
- Follow-up: #4 (User-level token version, 본 PR 머지 후 합류)

## 비고

### 핵심 흐름
`POST /api/v1/auth/oauth2/{provider}` Body `{ accessToken: "..." }` → provider 검증 → user 조회/생성 → AT/RT 발급 → HttpOnly Cookie

### Codex 리뷰 반영 (8건 총)

**게이트 1 (5건)**
| | 처리 |
|---|---|
| 🔴 `findOrCreateBySocial` race | `DataIntegrityViolationException` catch + race winner 재조회 |
| 🟡 외부 OAuth 호출이 tx 안 | `OAuthLoginService` 클래스 `@Transactional` 제거 |
| 🟡 Google `email_verified=null` 통과 | `!Boolean.TRUE.equals` 로 null/missing/false 모두 거부 |
| 🟡 외부 호출 실패 원인 분리 X | `ExternalApiException` 도입 |
| 🟢 Email 정규화 | trim + lowercase |

**mini 게이트 2 (3건)**
| | 처리 |
|---|---|
| 🟡 race catch 광범위 (다른 제약 위반도 USER_EMAIL_DUPLICATED 오분류) | UNIQUE 충돌만 보정, 그 외 원본 예외 그대로 throw |
| 🟡 oauth2 엔드포인트 traceId 통합 검증 부재 | `AuthOAuthFlowIT` (X-Trace-Id ↔ 본문 traceId 일관성 + header relay) |
| 🟢 OAuthProvider javadoc | 예외 계약(ExternalApiException + BusinessException) 명시 |

### 의도된 설계 결정 (트레이드오프 — `docs/AUTH_SECURITY.md`)

1. **User entity 에 JPA 어노테이션** — DDD-lite 절충안
2. **role 항상 "USER"** — V1 스키마, admins 별도 테이블
3. **같은 email + 다른 provider → `USER_EMAIL_DUPLICATED`** — 가이드 §12 미결정
4. **`/auth/login` (이메일/비밀번호) 부재** — 5/6 이후
5. **token version 도입 X** — 후속 이슈 #4
6. **Provider 외부 호출 단위 테스트 minimal** — 가이드 §7.3 트리비얼 어댑터

### 테스트 (45 신규, 누계 113 PASS)

- `EmailTest` 9 / `UserTest` 5 / `UserApplicationServiceTest` 9 (race 시나리오 4 포함)
- `OAuthUserInfoTest` 4 / `OAuthProviderJsonTest` 4 / `OAuthProviderGuardTest` 4
- `OAuthLoginServiceTest` 7 (ExternalApiException 변환 검증 포함)
- `AuthControllerTest` oauth2 5 / **`AuthOAuthFlowIT` 3** (TraceIdFilter 통합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)