### PR TITLE
chore: .env.example + README 환경변수 가이드

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,75 @@
+# ========================================================================
+# 쓸랭(Sseulang) 백엔드 환경변수 템플릿
+#
+# 사용법:
+#   1. 본 파일을 .env 로 복사: `cp .env.example .env`
+#   2. 빈 값들을 채우기 (특히 JWT_SECRET 은 64자 이상 random)
+#   3. IntelliJ Run Configuration 의 EnvFile 또는 직접 export 로 주입
+#
+# .env / .env.* 는 .gitignore 처리됨. 본 .env.example 만 추적.
+# ========================================================================
+
+# =============== Application Profile ===============
+SPRING_PROFILES_ACTIVE=local
+
+
+# =============== JWT (지금 사용 중) ===============
+# 64자 이상 random string. local 은 application-local.yml 의 fallback 사용 가능.
+# prod 는 default 없음 — 반드시 환경변수.
+# 생성 예: openssl rand -hex 64
+JWT_SECRET=
+
+
+# =============== Cookie (prod 에서만) ===============
+# 운영 도메인. local 프로필은 application-local.yml 의 "localhost" hardcoded.
+# prod 는 default 없음.
+COOKIE_DOMAIN=
+
+
+# =============== Database (prod 에서만) ===============
+# local 은 docker-compose.yml + application-local.yml hardcoded
+# (DB sseulang / user sseulang / pw sseulangpw / port 3307)
+DB_URL=
+DB_USERNAME=
+DB_PASSWORD=
+
+
+# =============== Redis (prod 에서만) ===============
+# local 은 docker-compose 의 6380 + application-local.yml hardcoded
+REDIS_HOST=
+REDIS_PORT=6379
+REDIS_PASSWORD=
+
+
+# =============== MongoDB (prod 에서만) ===============
+# local 은 docker-compose + application-local.yml 의 sseulang/sseulangpw@localhost:27017
+MONGO_URI=
+
+
+# =============== OAuth (현재 코드는 사용 X) ===============
+# 가이드 §4.4 — 프론트가 access_token 발급, 백엔드는 token 만 검증.
+# 백엔드는 client_id / client_secret 직접 사용 X.
+# 향후 Spring OAuth2 Client 도입 또는 백엔드 주도 OAuth 흐름 시 채울 것.
+KAKAO_REST_API_KEY=
+KAKAO_CLIENT_SECRET=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+
+# =============== AWS S3 (Day 5+ 이미지 업로드 시 필요) ===============
+# AWS IAM 사용자 생성 후 Access Key 발급. 권한: S3 PutObject / GetObject.
+AWS_ACCESS_KEY=
+AWS_SECRET_KEY=
+AWS_REGION=ap-northeast-2
+S3_BUCKET=sseulang-bucket
+
+
+# =============== 토스페이먼츠 (Day 7 결제 시 필요) ===============
+# 토스 개발자센터에서 테스트 키 발급.
+TOSS_CLIENT_KEY=
+TOSS_SECRET_KEY=
+
+
+# =============== CORS (prod) ===============
+# 콤마 구분. local 은 application-local.yml 의 localhost:3000, localhost:5173 hardcoded.
+CORS_ALLOWED_ORIGINS=

--- a/README.md
+++ b/README.md
@@ -29,20 +29,25 @@ docker compose up -d
 
 > 호스트 포트는 다른 로컬 컨테이너와 충돌 방지를 위해 기본 포트가 아닌 값으로 잡혀 있습니다. 컨테이너 내부 포트는 표준 그대로입니다.
 
-### 2) 환경 변수 (선택, 미설정 시 빈 값)
+### 2) 환경 변수
+
+`.env.example` 을 복사해서 `.env` 만들고 필요한 값 채우기:
 
 ```bash
-export JWT_SECRET="local-dev-secret-please-override-with-64-char-random-string-1234567890"
-export KAKAO_REST_API_KEY=...
-export KAKAO_CLIENT_SECRET=...
-export GOOGLE_CLIENT_ID=...
-export GOOGLE_CLIENT_SECRET=...
-export AWS_ACCESS_KEY=...
-export AWS_SECRET_KEY=...
-export S3_BUCKET=sseulang-bucket
-export TOSS_CLIENT_KEY=...
-export TOSS_SECRET_KEY=...
+cp .env.example .env
+# 편집기로 열어 JWT_SECRET 등 채우기
 ```
+
+`.env` 는 `.gitignore` 처리됨. IntelliJ EnvFile 플러그인 또는 `set -a; source .env; set +a` 로 주입.
+
+| 시점 | 채워야 할 변수 |
+|------|---------------|
+| **현재 (local 개발)** | 채울 것 없음 — `application-local.yml` 의 fallback 으로 시작 가능. `JWT_SECRET` 만 본인 값으로 덮어두면 더 안전. |
+| Day 5+ (이미지 업로드) | `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `S3_BUCKET` |
+| Day 7 (결제) | `TOSS_CLIENT_KEY`, `TOSS_SECRET_KEY` |
+| Day 11+ (배포) | prod 의 모든 변수 (`DB_URL`, `COOKIE_DOMAIN`, `MONGO_URI`, `REDIS_HOST`, `JWT_SECRET`, `CORS_ALLOWED_ORIGINS`) |
+
+> `KAKAO_*` / `GOOGLE_*` 는 가이드 §4.4 의 프론트 주도 OAuth 흐름 기준 백엔드 코드에서 직접 사용하지 않습니다 (백엔드는 access_token 만 검증). 향후 백엔드 주도 OAuth 도입 시 채울 것.
 
 ### 3) 애플리케이션 실행
 


### PR DESCRIPTION
## 변경 영역
- [ ] 보안/인증
- [ ] 결제/포인트
- [ ] 거래 상태 머신
- [ ] 동시성/락
- [ ] 일반 CRUD
- [x] 문서/설정만

## Codex 리뷰
- [ ] 🔴 즉시 리뷰 완료 (보안/돈 영역)
- [ ] 🟡 PR 풀 리뷰 완료
- [x] ❌ 해당 없음 (`.env.example` + README — 가이드 §9.5 거부 영역)

## 체크리스트
- [x] CLAUDE.md 컨벤션 준수
- [x] 테스트 작성 — 해당 없음 (문서/설정만)
- [x] traceId 로깅 확인 — 해당 없음
- [x] 민감 정보(비밀번호/토큰/카드번호) 로깅 없음 — `.env.example` 은 placeholder 만, 실제 값 X
- [x] @Transactional 경계 검토 완료 — 해당 없음

## 관련 이슈
- N/A (인프라성 작업)

## 비고

### 배경

env var placeholder 가 여러 곳(`application-local.yml`, `application-prod.yml`, README, 가이드)에 흩어져 있고 시점별로 필요한 변수가 달랐음. 새 PC 클론 시 무엇을 채워야 할지 한눈에 보기 어려운 상태.

### 변경

**`.env.example` 신규**
- 9개 그룹 — JWT / Cookie / DB / Redis / MongoDB / OAuth / AWS S3 / 토스 / CORS
- 각 그룹마다 "현재 필요 / Day 5+ / Day 7 / 배포 시" 주석으로 채우는 시점 명시
- `.gitignore` 의 `.env.*` 패턴은 이미 `!.env.example` 예외 처리됨

**`README.md` 환경 변수 섹션 갱신**
- 기존 `export JWT_SECRET=...` 줄줄이 → `cp .env.example .env` 흐름으로 단순화
- 시점별 표 추가 (현재 / Day 5+ / Day 7 / Day 11+ 배포)
- OAuth 키가 백엔드 코드에서 직접 사용되지 않는다는 점 명시 (가이드 §4.4 프론트 주도)

### 본 PR 에 포함 X

- `application-prod.yml` 의 default 값 추가/조정 — 별개 작업
- 실제 비밀키 발급 (카카오/구글/AWS/토스 콘솔) — 사용자 manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)