### PR TITLE
feat: Day 4 — Item CRUD/검색/Wishlist/S3 + 게이트 2 보강

### DIFF
--- a/src/main/java/com/sseulang/domain/category/application/CategoryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/category/application/CategoryApplicationService.java
@@ -1,0 +1,54 @@
+package com.sseulang.domain.category.application;
+
+import com.sseulang.domain.category.application.dto.CategoryNodeResult;
+import com.sseulang.domain.category.application.dto.CategoryResult;
+import com.sseulang.domain.category.domain.Category;
+import com.sseulang.domain.category.domain.CategoryRepository;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+public class CategoryApplicationService {
+
+    private final CategoryRepository categoryRepository;
+
+    public CategoryApplicationService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    /**
+     * 활성 카테고리 전체를 트리로 조립해 반환. 단일 SELECT 결과를 in-memory 로 그룹핑한다.
+     * Repository 가 parent NULL → parentId asc → sortOrder asc 순으로 정렬해주므로 1-pass 로 조립 가능.
+     */
+    public List<CategoryNodeResult> getActiveTree() {
+        List<Category> all = categoryRepository.findAllActiveSorted();
+
+        Map<Long, List<CategoryNodeResult>> childrenByParent = new HashMap<>();
+        List<CategoryNodeResult> roots = new ArrayList<>();
+
+        for (Category c : all) {
+            List<CategoryNodeResult> children = childrenByParent.computeIfAbsent(c.getId(), k -> new ArrayList<>());
+            CategoryNodeResult node = new CategoryNodeResult(c.getId(), c.getName(), c.getSortOrder(), children);
+            if (c.isRoot()) {
+                roots.add(node);
+            } else {
+                childrenByParent.computeIfAbsent(c.getParentId(), k -> new ArrayList<>()).add(node);
+            }
+        }
+        return roots;
+    }
+
+    public CategoryResult getById(Long id) {
+        Category c = categoryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+        return new CategoryResult(c.getId(), c.getParentId(), c.getName(), c.getSortOrder());
+    }
+}

--- a/src/main/java/com/sseulang/domain/category/application/CategoryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/category/application/CategoryApplicationService.java
@@ -51,4 +51,18 @@ public class CategoryApplicationService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
         return new CategoryResult(c.getId(), c.getParentId(), c.getName(), c.getSortOrder());
     }
+
+    /**
+     * 다른 도메인 ApplicationService 가 카테고리 존재 검증할 때 사용. {@code id} 가 null 이면
+     * 검증 스킵 (카테고리 미지정 허용 정책). CLAUDE.md §3.3 의 "다른 도메인 Repository 직접 호출 금지"
+     * 룰에 맞춰 외부 도메인이 본 메서드만 의존하게 한다.
+     */
+    public void requireExists(Long id) {
+        if (id == null) {
+            return;
+        }
+        if (categoryRepository.findById(id).isEmpty()) {
+            throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/com/sseulang/domain/category/application/dto/CategoryNodeResult.java
+++ b/src/main/java/com/sseulang/domain/category/application/dto/CategoryNodeResult.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.category.application.dto;
+
+import java.util.List;
+
+/** 카테고리 트리 노드. 자식이 없으면 {@code children} 은 빈 리스트. */
+public record CategoryNodeResult(
+        Long id,
+        String name,
+        int sortOrder,
+        List<CategoryNodeResult> children
+) { }

--- a/src/main/java/com/sseulang/domain/category/application/dto/CategoryResult.java
+++ b/src/main/java/com/sseulang/domain/category/application/dto/CategoryResult.java
@@ -1,0 +1,9 @@
+package com.sseulang.domain.category.application.dto;
+
+/** 카테고리 단건 평탄 결과 (트리 미포함). */
+public record CategoryResult(
+        Long id,
+        Long parentId,
+        String name,
+        int sortOrder
+) { }

--- a/src/main/java/com/sseulang/domain/category/domain/Category.java
+++ b/src/main/java/com/sseulang/domain/category/domain/Category.java
@@ -1,0 +1,79 @@
+package com.sseulang.domain.category.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Category Aggregate Root. V1 스키마 {@code categories} 매핑 (self-ref).
+ *
+ * <p>트리 깊이는 시드(`V2__seed_categories.sql`) 기준 2단(1차→2차). 도메인 자체에 깊이 제한
+ * 강제는 없음 — Application/Service 에서 트리 조립 시 단일 SELECT 후 in-memory 그룹핑.</p>
+ *
+ * <p>parent 는 self-ref FK 로 두되 도메인 모델은 {@code parentId(Long)} 만 보유. {@code @ManyToOne}
+ * 자기참조는 N+1 위험이 커서 명시 ID 만 들고 트리는 어플리케이션 레이어에서 조립.</p>
+ */
+@Entity
+@Table(name = "categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseEntity {
+
+    private static final int NAME_MAX_LENGTH = 50;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "parent_id")
+    private Long parentId;
+
+    @Column(name = "name", nullable = false, length = NAME_MAX_LENGTH)
+    private String name;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    public static Category createRoot(String name, int sortOrder) {
+        return create(null, name, sortOrder);
+    }
+
+    public static Category createChild(Long parentId, String name, int sortOrder) {
+        if (parentId == null || parentId <= 0) {
+            throw new IllegalArgumentException("parentId 는 양수여야 합니다");
+        }
+        return create(parentId, name, sortOrder);
+    }
+
+    public boolean isRoot() {
+        return parentId == null;
+    }
+
+    private static Category create(Long parentId, String name, int sortOrder) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name 은 비어있을 수 없습니다");
+        }
+        if (name.length() > NAME_MAX_LENGTH) {
+            throw new IllegalArgumentException("name 은 " + NAME_MAX_LENGTH + "자를 초과할 수 없습니다");
+        }
+        if (sortOrder < 0) {
+            throw new IllegalArgumentException("sortOrder 는 0 이상이어야 합니다");
+        }
+        Category c = new Category();
+        c.parentId = parentId;
+        c.name = name;
+        c.sortOrder = sortOrder;
+        c.active = true;
+        return c;
+    }
+}

--- a/src/main/java/com/sseulang/domain/category/domain/CategoryRepository.java
+++ b/src/main/java/com/sseulang/domain/category/domain/CategoryRepository.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.category.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Category Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
+ * 구현은 {@code domain/category/infrastructure/persistence}.
+ */
+public interface CategoryRepository {
+
+    Optional<Category> findById(Long id);
+
+    /**
+     * 활성 카테고리 전부 조회. parent_id 우선(NULL 먼저), sort_order 순. 트리 조립은 호출자가 in-memory 로.
+     */
+    List<Category> findAllActiveSorted();
+}

--- a/src/main/java/com/sseulang/domain/category/infrastructure/persistence/CategoryJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/category/infrastructure/persistence/CategoryJpaRepository.java
@@ -1,0 +1,22 @@
+package com.sseulang.domain.category.infrastructure.persistence;
+
+import com.sseulang.domain.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+/** Spring Data JPA — {@link CategoryRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
+interface CategoryJpaRepository extends JpaRepository<Category, Long> {
+
+    @Query("""
+        SELECT c FROM Category c
+        WHERE c.active = true
+        ORDER BY
+          CASE WHEN c.parentId IS NULL THEN 0 ELSE 1 END,
+          c.parentId,
+          c.sortOrder,
+          c.id
+    """)
+    List<Category> findAllActiveSorted();
+}

--- a/src/main/java/com/sseulang/domain/category/infrastructure/persistence/CategoryRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/category/infrastructure/persistence/CategoryRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.sseulang.domain.category.infrastructure.persistence;
+
+import com.sseulang.domain.category.domain.Category;
+import com.sseulang.domain.category.domain.CategoryRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class CategoryRepositoryImpl implements CategoryRepository {
+
+    private final CategoryJpaRepository jpa;
+
+    public CategoryRepositoryImpl(CategoryJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Optional<Category> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public List<Category> findAllActiveSorted() {
+        return jpa.findAllActiveSorted();
+    }
+}

--- a/src/main/java/com/sseulang/domain/category/presentation/CategoryController.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/CategoryController.java
@@ -1,0 +1,36 @@
+package com.sseulang.domain.category.presentation;
+
+import com.sseulang.domain.category.application.CategoryApplicationService;
+import com.sseulang.domain.category.presentation.dto.CategoryNodeResponse;
+import com.sseulang.domain.category.presentation.dto.CategoryResponse;
+import com.sseulang.global.common.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/categories")
+public class CategoryController {
+
+    private final CategoryApplicationService categoryService;
+
+    public CategoryController(CategoryApplicationService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping
+    public ApiResponse<List<CategoryNodeResponse>> getTree() {
+        List<CategoryNodeResponse> tree = categoryService.getActiveTree().stream()
+                .map(CategoryNodeResponse::from)
+                .toList();
+        return ApiResponse.ok(tree);
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<CategoryResponse> getOne(@PathVariable("id") Long id) {
+        return ApiResponse.ok(CategoryResponse.from(categoryService.getById(id)));
+    }
+}

--- a/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryNodeResponse.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryNodeResponse.java
@@ -1,0 +1,21 @@
+package com.sseulang.domain.category.presentation.dto;
+
+import com.sseulang.domain.category.application.dto.CategoryNodeResult;
+
+import java.util.List;
+
+public record CategoryNodeResponse(
+        Long id,
+        String name,
+        int sortOrder,
+        List<CategoryNodeResponse> children
+) {
+    public static CategoryNodeResponse from(CategoryNodeResult node) {
+        return new CategoryNodeResponse(
+                node.id(),
+                node.name(),
+                node.sortOrder(),
+                node.children().stream().map(CategoryNodeResponse::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryResponse.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryResponse.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.category.presentation.dto;
+
+import com.sseulang.domain.category.application.dto.CategoryResult;
+
+public record CategoryResponse(
+        Long id,
+        Long parentId,
+        String name,
+        int sortOrder
+) {
+    public static CategoryResponse from(CategoryResult result) {
+        return new CategoryResponse(result.id(), result.parentId(), result.name(), result.sortOrder());
+    }
+}

--- a/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
+++ b/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
@@ -1,0 +1,87 @@
+package com.sseulang.domain.file.application;
+
+import com.sseulang.domain.file.application.dto.PresignRequestItem;
+import com.sseulang.domain.file.application.dto.PresignResult;
+import com.sseulang.domain.file.domain.FilePurpose;
+import com.sseulang.domain.file.domain.PresignedUrlGenerator;
+import com.sseulang.domain.file.domain.PresignedUrlResult;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 이미지 업로드용 S3 presigned URL 발급. 가이드 §4.5:
+ *
+ * <ul>
+ *   <li>Content-Type: {@code image/*}</li>
+ *   <li>Content-Length: ≤ 5MB</li>
+ *   <li>만료: 5분</li>
+ *   <li>파일명: 백엔드 UUID 강제 (사용자 입력 무시)</li>
+ *   <li>key 패턴: {@code {purpose}/{ownerId}/{uuid}.{ext}}</li>
+ * </ul>
+ */
+@Service
+public class FileApplicationService {
+
+    private static final long MAX_CONTENT_LENGTH = 5L * 1024 * 1024;
+    private static final Duration PRESIGN_EXPIRE = Duration.ofMinutes(5);
+    private static final int MAX_FILES_PER_REQUEST = 10;
+
+    private static final Map<String, String> EXTENSION_BY_CONTENT_TYPE = Map.of(
+            "image/jpeg", "jpg",
+            "image/jpg",  "jpg",
+            "image/png",  "png",
+            "image/webp", "webp",
+            "image/gif",  "gif"
+    );
+
+    private final PresignedUrlGenerator generator;
+
+    public FileApplicationService(PresignedUrlGenerator generator) {
+        this.generator = generator;
+    }
+
+    public List<PresignResult> issue(FilePurpose purpose, Long ownerId, List<PresignRequestItem> files) {
+        if (purpose == null) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        if (ownerId == null || ownerId <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        if (files == null || files.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        if (files.size() > MAX_FILES_PER_REQUEST) {
+            throw new BusinessException(ErrorCode.FILE_VALIDATION_FAILED);
+        }
+
+        List<PresignResult> results = new ArrayList<>(files.size());
+        for (PresignRequestItem f : files) {
+            validate(f);
+            String key = buildKey(purpose, ownerId, f.contentType());
+            PresignedUrlResult issued = generator.generate(key, f.contentType(), PRESIGN_EXPIRE);
+            results.add(new PresignResult(issued.presignedUrl(), issued.key()));
+        }
+        return results;
+    }
+
+    private static void validate(PresignRequestItem f) {
+        if (f.contentType() == null || !EXTENSION_BY_CONTENT_TYPE.containsKey(f.contentType().toLowerCase())) {
+            throw new BusinessException(ErrorCode.FILE_VALIDATION_FAILED);
+        }
+        if (f.contentLength() <= 0 || f.contentLength() > MAX_CONTENT_LENGTH) {
+            throw new BusinessException(ErrorCode.FILE_VALIDATION_FAILED);
+        }
+    }
+
+    private static String buildKey(FilePurpose purpose, Long ownerId, String contentType) {
+        String ext = EXTENSION_BY_CONTENT_TYPE.get(contentType.toLowerCase());
+        return purpose.folder() + "/" + ownerId + "/" + UUID.randomUUID() + "." + ext;
+    }
+}

--- a/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
+++ b/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
@@ -11,8 +11,10 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -25,6 +27,15 @@ import java.util.UUID;
  *   <li>파일명: 백엔드 UUID 강제 (사용자 입력 무시)</li>
  *   <li>key 패턴: {@code {purpose}/{ownerId}/{uuid}.{ext}}</li>
  * </ul>
+ *
+ * <p><b>일반 사용자 엔드포인트의 화이트리스트</b> — Codex 게이트 2 (2026-04-29) 권한 누수 보강:
+ * 일반 사용자는 자기 자원에 해당하는 {@link FilePurpose#PROFILE} / {@link FilePurpose#ITEM} 만 발급 가능.
+ * {@code NOTICE} / {@code BANNER} 는 관리자 도메인이, {@code MESSAGE} 는 chat 도메인이 각자
+ * 별도 엔드포인트로 직접 호출해야 하며 본 메서드는 거부({@link ErrorCode#FORBIDDEN})한다.</p>
+ *
+ * <p><b>폴더 구조 후속 정리(TODO)</b>: 가이드 §4.5 는 {@code items/{itemId}/...} 를 명시하지만
+ * 등록 전엔 itemId 가 없어 본 PR 에선 {@code items/{userId}/...} 로 임시 보관. 등록 시 백엔드가
+ * S3 copy 로 정식 폴더로 이동하는 흐름은 후속 작업.</p>
  */
 @Service
 public class FileApplicationService {
@@ -32,6 +43,12 @@ public class FileApplicationService {
     private static final long MAX_CONTENT_LENGTH = 5L * 1024 * 1024;
     private static final Duration PRESIGN_EXPIRE = Duration.ofMinutes(5);
     private static final int MAX_FILES_PER_REQUEST = 10;
+
+    /** 일반 사용자가 직접 호출 가능한 purpose. 그 외는 도메인 전용 엔드포인트로 분리. */
+    private static final Set<FilePurpose> USER_ALLOWED_PURPOSES = EnumSet.of(
+            FilePurpose.PROFILE,
+            FilePurpose.ITEM
+    );
 
     private static final Map<String, String> EXTENSION_BY_CONTENT_TYPE = Map.of(
             "image/jpeg", "jpg",
@@ -47,6 +64,22 @@ public class FileApplicationService {
         this.generator = generator;
     }
 
+    /**
+     * 일반 사용자 진입점. {@link #USER_ALLOWED_PURPOSES} 외 purpose 는 거부한다.
+     */
+    public List<PresignResult> issueForUser(FilePurpose purpose, Long ownerId, List<PresignRequestItem> files) {
+        if (purpose == null) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        if (!USER_ALLOWED_PURPOSES.contains(purpose)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return issue(purpose, ownerId, files);
+    }
+
+    /**
+     * 도메인 내부(관리자·chat 등)에서 직접 호출 — purpose 화이트리스트 X. 호출자가 권한 검증 책임.
+     */
     public List<PresignResult> issue(FilePurpose purpose, Long ownerId, List<PresignRequestItem> files) {
         if (purpose == null) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST);

--- a/src/main/java/com/sseulang/domain/file/application/dto/PresignRequestItem.java
+++ b/src/main/java/com/sseulang/domain/file/application/dto/PresignRequestItem.java
@@ -1,0 +1,3 @@
+package com.sseulang.domain.file.application.dto;
+
+public record PresignRequestItem(String contentType, long contentLength) { }

--- a/src/main/java/com/sseulang/domain/file/application/dto/PresignResult.java
+++ b/src/main/java/com/sseulang/domain/file/application/dto/PresignResult.java
@@ -1,0 +1,3 @@
+package com.sseulang.domain.file.application.dto;
+
+public record PresignResult(String presignedUrl, String key) { }

--- a/src/main/java/com/sseulang/domain/file/domain/FilePurpose.java
+++ b/src/main/java/com/sseulang/domain/file/domain/FilePurpose.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.file.domain;
+
+/**
+ * 업로드 용도. S3 폴더 구조 1단계 — {@code {purpose}/{ownerId}/{uuid}.{ext}}.
+ *
+ * <p>가이드 §4.5 폴더 구조와 정합. {@code messages/{roomId}/...} 처럼 owner 의미가 다른 케이스도
+ * controller 에서 owner 를 적절히 결정해 전달한다.</p>
+ */
+public enum FilePurpose {
+    PROFILE("profiles"),
+    ITEM("items"),
+    MESSAGE("messages"),
+    NOTICE("notices"),
+    BANNER("banners");
+
+    private final String folder;
+
+    FilePurpose(String folder) {
+        this.folder = folder;
+    }
+
+    public String folder() {
+        return folder;
+    }
+}

--- a/src/main/java/com/sseulang/domain/file/domain/PresignedUrlGenerator.java
+++ b/src/main/java/com/sseulang/domain/file/domain/PresignedUrlGenerator.java
@@ -1,0 +1,12 @@
+package com.sseulang.domain.file.domain;
+
+import java.time.Duration;
+
+/**
+ * S3 등 외부 스토리지의 PUT 용 presigned URL 발급 인터페이스. 도메인 layer 인터페이스 — 외부 SDK 의존 X.
+ * 구현은 {@code domain/file/infrastructure/s3/S3PresignedUrlGenerator}.
+ */
+public interface PresignedUrlGenerator {
+
+    PresignedUrlResult generate(String key, String contentType, Duration expiresIn);
+}

--- a/src/main/java/com/sseulang/domain/file/domain/PresignedUrlResult.java
+++ b/src/main/java/com/sseulang/domain/file/domain/PresignedUrlResult.java
@@ -1,0 +1,3 @@
+package com.sseulang.domain.file.domain;
+
+public record PresignedUrlResult(String presignedUrl, String key) { }

--- a/src/main/java/com/sseulang/domain/file/infrastructure/s3/S3PresignedUrlGenerator.java
+++ b/src/main/java/com/sseulang/domain/file/infrastructure/s3/S3PresignedUrlGenerator.java
@@ -1,0 +1,39 @@
+package com.sseulang.domain.file.infrastructure.s3;
+
+import com.sseulang.domain.file.domain.PresignedUrlGenerator;
+import com.sseulang.domain.file.domain.PresignedUrlResult;
+import com.sseulang.global.infra.s3.S3Properties;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+
+@Component
+public class S3PresignedUrlGenerator implements PresignedUrlGenerator {
+
+    private final S3Presigner presigner;
+    private final String bucket;
+
+    public S3PresignedUrlGenerator(S3Presigner presigner, S3Properties props) {
+        this.presigner = presigner;
+        this.bucket = props.s3().bucket();
+    }
+
+    @Override
+    public PresignedUrlResult generate(String key, String contentType, Duration expiresIn) {
+        PutObjectRequest put = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(contentType)
+                .build();
+        PutObjectPresignRequest req = PutObjectPresignRequest.builder()
+                .signatureDuration(expiresIn)
+                .putObjectRequest(put)
+                .build();
+        PresignedPutObjectRequest presigned = presigner.presignPutObject(req);
+        return new PresignedUrlResult(presigned.url().toString(), key);
+    }
+}

--- a/src/main/java/com/sseulang/domain/file/presentation/FileController.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/FileController.java
@@ -33,7 +33,7 @@ public class FileController {
         List<PresignRequestItem> items = request.files().stream()
                 .map(f -> new PresignRequestItem(f.contentType(), f.contentLength()))
                 .toList();
-        List<PresignResult> results = fileService.issue(request.purpose(), userId, items);
+        List<PresignResult> results = fileService.issueForUser(request.purpose(), userId, items);
         return ApiResponse.ok(PresignedUrlResponse.from(results));
     }
 }

--- a/src/main/java/com/sseulang/domain/file/presentation/FileController.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/FileController.java
@@ -1,0 +1,39 @@
+package com.sseulang.domain.file.presentation;
+
+import com.sseulang.domain.file.application.FileApplicationService;
+import com.sseulang.domain.file.application.dto.PresignRequestItem;
+import com.sseulang.domain.file.application.dto.PresignResult;
+import com.sseulang.domain.file.presentation.dto.PresignedUrlRequest;
+import com.sseulang.domain.file.presentation.dto.PresignedUrlResponse;
+import com.sseulang.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/files")
+public class FileController {
+
+    private final FileApplicationService fileService;
+
+    public FileController(FileApplicationService fileService) {
+        this.fileService = fileService;
+    }
+
+    @PostMapping("/presigned-url")
+    public ApiResponse<PresignedUrlResponse> issue(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody PresignedUrlRequest request
+    ) {
+        List<PresignRequestItem> items = request.files().stream()
+                .map(f -> new PresignRequestItem(f.contentType(), f.contentLength()))
+                .toList();
+        List<PresignResult> results = fileService.issue(request.purpose(), userId, items);
+        return ApiResponse.ok(PresignedUrlResponse.from(results));
+    }
+}

--- a/src/main/java/com/sseulang/domain/file/presentation/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/dto/PresignedUrlRequest.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.file.presentation.dto;
+
+import com.sseulang.domain.file.domain.FilePurpose;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record PresignedUrlRequest(
+        @NotNull FilePurpose purpose,
+        @NotEmpty @Valid List<PresignedFileItem> files
+) {
+    public record PresignedFileItem(
+            @NotNull String contentType,
+            @NotNull Long contentLength
+    ) { }
+}

--- a/src/main/java/com/sseulang/domain/file/presentation/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/dto/PresignedUrlResponse.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.file.presentation.dto;
+
+import com.sseulang.domain.file.application.dto.PresignResult;
+
+import java.util.List;
+
+public record PresignedUrlResponse(List<Upload> uploads) {
+
+    public record Upload(String presignedUrl, String key) {
+        public static Upload from(PresignResult r) {
+            return new Upload(r.presignedUrl(), r.key());
+        }
+    }
+
+    public static PresignedUrlResponse from(List<PresignResult> results) {
+        return new PresignedUrlResponse(results.stream().map(Upload::from).toList());
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -1,0 +1,115 @@
+package com.sseulang.domain.item.application;
+
+import com.sseulang.domain.category.domain.CategoryRepository;
+import com.sseulang.domain.item.application.dto.ItemDetailResult;
+import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
+import com.sseulang.domain.item.application.dto.ItemSummaryResult;
+import com.sseulang.domain.item.application.dto.ItemUpdateCommand;
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemRepository;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class ItemApplicationService {
+
+    private final ItemRepository itemRepository;
+    private final CategoryRepository categoryRepository;
+
+    public ItemApplicationService(
+            ItemRepository itemRepository,
+            CategoryRepository categoryRepository
+    ) {
+        this.itemRepository = itemRepository;
+        this.categoryRepository = categoryRepository;
+    }
+
+    @Transactional
+    public Long register(ItemRegisterCommand cmd) {
+        validateCategoryExists(cmd.categoryId());
+        Item item = Item.create(
+                cmd.sellerId(), cmd.categoryId(),
+                cmd.title(), cmd.description(),
+                cmd.price(), cmd.deposit(), cmd.rentalUnit(), cmd.tradeType(),
+                cmd.region()
+        );
+        applyImages(item, cmd.imageUrls());
+        return itemRepository.save(item).getId();
+    }
+
+    @Transactional
+    public ItemDetailResult getById(Long id) {
+        Item item = findOrThrow(id);
+        item.incrementViewCount();
+        return ItemDetailResult.from(item);
+    }
+
+    public Page<ItemSummaryResult> listLatest(Pageable pageable) {
+        return itemRepository.findVisibleLatest(pageable).map(ItemSummaryResult::from);
+    }
+
+    @Transactional
+    public void update(Long id, Long requesterId, ItemUpdateCommand cmd) {
+        Item item = findOwnedOrThrow(id, requesterId);
+
+        item.updateInfo(
+                cmd.title(), cmd.description(),
+                cmd.price(), cmd.deposit(), cmd.rentalUnit(), cmd.region()
+        );
+
+        if (cmd.categoryId() != null) {
+            validateCategoryExists(cmd.categoryId());
+            item.assignCategory(cmd.categoryId());
+        }
+        if (cmd.imageUrls() != null) {
+            item.clearImages();
+            applyImages(item, cmd.imageUrls());
+        }
+    }
+
+    @Transactional
+    public void delete(Long id, Long requesterId) {
+        Item item = findOwnedOrThrow(id, requesterId);
+        item.markAsDeleted();
+    }
+
+    private Item findOrThrow(Long id) {
+        return itemRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+    }
+
+    private Item findOwnedOrThrow(Long id, Long requesterId) {
+        Item item = findOrThrow(id);
+        if (!item.isOwnedBy(requesterId)) {
+            throw new BusinessException(ErrorCode.ITEM_FORBIDDEN);
+        }
+        return item;
+    }
+
+    private void validateCategoryExists(Long categoryId) {
+        if (categoryId == null) {
+            return;
+        }
+        if (categoryRepository.findById(categoryId).isEmpty()) {
+            throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
+        }
+    }
+
+    private static void applyImages(Item item, List<String> imageUrls) {
+        if (imageUrls == null || imageUrls.isEmpty()) {
+            return;
+        }
+        int order = 0;
+        for (String url : imageUrls) {
+            order++;
+            item.addImage(url, order, order == 1);
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -41,6 +41,7 @@ public class ItemApplicationService {
                 cmd.region()
         );
         applyImages(item, cmd.imageUrls());
+        applyHashtags(item, cmd.hashtags());
         return itemRepository.save(item).getId();
     }
 
@@ -71,6 +72,10 @@ public class ItemApplicationService {
         if (cmd.imageUrls() != null) {
             item.clearImages();
             applyImages(item, cmd.imageUrls());
+        }
+        if (cmd.hashtags() != null) {
+            item.clearHashtags();
+            applyHashtags(item, cmd.hashtags());
         }
     }
 
@@ -110,6 +115,15 @@ public class ItemApplicationService {
         for (String url : imageUrls) {
             order++;
             item.addImage(url, order, order == 1);
+        }
+    }
+
+    private static void applyHashtags(Item item, List<String> hashtags) {
+        if (hashtags == null || hashtags.isEmpty()) {
+            return;
+        }
+        for (String tag : hashtags) {
+            item.addHashtag(tag);
         }
     }
 }

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.item.application;
 import com.sseulang.domain.category.domain.CategoryRepository;
 import com.sseulang.domain.item.application.dto.ItemDetailResult;
 import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
+import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
 import com.sseulang.domain.item.application.dto.ItemSummaryResult;
 import com.sseulang.domain.item.application.dto.ItemUpdateCommand;
 import com.sseulang.domain.item.domain.Item;
@@ -52,8 +53,8 @@ public class ItemApplicationService {
         return ItemDetailResult.from(item);
     }
 
-    public Page<ItemSummaryResult> listLatest(Pageable pageable) {
-        return itemRepository.findVisibleLatest(pageable).map(ItemSummaryResult::from);
+    public Page<ItemSummaryResult> search(ItemSearchCriteria criteria, Pageable pageable) {
+        return itemRepository.search(criteria, pageable).map(ItemSummaryResult::from);
     }
 
     @Transactional

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -1,6 +1,6 @@
 package com.sseulang.domain.item.application;
 
-import com.sseulang.domain.category.domain.CategoryRepository;
+import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.item.application.dto.ItemDetailResult;
 import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
 import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
@@ -8,8 +8,10 @@ import com.sseulang.domain.item.application.dto.ItemSummaryResult;
 import com.sseulang.domain.item.application.dto.ItemUpdateCommand;
 import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.item.domain.ItemRepository;
+import com.sseulang.domain.item.domain.ItemStatus;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -22,19 +24,19 @@ import java.util.List;
 public class ItemApplicationService {
 
     private final ItemRepository itemRepository;
-    private final CategoryRepository categoryRepository;
+    private final CategoryApplicationService categoryApplicationService;
 
     public ItemApplicationService(
             ItemRepository itemRepository,
-            CategoryRepository categoryRepository
+            CategoryApplicationService categoryApplicationService
     ) {
         this.itemRepository = itemRepository;
-        this.categoryRepository = categoryRepository;
+        this.categoryApplicationService = categoryApplicationService;
     }
 
     @Transactional
     public Long register(ItemRegisterCommand cmd) {
-        validateCategoryExists(cmd.categoryId());
+        categoryApplicationService.requireExists(cmd.categoryId());
         Item item = Item.create(
                 cmd.sellerId(), cmd.categoryId(),
                 cmd.title(), cmd.description(),
@@ -67,7 +69,7 @@ public class ItemApplicationService {
         );
 
         if (cmd.categoryId() != null) {
-            validateCategoryExists(cmd.categoryId());
+            categoryApplicationService.requireExists(cmd.categoryId());
             item.assignCategory(cmd.categoryId());
         }
         if (cmd.imageUrls() != null) {
@@ -86,6 +88,34 @@ public class ItemApplicationService {
         item.markAsDeleted();
     }
 
+    /**
+     * 다른 도메인 ApplicationService 가 "활성 Item 존재"만 검증할 때 사용 — Wishlist 등.
+     * status=삭제 는 ITEM_NOT_FOUND. CLAUDE.md §3.3 의 다른 도메인 Repository 직접 호출 금지 룰
+     * 정합 — 외부는 본 메서드를 통해서만 Item 검증.
+     */
+    public void requireActiveItem(Long id) {
+        Item item = findOrThrow(id);
+        if (item.getStatus() == ItemStatus.삭제) {
+            throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
+        }
+    }
+
+    /**
+     * {@code wishlist_count} 원자 증가. Wishlist 도메인이 찜 추가 성공 직후 호출.
+     */
+    @Transactional
+    public void incrementWishlistCount(Long itemId) {
+        itemRepository.incrementWishlistCount(itemId);
+    }
+
+    /**
+     * {@code wishlist_count} 원자 감소. 음수 방지는 Repository 쪽 SQL 가드.
+     */
+    @Transactional
+    public void decrementWishlistCount(Long itemId) {
+        itemRepository.decrementWishlistCount(itemId);
+    }
+
     private Item findOrThrow(Long id) {
         return itemRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
@@ -97,15 +127,6 @@ public class ItemApplicationService {
             throw new BusinessException(ErrorCode.ITEM_FORBIDDEN);
         }
         return item;
-    }
-
-    private void validateCategoryExists(Long categoryId) {
-        if (categoryId == null) {
-            return;
-        }
-        if (categoryRepository.findById(categoryId).isEmpty()) {
-            throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
-        }
     }
 
     private static void applyImages(Item item, List<String> imageUrls) {

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemDetailResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemDetailResult.java
@@ -1,6 +1,7 @@
 package com.sseulang.domain.item.application.dto;
 
 import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemHashtag;
 import com.sseulang.domain.item.domain.ItemStatus;
 import com.sseulang.domain.item.domain.RentalUnit;
 import com.sseulang.domain.item.domain.TradeType;
@@ -23,6 +24,7 @@ public record ItemDetailResult(
         int viewCount,
         int wishlistCount,
         List<ItemImageResult> images,
+        List<String> hashtags,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -42,6 +44,7 @@ public record ItemDetailResult(
                 item.getViewCount(),
                 item.getWishlistCount(),
                 item.getImages().stream().map(ItemImageResult::from).toList(),
+                item.getHashtags().stream().map(ItemHashtag::getTag).toList(),
                 item.getCreatedAt(),
                 item.getUpdatedAt()
         );

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemDetailResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemDetailResult.java
@@ -1,0 +1,49 @@
+package com.sseulang.domain.item.application.dto;
+
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.RentalUnit;
+import com.sseulang.domain.item.domain.TradeType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ItemDetailResult(
+        Long id,
+        Long sellerId,
+        Long categoryId,
+        String title,
+        String description,
+        long price,
+        Long deposit,
+        RentalUnit rentalUnit,
+        TradeType tradeType,
+        ItemStatus status,
+        String region,
+        int viewCount,
+        int wishlistCount,
+        List<ItemImageResult> images,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ItemDetailResult from(Item item) {
+        return new ItemDetailResult(
+                item.getId(),
+                item.getSellerId(),
+                item.getCategoryId(),
+                item.getTitle(),
+                item.getDescription(),
+                item.getPrice(),
+                item.getDeposit(),
+                item.getRentalUnit(),
+                item.getTradeType(),
+                item.getStatus(),
+                item.getRegion(),
+                item.getViewCount(),
+                item.getWishlistCount(),
+                item.getImages().stream().map(ItemImageResult::from).toList(),
+                item.getCreatedAt(),
+                item.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemImageResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemImageResult.java
@@ -1,0 +1,9 @@
+package com.sseulang.domain.item.application.dto;
+
+import com.sseulang.domain.item.domain.ItemImage;
+
+public record ItemImageResult(String imageUrl, int sortOrder, boolean thumbnail) {
+    public static ItemImageResult from(ItemImage image) {
+        return new ItemImageResult(image.getImageUrl(), image.getSortOrder(), image.isThumbnail());
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemRegisterCommand.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemRegisterCommand.java
@@ -1,0 +1,19 @@
+package com.sseulang.domain.item.application.dto;
+
+import com.sseulang.domain.item.domain.RentalUnit;
+import com.sseulang.domain.item.domain.TradeType;
+
+import java.util.List;
+
+public record ItemRegisterCommand(
+        Long sellerId,
+        Long categoryId,
+        String title,
+        String description,
+        long price,
+        Long deposit,
+        RentalUnit rentalUnit,
+        TradeType tradeType,
+        String region,
+        List<String> imageUrls
+) { }

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemRegisterCommand.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemRegisterCommand.java
@@ -15,5 +15,6 @@ public record ItemRegisterCommand(
         RentalUnit rentalUnit,
         TradeType tradeType,
         String region,
-        List<String> imageUrls
+        List<String> imageUrls,
+        List<String> hashtags
 ) { }

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemSearchCriteria.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemSearchCriteria.java
@@ -1,0 +1,21 @@
+package com.sseulang.domain.item.application.dto;
+
+import com.sseulang.domain.item.domain.TradeType;
+
+/**
+ * Item 검색 조건. null/blank 필드는 무시.
+ *
+ * <p>키워드 q 는 LIKE 검색 (FULLTEXT 도입은 5/6 이후). 태그는 단건 매칭 — 다중 AND 는 후속 작업.</p>
+ */
+public record ItemSearchCriteria(
+        String q,
+        Long categoryId,
+        TradeType tradeType,
+        Long minPrice,
+        Long maxPrice,
+        String tag
+) {
+    public static ItemSearchCriteria empty() {
+        return new ItemSearchCriteria(null, null, null, null, null, null);
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemSearchCriteria.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemSearchCriteria.java
@@ -5,7 +5,8 @@ import com.sseulang.domain.item.domain.TradeType;
 /**
  * Item 검색 조건. null/blank 필드는 무시.
  *
- * <p>키워드 q 는 LIKE 검색 (FULLTEXT 도입은 5/6 이후). 태그는 단건 매칭 — 다중 AND 는 후속 작업.</p>
+ * <p>키워드 q 는 현재 LIKE 검색 — FULLTEXT(MATCH AGAINST + ngram) 마이그는 issue #10 트래킹.
+ * 태그는 단건 매칭 — 다중 AND 는 후속 작업.</p>
  */
 public record ItemSearchCriteria(
         String q,

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemSummaryResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemSummaryResult.java
@@ -1,0 +1,36 @@
+package com.sseulang.domain.item.application.dto;
+
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.TradeType;
+
+import java.time.LocalDateTime;
+
+/**
+ * 목록용 요약. 썸네일은 N+1 회피를 위해 본 PR 에선 미포함 — 검색·필터 PR 에서 fetch 최적화 후 추가.
+ */
+public record ItemSummaryResult(
+        Long id,
+        Long sellerId,
+        Long categoryId,
+        String title,
+        long price,
+        TradeType tradeType,
+        ItemStatus status,
+        String region,
+        LocalDateTime createdAt
+) {
+    public static ItemSummaryResult from(Item item) {
+        return new ItemSummaryResult(
+                item.getId(),
+                item.getSellerId(),
+                item.getCategoryId(),
+                item.getTitle(),
+                item.getPrice(),
+                item.getTradeType(),
+                item.getStatus(),
+                item.getRegion(),
+                item.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemUpdateCommand.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemUpdateCommand.java
@@ -1,0 +1,20 @@
+package com.sseulang.domain.item.application.dto;
+
+import com.sseulang.domain.item.domain.RentalUnit;
+
+import java.util.List;
+
+/**
+ * 물품 수정 커맨드. {@code imageUrls} 가 {@code null} 이면 이미지 변경 없음 — non-null 이면 전체 교체.
+ * {@code categoryId} 동일 정책.
+ */
+public record ItemUpdateCommand(
+        Long categoryId,
+        String title,
+        String description,
+        long price,
+        Long deposit,
+        RentalUnit rentalUnit,
+        String region,
+        List<String> imageUrls
+) { }

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemUpdateCommand.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemUpdateCommand.java
@@ -5,8 +5,8 @@ import com.sseulang.domain.item.domain.RentalUnit;
 import java.util.List;
 
 /**
- * 물품 수정 커맨드. {@code imageUrls} 가 {@code null} 이면 이미지 변경 없음 — non-null 이면 전체 교체.
- * {@code categoryId} 동일 정책.
+ * 물품 수정 커맨드. 컬렉션 필드({@code imageUrls}, {@code hashtags})는 {@code null} 이면 변경 없음 —
+ * non-null 이면 전체 교체. {@code categoryId} 동일 정책.
  */
 public record ItemUpdateCommand(
         Long categoryId,
@@ -16,5 +16,6 @@ public record ItemUpdateCommand(
         Long deposit,
         RentalUnit rentalUnit,
         String region,
-        List<String> imageUrls
+        List<String> imageUrls,
+        List<String> hashtags
 ) { }

--- a/src/main/java/com/sseulang/domain/item/domain/Item.java
+++ b/src/main/java/com/sseulang/domain/item/domain/Item.java
@@ -20,7 +20,9 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Item Aggregate Root. V1 스키마 {@code items} 매핑.
@@ -89,6 +91,9 @@ public class Item extends BaseEntity {
     @OrderBy("sortOrder ASC")
     private final List<ItemImage> images = new ArrayList<>();
 
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<ItemHashtag> hashtags = new ArrayList<>();
+
     public static Item create(
             Long sellerId,
             Long categoryId,
@@ -144,6 +149,31 @@ public class Item extends BaseEntity {
     /** 외부에 노출되는 이미지 컬렉션은 immutable. 변경은 {@link #addImage} / {@link #clearImages}. */
     public List<ItemImage> getImages() {
         return Collections.unmodifiableList(images);
+    }
+
+    /**
+     * 해시태그 추가. 동일 태그(대소문자/공백 정규화 후)는 중복으로 간주해 무시 — DB UNIQUE(item_id, tag)
+     * 와 정합. 태그 자체 검증(blank, 길이)은 {@link ItemHashtag} 생성자에서 IAE.
+     */
+    public void addHashtag(String tag) {
+        ItemHashtag candidate = new ItemHashtag(this, tag);
+        Set<String> existing = new HashSet<>();
+        for (ItemHashtag h : hashtags) {
+            existing.add(h.getTag());
+        }
+        if (existing.contains(candidate.getTag())) {
+            return;
+        }
+        hashtags.add(candidate);
+    }
+
+    public void clearHashtags() {
+        hashtags.clear();
+    }
+
+    /** 외부에 노출되는 해시태그 컬렉션은 immutable. */
+    public List<ItemHashtag> getHashtags() {
+        return Collections.unmodifiableList(hashtags);
     }
 
     public void updateInfo(

--- a/src/main/java/com/sseulang/domain/item/domain/Item.java
+++ b/src/main/java/com/sseulang/domain/item/domain/Item.java
@@ -185,7 +185,7 @@ public class Item extends BaseEntity {
             String region
     ) {
         if (!status.isEditable()) {
-            throw new IllegalStateException("현재 상태(" + status + ")에서는 수정할 수 없습니다");
+            throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
         }
         validateTitle(title);
         validateDescription(description);
@@ -209,7 +209,7 @@ public class Item extends BaseEntity {
 
     public void markAsHidden() {
         if (status == ItemStatus.삭제) {
-            throw new IllegalStateException("삭제된 물품은 비공개로 전환할 수 없습니다");
+            throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
         }
         this.status = ItemStatus.비공개;
     }
@@ -220,7 +220,7 @@ public class Item extends BaseEntity {
 
     public void restore() {
         if (status != ItemStatus.비공개) {
-            throw new IllegalStateException("비공개 상태에서만 복구할 수 있습니다");
+            throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
         }
         this.status = ItemStatus.판매중;
     }

--- a/src/main/java/com/sseulang/domain/item/domain/Item.java
+++ b/src/main/java/com/sseulang/domain/item/domain/Item.java
@@ -1,0 +1,244 @@
+package com.sseulang.domain.item.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Item Aggregate Root. V1 스키마 {@code items} 매핑.
+ *
+ * <p>자식 Entity {@link ItemImage} 는 본 Root 메서드를 통해서만 추가/제거. 외부에서 컬렉션
+ * 직접 조작 금지({@link #getImages()} 는 unmodifiable view).</p>
+ *
+ * <p>거래 진행 상태(예약/거래완료) 전이는 transaction 도메인이 트리거하며, 본 Aggregate 는
+ * 판매자 본인이 직접 호출 가능한 {@link #updateInfo}, {@link #markAsHidden}, {@link #markAsDeleted},
+ * {@link #restore} 만 노출한다.</p>
+ */
+@Entity
+@Table(name = "items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Item extends BaseEntity {
+
+    private static final int MAX_IMAGES = 5;
+    private static final int TITLE_MAX_LENGTH = 200;
+    private static final int REGION_MAX_LENGTH = 100;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "category_id")
+    private Long categoryId;
+
+    @Column(name = "title", nullable = false, length = TITLE_MAX_LENGTH)
+    private String title;
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "price", nullable = false)
+    private long price;
+
+    @Column(name = "deposit")
+    private Long deposit;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "rental_unit", length = 20)
+    private RentalUnit rentalUnit;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trade_type", nullable = false)
+    private TradeType tradeType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ItemStatus status;
+
+    @Column(name = "region", length = REGION_MAX_LENGTH)
+    private String region;
+
+    @Column(name = "view_count", nullable = false)
+    private int viewCount;
+
+    @Column(name = "wishlist_count", nullable = false)
+    private int wishlistCount;
+
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
+    private final List<ItemImage> images = new ArrayList<>();
+
+    public static Item create(
+            Long sellerId,
+            Long categoryId,
+            String title,
+            String description,
+            long price,
+            Long deposit,
+            RentalUnit rentalUnit,
+            TradeType tradeType,
+            String region
+    ) {
+        if (sellerId == null || sellerId <= 0) {
+            throw new IllegalArgumentException("sellerId 는 양수여야 합니다");
+        }
+        if (tradeType == null) {
+            throw new IllegalArgumentException("tradeType 은 필수입니다");
+        }
+        validateTitle(title);
+        validateDescription(description);
+        if (price < 0) {
+            throw new IllegalArgumentException("price 는 0 이상이어야 합니다");
+        }
+        validateRentalFields(tradeType, deposit, rentalUnit);
+        validateRegion(region);
+
+        Item item = new Item();
+        item.sellerId = sellerId;
+        item.categoryId = categoryId;
+        item.title = title;
+        item.description = description;
+        item.price = price;
+        item.deposit = deposit;
+        item.rentalUnit = rentalUnit;
+        item.tradeType = tradeType;
+        item.region = region;
+        item.status = ItemStatus.판매중;
+        item.viewCount = 0;
+        item.wishlistCount = 0;
+        return item;
+    }
+
+    public void addImage(String imageUrl, int sortOrder, boolean thumbnail) {
+        if (images.size() >= MAX_IMAGES) {
+            throw new BusinessException(ErrorCode.ITEM_IMAGE_LIMIT_EXCEEDED);
+        }
+        images.add(new ItemImage(this, imageUrl, sortOrder, thumbnail));
+    }
+
+    public void clearImages() {
+        images.clear();
+    }
+
+    /** 외부에 노출되는 이미지 컬렉션은 immutable. 변경은 {@link #addImage} / {@link #clearImages}. */
+    public List<ItemImage> getImages() {
+        return Collections.unmodifiableList(images);
+    }
+
+    public void updateInfo(
+            String title,
+            String description,
+            long price,
+            Long deposit,
+            RentalUnit rentalUnit,
+            String region
+    ) {
+        if (!status.isEditable()) {
+            throw new IllegalStateException("현재 상태(" + status + ")에서는 수정할 수 없습니다");
+        }
+        validateTitle(title);
+        validateDescription(description);
+        if (price < 0) {
+            throw new IllegalArgumentException("price 는 0 이상이어야 합니다");
+        }
+        validateRentalFields(tradeType, deposit, rentalUnit);
+        validateRegion(region);
+
+        this.title = title;
+        this.description = description;
+        this.price = price;
+        this.deposit = deposit;
+        this.rentalUnit = rentalUnit;
+        this.region = region;
+    }
+
+    public void assignCategory(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public void markAsHidden() {
+        if (status == ItemStatus.삭제) {
+            throw new IllegalStateException("삭제된 물품은 비공개로 전환할 수 없습니다");
+        }
+        this.status = ItemStatus.비공개;
+    }
+
+    public void markAsDeleted() {
+        this.status = ItemStatus.삭제;
+    }
+
+    public void restore() {
+        if (status != ItemStatus.비공개) {
+            throw new IllegalStateException("비공개 상태에서만 복구할 수 있습니다");
+        }
+        this.status = ItemStatus.판매중;
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return userId != null && userId.equals(this.sellerId);
+    }
+
+    private static void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("title 은 비어있을 수 없습니다");
+        }
+        if (title.length() > TITLE_MAX_LENGTH) {
+            throw new IllegalArgumentException("title 은 " + TITLE_MAX_LENGTH + "자를 초과할 수 없습니다");
+        }
+    }
+
+    private static void validateDescription(String description) {
+        if (description == null || description.isBlank()) {
+            throw new IllegalArgumentException("description 은 비어있을 수 없습니다");
+        }
+    }
+
+    private static void validateRegion(String region) {
+        if (region != null && region.length() > REGION_MAX_LENGTH) {
+            throw new IllegalArgumentException("region 은 " + REGION_MAX_LENGTH + "자를 초과할 수 없습니다");
+        }
+    }
+
+    private static void validateRentalFields(TradeType tradeType, Long deposit, RentalUnit rentalUnit) {
+        if (tradeType.requiresDeposit()) {
+            if (deposit == null || deposit < 0) {
+                throw new IllegalArgumentException("대여 거래는 0 이상의 deposit 이 필수입니다");
+            }
+            if (rentalUnit == null) {
+                throw new IllegalArgumentException("대여 거래는 rentalUnit 이 필수입니다");
+            }
+        } else {
+            if (deposit != null) {
+                throw new IllegalArgumentException("대여 외 거래에는 deposit 을 지정할 수 없습니다");
+            }
+            if (rentalUnit != null) {
+                throw new IllegalArgumentException("대여 외 거래에는 rentalUnit 을 지정할 수 없습니다");
+            }
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/domain/ItemHashtag.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemHashtag.java
@@ -1,0 +1,52 @@
+package com.sseulang.domain.item.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Item 자식 엔티티. 외부 직접 생성/조작 금지 — Aggregate Root({@link Item}) 의 메서드를 통해서만.
+ *
+ * <p>{@code item_hashtags} 테이블은 {@code created_at}/{@code updated_at} 모두 없으므로 BaseEntity 상속 X.</p>
+ */
+@Entity
+@Table(name = "item_hashtags")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemHashtag {
+
+    static final int TAG_MAX_LENGTH = 50;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Column(name = "tag", nullable = false, length = TAG_MAX_LENGTH)
+    private String tag;
+
+    /** Aggregate Root 만 호출 — package-private. */
+    ItemHashtag(Item item, String tag) {
+        if (tag == null || tag.isBlank()) {
+            throw new IllegalArgumentException("tag 는 비어있을 수 없습니다");
+        }
+        String normalized = tag.strip();
+        if (normalized.length() > TAG_MAX_LENGTH) {
+            throw new IllegalArgumentException("tag 는 " + TAG_MAX_LENGTH + "자를 초과할 수 없습니다");
+        }
+        this.item = item;
+        this.tag = normalized;
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/domain/ItemImage.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemImage.java
@@ -1,0 +1,65 @@
+package com.sseulang.domain.item.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * Item 자식 엔티티. 외부 직접 생성/조작 금지 — Aggregate Root({@link Item}) 의 메서드를 통해서만.
+ *
+ * <p>{@code item_images} 테이블엔 {@code created_at} 만 있고 {@code updated_at} 이 없으므로
+ * {@link com.sseulang.global.common.BaseEntity} 상속 X.</p>
+ */
+@Entity
+@Table(name = "item_images")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(name = "is_thumbnail", nullable = false)
+    private boolean thumbnail;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** Aggregate Root 만 호출 — package-private. */
+    ItemImage(Item item, String imageUrl, int sortOrder, boolean thumbnail) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            throw new IllegalArgumentException("imageUrl 은 비어있을 수 없습니다");
+        }
+        this.item = item;
+        this.imageUrl = imageUrl;
+        this.sortOrder = sortOrder;
+        this.thumbnail = thumbnail;
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.item.domain;
 
+import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -7,14 +8,14 @@ import java.util.Optional;
 
 /**
  * Item Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
- * 검색·필터(QueryDSL) 는 별도 작업에서 추가.
+ * 검색·필터(QueryDSL) 구현은 {@code infrastructure/persistence/ItemQuerydslRepository}.
  */
 public interface ItemRepository {
 
     Optional<Item> findById(Long id);
 
-    /** 삭제 상태가 아닌 물품을 최신순으로 페이지 단위 조회. */
-    Page<Item> findVisibleLatest(Pageable pageable);
+    /** 동적 검색·필터 + 최신순 정렬. criteria 의 모든 필드가 null 이면 전체 (status != 삭제) 최신순. */
+    Page<Item> search(ItemSearchCriteria criteria, Pageable pageable);
 
     Item save(Item item);
 

--- a/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
@@ -1,0 +1,22 @@
+package com.sseulang.domain.item.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+/**
+ * Item Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
+ * 검색·필터(QueryDSL) 는 별도 작업에서 추가.
+ */
+public interface ItemRepository {
+
+    Optional<Item> findById(Long id);
+
+    /** 삭제 상태가 아닌 물품을 최신순으로 페이지 단위 조회. */
+    Page<Item> findVisibleLatest(Pageable pageable);
+
+    Item save(Item item);
+
+    void delete(Item item);
+}

--- a/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
@@ -20,4 +20,15 @@ public interface ItemRepository {
     Item save(Item item);
 
     void delete(Item item);
+
+    /**
+     * {@code wishlist_count} 원자 증가. 영향받은 행 수 반환. 레이스 가능성 있는 카운터를 동시성 안전하게.
+     */
+    int incrementWishlistCount(Long itemId);
+
+    /**
+     * {@code wishlist_count} 원자 감소. 음수가 되지 않도록 {@code AND wishlist_count > 0} 조건 강제.
+     * 영향받은 행 수 반환.
+     */
+    int decrementWishlistCount(Long itemId);
 }

--- a/src/main/java/com/sseulang/domain/item/domain/ItemStatus.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemStatus.java
@@ -1,0 +1,23 @@
+package com.sseulang.domain.item.domain;
+
+/**
+ * 물품 상태. DB ENUM('판매중','예약','거래완료','비공개','삭제') 1:1 매핑.
+ *
+ * <p>거래 관련 상태(예약, 거래완료) 전이는 {@code transaction} 도메인이 트리거 — Item 자체로는
+ * markAsHidden / markAsDeleted / restore 만 직접 노출.</p>
+ */
+public enum ItemStatus {
+    판매중,
+    예약,
+    거래완료,
+    비공개,
+    삭제;
+
+    public boolean isEditable() {
+        return this == 판매중 || this == 비공개;
+    }
+
+    public boolean isVisible() {
+        return this == 판매중 || this == 예약 || this == 거래완료;
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/domain/RentalUnit.java
+++ b/src/main/java/com/sseulang/domain/item/domain/RentalUnit.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.item.domain;
+
+/**
+ * 대여 단위. DB는 VARCHAR(20) — '시간 | 일 | 주 | 월'. {@code @Enumerated(EnumType.STRING)} 으로 그대로 저장.
+ */
+public enum RentalUnit {
+    시간,
+    일,
+    주,
+    월
+}

--- a/src/main/java/com/sseulang/domain/item/domain/TradeType.java
+++ b/src/main/java/com/sseulang/domain/item/domain/TradeType.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.item.domain;
+
+/**
+ * 거래 타입. DB ENUM('대여','판매','나눔') 과 1:1 매핑 — {@code @Enumerated(EnumType.STRING)} 으로 name 그대로 저장.
+ */
+public enum TradeType {
+    대여,
+    판매,
+    나눔;
+
+    public boolean requiresDeposit() {
+        return this == 대여;
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
@@ -1,14 +1,8 @@
 package com.sseulang.domain.item.infrastructure.persistence;
 
 import com.sseulang.domain.item.domain.Item;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 /** Spring Data JPA — {@link ItemRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
 interface ItemJpaRepository extends JpaRepository<Item, Long> {
-
-    @Query("SELECT i FROM Item i WHERE i.status <> com.sseulang.domain.item.domain.ItemStatus.삭제")
-    Page<Item> findVisibleLatest(Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
@@ -2,7 +2,18 @@ package com.sseulang.domain.item.infrastructure.persistence;
 
 import com.sseulang.domain.item.domain.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Spring Data JPA — {@link ItemRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
 interface ItemJpaRepository extends JpaRepository<Item, Long> {
+
+    @Modifying
+    @Query("UPDATE Item i SET i.wishlistCount = i.wishlistCount + 1 WHERE i.id = :id")
+    int incrementWishlistCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Item i SET i.wishlistCount = i.wishlistCount - 1 WHERE i.id = :id AND i.wishlistCount > 0")
+    int decrementWishlistCount(@Param("id") Long id);
 }

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.item.infrastructure.persistence;
+
+import com.sseulang.domain.item.domain.Item;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+/** Spring Data JPA — {@link ItemRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
+interface ItemJpaRepository extends JpaRepository<Item, Long> {
+
+    @Query("SELECT i FROM Item i WHERE i.status <> com.sseulang.domain.item.domain.ItemStatus.삭제")
+    Page<Item> findVisibleLatest(Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
@@ -1,0 +1,76 @@
+package com.sseulang.domain.item.infrastructure.persistence;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.QItem;
+import com.sseulang.domain.item.domain.QItemHashtag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Item 동적 검색 — QueryDSL BooleanBuilder. q 는 단순 LIKE (FULLTEXT 마이그레이션은 후속).
+ */
+@Repository
+public class ItemQuerydslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ItemQuerydslRepository(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    public Page<Item> search(ItemSearchCriteria criteria, Pageable pageable) {
+        QItem item = QItem.item;
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(item.status.ne(ItemStatus.삭제));
+
+        if (criteria.q() != null && !criteria.q().isBlank()) {
+            String pattern = "%" + criteria.q().strip() + "%";
+            where.and(item.title.like(pattern).or(item.description.like(pattern)));
+        }
+        if (criteria.categoryId() != null) {
+            where.and(item.categoryId.eq(criteria.categoryId()));
+        }
+        if (criteria.tradeType() != null) {
+            where.and(item.tradeType.eq(criteria.tradeType()));
+        }
+        if (criteria.minPrice() != null) {
+            where.and(item.price.goe(criteria.minPrice()));
+        }
+        if (criteria.maxPrice() != null) {
+            where.and(item.price.loe(criteria.maxPrice()));
+        }
+        if (criteria.tag() != null && !criteria.tag().isBlank()) {
+            QItemHashtag h = QItemHashtag.itemHashtag;
+            where.and(JPAExpressions
+                    .selectOne()
+                    .from(h)
+                    .where(h.item.eq(item).and(h.tag.eq(criteria.tag().strip())))
+                    .exists());
+        }
+
+        List<Item> content = queryFactory
+                .selectFrom(item)
+                .where(where)
+                .orderBy(item.createdAt.desc(), item.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(item.count())
+                .from(item)
+                .where(where)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0L : total);
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
@@ -16,7 +16,10 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 /**
- * Item 동적 검색 — QueryDSL BooleanBuilder. q 는 단순 LIKE (FULLTEXT 마이그레이션은 후속).
+ * Item 동적 검색 — QueryDSL BooleanBuilder.
+ *
+ * <p>q 검색은 현재 단순 {@code LIKE '%q%'} 로, V1 스키마의 FULLTEXT(ngram) 인덱스를 활용하지 못한다.
+ * 데이터 규모가 커지면 풀스캔 위험 — MATCH AGAINST 마이그는 별도 트래킹: <a href="https://github.com/sseullaeng/sl-server/issues/10">issue #10</a>.</p>
  */
 @Repository
 public class ItemQuerydslRepository {

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.sseulang.domain.item.infrastructure.persistence;
+
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class ItemRepositoryImpl implements ItemRepository {
+
+    private final ItemJpaRepository jpa;
+
+    public ItemRepositoryImpl(ItemJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Optional<Item> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Page<Item> findVisibleLatest(Pageable pageable) {
+        return jpa.findVisibleLatest(pageable);
+    }
+
+    @Override
+    public Item save(Item item) {
+        return jpa.save(item);
+    }
+
+    @Override
+    public void delete(Item item) {
+        jpa.delete(item);
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
@@ -39,4 +39,14 @@ public class ItemRepositoryImpl implements ItemRepository {
     public void delete(Item item) {
         jpa.delete(item);
     }
+
+    @Override
+    public int incrementWishlistCount(Long itemId) {
+        return jpa.incrementWishlistCount(itemId);
+    }
+
+    @Override
+    public int decrementWishlistCount(Long itemId) {
+        return jpa.decrementWishlistCount(itemId);
+    }
 }

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.item.infrastructure.persistence;
 
+import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
 import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.item.domain.ItemRepository;
 import org.springframework.data.domain.Page;
@@ -12,9 +13,11 @@ import java.util.Optional;
 public class ItemRepositoryImpl implements ItemRepository {
 
     private final ItemJpaRepository jpa;
+    private final ItemQuerydslRepository querydsl;
 
-    public ItemRepositoryImpl(ItemJpaRepository jpa) {
+    public ItemRepositoryImpl(ItemJpaRepository jpa, ItemQuerydslRepository querydsl) {
         this.jpa = jpa;
+        this.querydsl = querydsl;
     }
 
     @Override
@@ -23,8 +26,8 @@ public class ItemRepositoryImpl implements ItemRepository {
     }
 
     @Override
-    public Page<Item> findVisibleLatest(Pageable pageable) {
-        return jpa.findVisibleLatest(pageable);
+    public Page<Item> search(ItemSearchCriteria criteria, Pageable pageable) {
+        return querydsl.search(criteria, pageable);
     }
 
     @Override

--- a/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
@@ -1,0 +1,87 @@
+package com.sseulang.domain.item.presentation;
+
+import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.presentation.dto.ItemDetailResponse;
+import com.sseulang.domain.item.presentation.dto.ItemIdResponse;
+import com.sseulang.domain.item.presentation.dto.ItemRegisterRequest;
+import com.sseulang.domain.item.presentation.dto.ItemSummaryResponse;
+import com.sseulang.domain.item.presentation.dto.ItemUpdateRequest;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/items")
+public class ItemController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final ItemApplicationService itemService;
+
+    public ItemController(ItemApplicationService itemService) {
+        this.itemService = itemService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ItemIdResponse>> register(
+            @AuthenticationPrincipal Long sellerId,
+            @Valid @RequestBody ItemRegisterRequest request
+    ) {
+        Long id = itemService.register(request.toCommand(sellerId));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(new ItemIdResponse(id)));
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<ItemSummaryResponse>> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+
+        Page<ItemSummaryResponse> result = itemService.listLatest(pageable)
+                .map(ItemSummaryResponse::from);
+        return ApiResponse.ok(PageResponse.from(result));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<ItemDetailResponse> getOne(@PathVariable("id") Long id) {
+        return ApiResponse.ok(ItemDetailResponse.from(itemService.getById(id)));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<Void> update(
+            @AuthenticationPrincipal Long requesterId,
+            @PathVariable("id") Long id,
+            @Valid @RequestBody ItemUpdateRequest request
+    ) {
+        itemService.update(id, requesterId, request.toCommand());
+        return ApiResponse.ok();
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal Long requesterId,
+            @PathVariable("id") Long id
+    ) {
+        itemService.delete(id, requesterId);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
@@ -1,6 +1,8 @@
 package com.sseulang.domain.item.presentation;
 
 import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
+import com.sseulang.domain.item.domain.TradeType;
 import com.sseulang.domain.item.presentation.dto.ItemDetailResponse;
 import com.sseulang.domain.item.presentation.dto.ItemIdResponse;
 import com.sseulang.domain.item.presentation.dto.ItemRegisterRequest;
@@ -49,14 +51,21 @@ public class ItemController {
 
     @GetMapping
     public ApiResponse<PageResponse<ItemSummaryResponse>> list(
+            @RequestParam(name = "q", required = false) String q,
+            @RequestParam(name = "categoryId", required = false) Long categoryId,
+            @RequestParam(name = "tradeType", required = false) TradeType tradeType,
+            @RequestParam(name = "minPrice", required = false) Long minPrice,
+            @RequestParam(name = "maxPrice", required = false) Long maxPrice,
+            @RequestParam(name = "tag", required = false) String tag,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
         int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
         int safePage = Math.max(page, 0);
         Pageable pageable = PageRequest.of(safePage, safeSize);
+        ItemSearchCriteria criteria = new ItemSearchCriteria(q, categoryId, tradeType, minPrice, maxPrice, tag);
 
-        Page<ItemSummaryResponse> result = itemService.listLatest(pageable)
+        Page<ItemSummaryResponse> result = itemService.search(criteria, pageable)
                 .map(ItemSummaryResponse::from);
         return ApiResponse.ok(PageResponse.from(result));
     }

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemDetailResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemDetailResponse.java
@@ -23,6 +23,7 @@ public record ItemDetailResponse(
         int viewCount,
         int wishlistCount,
         List<ItemImageResponse> images,
+        List<String> hashtags,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -34,6 +35,7 @@ public record ItemDetailResponse(
                 r.status(), r.region(),
                 r.viewCount(), r.wishlistCount(),
                 r.images().stream().map(ItemImageResponse::from).toList(),
+                r.hashtags(),
                 r.createdAt(), r.updatedAt()
         );
     }

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemDetailResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemDetailResponse.java
@@ -1,0 +1,40 @@
+package com.sseulang.domain.item.presentation.dto;
+
+import com.sseulang.domain.item.application.dto.ItemDetailResult;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.RentalUnit;
+import com.sseulang.domain.item.domain.TradeType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ItemDetailResponse(
+        Long id,
+        Long sellerId,
+        Long categoryId,
+        String title,
+        String description,
+        long price,
+        Long deposit,
+        RentalUnit rentalUnit,
+        TradeType tradeType,
+        ItemStatus status,
+        String region,
+        int viewCount,
+        int wishlistCount,
+        List<ItemImageResponse> images,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ItemDetailResponse from(ItemDetailResult r) {
+        return new ItemDetailResponse(
+                r.id(), r.sellerId(), r.categoryId(),
+                r.title(), r.description(),
+                r.price(), r.deposit(), r.rentalUnit(), r.tradeType(),
+                r.status(), r.region(),
+                r.viewCount(), r.wishlistCount(),
+                r.images().stream().map(ItemImageResponse::from).toList(),
+                r.createdAt(), r.updatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemIdResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemIdResponse.java
@@ -1,0 +1,3 @@
+package com.sseulang.domain.item.presentation.dto;
+
+public record ItemIdResponse(Long id) { }

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemImageResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemImageResponse.java
@@ -1,0 +1,9 @@
+package com.sseulang.domain.item.presentation.dto;
+
+import com.sseulang.domain.item.application.dto.ItemImageResult;
+
+public record ItemImageResponse(String imageUrl, int sortOrder, boolean thumbnail) {
+    public static ItemImageResponse from(ItemImageResult r) {
+        return new ItemImageResponse(r.imageUrl(), r.sortOrder(), r.thumbnail());
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemRegisterRequest.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemRegisterRequest.java
@@ -19,12 +19,13 @@ public record ItemRegisterRequest(
         RentalUnit rentalUnit,
         @NotNull TradeType tradeType,
         @Size(max = 100) String region,
-        List<String> imageUrls
+        List<String> imageUrls,
+        List<String> hashtags
 ) {
     public ItemRegisterCommand toCommand(Long sellerId) {
         return new ItemRegisterCommand(
                 sellerId, categoryId, title, description,
-                price, deposit, rentalUnit, tradeType, region, imageUrls
+                price, deposit, rentalUnit, tradeType, region, imageUrls, hashtags
         );
     }
 }

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemRegisterRequest.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemRegisterRequest.java
@@ -1,0 +1,30 @@
+package com.sseulang.domain.item.presentation.dto;
+
+import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
+import com.sseulang.domain.item.domain.RentalUnit;
+import com.sseulang.domain.item.domain.TradeType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ItemRegisterRequest(
+        Long categoryId,
+        @NotBlank @Size(max = 200) String title,
+        @NotBlank String description,
+        @NotNull @PositiveOrZero Long price,
+        @PositiveOrZero Long deposit,
+        RentalUnit rentalUnit,
+        @NotNull TradeType tradeType,
+        @Size(max = 100) String region,
+        List<String> imageUrls
+) {
+    public ItemRegisterCommand toCommand(Long sellerId) {
+        return new ItemRegisterCommand(
+                sellerId, categoryId, title, description,
+                price, deposit, rentalUnit, tradeType, region, imageUrls
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemSummaryResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.sseulang.domain.item.presentation.dto;
+
+import com.sseulang.domain.item.application.dto.ItemSummaryResult;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.TradeType;
+
+import java.time.LocalDateTime;
+
+public record ItemSummaryResponse(
+        Long id,
+        Long sellerId,
+        Long categoryId,
+        String title,
+        long price,
+        TradeType tradeType,
+        ItemStatus status,
+        String region,
+        LocalDateTime createdAt
+) {
+    public static ItemSummaryResponse from(ItemSummaryResult r) {
+        return new ItemSummaryResponse(
+                r.id(), r.sellerId(), r.categoryId(),
+                r.title(), r.price(),
+                r.tradeType(), r.status(), r.region(),
+                r.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemUpdateRequest.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.sseulang.domain.item.presentation.dto;
+
+import com.sseulang.domain.item.application.dto.ItemUpdateCommand;
+import com.sseulang.domain.item.domain.RentalUnit;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ItemUpdateRequest(
+        Long categoryId,
+        @NotBlank @Size(max = 200) String title,
+        @NotBlank String description,
+        @NotNull @PositiveOrZero Long price,
+        @PositiveOrZero Long deposit,
+        RentalUnit rentalUnit,
+        @Size(max = 100) String region,
+        List<String> imageUrls
+) {
+    public ItemUpdateCommand toCommand() {
+        return new ItemUpdateCommand(
+                categoryId, title, description, price, deposit, rentalUnit, region, imageUrls
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemUpdateRequest.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemUpdateRequest.java
@@ -17,11 +17,12 @@ public record ItemUpdateRequest(
         @PositiveOrZero Long deposit,
         RentalUnit rentalUnit,
         @Size(max = 100) String region,
-        List<String> imageUrls
+        List<String> imageUrls,
+        List<String> hashtags
 ) {
     public ItemUpdateCommand toCommand() {
         return new ItemUpdateCommand(
-                categoryId, title, description, price, deposit, rentalUnit, region, imageUrls
+                categoryId, title, description, price, deposit, rentalUnit, region, imageUrls, hashtags
         );
     }
 }

--- a/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
+++ b/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
@@ -1,0 +1,55 @@
+package com.sseulang.domain.wishlist.application;
+
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemRepository;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.wishlist.domain.Wishlist;
+import com.sseulang.domain.wishlist.domain.WishlistRepository;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class WishlistApplicationService {
+
+    private final WishlistRepository wishlistRepository;
+    private final ItemRepository itemRepository;
+
+    public WishlistApplicationService(
+            WishlistRepository wishlistRepository,
+            ItemRepository itemRepository
+    ) {
+        this.wishlistRepository = wishlistRepository;
+        this.itemRepository = itemRepository;
+    }
+
+    /**
+     * 찜 추가. 이미 있으면 멱등하게 무시. 삭제된 물품은 거부.
+     * UNIQUE(user_id, item_id) race 는 catch 후 무시.
+     */
+    @Transactional
+    public void add(Long userId, Long itemId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        if (item.getStatus() == ItemStatus.삭제) {
+            throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
+        }
+        if (wishlistRepository.existsByUserIdAndItemId(userId, itemId)) {
+            return;
+        }
+        try {
+            wishlistRepository.save(Wishlist.create(userId, itemId));
+        } catch (DataIntegrityViolationException race) {
+            // UNIQUE 충돌 race — 동일 userId+itemId 가 동시에 박힌 경우. 후속 호출도 결과 동일하므로 무시.
+        }
+    }
+
+    /** 멱등 삭제. 없는 항목은 그냥 통과. */
+    @Transactional
+    public void remove(Long userId, Long itemId) {
+        wishlistRepository.deleteByUserIdAndItemId(userId, itemId);
+    }
+}

--- a/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
+++ b/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
@@ -1,12 +1,9 @@
 package com.sseulang.domain.wishlist.application;
 
-import com.sseulang.domain.item.domain.Item;
-import com.sseulang.domain.item.domain.ItemRepository;
-import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.domain.wishlist.domain.Wishlist;
 import com.sseulang.domain.wishlist.domain.WishlistRepository;
-import com.sseulang.global.exception.BusinessException;
-import com.sseulang.global.exception.ErrorCode;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,41 +12,59 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class WishlistApplicationService {
 
+    /**
+     * V1 스키마({@code uk_wishlists_user_item}) 의 UNIQUE 제약 이름. 동시 add race 만 멱등 처리하고
+     * 그 외 무결성 위반(FK / 다른 제약)은 그대로 던져 시스템 에러로 노출한다 — Codex 게이트 2 보정.
+     */
+    private static final String UNIQUE_USER_ITEM = "uk_wishlists_user_item";
+
     private final WishlistRepository wishlistRepository;
-    private final ItemRepository itemRepository;
+    private final ItemApplicationService itemApplicationService;
 
     public WishlistApplicationService(
             WishlistRepository wishlistRepository,
-            ItemRepository itemRepository
+            ItemApplicationService itemApplicationService
     ) {
         this.wishlistRepository = wishlistRepository;
-        this.itemRepository = itemRepository;
+        this.itemApplicationService = itemApplicationService;
     }
 
     /**
-     * 찜 추가. 이미 있으면 멱등하게 무시. 삭제된 물품은 거부.
-     * UNIQUE(user_id, item_id) race 는 catch 후 무시.
+     * 찜 추가. Item 존재 검증은 {@link ItemApplicationService#requireActiveItem} 위임 (CLAUDE.md
+     * §3.3 — 다른 도메인 Repository 직접 호출 금지). 이미 있으면 멱등하게 무시.
+     * UNIQUE(user_id, item_id) race 는 catch 후 무시 — 그 외 무결성 위반은 재던지기.
      */
     @Transactional
     public void add(Long userId, Long itemId) {
-        Item item = itemRepository.findById(itemId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
-        if (item.getStatus() == ItemStatus.삭제) {
-            throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
-        }
+        itemApplicationService.requireActiveItem(itemId);
         if (wishlistRepository.existsByUserIdAndItemId(userId, itemId)) {
             return;
         }
         try {
             wishlistRepository.save(Wishlist.create(userId, itemId));
-        } catch (DataIntegrityViolationException race) {
-            // UNIQUE 충돌 race — 동일 userId+itemId 가 동시에 박힌 경우. 후속 호출도 결과 동일하므로 무시.
+            itemApplicationService.incrementWishlistCount(itemId);
+        } catch (DataIntegrityViolationException violation) {
+            if (isUniqueUserItemConflict(violation)) {
+                return;
+            }
+            throw violation;
         }
     }
 
-    /** 멱등 삭제. 없는 항목은 그냥 통과. */
+    /**
+     * 멱등 삭제. 실제 삭제된 row 가 1 건일 때만 wishlist_count 감소 — 동시 remove 시 underflow 방지.
+     */
     @Transactional
     public void remove(Long userId, Long itemId) {
-        wishlistRepository.deleteByUserIdAndItemId(userId, itemId);
+        int deleted = wishlistRepository.deleteByUserIdAndItemId(userId, itemId);
+        if (deleted > 0) {
+            itemApplicationService.decrementWishlistCount(itemId);
+        }
+    }
+
+    private static boolean isUniqueUserItemConflict(DataIntegrityViolationException violation) {
+        Throwable cause = violation.getCause();
+        return cause instanceof ConstraintViolationException cve
+                && UNIQUE_USER_ITEM.equalsIgnoreCase(cve.getConstraintName());
     }
 }

--- a/src/main/java/com/sseulang/domain/wishlist/domain/Wishlist.java
+++ b/src/main/java/com/sseulang/domain/wishlist/domain/Wishlist.java
@@ -1,0 +1,55 @@
+package com.sseulang.domain.wishlist.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * Wishlist Aggregate Root. {@code wishlists} 테이블 — UNIQUE(user_id, item_id).
+ * BaseEntity 미사용 (updated_at 컬럼 없음).
+ */
+@Entity
+@Table(name = "wishlists")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Wishlist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static Wishlist create(Long userId, Long itemId) {
+        if (userId == null || userId <= 0) {
+            throw new IllegalArgumentException("userId 는 양수여야 합니다");
+        }
+        if (itemId == null || itemId <= 0) {
+            throw new IllegalArgumentException("itemId 는 양수여야 합니다");
+        }
+        Wishlist w = new Wishlist();
+        w.userId = userId;
+        w.itemId = itemId;
+        return w;
+    }
+}

--- a/src/main/java/com/sseulang/domain/wishlist/domain/WishlistRepository.java
+++ b/src/main/java/com/sseulang/domain/wishlist/domain/WishlistRepository.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.wishlist.domain;
+
+public interface WishlistRepository {
+
+    boolean existsByUserIdAndItemId(Long userId, Long itemId);
+
+    Wishlist save(Wishlist wishlist);
+
+    /** 멱등 삭제. 존재하지 않아도 예외 없이 0 건 처리. */
+    void deleteByUserIdAndItemId(Long userId, Long itemId);
+}

--- a/src/main/java/com/sseulang/domain/wishlist/domain/WishlistRepository.java
+++ b/src/main/java/com/sseulang/domain/wishlist/domain/WishlistRepository.java
@@ -6,6 +6,9 @@ public interface WishlistRepository {
 
     Wishlist save(Wishlist wishlist);
 
-    /** 멱등 삭제. 존재하지 않아도 예외 없이 0 건 처리. */
-    void deleteByUserIdAndItemId(Long userId, Long itemId);
+    /**
+     * 멱등 삭제. 존재하지 않아도 예외 없이 0 건 처리. 영향받은 행 수를 반환 — 호출자가 후속 액션
+     * (예: items.wishlist_count 감소)을 결정할 때 사용.
+     */
+    int deleteByUserIdAndItemId(Long userId, Long itemId);
 }

--- a/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistJpaRepository.java
@@ -1,0 +1,16 @@
+package com.sseulang.domain.wishlist.infrastructure.persistence;
+
+import com.sseulang.domain.wishlist.domain.Wishlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface WishlistJpaRepository extends JpaRepository<Wishlist, Long> {
+
+    boolean existsByUserIdAndItemId(Long userId, Long itemId);
+
+    @Modifying
+    @Query("DELETE FROM Wishlist w WHERE w.userId = :userId AND w.itemId = :itemId")
+    int deleteByUserAndItem(@Param("userId") Long userId, @Param("itemId") Long itemId);
+}

--- a/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistRepositoryImpl.java
@@ -24,7 +24,7 @@ public class WishlistRepositoryImpl implements WishlistRepository {
     }
 
     @Override
-    public void deleteByUserIdAndItemId(Long userId, Long itemId) {
-        jpa.deleteByUserAndItem(userId, itemId);
+    public int deleteByUserIdAndItemId(Long userId, Long itemId) {
+        return jpa.deleteByUserAndItem(userId, itemId);
     }
 }

--- a/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.sseulang.domain.wishlist.infrastructure.persistence;
+
+import com.sseulang.domain.wishlist.domain.Wishlist;
+import com.sseulang.domain.wishlist.domain.WishlistRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class WishlistRepositoryImpl implements WishlistRepository {
+
+    private final WishlistJpaRepository jpa;
+
+    public WishlistRepositoryImpl(WishlistJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public boolean existsByUserIdAndItemId(Long userId, Long itemId) {
+        return jpa.existsByUserIdAndItemId(userId, itemId);
+    }
+
+    @Override
+    public Wishlist save(Wishlist wishlist) {
+        return jpa.save(wishlist);
+    }
+
+    @Override
+    public void deleteByUserIdAndItemId(Long userId, Long itemId) {
+        jpa.deleteByUserAndItem(userId, itemId);
+    }
+}

--- a/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
+++ b/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
@@ -1,0 +1,43 @@
+package com.sseulang.domain.wishlist.presentation;
+
+import com.sseulang.domain.wishlist.application.WishlistApplicationService;
+import com.sseulang.global.common.ApiResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Wishlist 진입점은 Item 자원 하위로 둔다 (가이드 §6.1):
+ * {@code POST /api/v1/items/{id}/wishlist}, {@code DELETE /api/v1/items/{id}/wishlist}.
+ */
+@RestController
+@RequestMapping("/api/v1/items/{itemId}/wishlist")
+public class WishlistController {
+
+    private final WishlistApplicationService wishlistService;
+
+    public WishlistController(WishlistApplicationService wishlistService) {
+        this.wishlistService = wishlistService;
+    }
+
+    @PostMapping
+    public ApiResponse<Void> add(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable("itemId") Long itemId
+    ) {
+        wishlistService.add(userId, itemId);
+        return ApiResponse.ok();
+    }
+
+    @DeleteMapping
+    public ApiResponse<Void> remove(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable("itemId") Long itemId
+    ) {
+        wishlistService.remove(userId, itemId);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/global/config/QuerydslConfig.java
+++ b/src/main/java/com/sseulang/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.sseulang.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/sseulang/global/config/SecurityConfig.java
+++ b/src/main/java/com/sseulang/global/config/SecurityConfig.java
@@ -88,6 +88,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AUTH_ENDPOINTS).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/items/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/categories/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
     USER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     USER_BLOCKED(HttpStatus.FORBIDDEN, "차단된 계정입니다."),
 
+    // 카테고리
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
+
     // 물품
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "물품을 찾을 수 없습니다."),
     ITEM_FORBIDDEN(HttpStatus.FORBIDDEN, "물품에 대한 권한이 없습니다."),

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "물품을 찾을 수 없습니다."),
     ITEM_FORBIDDEN(HttpStatus.FORBIDDEN, "물품에 대한 권한이 없습니다."),
     ITEM_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지는 최대 5장까지 등록할 수 있습니다."),
+    ITEM_INVALID_STATE(HttpStatus.BAD_REQUEST, "현재 상태에서 수행할 수 없는 동작입니다."),
 
     // 거래
     TRANSACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),

--- a/src/main/java/com/sseulang/global/infra/s3/S3Config.java
+++ b/src/main/java/com/sseulang/global/infra/s3/S3Config.java
@@ -1,0 +1,27 @@
+package com.sseulang.global.infra.s3;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    public S3Presigner s3Presigner(S3Properties props) {
+        S3Presigner.Builder builder = S3Presigner.builder()
+                .region(Region.of(props.region()));
+
+        if (props.accessKey() != null && !props.accessKey().isBlank()
+                && props.secretKey() != null && !props.secretKey().isBlank()) {
+            builder.credentialsProvider(StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(props.accessKey(), props.secretKey())
+            ));
+        }
+        // accessKey 비어있으면 DefaultCredentialsProvider 폴백 (env / IAM role / shared profile)
+        return builder.build();
+    }
+}

--- a/src/main/java/com/sseulang/global/infra/s3/S3Properties.java
+++ b/src/main/java/com/sseulang/global/infra/s3/S3Properties.java
@@ -1,0 +1,17 @@
+package com.sseulang.global.infra.s3;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * AWS S3 자격증명 + 버킷 설정. 로컬 개발 환경에서는 accessKey/secretKey 가 빈 값일 수 있음 —
+ * 그 경우 {@link S3Config} 가 DefaultCredentialsProvider 로 폴백.
+ */
+@ConfigurationProperties(prefix = "app.aws")
+public record S3Properties(
+        String accessKey,
+        String secretKey,
+        String region,
+        Bucket s3
+) {
+    public record Bucket(String bucket, long presignedUrlExpireSeconds) { }
+}

--- a/src/test/java/com/sseulang/domain/category/application/CategoryApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/category/application/CategoryApplicationServiceTest.java
@@ -1,0 +1,103 @@
+package com.sseulang.domain.category.application;
+
+import com.sseulang.domain.category.application.dto.CategoryNodeResult;
+import com.sseulang.domain.category.application.dto.CategoryResult;
+import com.sseulang.domain.category.domain.Category;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CategoryApplicationServiceTest {
+
+    private InMemoryFakeCategoryRepository repo;
+    private CategoryApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        repo = new InMemoryFakeCategoryRepository();
+        service = new CategoryApplicationService(repo);
+    }
+
+    @Test
+    @DisplayName("getActiveTree 빈 저장소_빈 리스트")
+    void getActiveTree_빈_저장소_빈_리스트() {
+        assertThat(service.getActiveTree()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getActiveTree 루트만_자식 없음")
+    void getActiveTree_루트만() {
+        Category digital = repo.insert(Category.createRoot("디지털/가전", 1));
+        Category furniture = repo.insert(Category.createRoot("가구/인테리어", 2));
+
+        List<CategoryNodeResult> tree = service.getActiveTree();
+
+        assertThat(tree).hasSize(2);
+        assertThat(tree.get(0).name()).isEqualTo("디지털/가전");
+        assertThat(tree.get(0).children()).isEmpty();
+        assertThat(tree.get(1).name()).isEqualTo("가구/인테리어");
+        assertThat(tree.get(0).id()).isEqualTo(digital.getId());
+        assertThat(tree.get(1).id()).isEqualTo(furniture.getId());
+    }
+
+    @Test
+    @DisplayName("getActiveTree 루트+2차_자식이 sortOrder 순으로 묶임")
+    void getActiveTree_2단_트리() {
+        Category digital = repo.insert(Category.createRoot("디지털/가전", 1));
+        repo.insert(Category.createChild(digital.getId(), "노트북", 3));
+        repo.insert(Category.createChild(digital.getId(), "스마트폰", 1));
+        repo.insert(Category.createChild(digital.getId(), "태블릿/PC", 2));
+
+        List<CategoryNodeResult> tree = service.getActiveTree();
+
+        assertThat(tree).hasSize(1);
+        CategoryNodeResult root = tree.get(0);
+        assertThat(root.children())
+                .extracting(CategoryNodeResult::name)
+                .containsExactly("스마트폰", "태블릿/PC", "노트북");
+    }
+
+    @Test
+    @DisplayName("getActiveTree 루트끼리도 sortOrder 순")
+    void getActiveTree_루트_정렬() {
+        repo.insert(Category.createRoot("기타", 99));
+        repo.insert(Category.createRoot("디지털/가전", 1));
+        repo.insert(Category.createRoot("가구/인테리어", 2));
+
+        List<CategoryNodeResult> tree = service.getActiveTree();
+
+        assertThat(tree)
+                .extracting(CategoryNodeResult::name)
+                .containsExactly("디지털/가전", "가구/인테리어", "기타");
+    }
+
+    @Test
+    @DisplayName("getById 정상")
+    void getById_정상() {
+        Category root = repo.insert(Category.createRoot("디지털/가전", 1));
+        Category child = repo.insert(Category.createChild(root.getId(), "스마트폰", 1));
+
+        CategoryResult r = service.getById(child.getId());
+
+        assertThat(r.id()).isEqualTo(child.getId());
+        assertThat(r.parentId()).isEqualTo(root.getId());
+        assertThat(r.name()).isEqualTo("스마트폰");
+        assertThat(r.sortOrder()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("getById 없는 id_CATEGORY_NOT_FOUND")
+    void getById_없는_id() {
+        assertThatThrownBy(() -> service.getById(9999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CATEGORY_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/sseulang/domain/category/application/InMemoryFakeCategoryRepository.java
+++ b/src/test/java/com/sseulang/domain/category/application/InMemoryFakeCategoryRepository.java
@@ -1,0 +1,48 @@
+package com.sseulang.domain.category.application;
+
+import com.sseulang.domain.category.domain.Category;
+import com.sseulang.domain.category.domain.CategoryRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 테스트용 인메모리 fake. {@code findAllActiveSorted} 가 prod 와 동일한 정렬을 흉내 내야
+ * ApplicationService 의 1-pass 트리 조립이 정상 동작한다 — parent null 먼저, parentId asc, sortOrder asc.
+ */
+public class InMemoryFakeCategoryRepository implements CategoryRepository {
+
+    private final Map<Long, Category> store = new HashMap<>();
+    private long sequence = 0;
+
+    public Category insert(Category c) {
+        long id = ++sequence;
+        ReflectionTestUtils.setField(c, "id", id);
+        store.put(id, c);
+        return c;
+    }
+
+    @Override
+    public Optional<Category> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public List<Category> findAllActiveSorted() {
+        List<Category> active = new ArrayList<>();
+        for (Category c : store.values()) {
+            if (c.isActive()) active.add(c);
+        }
+        active.sort(Comparator
+                .comparing((Category c) -> c.getParentId() == null ? 0 : 1)
+                .thenComparing(c -> c.getParentId() == null ? Long.MIN_VALUE : c.getParentId())
+                .thenComparingInt(Category::getSortOrder)
+                .thenComparing(Category::getId));
+        return active;
+    }
+}

--- a/src/test/java/com/sseulang/domain/category/domain/CategoryTest.java
+++ b/src/test/java/com/sseulang/domain/category/domain/CategoryTest.java
@@ -1,0 +1,74 @@
+package com.sseulang.domain.category.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CategoryTest {
+
+    @Test
+    @DisplayName("createRoot 정상_parentId null 이고 active=true")
+    void createRoot_정상() {
+        Category c = Category.createRoot("디지털/가전", 1);
+
+        assertThat(c.getParentId()).isNull();
+        assertThat(c.getName()).isEqualTo("디지털/가전");
+        assertThat(c.getSortOrder()).isEqualTo(1);
+        assertThat(c.isActive()).isTrue();
+        assertThat(c.isRoot()).isTrue();
+    }
+
+    @Test
+    @DisplayName("createChild 정상_parentId 가 박힘")
+    void createChild_정상() {
+        Category c = Category.createChild(7L, "스마트폰", 1);
+
+        assertThat(c.getParentId()).isEqualTo(7L);
+        assertThat(c.getName()).isEqualTo("스마트폰");
+        assertThat(c.isRoot()).isFalse();
+    }
+
+    @Test
+    @DisplayName("createRoot 빈 name_거부")
+    void createRoot_빈_name_거부() {
+        assertThatThrownBy(() -> Category.createRoot("", 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Category.createRoot(null, 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Category.createRoot("   ", 1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("createRoot name 50자 초과_거부")
+    void createRoot_name_길이초과_거부() {
+        String tooLong = "가".repeat(51);
+        assertThatThrownBy(() -> Category.createRoot(tooLong, 1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("createRoot 음수 sortOrder_거부")
+    void createRoot_음수_sortOrder_거부() {
+        assertThatThrownBy(() -> Category.createRoot("name", -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("createChild null parentId_거부")
+    void createChild_null_parentId_거부() {
+        assertThatThrownBy(() -> Category.createChild(null, "스마트폰", 1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("createChild 0 이하 parentId_거부")
+    void createChild_비양수_parentId_거부() {
+        assertThatThrownBy(() -> Category.createChild(0L, "name", 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Category.createChild(-1L, "name", 1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/sseulang/domain/file/application/FakePresignedUrlGenerator.java
+++ b/src/test/java/com/sseulang/domain/file/application/FakePresignedUrlGenerator.java
@@ -1,0 +1,17 @@
+package com.sseulang.domain.file.application;
+
+import com.sseulang.domain.file.domain.PresignedUrlGenerator;
+import com.sseulang.domain.file.domain.PresignedUrlResult;
+
+import java.time.Duration;
+
+public class FakePresignedUrlGenerator implements PresignedUrlGenerator {
+
+    @Override
+    public PresignedUrlResult generate(String key, String contentType, Duration expiresIn) {
+        String url = "https://fake.s3/" + key
+                + "?ct=" + contentType
+                + "&exp=" + expiresIn.toSeconds();
+        return new PresignedUrlResult(url, key);
+    }
+}

--- a/src/test/java/com/sseulang/domain/file/application/FileApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/file/application/FileApplicationServiceTest.java
@@ -129,6 +129,35 @@ class FileApplicationServiceTest {
                 .isInstanceOf(BusinessException.class);
     }
 
+    @Test
+    @DisplayName("issueForUser PROFILE/ITEM 만 허용")
+    void issueForUser_화이트리스트() {
+        assertThat(service.issueForUser(FilePurpose.PROFILE, OWNER, List.of(jpeg()))).hasSize(1);
+        assertThat(service.issueForUser(FilePurpose.ITEM, OWNER, List.of(jpeg()))).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("issueForUser NOTICE/BANNER/MESSAGE_FORBIDDEN")
+    void issueForUser_관리자_도메인_거부() {
+        assertThatThrownBy(() -> service.issueForUser(FilePurpose.NOTICE, OWNER, List.of(jpeg())))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.FORBIDDEN);
+        assertThatThrownBy(() -> service.issueForUser(FilePurpose.BANNER, OWNER, List.of(jpeg())))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.FORBIDDEN);
+        assertThatThrownBy(() -> service.issueForUser(FilePurpose.MESSAGE, OWNER, List.of(jpeg())))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("issueForUser null purpose_INVALID_REQUEST")
+    void issueForUser_null() {
+        assertThatThrownBy(() -> service.issueForUser(null, OWNER, List.of(jpeg())))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REQUEST);
+    }
+
     private static PresignRequestItem jpeg() {
         return new PresignRequestItem("image/jpeg", 1024L);
     }

--- a/src/test/java/com/sseulang/domain/file/application/FileApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/file/application/FileApplicationServiceTest.java
@@ -1,0 +1,135 @@
+package com.sseulang.domain.file.application;
+
+import com.sseulang.domain.file.application.dto.PresignRequestItem;
+import com.sseulang.domain.file.application.dto.PresignResult;
+import com.sseulang.domain.file.domain.FilePurpose;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileApplicationServiceTest {
+
+    private static final Long OWNER = 100L;
+
+    private FileApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new FileApplicationService(new FakePresignedUrlGenerator());
+    }
+
+    @Test
+    @DisplayName("issue 정상_key 패턴 = {folder}/{ownerId}/{uuid}.{ext}")
+    void issue_정상() {
+        List<PresignResult> results = service.issue(FilePurpose.ITEM, OWNER, List.of(
+                new PresignRequestItem("image/jpeg", 1024L),
+                new PresignRequestItem("image/png", 2048L)
+        ));
+
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).key()).matches("items/100/[0-9a-f-]+\\.jpg");
+        assertThat(results.get(1).key()).matches("items/100/[0-9a-f-]+\\.png");
+        assertThat(results.get(0).presignedUrl()).contains("ct=image/jpeg");
+        assertThat(results.get(0).presignedUrl()).contains("exp=300");
+    }
+
+    @Test
+    @DisplayName("issue purpose 별 폴더 매핑")
+    void issue_폴더() {
+        assertThat(service.issue(FilePurpose.PROFILE, OWNER, List.of(jpeg())).get(0).key())
+                .startsWith("profiles/100/");
+        assertThat(service.issue(FilePurpose.MESSAGE, OWNER, List.of(jpeg())).get(0).key())
+                .startsWith("messages/100/");
+        assertThat(service.issue(FilePurpose.NOTICE, OWNER, List.of(jpeg())).get(0).key())
+                .startsWith("notices/100/");
+        assertThat(service.issue(FilePurpose.BANNER, OWNER, List.of(jpeg())).get(0).key())
+                .startsWith("banners/100/");
+    }
+
+    @Test
+    @DisplayName("issue contentType image/* 외_거부")
+    void issue_비이미지_거부() {
+        assertThatThrownBy(() -> service.issue(FilePurpose.ITEM, OWNER, List.of(
+                new PresignRequestItem("application/pdf", 1024L)
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FILE_VALIDATION_FAILED);
+    }
+
+    @Test
+    @DisplayName("issue 5MB 초과_거부")
+    void issue_5MB_초과_거부() {
+        assertThatThrownBy(() -> service.issue(FilePurpose.ITEM, OWNER, List.of(
+                new PresignRequestItem("image/jpeg", 5L * 1024 * 1024 + 1)
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FILE_VALIDATION_FAILED);
+    }
+
+    @Test
+    @DisplayName("issue 5MB 정확히는 허용")
+    void issue_5MB_정확_허용() {
+        List<PresignResult> r = service.issue(FilePurpose.ITEM, OWNER, List.of(
+                new PresignRequestItem("image/jpeg", 5L * 1024 * 1024)
+        ));
+        assertThat(r).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("issue 0 또는 음수 size_거부")
+    void issue_size_비양수_거부() {
+        assertThatThrownBy(() -> service.issue(FilePurpose.ITEM, OWNER, List.of(
+                new PresignRequestItem("image/jpeg", 0L)
+        ))).isInstanceOf(BusinessException.class);
+
+        assertThatThrownBy(() -> service.issue(FilePurpose.ITEM, OWNER, List.of(
+                new PresignRequestItem("image/jpeg", -1L)
+        ))).isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("issue 빈 파일 리스트_INVALID_REQUEST")
+    void issue_빈_리스트() {
+        assertThatThrownBy(() -> service.issue(FilePurpose.ITEM, OWNER, List.of()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
+    @DisplayName("issue 파일 11개_FILE_VALIDATION_FAILED")
+    void issue_파일초과() {
+        List<PresignRequestItem> many = new ArrayList<>();
+        for (int i = 0; i < 11; i++) many.add(jpeg());
+
+        assertThatThrownBy(() -> service.issue(FilePurpose.ITEM, OWNER, many))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FILE_VALIDATION_FAILED);
+    }
+
+    @Test
+    @DisplayName("issue null purpose / ownerId_INVALID_REQUEST")
+    void issue_null_파라미터() {
+        assertThatThrownBy(() -> service.issue(null, OWNER, List.of(jpeg())))
+                .isInstanceOf(BusinessException.class);
+        assertThatThrownBy(() -> service.issue(FilePurpose.ITEM, null, List.of(jpeg())))
+                .isInstanceOf(BusinessException.class);
+        assertThatThrownBy(() -> service.issue(FilePurpose.ITEM, 0L, List.of(jpeg())))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    private static PresignRequestItem jpeg() {
+        return new PresignRequestItem("image/jpeg", 1024L);
+    }
+}

--- a/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
+++ b/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
@@ -85,4 +85,20 @@ public class InMemoryFakeItemRepository implements ItemRepository {
     public void delete(Item item) {
         store.remove(item.getId());
     }
+
+    @Override
+    public int incrementWishlistCount(Long itemId) {
+        Item item = store.get(itemId);
+        if (item == null) return 0;
+        ReflectionTestUtils.setField(item, "wishlistCount", item.getWishlistCount() + 1);
+        return 1;
+    }
+
+    @Override
+    public int decrementWishlistCount(Long itemId) {
+        Item item = store.get(itemId);
+        if (item == null || item.getWishlistCount() <= 0) return 0;
+        ReflectionTestUtils.setField(item, "wishlistCount", item.getWishlistCount() - 1);
+        return 1;
+    }
 }

--- a/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
+++ b/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
@@ -1,0 +1,53 @@
+package com.sseulang.domain.item.application;
+
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemRepository;
+import com.sseulang.domain.item.domain.ItemStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** 테스트용 인메모리 fake. id 자동 부여 + status != 삭제 인 것만 반환. */
+public class InMemoryFakeItemRepository implements ItemRepository {
+
+    private final Map<Long, Item> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public Optional<Item> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Page<Item> findVisibleLatest(Pageable pageable) {
+        List<Item> visible = store.values().stream()
+                .filter(i -> i.getStatus() != ItemStatus.삭제)
+                .sorted(Comparator.comparingLong(Item::getId).reversed())
+                .toList();
+        int start = Math.min((int) pageable.getOffset(), visible.size());
+        int end = Math.min(start + pageable.getPageSize(), visible.size());
+        return new PageImpl<>(visible.subList(start, end), pageable, visible.size());
+    }
+
+    @Override
+    public Item save(Item item) {
+        if (item.getId() == null) {
+            long id = ++sequence;
+            ReflectionTestUtils.setField(item, "id", id);
+        }
+        store.put(item.getId(), item);
+        return item;
+    }
+
+    @Override
+    public void delete(Item item) {
+        store.remove(item.getId());
+    }
+}

--- a/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
+++ b/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
@@ -1,6 +1,8 @@
 package com.sseulang.domain.item.application;
 
+import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
 import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemHashtag;
 import com.sseulang.domain.item.domain.ItemRepository;
 import com.sseulang.domain.item.domain.ItemStatus;
 import org.springframework.data.domain.Page;
@@ -13,8 +15,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
-/** 테스트용 인메모리 fake. id 자동 부여 + status != 삭제 인 것만 반환. */
+/**
+ * 테스트용 인메모리 fake. id 자동 부여 + status != 삭제 인 것만 검색에 노출.
+ *
+ * <p>{@code search} 는 prod {@link com.sseulang.domain.item.infrastructure.persistence.ItemQuerydslRepository}
+ * 와 동일한 의미로 동작해야 하므로 같은 필터 의미를 흉내 낸다.</p>
+ */
 public class InMemoryFakeItemRepository implements ItemRepository {
 
     private final Map<Long, Item> store = new HashMap<>();
@@ -26,14 +34,41 @@ public class InMemoryFakeItemRepository implements ItemRepository {
     }
 
     @Override
-    public Page<Item> findVisibleLatest(Pageable pageable) {
-        List<Item> visible = store.values().stream()
-                .filter(i -> i.getStatus() != ItemStatus.삭제)
+    public Page<Item> search(ItemSearchCriteria criteria, Pageable pageable) {
+        Stream<Item> stream = store.values().stream()
+                .filter(i -> i.getStatus() != ItemStatus.삭제);
+
+        if (criteria.q() != null && !criteria.q().isBlank()) {
+            String q = criteria.q().strip().toLowerCase();
+            stream = stream.filter(i ->
+                    i.getTitle().toLowerCase().contains(q)
+                            || i.getDescription().toLowerCase().contains(q));
+        }
+        if (criteria.categoryId() != null) {
+            stream = stream.filter(i -> criteria.categoryId().equals(i.getCategoryId()));
+        }
+        if (criteria.tradeType() != null) {
+            stream = stream.filter(i -> criteria.tradeType() == i.getTradeType());
+        }
+        if (criteria.minPrice() != null) {
+            stream = stream.filter(i -> i.getPrice() >= criteria.minPrice());
+        }
+        if (criteria.maxPrice() != null) {
+            stream = stream.filter(i -> i.getPrice() <= criteria.maxPrice());
+        }
+        if (criteria.tag() != null && !criteria.tag().isBlank()) {
+            String tag = criteria.tag().strip();
+            stream = stream.filter(i -> i.getHashtags().stream()
+                    .map(ItemHashtag::getTag).anyMatch(t -> t.equals(tag)));
+        }
+
+        List<Item> filtered = stream
                 .sorted(Comparator.comparingLong(Item::getId).reversed())
                 .toList();
-        int start = Math.min((int) pageable.getOffset(), visible.size());
-        int end = Math.min(start + pageable.getPageSize(), visible.size());
-        return new PageImpl<>(visible.subList(start, end), pageable, visible.size());
+
+        int start = Math.min((int) pageable.getOffset(), filtered.size());
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
     }
 
     @Override

--- a/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
@@ -38,11 +38,13 @@ class ItemApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("register 정상_id 발급되고 이미지 add")
+    @DisplayName("register 정상_id 발급되고 이미지+해시태그 add")
     void register_정상() {
         Long id = service.register(new ItemRegisterCommand(
                 SELLER, categoryId, "title", "desc", 10_000L, null, null, TradeType.판매,
-                "서울", List.of("https://img/1", "https://img/2")
+                "서울",
+                List.of("https://img/1", "https://img/2"),
+                List.of("아이폰", "미개봉")
         ));
 
         ItemDetailResult result = service.getById(id);
@@ -50,13 +52,14 @@ class ItemApplicationServiceTest {
         assertThat(result.sellerId()).isEqualTo(SELLER);
         assertThat(result.images()).hasSize(2);
         assertThat(result.images().get(0).thumbnail()).isTrue();
+        assertThat(result.hashtags()).containsExactly("아이폰", "미개봉");
     }
 
     @Test
     @DisplayName("register 없는 카테고리_CATEGORY_NOT_FOUND")
     void register_없는_카테고리_거부() {
         assertThatThrownBy(() -> service.register(new ItemRegisterCommand(
-                SELLER, 9999L, "t", "d", 1L, null, null, TradeType.판매, null, null
+                SELLER, 9999L, "t", "d", 1L, null, null, TradeType.판매, null, null, null
         )))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
@@ -67,7 +70,7 @@ class ItemApplicationServiceTest {
     @DisplayName("register null 카테고리_허용")
     void register_null_카테고리_허용() {
         Long id = service.register(new ItemRegisterCommand(
-                SELLER, null, "t", "d", 1L, null, null, TradeType.판매, null, null
+                SELLER, null, "t", "d", 1L, null, null, TradeType.판매, null, null, null
         ));
         assertThat(service.getById(id).categoryId()).isNull();
     }
@@ -98,7 +101,7 @@ class ItemApplicationServiceTest {
         Long id = registerSimple();
 
         service.update(id, SELLER, new ItemUpdateCommand(
-                null, "new title", "new desc", 50_000L, null, null, "부산", null
+                null, "new title", "new desc", 50_000L, null, null, "부산", null, null
         ));
 
         ItemDetailResult r = service.getById(id);
@@ -113,7 +116,7 @@ class ItemApplicationServiceTest {
         Long id = registerSimple();
 
         assertThatThrownBy(() -> service.update(id, OTHER, new ItemUpdateCommand(
-                null, "x", "y", 1L, null, null, null, null
+                null, "x", "y", 1L, null, null, null, null, null
         )))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
@@ -125,16 +128,48 @@ class ItemApplicationServiceTest {
     void update_이미지_전체교체() {
         Long id = service.register(new ItemRegisterCommand(
                 SELLER, categoryId, "t", "d", 1L, null, null, TradeType.판매, null,
-                List.of("https://old/1", "https://old/2")
+                List.of("https://old/1", "https://old/2"), null
         ));
 
         service.update(id, SELLER, new ItemUpdateCommand(
-                null, "t", "d", 1L, null, null, null, List.of("https://new/1")
+                null, "t", "d", 1L, null, null, null, List.of("https://new/1"), null
         ));
 
         ItemDetailResult r = service.getById(id);
         assertThat(r.images()).hasSize(1);
         assertThat(r.images().get(0).imageUrl()).isEqualTo("https://new/1");
+    }
+
+    @Test
+    @DisplayName("update hashtags non-null_전체 교체")
+    void update_해시태그_전체교체() {
+        Long id = service.register(new ItemRegisterCommand(
+                SELLER, categoryId, "t", "d", 1L, null, null, TradeType.판매, null,
+                null, List.of("old1", "old2")
+        ));
+
+        service.update(id, SELLER, new ItemUpdateCommand(
+                null, "t", "d", 1L, null, null, null, null, List.of("new1")
+        ));
+
+        ItemDetailResult r = service.getById(id);
+        assertThat(r.hashtags()).containsExactly("new1");
+    }
+
+    @Test
+    @DisplayName("update hashtags null_변경 없음")
+    void update_해시태그_null_유지() {
+        Long id = service.register(new ItemRegisterCommand(
+                SELLER, categoryId, "t", "d", 1L, null, null, TradeType.판매, null,
+                null, List.of("keep1", "keep2")
+        ));
+
+        service.update(id, SELLER, new ItemUpdateCommand(
+                null, "t", "d", 1L, null, null, null, null, null
+        ));
+
+        ItemDetailResult r = service.getById(id);
+        assertThat(r.hashtags()).containsExactly("keep1", "keep2");
     }
 
     @Test
@@ -144,7 +179,6 @@ class ItemApplicationServiceTest {
 
         service.delete(id, SELLER);
 
-        // 직접 repo 통해 status 검증 (삭제 후에도 row 는 남고 status 만 변경 — soft delete)
         assertThat(itemRepo.findById(id)).isPresent();
         assertThat(itemRepo.findById(id).get().getStatus()).isEqualTo(ItemStatus.삭제);
     }
@@ -164,11 +198,12 @@ class ItemApplicationServiceTest {
     @DisplayName("update 대여_정상_deposit/rentalUnit 박힘")
     void update_대여() {
         Long id = service.register(new ItemRegisterCommand(
-                SELLER, categoryId, "t", "d", 1L, 10_000L, RentalUnit.일, TradeType.대여, null, null
+                SELLER, categoryId, "t", "d", 1L, 10_000L, RentalUnit.일, TradeType.대여, null,
+                null, null
         ));
 
         service.update(id, SELLER, new ItemUpdateCommand(
-                null, "t", "d", 1L, 20_000L, RentalUnit.주, null, null
+                null, "t", "d", 1L, 20_000L, RentalUnit.주, null, null, null
         ));
 
         ItemDetailResult r = service.getById(id);
@@ -178,7 +213,7 @@ class ItemApplicationServiceTest {
 
     private Long registerSimple() {
         return service.register(new ItemRegisterCommand(
-                SELLER, categoryId, "t", "d", 1_000L, null, null, TradeType.판매, null, null
+                SELLER, categoryId, "t", "d", 1_000L, null, null, TradeType.판매, null, null, null
         ));
     }
 }

--- a/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
@@ -1,0 +1,184 @@
+package com.sseulang.domain.item.application;
+
+import com.sseulang.domain.category.application.InMemoryFakeCategoryRepository;
+import com.sseulang.domain.category.domain.Category;
+import com.sseulang.domain.item.application.dto.ItemDetailResult;
+import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
+import com.sseulang.domain.item.application.dto.ItemUpdateCommand;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.RentalUnit;
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ItemApplicationServiceTest {
+
+    private static final Long SELLER = 100L;
+    private static final Long OTHER = 200L;
+
+    private InMemoryFakeItemRepository itemRepo;
+    private InMemoryFakeCategoryRepository categoryRepo;
+    private ItemApplicationService service;
+    private Long categoryId;
+
+    @BeforeEach
+    void setUp() {
+        itemRepo = new InMemoryFakeItemRepository();
+        categoryRepo = new InMemoryFakeCategoryRepository();
+        service = new ItemApplicationService(itemRepo, categoryRepo);
+        categoryId = categoryRepo.insert(Category.createRoot("디지털/가전", 1)).getId();
+    }
+
+    @Test
+    @DisplayName("register 정상_id 발급되고 이미지 add")
+    void register_정상() {
+        Long id = service.register(new ItemRegisterCommand(
+                SELLER, categoryId, "title", "desc", 10_000L, null, null, TradeType.판매,
+                "서울", List.of("https://img/1", "https://img/2")
+        ));
+
+        ItemDetailResult result = service.getById(id);
+        assertThat(result.id()).isEqualTo(id);
+        assertThat(result.sellerId()).isEqualTo(SELLER);
+        assertThat(result.images()).hasSize(2);
+        assertThat(result.images().get(0).thumbnail()).isTrue();
+    }
+
+    @Test
+    @DisplayName("register 없는 카테고리_CATEGORY_NOT_FOUND")
+    void register_없는_카테고리_거부() {
+        assertThatThrownBy(() -> service.register(new ItemRegisterCommand(
+                SELLER, 9999L, "t", "d", 1L, null, null, TradeType.판매, null, null
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CATEGORY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("register null 카테고리_허용")
+    void register_null_카테고리_허용() {
+        Long id = service.register(new ItemRegisterCommand(
+                SELLER, null, "t", "d", 1L, null, null, TradeType.판매, null, null
+        ));
+        assertThat(service.getById(id).categoryId()).isNull();
+    }
+
+    @Test
+    @DisplayName("getById 정상_viewCount 1 증가")
+    void getById_view_증가() {
+        Long id = registerSimple();
+
+        service.getById(id);
+        ItemDetailResult result = service.getById(id);
+
+        assertThat(result.viewCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("getById 없는 id_ITEM_NOT_FOUND")
+    void getById_없음() {
+        assertThatThrownBy(() -> service.getById(9999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("update 본인_정상")
+    void update_본인() {
+        Long id = registerSimple();
+
+        service.update(id, SELLER, new ItemUpdateCommand(
+                null, "new title", "new desc", 50_000L, null, null, "부산", null
+        ));
+
+        ItemDetailResult r = service.getById(id);
+        assertThat(r.title()).isEqualTo("new title");
+        assertThat(r.price()).isEqualTo(50_000L);
+        assertThat(r.region()).isEqualTo("부산");
+    }
+
+    @Test
+    @DisplayName("update 타인_ITEM_FORBIDDEN")
+    void update_타인_거부() {
+        Long id = registerSimple();
+
+        assertThatThrownBy(() -> service.update(id, OTHER, new ItemUpdateCommand(
+                null, "x", "y", 1L, null, null, null, null
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("update imageUrls non-null_전체 교체")
+    void update_이미지_전체교체() {
+        Long id = service.register(new ItemRegisterCommand(
+                SELLER, categoryId, "t", "d", 1L, null, null, TradeType.판매, null,
+                List.of("https://old/1", "https://old/2")
+        ));
+
+        service.update(id, SELLER, new ItemUpdateCommand(
+                null, "t", "d", 1L, null, null, null, List.of("https://new/1")
+        ));
+
+        ItemDetailResult r = service.getById(id);
+        assertThat(r.images()).hasSize(1);
+        assertThat(r.images().get(0).imageUrl()).isEqualTo("https://new/1");
+    }
+
+    @Test
+    @DisplayName("delete 본인_status=삭제")
+    void delete_본인() {
+        Long id = registerSimple();
+
+        service.delete(id, SELLER);
+
+        // 직접 repo 통해 status 검증 (삭제 후에도 row 는 남고 status 만 변경 — soft delete)
+        assertThat(itemRepo.findById(id)).isPresent();
+        assertThat(itemRepo.findById(id).get().getStatus()).isEqualTo(ItemStatus.삭제);
+    }
+
+    @Test
+    @DisplayName("delete 타인_ITEM_FORBIDDEN")
+    void delete_타인_거부() {
+        Long id = registerSimple();
+
+        assertThatThrownBy(() -> service.delete(id, OTHER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("update 대여_정상_deposit/rentalUnit 박힘")
+    void update_대여() {
+        Long id = service.register(new ItemRegisterCommand(
+                SELLER, categoryId, "t", "d", 1L, 10_000L, RentalUnit.일, TradeType.대여, null, null
+        ));
+
+        service.update(id, SELLER, new ItemUpdateCommand(
+                null, "t", "d", 1L, 20_000L, RentalUnit.주, null, null
+        ));
+
+        ItemDetailResult r = service.getById(id);
+        assertThat(r.deposit()).isEqualTo(20_000L);
+        assertThat(r.rentalUnit()).isEqualTo(RentalUnit.주);
+    }
+
+    private Long registerSimple() {
+        return service.register(new ItemRegisterCommand(
+                SELLER, categoryId, "t", "d", 1_000L, null, null, TradeType.판매, null, null
+        ));
+    }
+}

--- a/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.item.application;
 
+import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.application.InMemoryFakeCategoryRepository;
 import com.sseulang.domain.category.domain.Category;
 import com.sseulang.domain.item.application.dto.ItemDetailResult;
@@ -33,7 +34,8 @@ class ItemApplicationServiceTest {
     void setUp() {
         itemRepo = new InMemoryFakeItemRepository();
         categoryRepo = new InMemoryFakeCategoryRepository();
-        service = new ItemApplicationService(itemRepo, categoryRepo);
+        CategoryApplicationService categoryService = new CategoryApplicationService(categoryRepo);
+        service = new ItemApplicationService(itemRepo, categoryService);
         categoryId = categoryRepo.insert(Category.createRoot("디지털/가전", 1)).getId();
     }
 

--- a/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
@@ -34,7 +34,9 @@ class ItemSearchTest {
     void setUp() {
         itemRepo = new InMemoryFakeItemRepository();
         InMemoryFakeCategoryRepository categoryRepo = new InMemoryFakeCategoryRepository();
-        service = new ItemApplicationService(itemRepo, categoryRepo);
+        com.sseulang.domain.category.application.CategoryApplicationService catSvc =
+                new com.sseulang.domain.category.application.CategoryApplicationService(categoryRepo);
+        service = new ItemApplicationService(itemRepo, catSvc);
         catA = categoryRepo.insert(Category.createRoot("A", 1)).getId();
         catB = categoryRepo.insert(Category.createRoot("B", 2)).getId();
     }

--- a/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
@@ -1,0 +1,200 @@
+package com.sseulang.domain.item.application;
+
+import com.sseulang.domain.category.application.InMemoryFakeCategoryRepository;
+import com.sseulang.domain.category.domain.Category;
+import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
+import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
+import com.sseulang.domain.item.application.dto.ItemSummaryResult;
+import com.sseulang.domain.item.domain.RentalUnit;
+import com.sseulang.domain.item.domain.TradeType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 검색·필터 단위 테스트. {@link InMemoryFakeItemRepository#search} 는 prod QueryDSL 구현과
+ * 동일한 필터 의미를 가져야 한다 — 본 테스트는 그 계약을 검증.
+ */
+class ItemSearchTest {
+
+    private static final Long SELLER = 100L;
+
+    private InMemoryFakeItemRepository itemRepo;
+    private ItemApplicationService service;
+    private Long catA;
+    private Long catB;
+
+    @BeforeEach
+    void setUp() {
+        itemRepo = new InMemoryFakeItemRepository();
+        InMemoryFakeCategoryRepository categoryRepo = new InMemoryFakeCategoryRepository();
+        service = new ItemApplicationService(itemRepo, categoryRepo);
+        catA = categoryRepo.insert(Category.createRoot("A", 1)).getId();
+        catB = categoryRepo.insert(Category.createRoot("B", 2)).getId();
+    }
+
+    @Test
+    @DisplayName("search 빈 criteria_삭제 제외 전체")
+    void search_빈_criteria() {
+        register("아이폰", "박스 미개봉", catA, TradeType.판매, 100_000L, null);
+        register("갤럭시", "S급", catB, TradeType.판매, 200_000L, null);
+
+        Page<ItemSummaryResult> result = service.search(ItemSearchCriteria.empty(), PageRequest.of(0, 10));
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("search q=title 부분일치")
+    void search_q_title() {
+        register("아이폰 14 Pro", "박스 미개봉", catA, TradeType.판매, 100_000L, null);
+        register("갤럭시 S24", "S급", catB, TradeType.판매, 200_000L, null);
+
+        Page<ItemSummaryResult> result = service.search(
+                new ItemSearchCriteria("아이폰", null, null, null, null, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(ItemSummaryResult::title)
+                .containsExactly("아이폰 14 Pro");
+    }
+
+    @Test
+    @DisplayName("search q=description 부분일치")
+    void search_q_description() {
+        register("물건1", "정품 풀박스", catA, TradeType.판매, 100_000L, null);
+        register("물건2", "사용감 있음", catA, TradeType.판매, 200_000L, null);
+
+        Page<ItemSummaryResult> result = service.search(
+                new ItemSearchCriteria("정품", null, null, null, null, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).title()).isEqualTo("물건1");
+    }
+
+    @Test
+    @DisplayName("search categoryId 필터")
+    void search_categoryId() {
+        register("a1", "d", catA, TradeType.판매, 100L, null);
+        register("a2", "d", catA, TradeType.판매, 200L, null);
+        register("b1", "d", catB, TradeType.판매, 300L, null);
+
+        Page<ItemSummaryResult> result = service.search(
+                new ItemSearchCriteria(null, catA, null, null, null, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("search tradeType 필터")
+    void search_tradeType() {
+        register("판매물", "d", catA, TradeType.판매, 100L, null);
+        register("나눔물", "d", catA, TradeType.나눔, 0L, null);
+        register("대여물", "d", catA, TradeType.대여, 100L, RentalUnit.일);
+
+        Page<ItemSummaryResult> result = service.search(
+                new ItemSearchCriteria(null, null, TradeType.나눔, null, null, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).title()).isEqualTo("나눔물");
+    }
+
+    @Test
+    @DisplayName("search 가격 범위 필터")
+    void search_price_range() {
+        register("싼것", "d", catA, TradeType.판매, 1_000L, null);
+        register("중간", "d", catA, TradeType.판매, 50_000L, null);
+        register("비싼것", "d", catA, TradeType.판매, 1_000_000L, null);
+
+        Page<ItemSummaryResult> result = service.search(
+                new ItemSearchCriteria(null, null, null, 10_000L, 100_000L, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(ItemSummaryResult::title)
+                .containsExactly("중간");
+    }
+
+    @Test
+    @DisplayName("search tag 필터")
+    void search_tag() {
+        Long id1 = service.register(new ItemRegisterCommand(
+                SELLER, catA, "i1", "d", 1L, null, null, TradeType.판매, null,
+                null, List.of("아이폰", "미개봉")
+        ));
+        Long id2 = service.register(new ItemRegisterCommand(
+                SELLER, catA, "i2", "d", 1L, null, null, TradeType.판매, null,
+                null, List.of("갤럭시")
+        ));
+
+        Page<ItemSummaryResult> result = service.search(
+                new ItemSearchCriteria(null, null, null, null, null, "아이폰"),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(ItemSummaryResult::id)
+                .containsExactly(id1);
+        assertThat(id2).isNotEqualTo(id1);
+    }
+
+    @Test
+    @DisplayName("search 삭제 상태 제외")
+    void search_삭제_제외() {
+        Long alive = registerSimple();
+        Long willDelete = registerSimple();
+        service.delete(willDelete, SELLER);
+
+        Page<ItemSummaryResult> result = service.search(ItemSearchCriteria.empty(), PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(ItemSummaryResult::id).containsExactly(alive);
+    }
+
+    @Test
+    @DisplayName("search 페이징")
+    void search_페이징() {
+        for (int i = 0; i < 25; i++) {
+            registerSimple();
+        }
+        Page<ItemSummaryResult> page0 = service.search(ItemSearchCriteria.empty(), PageRequest.of(0, 10));
+        Page<ItemSummaryResult> page2 = service.search(ItemSearchCriteria.empty(), PageRequest.of(2, 10));
+
+        assertThat(page0.getContent()).hasSize(10);
+        assertThat(page0.getTotalElements()).isEqualTo(25);
+        assertThat(page0.getTotalPages()).isEqualTo(3);
+        assertThat(page2.getContent()).hasSize(5);
+    }
+
+    @Test
+    @DisplayName("search 결합 — categoryId + tradeType + price")
+    void search_결합() {
+        register("a1", "d", catA, TradeType.판매, 50_000L, null);
+        register("a2", "d", catA, TradeType.대여, 50_000L, RentalUnit.일);
+        register("b1", "d", catB, TradeType.판매, 50_000L, null);
+        register("a3", "d", catA, TradeType.판매, 5_000_000L, null);
+
+        Page<ItemSummaryResult> result = service.search(
+                new ItemSearchCriteria(null, catA, TradeType.판매, 0L, 100_000L, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(ItemSummaryResult::title).containsExactly("a1");
+    }
+
+    private Long register(String title, String desc, Long categoryId, TradeType type, long price, RentalUnit unit) {
+        Long deposit = type.requiresDeposit() ? 10_000L : null;
+        return service.register(new ItemRegisterCommand(
+                SELLER, categoryId, title, desc, price, deposit, unit, type, null, null, null
+        ));
+    }
+
+    private Long registerSimple() {
+        return service.register(new ItemRegisterCommand(
+                SELLER, catA, "t" + System.nanoTime(), "d", 1L, null, null, TradeType.판매, null, null, null
+        ));
+    }
+}

--- a/src/test/java/com/sseulang/domain/item/domain/ItemTest.java
+++ b/src/test/java/com/sseulang/domain/item/domain/ItemTest.java
@@ -1,0 +1,193 @@
+package com.sseulang.domain.item.domain;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ItemTest {
+
+    private static final long SELLER = 1L;
+    private static final long CATEGORY = 7L;
+
+    @Test
+    @DisplayName("create 판매_정상_status=판매중, viewCount=0")
+    void create_판매_정상() {
+        Item item = Item.create(SELLER, CATEGORY, "title", "desc", 10_000L, null, null, TradeType.판매, "서울");
+
+        assertThat(item.getSellerId()).isEqualTo(SELLER);
+        assertThat(item.getCategoryId()).isEqualTo(CATEGORY);
+        assertThat(item.getTitle()).isEqualTo("title");
+        assertThat(item.getPrice()).isEqualTo(10_000L);
+        assertThat(item.getDeposit()).isNull();
+        assertThat(item.getRentalUnit()).isNull();
+        assertThat(item.getTradeType()).isEqualTo(TradeType.판매);
+        assertThat(item.getStatus()).isEqualTo(ItemStatus.판매중);
+        assertThat(item.getViewCount()).isZero();
+        assertThat(item.getImages()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("create 나눔_정상_price=0")
+    void create_나눔_정상() {
+        Item item = Item.create(SELLER, CATEGORY, "t", "d", 0L, null, null, TradeType.나눔, null);
+        assertThat(item.getTradeType()).isEqualTo(TradeType.나눔);
+        assertThat(item.getPrice()).isZero();
+    }
+
+    @Test
+    @DisplayName("create 대여_정상_deposit/rentalUnit 박힘")
+    void create_대여_정상() {
+        Item item = Item.create(SELLER, CATEGORY, "t", "d", 5_000L, 50_000L, RentalUnit.일, TradeType.대여, null);
+        assertThat(item.getDeposit()).isEqualTo(50_000L);
+        assertThat(item.getRentalUnit()).isEqualTo(RentalUnit.일);
+    }
+
+    @Test
+    @DisplayName("create 대여인데 deposit 누락_거부")
+    void create_대여_deposit_누락_거부() {
+        assertThatThrownBy(() ->
+                Item.create(SELLER, CATEGORY, "t", "d", 1_000L, null, RentalUnit.일, TradeType.대여, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create 대여인데 rentalUnit 누락_거부")
+    void create_대여_rentalUnit_누락_거부() {
+        assertThatThrownBy(() ->
+                Item.create(SELLER, CATEGORY, "t", "d", 1_000L, 10_000L, null, TradeType.대여, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create 판매인데 deposit 박으면_거부")
+    void create_판매_deposit_박으면_거부() {
+        assertThatThrownBy(() ->
+                Item.create(SELLER, CATEGORY, "t", "d", 1_000L, 5_000L, null, TradeType.판매, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create 빈 title_거부")
+    void create_빈_title_거부() {
+        assertThatThrownBy(() ->
+                Item.create(SELLER, CATEGORY, "", "d", 1_000L, null, null, TradeType.판매, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                Item.create(SELLER, CATEGORY, null, "d", 1_000L, null, null, TradeType.판매, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create title 200자 초과_거부")
+    void create_title_길이초과_거부() {
+        String tooLong = "가".repeat(201);
+        assertThatThrownBy(() ->
+                Item.create(SELLER, CATEGORY, tooLong, "d", 1_000L, null, null, TradeType.판매, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create 음수 price_거부")
+    void create_음수_price_거부() {
+        assertThatThrownBy(() ->
+                Item.create(SELLER, CATEGORY, "t", "d", -1L, null, null, TradeType.판매, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create null sellerId_거부")
+    void create_null_sellerId_거부() {
+        assertThatThrownBy(() ->
+                Item.create(null, CATEGORY, "t", "d", 1_000L, null, null, TradeType.판매, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("addImage 1~5장 정상")
+    void addImage_5장_정상() {
+        Item item = saleItem();
+        for (int i = 1; i <= 5; i++) {
+            item.addImage("https://img/" + i, i, i == 1);
+        }
+        assertThat(item.getImages()).hasSize(5);
+        assertThat(item.getImages().get(0).isThumbnail()).isTrue();
+    }
+
+    @Test
+    @DisplayName("addImage 6번째_ITEM_IMAGE_LIMIT_EXCEEDED")
+    void addImage_6장_거부() {
+        Item item = saleItem();
+        for (int i = 1; i <= 5; i++) {
+            item.addImage("https://img/" + i, i, false);
+        }
+        assertThatThrownBy(() -> item.addImage("https://img/6", 6, false))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_IMAGE_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("updateInfo 판매중_정상")
+    void updateInfo_판매중_정상() {
+        Item item = saleItem();
+        item.updateInfo("new title", "new desc", 20_000L, null, null, "부산");
+
+        assertThat(item.getTitle()).isEqualTo("new title");
+        assertThat(item.getPrice()).isEqualTo(20_000L);
+        assertThat(item.getRegion()).isEqualTo("부산");
+    }
+
+    @Test
+    @DisplayName("updateInfo 거래완료_거부")
+    void updateInfo_거래완료_거부() {
+        Item item = saleItem();
+        item.markAsDeleted();
+        assertThatThrownBy(() ->
+                item.updateInfo("x", "y", 1L, null, null, null))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("markAsHidden / restore 상태 전이")
+    void hidden_restore() {
+        Item item = saleItem();
+        item.markAsHidden();
+        assertThat(item.getStatus()).isEqualTo(ItemStatus.비공개);
+        item.restore();
+        assertThat(item.getStatus()).isEqualTo(ItemStatus.판매중);
+    }
+
+    @Test
+    @DisplayName("markAsDeleted 후 restore_거부")
+    void markAsDeleted_후_restore_거부() {
+        Item item = saleItem();
+        item.markAsDeleted();
+        assertThatThrownBy(item::restore).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("incrementViewCount")
+    void incrementViewCount() {
+        Item item = saleItem();
+        item.incrementViewCount();
+        item.incrementViewCount();
+        assertThat(item.getViewCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("isOwnedBy")
+    void isOwnedBy() {
+        Item item = saleItem();
+        assertThat(item.isOwnedBy(SELLER)).isTrue();
+        assertThat(item.isOwnedBy(SELLER + 1)).isFalse();
+        assertThat(item.isOwnedBy(null)).isFalse();
+    }
+
+    private static Item saleItem() {
+        return Item.create(SELLER, CATEGORY, "t", "d", 10_000L, null, null, TradeType.판매, "서울");
+    }
+}

--- a/src/test/java/com/sseulang/domain/item/domain/ItemTest.java
+++ b/src/test/java/com/sseulang/domain/item/domain/ItemTest.java
@@ -187,6 +187,58 @@ class ItemTest {
         assertThat(item.isOwnedBy(null)).isFalse();
     }
 
+    @Test
+    @DisplayName("addHashtag 정상_3개")
+    void addHashtag_정상() {
+        Item item = saleItem();
+        item.addHashtag("아이폰");
+        item.addHashtag("미개봉");
+        item.addHashtag("정품");
+        assertThat(item.getHashtags()).extracting("tag")
+                .containsExactly("아이폰", "미개봉", "정품");
+    }
+
+    @Test
+    @DisplayName("addHashtag 중복_무시")
+    void addHashtag_중복_무시() {
+        Item item = saleItem();
+        item.addHashtag("아이폰");
+        item.addHashtag("아이폰");
+        item.addHashtag("  아이폰  ");  // 공백 정규화 후 동일
+        assertThat(item.getHashtags()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("addHashtag 빈 태그_거부")
+    void addHashtag_빈_거부() {
+        Item item = saleItem();
+        assertThatThrownBy(() -> item.addHashtag(""))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> item.addHashtag(null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> item.addHashtag("   "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("addHashtag 50자 초과_거부")
+    void addHashtag_길이초과_거부() {
+        Item item = saleItem();
+        String tooLong = "가".repeat(51);
+        assertThatThrownBy(() -> item.addHashtag(tooLong))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("clearHashtags")
+    void clearHashtags() {
+        Item item = saleItem();
+        item.addHashtag("a");
+        item.addHashtag("b");
+        item.clearHashtags();
+        assertThat(item.getHashtags()).isEmpty();
+    }
+
     private static Item saleItem() {
         return Item.create(SELLER, CATEGORY, "t", "d", 10_000L, null, null, TradeType.판매, "서울");
     }

--- a/src/test/java/com/sseulang/domain/item/domain/ItemTest.java
+++ b/src/test/java/com/sseulang/domain/item/domain/ItemTest.java
@@ -142,13 +142,15 @@ class ItemTest {
     }
 
     @Test
-    @DisplayName("updateInfo 거래완료_거부")
-    void updateInfo_거래완료_거부() {
+    @DisplayName("updateInfo 삭제 상태_ITEM_INVALID_STATE")
+    void updateInfo_삭제_상태_거부() {
         Item item = saleItem();
         item.markAsDeleted();
         assertThatThrownBy(() ->
                 item.updateInfo("x", "y", 1L, null, null, null))
-                .isInstanceOf(IllegalStateException.class);
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_INVALID_STATE);
     }
 
     @Test
@@ -162,11 +164,14 @@ class ItemTest {
     }
 
     @Test
-    @DisplayName("markAsDeleted 후 restore_거부")
+    @DisplayName("markAsDeleted 후 restore_ITEM_INVALID_STATE")
     void markAsDeleted_후_restore_거부() {
         Item item = saleItem();
         item.markAsDeleted();
-        assertThatThrownBy(item::restore).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(item::restore)
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_INVALID_STATE);
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepositoryIT.java
+++ b/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepositoryIT.java
@@ -1,0 +1,210 @@
+package com.sseulang.domain.item.infrastructure.persistence;
+
+import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.RentalUnit;
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.global.config.JpaAuditingConfig;
+import com.sseulang.global.config.QuerydslConfig;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link ItemQuerydslRepository} 통합 테스트 — testcontainers MySQL 8 + Flyway 실 마이그레이션.
+ *
+ * <p>Codex 게이트 2 권고: 검색 핵심 로직을 in-memory fake 로만 검증하면 prod QueryDSL/JPA/MySQL 의미와
+ * 쉽게 드리프트한다. 본 IT 는 prod 와 동일한 MySQL 위에서 정렬, 삭제 제외, 태그 EXISTS, LIKE 결합을 검증.</p>
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QuerydslConfig.class, JpaAuditingConfig.class, ItemQuerydslRepository.class})
+@Testcontainers
+class ItemQuerydslRepositoryIT {
+
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("sseulang_test")
+            .withUsername("test")
+            .withPassword("testpw")
+            .withCommand("--character-set-server=utf8mb4",
+                    "--collation-server=utf8mb4_unicode_ci",
+                    "--ngram_token_size=2");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("spring.flyway.locations", () -> "classpath:db/migration");
+    }
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ItemQuerydslRepository repository;
+
+    private Long sellerId;
+
+    @BeforeEach
+    void setUp() {
+        // FK fk_items_seller 충족용 User 1건. (provider,id) UNIQUE 충돌 방지 위해 nano time.
+        User user = User.createSocialUser(
+                SocialProvider.KAKAO,
+                "kakao-" + System.nanoTime(),
+                new Email("it-" + System.nanoTime() + "@example.com"),
+                "tester",
+                null
+        );
+        em.persist(user);
+        em.flush();
+        sellerId = user.getId();
+    }
+
+    @Test
+    @DisplayName("search 빈 criteria_삭제 제외 + createdAt desc 정렬")
+    void search_정렬() {
+        Item older = persistItem("older", TradeType.판매, 100L);
+        sleepMs(20);
+        Item middle = persistItem("middle", TradeType.판매, 100L);
+        sleepMs(20);
+        Item newer = persistItem("newer", TradeType.판매, 100L);
+
+        Page<Item> result = repository.search(ItemSearchCriteria.empty(), PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Item::getId)
+                .containsExactly(newer.getId(), middle.getId(), older.getId());
+    }
+
+    @Test
+    @DisplayName("search 삭제 상태 제외")
+    void search_삭제_제외() {
+        Item alive = persistItem("alive", TradeType.판매, 100L);
+        Item dead = persistItem("dead", TradeType.판매, 100L);
+        dead.markAsDeleted();
+        em.merge(dead);
+        em.flush();
+        em.clear();
+
+        Page<Item> result = repository.search(ItemSearchCriteria.empty(), PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Item::getId)
+                .containsExactly(alive.getId());
+    }
+
+    @Test
+    @DisplayName("search q 부분일치")
+    void search_q() {
+        persistItem("아이폰 14 Pro", TradeType.판매, 100L);
+        persistItem("갤럭시 S24", TradeType.판매, 100L);
+
+        Page<Item> result = repository.search(
+                new ItemSearchCriteria("아이폰", null, null, null, null, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Item::getTitle)
+                .containsExactly("아이폰 14 Pro");
+    }
+
+    @Test
+    @DisplayName("search 가격 범위 + tradeType 결합")
+    void search_결합() {
+        persistItem("싼것", TradeType.판매, 1_000L);
+        persistItem("중간_나눔", TradeType.나눔, 0L);
+        Item target = persistItem("중간_판매", TradeType.판매, 50_000L);
+        persistItem("비싼것", TradeType.판매, 1_000_000L);
+
+        Page<Item> result = repository.search(
+                new ItemSearchCriteria(null, null, TradeType.판매, 10_000L, 100_000L, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Item::getId)
+                .containsExactly(target.getId());
+    }
+
+    @Test
+    @DisplayName("search tag EXISTS 서브쿼리")
+    void search_tag() {
+        Item iphone = persistItem("아이폰", TradeType.판매, 100L);
+        iphone.addHashtag("미개봉");
+        iphone.addHashtag("정품");
+        em.merge(iphone);
+
+        Item galaxy = persistItem("갤럭시", TradeType.판매, 100L);
+        galaxy.addHashtag("정품");
+        em.merge(galaxy);
+
+        em.flush();
+        em.clear();
+
+        Page<Item> hit = repository.search(
+                new ItemSearchCriteria(null, null, null, null, null, "미개봉"),
+                PageRequest.of(0, 10));
+
+        assertThat(hit.getContent())
+                .extracting(Item::getId)
+                .containsExactly(iphone.getId());
+    }
+
+    @Test
+    @DisplayName("search 페이징 — total/페이지 동작")
+    void search_페이징() {
+        for (int i = 0; i < 12; i++) {
+            persistItem("t" + i, TradeType.판매, 100L);
+            sleepMs(5);
+        }
+
+        Page<Item> page0 = repository.search(ItemSearchCriteria.empty(), PageRequest.of(0, 5));
+        Page<Item> page2 = repository.search(ItemSearchCriteria.empty(), PageRequest.of(2, 5));
+
+        assertThat(page0.getTotalElements()).isEqualTo(12);
+        assertThat(page0.getTotalPages()).isEqualTo(3);
+        assertThat(page0.getContent()).hasSize(5);
+        assertThat(page2.getContent()).hasSize(2);
+    }
+
+    private Item persistItem(String title, TradeType type, long price) {
+        Long deposit = type.requiresDeposit() ? 10_000L : null;
+        RentalUnit unit = type.requiresDeposit() ? RentalUnit.일 : null;
+        Item item = Item.create(sellerId, null, title, "desc", price, deposit, unit, type, null);
+        em.persist(item);
+        em.flush();
+        return item;
+    }
+
+    private static void sleepMs(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/test/java/com/sseulang/domain/wishlist/application/InMemoryFakeWishlistRepository.java
+++ b/src/test/java/com/sseulang/domain/wishlist/application/InMemoryFakeWishlistRepository.java
@@ -32,8 +32,8 @@ public class InMemoryFakeWishlistRepository implements WishlistRepository {
     }
 
     @Override
-    public void deleteByUserIdAndItemId(Long userId, Long itemId) {
-        store.remove(key(userId, itemId));
+    public int deleteByUserIdAndItemId(Long userId, Long itemId) {
+        return store.remove(key(userId, itemId)) != null ? 1 : 0;
     }
 
     public int size() {

--- a/src/test/java/com/sseulang/domain/wishlist/application/InMemoryFakeWishlistRepository.java
+++ b/src/test/java/com/sseulang/domain/wishlist/application/InMemoryFakeWishlistRepository.java
@@ -1,0 +1,42 @@
+package com.sseulang.domain.wishlist.application;
+
+import com.sseulang.domain.wishlist.domain.Wishlist;
+import com.sseulang.domain.wishlist.domain.WishlistRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InMemoryFakeWishlistRepository implements WishlistRepository {
+
+    /** key = userId|itemId */
+    private final Map<String, Wishlist> store = new HashMap<>();
+    private long sequence = 0;
+
+    private static String key(Long userId, Long itemId) {
+        return userId + "|" + itemId;
+    }
+
+    @Override
+    public boolean existsByUserIdAndItemId(Long userId, Long itemId) {
+        return store.containsKey(key(userId, itemId));
+    }
+
+    @Override
+    public Wishlist save(Wishlist wishlist) {
+        if (wishlist.getId() == null) {
+            ReflectionTestUtils.setField(wishlist, "id", ++sequence);
+        }
+        store.put(key(wishlist.getUserId(), wishlist.getItemId()), wishlist);
+        return wishlist;
+    }
+
+    @Override
+    public void deleteByUserIdAndItemId(Long userId, Long itemId) {
+        store.remove(key(userId, itemId));
+    }
+
+    public int size() {
+        return store.size();
+    }
+}

--- a/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
@@ -1,0 +1,89 @@
+package com.sseulang.domain.wishlist.application;
+
+import com.sseulang.domain.item.application.InMemoryFakeItemRepository;
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WishlistApplicationServiceTest {
+
+    private static final Long USER = 1L;
+
+    private InMemoryFakeWishlistRepository wishRepo;
+    private InMemoryFakeItemRepository itemRepo;
+    private WishlistApplicationService service;
+    private Long itemId;
+
+    @BeforeEach
+    void setUp() {
+        wishRepo = new InMemoryFakeWishlistRepository();
+        itemRepo = new InMemoryFakeItemRepository();
+        service = new WishlistApplicationService(wishRepo, itemRepo);
+
+        Item item = itemRepo.save(Item.create(
+                999L, null, "t", "d", 1L, null, null, TradeType.판매, null
+        ));
+        itemId = item.getId();
+    }
+
+    @Test
+    @DisplayName("add 정상_저장됨")
+    void add_정상() {
+        service.add(USER, itemId);
+        assertThat(wishRepo.existsByUserIdAndItemId(USER, itemId)).isTrue();
+        assertThat(wishRepo.size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("add 중복_idempotent")
+    void add_중복() {
+        service.add(USER, itemId);
+        service.add(USER, itemId);
+        service.add(USER, itemId);
+        assertThat(wishRepo.size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("add 없는 item_ITEM_NOT_FOUND")
+    void add_없는_item() {
+        assertThatThrownBy(() -> service.add(USER, 9999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("add 삭제된 item_ITEM_NOT_FOUND")
+    void add_삭제된_item() {
+        Item item = itemRepo.findById(itemId).orElseThrow();
+        item.markAsDeleted();
+        itemRepo.save(item);
+
+        assertThatThrownBy(() -> service.add(USER, itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("remove 정상")
+    void remove_정상() {
+        service.add(USER, itemId);
+        service.remove(USER, itemId);
+        assertThat(wishRepo.existsByUserIdAndItemId(USER, itemId)).isFalse();
+    }
+
+    @Test
+    @DisplayName("remove 없는 항목_idempotent")
+    void remove_없는_항목() {
+        service.remove(USER, itemId);  // 추가도 안 했는데 호출
+        assertThat(wishRepo.size()).isZero();
+    }
+}

--- a/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
@@ -1,6 +1,9 @@
 package com.sseulang.domain.wishlist.application;
 
+import com.sseulang.domain.category.application.CategoryApplicationService;
+import com.sseulang.domain.category.application.InMemoryFakeCategoryRepository;
 import com.sseulang.domain.item.application.InMemoryFakeItemRepository;
+import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.item.domain.TradeType;
 import com.sseulang.global.exception.BusinessException;
@@ -25,7 +28,9 @@ class WishlistApplicationServiceTest {
     void setUp() {
         wishRepo = new InMemoryFakeWishlistRepository();
         itemRepo = new InMemoryFakeItemRepository();
-        service = new WishlistApplicationService(wishRepo, itemRepo);
+        CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc);
+        service = new WishlistApplicationService(wishRepo, itemSvc);
 
         Item item = itemRepo.save(Item.create(
                 999L, null, "t", "d", 1L, null, null, TradeType.판매, null
@@ -34,20 +39,24 @@ class WishlistApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("add 정상_저장됨")
+    @DisplayName("add 정상_저장 + wishlistCount 증가")
     void add_정상() {
         service.add(USER, itemId);
+
         assertThat(wishRepo.existsByUserIdAndItemId(USER, itemId)).isTrue();
         assertThat(wishRepo.size()).isEqualTo(1);
+        assertThat(itemRepo.findById(itemId).orElseThrow().getWishlistCount()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("add 중복_idempotent")
+    @DisplayName("add 중복_idempotent + 카운터 1 유지")
     void add_중복() {
         service.add(USER, itemId);
         service.add(USER, itemId);
         service.add(USER, itemId);
+
         assertThat(wishRepo.size()).isEqualTo(1);
+        assertThat(itemRepo.findById(itemId).orElseThrow().getWishlistCount()).isEqualTo(1);
     }
 
     @Test
@@ -73,17 +82,31 @@ class WishlistApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("remove 정상")
+    @DisplayName("remove 정상_카운터 감소")
     void remove_정상() {
         service.add(USER, itemId);
         service.remove(USER, itemId);
+
         assertThat(wishRepo.existsByUserIdAndItemId(USER, itemId)).isFalse();
+        assertThat(itemRepo.findById(itemId).orElseThrow().getWishlistCount()).isZero();
     }
 
     @Test
-    @DisplayName("remove 없는 항목_idempotent")
+    @DisplayName("remove 없는 항목_idempotent + 카운터 변동 없음")
     void remove_없는_항목() {
-        service.remove(USER, itemId);  // 추가도 안 했는데 호출
+        service.remove(USER, itemId);
+
         assertThat(wishRepo.size()).isZero();
+        assertThat(itemRepo.findById(itemId).orElseThrow().getWishlistCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("add → remove 반복_카운터 음수 안 됨")
+    void 반복_카운터_정합() {
+        service.add(USER, itemId);
+        service.remove(USER, itemId);
+        service.remove(USER, itemId);  // 한 번 더 — 멱등
+
+        assertThat(itemRepo.findById(itemId).orElseThrow().getWishlistCount()).isZero();
     }
 }

--- a/src/test/java/com/sseulang/domain/wishlist/domain/WishlistTest.java
+++ b/src/test/java/com/sseulang/domain/wishlist/domain/WishlistTest.java
@@ -1,0 +1,38 @@
+package com.sseulang.domain.wishlist.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WishlistTest {
+
+    @Test
+    @DisplayName("create 정상")
+    void create_정상() {
+        Wishlist w = Wishlist.create(1L, 100L);
+        assertThat(w.getUserId()).isEqualTo(1L);
+        assertThat(w.getItemId()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("create null/비양수 userId_거부")
+    void create_userId_거부() {
+        assertThatThrownBy(() -> Wishlist.create(null, 1L))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Wishlist.create(0L, 1L))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Wishlist.create(-1L, 1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create null/비양수 itemId_거부")
+    void create_itemId_거부() {
+        assertThatThrownBy(() -> Wishlist.create(1L, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Wishlist.create(1L, 0L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Summary

Day 4 일감 묶음 — Item Aggregate(자식 ItemImage/ItemHashtag) + Category + Wishlist + 검색·필터(QueryDSL) + S3 Presigned URL. Codex 게이트 2 (thread `019dd6d0-edd2-7531-80ec-c5aa43e7f52b`) 풀 리뷰 + Critical 2 / Warning 4 / 통합 테스트 권고 모두 반영.

- **신규 도메인 4개**: `category` / `item` / `wishlist` / `file`
- **테스트 누적**: 113 → **200 PASS / 0 FAIL** (+87 — 도메인/어플리케이션 단위 81 + 통합 IT 6)
- **Issue #10** 으로 FULLTEXT(MATCH AGAINST + ngram) 마이그 트래킹 분리

## Commits

| | 의미 |
|---|---|
| `37d8b38` | Category (4-layer + 트리 1-pass 조립 + 13) |
| `f86905f` | Item Aggregate + 기본 CRUD (5장 한도 + 권한 + 29) |
| `b1c6880` | ItemHashtag 자식 + 정규화 중복 무시 (+7) |
| `ac5d5c7` | Wishlist (멱등 + UNIQUE race) (+9) |
| `8bb09fd` | Item 검색·필터 QueryDSL BooleanBuilder (+10) |
| `af0a1c1` | S3 Presigned URL (인터페이스 분리, 일반 사용자/내부) (+9) |
| `8518770` | **fix: 게이트 2 풀 반영** (+10, 통합 IT 6 포함) |

## 게이트 2 처리 내역

### 🔴 Critical
- **File presign 권한 누수** — `FileApplicationService.issueForUser` 화이트리스트(PROFILE/ITEM). NOTICE/BANNER/MESSAGE 는 향후 admin·chat 도메인이 별도 발급 → 일반 사용자 진입점은 거부.
- **Wishlist broad catch** — cause `ConstraintViolationException` + constraint name `uk_wishlists_user_item` 일 때만 멱등 처리, 그 외 무결성 위반은 재던지기.

### 🟡 Warning
- **레이어 위반(CLAUDE.md §3.3)** — `Item/Wishlist` 의 다른 도메인 Repository 직접 호출 제거. `CategoryApplicationService.requireExists`, `ItemApplicationService.requireActiveItem / increment·decrementWishlistCount` 추가.
- **wishlist_count atomic** — `@Modifying` SQL `+1` / `-1 WHERE > 0`. delete 영향 행 1건일 때만 -1 호출.
- **IllegalStateException → BusinessException(ITEM_INVALID_STATE 신규, 400)** — 사용자 입력 오류가 500 떨어지던 회귀 차단.
- **FULLTEXT 마이그** — issue #10 분리 + 코드 주석.

### 🔵 Suggestion (별도/후순위)
- 상세 fetch join, viewCount atomic increment, enum AttributeConverter, BusinessException 도메인 직접 참조 — 본 PR 범위 외.

## 통합 테스트 (Codex 권고)

`ItemQuerydslRepositoryIT` — testcontainers MySQL 8 + Flyway 실 마이그레이션. 6 시나리오:
- createdAt desc 정렬 / 삭제 제외 / q LIKE 부분일치 / tag EXISTS 서브쿼리 / 가격+거래타입 결합 / 페이징

## 위험 영역

이번 PR은 **보안/돈/동시성 게이트 1 영역 밖** (Item CRUD / Category / Wishlist / 검색 / S3). 단,
- S3 presigned URL 발급은 권한 누수 영역 — Critical 1 처리됨
- Wishlist UNIQUE race 처리는 Day 3 OAuth race 패턴과 정합

## Test plan

- [ ] CI build 통과
- [ ] 로컬 `./gradlew test` — 200 PASS / 0 FAIL 재현
- [ ] testcontainers IT 1건 (`ItemQuerydslRepositoryIT`) 실행 시간 < 30초 확인
- [ ] dev 머지 후 Swagger UI 에서 새 endpoint 노출 확인:
  - `GET /api/v1/categories(/{id})`
  - `POST /api/v1/items` + `GET /api/v1/items?q=&categoryId=&tradeType=&minPrice=&maxPrice=&tag=&page=&size=`
  - `GET /api/v1/items/{id}` / `PATCH /api/v1/items/{id}` / `DELETE /api/v1/items/{id}`
  - `POST /api/v1/items/{id}/wishlist` / `DELETE /api/v1/items/{id}/wishlist`
  - `POST /api/v1/files/presigned-url` (PROFILE/ITEM 만)
- [ ] 후속 트래킹: issue #10 (FULLTEXT 마이그)

🤖 Generated with [Claude Code](https://claude.com/claude-code)