### PR TITLE
feat: Day 5 — Transaction 상태머신 + 동시 거래 차단 (게이트 1)

### DIFF
--- a/docs/SSEULANG_BACKEND_GUIDE.md
+++ b/docs/SSEULANG_BACKEND_GUIDE.md
@@ -666,4 +666,126 @@ PM과 추가 협의 필요한 부분:
 
 ---
 
+## 13. 트러블슈팅 노트 (Day별 누계)
+
+> 작업 중 마주친 이슈 + 해결 + 교훈. 새 이슈 발생 시 본 섹션에 누적.
+
+### 13.1 JPAQueryFactory 빈 미등록 (Day 4)
+**증상**: ItemQuerydslRepository 작성 시 `NoSuchBeanDefinitionException: JPAQueryFactory`.
+**원인**: `querydsl-apt` 는 Q-class 생성만, 빈 자동 등록 X.
+**해결**: `global/config/QuerydslConfig.java` 에 `@Bean public JPAQueryFactory jpaQueryFactory()` 직접 등록.
+**교훈**: 외부 라이브러리 빈은 명시적 Config 필요.
+
+### 13.2 한국어 ENUM 매핑 (Day 4)
+**증상**: DB ENUM `'대여','판매','나눔'` 과 Java enum 매핑 — 영문 enum + AttributeConverter는 보일러플레이트(6+ enum).
+**해결**: 한국어 식별자 enum + `@Enumerated(EnumType.STRING)`. Java가 한국어 식별자 허용, `name()` 그대로 매칭.
+```java
+public enum TradeType { 대여, 판매, 나눔 }
+```
+**트레이드오프**: enum rename = 데이터 마이그(영문 enum 동일 비용). DDD Ubiquitous Language와 정합.
+
+### 13.3 자식 엔티티 BaseEntity 상속 시 컬럼 mismatch (Day 4)
+**증상**: ItemImage `extends BaseEntity` → `Schema-validation: missing column [updated_at]`.
+**원인**: `item_images` 테이블엔 `created_at` 만 있고 `updated_at` 없음.
+**해결**: BaseEntity 상속 X. `@CreatedDate` + `@EntityListeners(AuditingEntityListener.class)` 만.
+**교훈**: 자식 엔티티는 테이블 정의(`updated_at` 유무) 먼저 확인.
+
+### 13.4 @DataJpaTest + testcontainers MySQL (Day 4)
+**증상**: `@DataJpaTest` 기본 H2 → 한국어 ENUM/ngram/FULLTEXT 미지원.
+**해결**:
+```java
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QuerydslConfig.class, JpaAuditingConfig.class, ItemQuerydslRepository.class})
+@Testcontainers
+class XxxIT {
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+        .withCommand("--ngram_token_size=2", "--character-set-server=utf8mb4");
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) { ... }
+}
+```
+**추가 함정**:
+- `@DataJpaTest` 는 `@EnableJpaAuditing` 자동 픽업 X → `@Import(JpaAuditingConfig.class)` 명시
+- `items.seller_id` FK RESTRICT → 테스트 setUp에서 User 1건 먼저 persist 필요
+
+### 13.5 Wishlist UNIQUE race — broad catch 위험 (Day 4, Codex 게이트 2)
+**증상**: 첫 구현 `catch (DataIntegrityViolationException e) { /* 무시 */ }` — UNIQUE 외 FK 위반도 "성공" 처리.
+**해결**: cause 좁은 검사
+```java
+if (cause instanceof ConstraintViolationException cve
+        && "uk_wishlists_user_item".equalsIgnoreCase(cve.getConstraintName())) {
+    return;
+}
+throw violation;
+```
+**교훈**: Day 3 OAuth race 처리 패턴 동일 — catch는 항상 의도한 케이스만 좁게.
+
+### 13.6 wishlist_count 영구 stale (Day 4, Codex 게이트 2)
+**증상**: Wishlist add/remove 가 `wishlists` 만 갱신, `items.wishlist_count` 0 고정.
+**해결**: `@Modifying` SQL atomic update + Wishlist 도메인이 ItemApplicationService 경유 호출. delete 영향 행 1건일 때만 -1, `wishlist_count > 0` 가드로 음수 방지.
+**교훈**: denormalized counter는 atomic update + 양방향 동기 필수.
+
+### 13.7 IllegalStateException → 500 회귀 (Day 4, Codex 게이트 2)
+**증상**: `Item.updateInfo` 거래완료/삭제 상태에서 IllegalStateException → GlobalExceptionHandler 500.
+**해결**: 신규 `ErrorCode.ITEM_INVALID_STATE` (400) + 도메인이 `BusinessException` throw.
+**교훈**: 단순 인자 검증은 `IllegalArgumentException`, 사용자 액션 컨텍스트의 상태 전이 거부는 `BusinessException` + 의미 있는 ErrorCode.
+
+### 13.8 File presign 권한 누수 (Day 4, Codex 게이트 2)
+**증상**: 일반 사용자가 `purpose=NOTICE`/`BANNER`/`MESSAGE` 로 관리자 자원 업로드 경로 선점 가능.
+**해결**: `FileApplicationService.issueForUser` 화이트리스트 (`{PROFILE, ITEM}` 만), 그 외 FORBIDDEN. 도메인 내부용 `issue` 는 권한 검증 책임 호출자.
+**교훈**: 사용자 입력 enum/discriminator는 항상 화이트리스트 검증, 진입점 분리로 권한 경계 명확히.
+
+### 13.9 레이어 위반 — 다른 도메인 Repository 직접 호출 (Day 4, Codex 게이트 2)
+**증상**: `ItemApplicationService → CategoryRepository`, `WishlistApplicationService → ItemRepository` 직접 호출. CLAUDE.md §3.3 위반.
+**해결**: `CategoryApplicationService.requireExists`, `ItemApplicationService.requireActiveItem` / `incrementWishlistCount` / `decrementWishlistCount` 추가, 다른 도메인은 ApplicationService 경유.
+**교훈**: 단순화 욕구로 컨벤션 우회 금지. 작업 시작 전 §3.3 룰 재확인.
+
+### 13.10 Codex 풀 리뷰 응답 30분+ 지연 (Day 4)
+**증상**: 첫 호출 60+ files / 3000+ insertions / 9 영역 prompt → 30분 응답 없음, 사용자 중단 (노트북 sleep 추정).
+**대응**: 메모리(`feedback_codex_dual_setup.md`)에 "게이트 2 라도 영역 2~3개씩 분할 호출" 룰 추가.
+**교훈**: prompt 사이즈 + 노트북 상태 양쪽 변수 고려.
+
+### 13.11 cause chain wrapper 누락 — 견고성 보강 (Day 4, Codex 검증)
+**증상**: `WishlistApplicationService` 의 isUniqueUserItemConflict 가 `violation.getCause()` 한 겹만 검사.
+**위험**: 드물게 `DataIntegrityViolationException → JpaSystemException → ConstraintViolationException` 처럼 wrapper 가 한 겹 더 끼면 race 가 500 으로 잘못 떨어질 수 있음.
+**해결**: cause chain traversal (자기참조 방어 포함) 으로 변경.
+```java
+Throwable cause = violation;
+while (cause != null) {
+    if (cause instanceof ConstraintViolationException cve
+            && UNIQUE_USER_ITEM.equalsIgnoreCase(cve.getConstraintName())) {
+        return true;
+    }
+    Throwable next = cause.getCause();
+    if (next == cause) return false;
+    cause = next;
+}
+```
+**교훈**: 예외 처리에서 cause chain 은 끝까지 따라가는 게 안전. 자기참조 방어 필수.
+
+### 13.12 Bulk update + persistence context 동기화 (Day 4, Codex 검증)
+**증상**: `Item.incrementWishlistCount` / `decrementWishlistCount` 가 JPA `@Modifying @Query` bulk update.
+**위험**: 같은 트랜잭션 안에서 후속으로 동일 Item 을 read 하면 stale 값 (persistence context 미동기).
+**현 상태**: wishlist add/remove 흐름은 호출 직후 read 가 없어 안전. 단 향후 같은 트랜잭션에서 재읽기 흐름 도입 시 회귀 가능.
+**해결**: 메서드에 stale 주의 javadoc 명시. 후속 `EntityManager.refresh` 또는 `flush+clear` 적용 hint.
+**교훈**: bulk update 는 동기화 책임이 호출자 → 항상 문서화.
+
+### 13.13 후속 이슈 트래킹 (Day 4 게이트 2 검증 권고)
+**Issue #12**: Item 등록 후 presigned key 승격 (`items/{userId}/...` → `items/{itemId}/...`) — 가이드 §4.5 정합 + ownership 검증
+**Issue #13**: Wishlist 동시성 IT — UNIQUE race + atomic counter underflow 검증 (testcontainers + CompletableFuture)
+머지 차단 X (견고성 보강 영역). 5/6 이후 또는 보안/돈 영역 작업 시 함께 진행 권장.
+
+---
+
+## 14. 작업 흐름 학습 (Day별 누계)
+
+- **TDD RED-GREEN-REFACTOR**: 도메인 단위는 테스트 우선, 어플리케이션은 권한·멱등성 케이스 우선
+- **Mockless Fake 패턴**: Mockito 대신 InMemoryFake* 직접 작성. 테스트 가독성 ↑, 단 prod 의미 드리프트 위험 → IT로 보완
+- **commit 분할**: 한 PR 내 의미 단위 분할 (Day 4 PR — 7 commit). 게이트 fix는 별도 commit으로 추적성 확보
+- **컨벤션 일관성**: CLAUDE.md / AGENTS.md 룰을 작업 시작 전 다시 확인. 단순화 욕구로 우회 금지
+
+---
+
 **🚀 Day 1 시작! 막히면 이 문서로 돌아와서 결정 사항 다시 확인.**

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.item.application;
 
 import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.item.application.dto.ItemDetailResult;
+import com.sseulang.domain.item.application.dto.ItemForTransactionResult;
 import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
 import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
 import com.sseulang.domain.item.application.dto.ItemSummaryResult;
@@ -11,7 +12,6 @@ import com.sseulang.domain.item.domain.ItemRepository;
 import com.sseulang.domain.item.domain.ItemStatus;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -98,6 +98,50 @@ public class ItemApplicationService {
         if (item.getStatus() == ItemStatus.삭제) {
             throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
         }
+    }
+
+    /**
+     * 거래 도메인이 거래 생성 시 호출. 비관적 락(PESSIMISTIC_WRITE)으로 Item 행을 잠근 뒤 활성(판매중) 검증.
+     * 가이드 §5.2 — reserve 와 create 동시 시 락 직렬화로 "예약 직후 새 채팅중 거래 저장" 회귀 차단.
+     * Codex 게이트 1 Warning 보강.
+     */
+    @Transactional
+    public ItemForTransactionResult findActiveForTransaction(Long itemId) {
+        Item item = itemRepository.findByIdForUpdate(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        if (item.getStatus() != ItemStatus.판매중) {
+            throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
+        }
+        return new ItemForTransactionResult(
+                item.getId(), item.getSellerId(), item.getTradeType(), item.getPrice(), item.getDeposit()
+        );
+    }
+
+    /**
+     * 거래 도메인이 reserve 시 호출. 비관적 락(PESSIMISTIC_WRITE)으로 Item 행을 잠그고 markAsReserved 호출.
+     * 가이드 §5.2 동시 거래 차단의 핵심 — 같은 트랜잭션 안에서 호출되면 락 유지 + 도메인 invariant 검증.
+     */
+    @Transactional
+    public void markItemAsReserved(Long itemId) {
+        Item item = itemRepository.findByIdForUpdate(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        item.markAsReserved();
+    }
+
+    /** 거래 도메인이 complete 시 호출. 비관적 락 + 예약 → 거래완료. */
+    @Transactional
+    public void markItemAsSold(Long itemId) {
+        Item item = itemRepository.findByIdForUpdate(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        item.markAsSold();
+    }
+
+    /** 거래 도메인이 cancel 시 호출 (예약 상태였던 거래만). 예약 → 판매중 복원. */
+    @Transactional
+    public void restoreItemFromReserved(Long itemId) {
+        Item item = itemRepository.findByIdForUpdate(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        item.restoreFromReserved();
     }
 
     /**

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -102,6 +102,11 @@ public class ItemApplicationService {
 
     /**
      * {@code wishlist_count} 원자 증가. Wishlist 도메인이 찜 추가 성공 직후 호출.
+     *
+     * <p><b>Stale 주의(bulk update)</b>: JPA bulk update 라 persistence context 가 자동 동기화되지
+     * 않는다. 같은 트랜잭션 안에서 후속으로 동일 {@code Item} 을 다시 읽을 경우 stale 값을 받을 수
+     * 있으므로 그때는 {@code EntityManager.refresh} 또는 {@code flush+clear} 필요. 현재 wishlist
+     * add/remove 흐름은 호출 직후 read 가 없어 안전.</p>
      */
     @Transactional
     public void incrementWishlistCount(Long itemId) {
@@ -110,6 +115,7 @@ public class ItemApplicationService {
 
     /**
      * {@code wishlist_count} 원자 감소. 음수 방지는 Repository 쪽 SQL 가드.
+     * Stale 주의는 {@link #incrementWishlistCount} 와 동일.
      */
     @Transactional
     public void decrementWishlistCount(Long itemId) {

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemForTransactionResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemForTransactionResult.java
@@ -1,0 +1,15 @@
+package com.sseulang.domain.item.application.dto;
+
+import com.sseulang.domain.item.domain.TradeType;
+
+/**
+ * 거래 도메인이 거래 생성 시 필요한 Item 정보. ItemApplicationService 가 활성 Item 만 반환.
+ * 다른 도메인이 ItemRepository 를 직접 참조하지 않도록 (CLAUDE.md §3.3).
+ */
+public record ItemForTransactionResult(
+        Long itemId,
+        Long sellerId,
+        TradeType tradeType,
+        long price,
+        Long deposit
+) { }

--- a/src/main/java/com/sseulang/domain/item/domain/Item.java
+++ b/src/main/java/com/sseulang/domain/item/domain/Item.java
@@ -225,6 +225,37 @@ public class Item extends BaseEntity {
         this.status = ItemStatus.판매중;
     }
 
+    /**
+     * 거래 도메인이 reserve 시 호출. 가이드 §5.2 동시 거래 차단의 핵심 — 이미 예약된 Item 에
+     * 다른 거래가 reserve 시도 시 {@link ErrorCode#TRANSACTION_RESERVED_BY_OTHER} 로 거부.
+     * 그 외 비활성 상태(거래완료/비공개/삭제)는 {@link ErrorCode#ITEM_INVALID_STATE}.
+     */
+    public void markAsReserved() {
+        if (status == ItemStatus.예약) {
+            throw new BusinessException(ErrorCode.TRANSACTION_RESERVED_BY_OTHER);
+        }
+        if (status != ItemStatus.판매중) {
+            throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
+        }
+        this.status = ItemStatus.예약;
+    }
+
+    /** 거래 도메인이 complete 시 호출. 예약 → 거래완료 만 허용. */
+    public void markAsSold() {
+        if (status != ItemStatus.예약) {
+            throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
+        }
+        this.status = ItemStatus.거래완료;
+    }
+
+    /** 거래 도메인이 cancel 시 호출. 예약 → 판매중 복원. 가이드 §5.2 — 채팅 재활성화 효과. */
+    public void restoreFromReserved() {
+        if (status != ItemStatus.예약) {
+            throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
+        }
+        this.status = ItemStatus.판매중;
+    }
+
     public void incrementViewCount() {
         this.viewCount++;
     }

--- a/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
@@ -14,6 +14,13 @@ public interface ItemRepository {
 
     Optional<Item> findById(Long id);
 
+    /**
+     * 비관적 쓰기 락(PESSIMISTIC_WRITE)으로 Item 조회. 가이드 §5.2 동시 거래 차단을 위한 핵심 —
+     * Transaction 도메인이 reserve/complete/cancel 시 Item 행을 잠그고 상태 전이.
+     * 첫 호출이 락 점유 → 후속 호출은 대기 → 락 해제 후 status 보고 적절히 거부 (TRANSACTION_RESERVED_BY_OTHER 등).
+     */
+    Optional<Item> findByIdForUpdate(Long id);
+
     /** 동적 검색·필터 + 최신순 정렬. criteria 의 모든 필드가 null 이면 전체 (status != 삭제) 최신순. */
     Page<Item> search(ItemSearchCriteria criteria, Pageable pageable);
 

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
@@ -1,13 +1,21 @@
 package com.sseulang.domain.item.infrastructure.persistence;
 
 import com.sseulang.domain.item.domain.Item;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 /** Spring Data JPA — {@link ItemRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
 interface ItemJpaRepository extends JpaRepository<Item, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT i FROM Item i WHERE i.id = :id")
+    Optional<Item> findByIdForUpdate(@Param("id") Long id);
 
     @Modifying
     @Query("UPDATE Item i SET i.wishlistCount = i.wishlistCount + 1 WHERE i.id = :id")

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
@@ -26,6 +26,11 @@ public class ItemRepositoryImpl implements ItemRepository {
     }
 
     @Override
+    public Optional<Item> findByIdForUpdate(Long id) {
+        return jpa.findByIdForUpdate(id);
+    }
+
+    @Override
     public Page<Item> search(ItemSearchCriteria criteria, Pageable pageable) {
         return querydsl.search(criteria, pageable);
     }

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -1,0 +1,125 @@
+package com.sseulang.domain.transaction.application;
+
+import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.application.dto.ItemForTransactionResult;
+import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
+import com.sseulang.domain.transaction.application.dto.TransactionResult;
+import com.sseulang.domain.transaction.domain.Transaction;
+import com.sseulang.domain.transaction.domain.TransactionRepository;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * Transaction 거래 흐름. 가이드 §5.1 / §5.2 정합:
+ *
+ * <ul>
+ *   <li>create: buyer 가 호출. <b>Item 비관적 락</b> + 활성(판매중) 검증 + 자기 거래 거부.
+ *       reserve 동시 시 락 직렬화 — "예약 직후 새 채팅중 거래" 회귀 차단.</li>
+ *   <li>reserve: seller 가 호출. <b>락 순서 Transaction → Item</b>.
+ *       같은 거래에 대한 reserve vs cancel race 도 Transaction 락이 직렬화 (Codex 게이트 1 Critical 1 보강).
+ *       다른 거래의 reserve 와는 Item 락이 직렬화 → status=예약 보고 거부.</li>
+ *   <li>complete: <b>현재 비활성</b> — 결제·포인트 도메인 (Day 7/8) 합류 전 활성화 시 금전 정합성 결함.
+ *       호출 시 {@link ErrorCode#TRANSACTION_COMPLETION_UNAVAILABLE} 503 (Codex 게이트 1 Critical 2 보강).</li>
+ *   <li>cancel: 양쪽 참여자 모두 호출 가능. Transaction 락 → 예약 상태였으면 Item 복원 (예약 → 판매중).</li>
+ * </ul>
+ */
+@Service
+@Transactional(readOnly = true)
+public class TransactionApplicationService {
+
+    private final TransactionRepository transactionRepository;
+    private final ItemApplicationService itemApplicationService;
+
+    public TransactionApplicationService(
+            TransactionRepository transactionRepository,
+            ItemApplicationService itemApplicationService
+    ) {
+        this.transactionRepository = transactionRepository;
+        this.itemApplicationService = itemApplicationService;
+    }
+
+    @Transactional
+    public Long create(TransactionCreateCommand cmd) {
+        ItemForTransactionResult info = itemApplicationService.findActiveForTransaction(cmd.itemId());
+        if (info.sellerId().equals(cmd.buyerId())) {
+            throw new BusinessException(ErrorCode.TRANSACTION_SELF_NOT_ALLOWED);
+        }
+        Transaction tx = Transaction.create(
+                info.itemId(),
+                info.sellerId(),
+                cmd.buyerId(),
+                info.tradeType(),
+                info.price(),
+                info.deposit(),
+                cmd.rentalStart(),
+                cmd.rentalEnd()
+        );
+        return transactionRepository.save(tx).getId();
+    }
+
+    @Transactional
+    public void reserve(Long transactionId, Long requesterId) {
+        Transaction tx = findOrThrowForUpdate(transactionId);
+        if (!tx.isSeller(requesterId)) {
+            throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
+        }
+        // Item 락 + 상태 전이 — 락 순서 Transaction → Item 고정 (deadlock 회피)
+        itemApplicationService.markItemAsReserved(tx.getItemId());
+        tx.markAsReserved(LocalDateTime.now());
+    }
+
+    /**
+     * 거래 완료 — <b>현재 비활성</b>. 결제·포인트 도메인 (Day 7/8) 합류 후 활성화.
+     *
+     * <p>활성화 시 흐름:
+     * <ol>
+     *   <li>Transaction 락 → seller 권한 검증</li>
+     *   <li>Item 락 → markAsSold</li>
+     *   <li>buyer 포인트 차감 → seller 포인트 적립 (atomic + id-asc 락 순서, 가이드 §4.8 §5.3)</li>
+     *   <li>Transaction.markAsCompleted</li>
+     * </ol>
+     */
+    @Transactional
+    public void complete(Long transactionId, Long requesterId) {
+        // Codex 게이트 1 Critical 2 — 포인트 이동 stub 인 채로 머지하면 거래완료가 되어도 돈이 안 움직임.
+        // Day 7/8 결제·포인트 도메인 합류 후 본 가드를 제거하고 정식 흐름으로 교체.
+        throw new BusinessException(ErrorCode.TRANSACTION_COMPLETION_UNAVAILABLE);
+    }
+
+    @Transactional
+    public void cancel(Long transactionId, Long requesterId, String reason) {
+        Transaction tx = findOrThrowForUpdate(transactionId);
+        if (!tx.isParticipant(requesterId)) {
+            throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
+        }
+        boolean wasReserved = tx.getStatus() == TransactionStatus.예약;
+        tx.cancel(LocalDateTime.now(), reason);
+        if (wasReserved) {
+            // 예약 상태였던 거래만 Item 을 판매중으로 복원 (가이드 §5.2 채팅 재활성화)
+            itemApplicationService.restoreItemFromReserved(tx.getItemId());
+        }
+    }
+
+    public TransactionResult getById(Long id, Long requesterId) {
+        Transaction tx = findOrThrow(id);
+        if (!tx.isParticipant(requesterId)) {
+            throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
+        }
+        return TransactionResult.from(tx);
+    }
+
+    private Transaction findOrThrow(Long id) {
+        return transactionRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRANSACTION_NOT_FOUND));
+    }
+
+    private Transaction findOrThrowForUpdate(Long id) {
+        return transactionRepository.findByIdForUpdate(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRANSACTION_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionCreateCommand.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionCreateCommand.java
@@ -1,0 +1,10 @@
+package com.sseulang.domain.transaction.application.dto;
+
+import java.time.LocalDateTime;
+
+public record TransactionCreateCommand(
+        Long itemId,
+        Long buyerId,
+        LocalDateTime rentalStart,
+        LocalDateTime rentalEnd
+) { }

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionResult.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionResult.java
@@ -1,0 +1,37 @@
+package com.sseulang.domain.transaction.application.dto;
+
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.domain.transaction.domain.Transaction;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+
+import java.time.LocalDateTime;
+
+public record TransactionResult(
+        Long id,
+        Long itemId,
+        Long sellerId,
+        Long buyerId,
+        TradeType tradeType,
+        long price,
+        Long deposit,
+        LocalDateTime rentalStart,
+        LocalDateTime rentalEnd,
+        TransactionStatus status,
+        LocalDateTime reservedAt,
+        LocalDateTime completedAt,
+        LocalDateTime canceledAt,
+        String cancelReason,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static TransactionResult from(Transaction t) {
+        return new TransactionResult(
+                t.getId(), t.getItemId(), t.getSellerId(), t.getBuyerId(),
+                t.getTradeType(), t.getPrice(), t.getDeposit(),
+                t.getRentalStart(), t.getRentalEnd(),
+                t.getStatus(), t.getReservedAt(), t.getCompletedAt(), t.getCanceledAt(),
+                t.getCancelReason(),
+                t.getCreatedAt(), t.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
@@ -1,0 +1,183 @@
+package com.sseulang.domain.transaction.domain;
+
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.global.common.BaseEntity;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Transaction Aggregate Root. V1 스키마 {@code transactions} 매핑.
+ *
+ * <p>가이드 §5.1 거래 상태 머신: {@code 채팅중 → 예약 → 거래완료} (또는 {@code 취소}).
+ * 동시 예약 차단은 본 Aggregate 가 아니라 ApplicationService 가 Item 비관적 락 + Item.markAsReserved
+ * conditional 전이로 처리. 본 Aggregate 자체는 단일 거래의 상태 머신만 책임.</p>
+ *
+ * <p>Setter 없음. 상태 변경은 명시 비즈니스 메서드만.</p>
+ */
+@Entity
+@Table(name = "transactions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Transaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "buyer_id", nullable = false)
+    private Long buyerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trade_type", nullable = false)
+    private TradeType tradeType;
+
+    @Column(name = "price", nullable = false)
+    private long price;
+
+    @Column(name = "deposit")
+    private Long deposit;
+
+    @Column(name = "rental_start")
+    private LocalDateTime rentalStart;
+
+    @Column(name = "rental_end")
+    private LocalDateTime rentalEnd;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private TransactionStatus status;
+
+    @Column(name = "reserved_at")
+    private LocalDateTime reservedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
+    @Column(name = "cancel_reason", length = 255)
+    private String cancelReason;
+
+    public static Transaction create(
+            Long itemId,
+            Long sellerId,
+            Long buyerId,
+            TradeType tradeType,
+            long price,
+            Long deposit,
+            LocalDateTime rentalStart,
+            LocalDateTime rentalEnd
+    ) {
+        if (itemId == null || itemId <= 0) {
+            throw new IllegalArgumentException("itemId 는 양수여야 합니다");
+        }
+        if (sellerId == null || sellerId <= 0) {
+            throw new IllegalArgumentException("sellerId 는 양수여야 합니다");
+        }
+        if (buyerId == null || buyerId <= 0) {
+            throw new IllegalArgumentException("buyerId 는 양수여야 합니다");
+        }
+        if (sellerId.equals(buyerId)) {
+            throw new IllegalArgumentException("seller 와 buyer 는 같을 수 없습니다");
+        }
+        if (tradeType == null) {
+            throw new IllegalArgumentException("tradeType 은 필수입니다");
+        }
+        if (price < 0) {
+            throw new IllegalArgumentException("price 는 0 이상이어야 합니다");
+        }
+        validateRentalFields(tradeType, deposit, rentalStart, rentalEnd);
+
+        Transaction t = new Transaction();
+        t.itemId = itemId;
+        t.sellerId = sellerId;
+        t.buyerId = buyerId;
+        t.tradeType = tradeType;
+        t.price = price;
+        t.deposit = deposit;
+        t.rentalStart = rentalStart;
+        t.rentalEnd = rentalEnd;
+        t.status = TransactionStatus.채팅중;
+        return t;
+    }
+
+    public void markAsReserved(LocalDateTime now) {
+        if (!status.canReserve()) {
+            throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
+        }
+        this.status = TransactionStatus.예약;
+        this.reservedAt = now;
+    }
+
+    public void markAsCompleted(LocalDateTime now) {
+        if (!status.canComplete()) {
+            throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
+        }
+        this.status = TransactionStatus.거래완료;
+        this.completedAt = now;
+    }
+
+    public void cancel(LocalDateTime now, String reason) {
+        if (!status.canCancel()) {
+            throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
+        }
+        this.status = TransactionStatus.취소;
+        this.canceledAt = now;
+        this.cancelReason = reason;
+    }
+
+    public boolean isSeller(Long userId) {
+        return userId != null && userId.equals(this.sellerId);
+    }
+
+    public boolean isBuyer(Long userId) {
+        return userId != null && userId.equals(this.buyerId);
+    }
+
+    public boolean isParticipant(Long userId) {
+        return isSeller(userId) || isBuyer(userId);
+    }
+
+    private static void validateRentalFields(
+            TradeType tradeType, Long deposit, LocalDateTime rentalStart, LocalDateTime rentalEnd
+    ) {
+        if (tradeType.requiresDeposit()) {
+            if (deposit == null || deposit < 0) {
+                throw new IllegalArgumentException("대여 거래는 0 이상의 deposit 이 필수입니다");
+            }
+            if (rentalStart == null || rentalEnd == null) {
+                throw new IllegalArgumentException("대여 거래는 rentalStart/rentalEnd 가 필수입니다");
+            }
+            if (!rentalEnd.isAfter(rentalStart)) {
+                throw new IllegalArgumentException("rentalEnd 는 rentalStart 보다 이후여야 합니다");
+            }
+        } else {
+            if (deposit != null) {
+                throw new IllegalArgumentException("대여 외 거래에는 deposit 을 지정할 수 없습니다");
+            }
+            if (rentalStart != null || rentalEnd != null) {
+                throw new IllegalArgumentException("대여 외 거래에는 rental 일정을 지정할 수 없습니다");
+            }
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -1,0 +1,22 @@
+package com.sseulang.domain.transaction.domain;
+
+import java.util.Optional;
+
+/**
+ * Transaction Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
+ */
+public interface TransactionRepository {
+
+    Optional<Transaction> findById(Long id);
+
+    /**
+     * 비관적 쓰기 락(PESSIMISTIC_WRITE)으로 Transaction 조회. 같은 거래에 대한 동시 reserve/cancel/complete
+     * race 직렬화 — Codex 게이트 1 보강 (Critical: tx 행 자체에 락이 없어 reserve vs cancel 가
+     * Transaction=취소, Item=예약 불일치를 만들 수 있던 케이스 차단).
+     *
+     * <p>락 순서: <b>Transaction → Item</b>. 모든 write flow 가 동일 순서를 지켜 deadlock 회피.</p>
+     */
+    Optional<Transaction> findByIdForUpdate(Long id);
+
+    Transaction save(Transaction transaction);
+}

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatus.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatus.java
@@ -1,0 +1,28 @@
+package com.sseulang.domain.transaction.domain;
+
+/**
+ * 거래 상태. DB ENUM('채팅중','예약','거래완료','취소') 1:1 매핑.
+ * 가이드 §5.1: {@code 채팅중 → 예약 → 거래완료} (또는 {@code 취소}).
+ */
+public enum TransactionStatus {
+    채팅중,
+    예약,
+    거래완료,
+    취소;
+
+    public boolean isTerminal() {
+        return this == 거래완료 || this == 취소;
+    }
+
+    public boolean canReserve() {
+        return this == 채팅중;
+    }
+
+    public boolean canComplete() {
+        return this == 예약;
+    }
+
+    public boolean canCancel() {
+        return this == 채팅중 || this == 예약;
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.transaction.infrastructure.persistence;
+
+import com.sseulang.domain.transaction.domain.Transaction;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+/** Spring Data JPA — {@link TransactionRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
+interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM Transaction t WHERE t.id = :id")
+    Optional<Transaction> findByIdForUpdate(@Param("id") Long id);
+}

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.sseulang.domain.transaction.infrastructure.persistence;
+
+import com.sseulang.domain.transaction.domain.Transaction;
+import com.sseulang.domain.transaction.domain.TransactionRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class TransactionRepositoryImpl implements TransactionRepository {
+
+    private final TransactionJpaRepository jpa;
+
+    public TransactionRepositoryImpl(TransactionJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Optional<Transaction> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Optional<Transaction> findByIdForUpdate(Long id) {
+        return jpa.findByIdForUpdate(id);
+    }
+
+    @Override
+    public Transaction save(Transaction transaction) {
+        return jpa.save(transaction);
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
@@ -1,0 +1,77 @@
+package com.sseulang.domain.transaction.presentation;
+
+import com.sseulang.domain.transaction.application.TransactionApplicationService;
+import com.sseulang.domain.transaction.presentation.dto.TransactionCreateRequest;
+import com.sseulang.domain.transaction.presentation.dto.TransactionIdResponse;
+import com.sseulang.domain.transaction.presentation.dto.TransactionPatchRequest;
+import com.sseulang.domain.transaction.presentation.dto.TransactionResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/transactions")
+public class TransactionController {
+
+    private final TransactionApplicationService transactionService;
+
+    public TransactionController(TransactionApplicationService transactionService) {
+        this.transactionService = transactionService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<TransactionIdResponse>> create(
+            @AuthenticationPrincipal Long buyerId,
+            @Valid @RequestBody TransactionCreateRequest request
+    ) {
+        Long id = transactionService.create(request.toCommand(buyerId));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(new TransactionIdResponse(id)));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<TransactionResponse> getOne(
+            @AuthenticationPrincipal Long requesterId,
+            @PathVariable("id") Long id
+    ) {
+        return ApiResponse.ok(TransactionResponse.from(transactionService.getById(id, requesterId)));
+    }
+
+    /**
+     * 거래 상태 전이. action 별 분기:
+     * <ul>
+     *   <li>{@code 예약}: seller 만 호출 가능. Item 비관적 락 + markAsReserved.</li>
+     *   <li>{@code 거래완료}: seller 만. (포인트 이동은 Day 8)</li>
+     *   <li>{@code 취소}: 양쪽 참여자. 예약 상태였다면 Item 판매중으로 복원.</li>
+     * </ul>
+     * action={@code 채팅중} 은 거부 — 채팅중은 create 시점에만 부여되는 초기 상태.
+     */
+    @PatchMapping("/{id}")
+    public ApiResponse<Void> patch(
+            @AuthenticationPrincipal Long requesterId,
+            @PathVariable("id") Long id,
+            @Valid @RequestBody TransactionPatchRequest request
+    ) {
+        if (request.isReserve()) {
+            transactionService.reserve(id, requesterId);
+        } else if (request.isComplete()) {
+            transactionService.complete(id, requesterId);
+        } else if (request.isCancel()) {
+            transactionService.cancel(id, requesterId, request.cancelReason());
+        } else {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionCreateRequest.java
@@ -1,0 +1,17 @@
+package com.sseulang.domain.transaction.presentation.dto;
+
+import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.time.LocalDateTime;
+
+public record TransactionCreateRequest(
+        @NotNull @Positive Long itemId,
+        LocalDateTime rentalStart,
+        LocalDateTime rentalEnd
+) {
+    public TransactionCreateCommand toCommand(Long buyerId) {
+        return new TransactionCreateCommand(itemId, buyerId, rentalStart, rentalEnd);
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionIdResponse.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionIdResponse.java
@@ -1,0 +1,3 @@
+package com.sseulang.domain.transaction.presentation.dto;
+
+public record TransactionIdResponse(Long id) { }

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchRequest.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchRequest.java
@@ -1,0 +1,26 @@
+package com.sseulang.domain.transaction.presentation.dto;
+
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 거래 상태 전이 요청. {@code action} 으로 의도된 상태(예약/거래완료/취소) 명시.
+ * cancelReason 은 action=취소 일 때만 의미. 다른 action 일 때 null/무시.
+ */
+public record TransactionPatchRequest(
+        @NotNull TransactionStatus action,
+        @Size(max = 255) String cancelReason
+) {
+    public boolean isReserve() {
+        return action == TransactionStatus.예약;
+    }
+
+    public boolean isComplete() {
+        return action == TransactionStatus.거래완료;
+    }
+
+    public boolean isCancel() {
+        return action == TransactionStatus.취소;
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionResponse.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionResponse.java
@@ -1,0 +1,37 @@
+package com.sseulang.domain.transaction.presentation.dto;
+
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.domain.transaction.application.dto.TransactionResult;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+
+import java.time.LocalDateTime;
+
+public record TransactionResponse(
+        Long id,
+        Long itemId,
+        Long sellerId,
+        Long buyerId,
+        TradeType tradeType,
+        long price,
+        Long deposit,
+        LocalDateTime rentalStart,
+        LocalDateTime rentalEnd,
+        TransactionStatus status,
+        LocalDateTime reservedAt,
+        LocalDateTime completedAt,
+        LocalDateTime canceledAt,
+        String cancelReason,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static TransactionResponse from(TransactionResult r) {
+        return new TransactionResponse(
+                r.id(), r.itemId(), r.sellerId(), r.buyerId(),
+                r.tradeType(), r.price(), r.deposit(),
+                r.rentalStart(), r.rentalEnd(),
+                r.status(), r.reservedAt(), r.completedAt(), r.canceledAt(),
+                r.cancelReason(),
+                r.createdAt(), r.updatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
+++ b/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
@@ -62,9 +62,25 @@ public class WishlistApplicationService {
         }
     }
 
+    /**
+     * cause chain 을 끝까지 따라가며 {@code uk_wishlists_user_item} 제약 위반인지 판별.
+     * 단순 {@code violation.getCause()} 만 보면 드물게 wrapper 가 한 겹 더 끼는 경우(예:
+     * {@code DataIntegrityViolationException → JpaSystemException → ConstraintViolationException})
+     * race 가 500 으로 잘못 떨어질 수 있어 traversal 로 보강 (Codex 게이트 2 검증 권고).
+     */
     private static boolean isUniqueUserItemConflict(DataIntegrityViolationException violation) {
-        Throwable cause = violation.getCause();
-        return cause instanceof ConstraintViolationException cve
-                && UNIQUE_USER_ITEM.equalsIgnoreCase(cve.getConstraintName());
+        Throwable cause = violation;
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException cve
+                    && UNIQUE_USER_ITEM.equalsIgnoreCase(cve.getConstraintName())) {
+                return true;
+            }
+            Throwable next = cause.getCause();
+            if (next == cause) {
+                return false; // 자기참조 방어
+            }
+            cause = next;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -38,8 +38,11 @@ public enum ErrorCode {
 
     // 거래
     TRANSACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),
+    TRANSACTION_FORBIDDEN(HttpStatus.FORBIDDEN, "거래에 대한 권한이 없습니다."),
     TRANSACTION_INVALID_STATE(HttpStatus.BAD_REQUEST, "현재 상태에서 수행할 수 없는 동작입니다."),
     TRANSACTION_RESERVED_BY_OTHER(HttpStatus.CONFLICT, "이미 다른 사용자와 예약된 거래입니다."),
+    TRANSACTION_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "본인의 물품으로는 거래를 시작할 수 없습니다."),
+    TRANSACTION_COMPLETION_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "거래 완료 처리는 결제·포인트 도메인 합류 후 활성화됩니다."),
 
     // 결제 / 포인트
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),

--- a/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
+++ b/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
@@ -34,6 +34,12 @@ public class InMemoryFakeItemRepository implements ItemRepository {
     }
 
     @Override
+    public Optional<Item> findByIdForUpdate(Long id) {
+        // fake — 락 의미 없음. 실제 동시성 검증은 testcontainers IT 에서.
+        return findById(id);
+    }
+
+    @Override
     public Page<Item> search(ItemSearchCriteria criteria, Pageable pageable) {
         Stream<Item> stream = store.values().stream()
                 .filter(i -> i.getStatus() != ItemStatus.삭제);

--- a/src/test/java/com/sseulang/domain/item/domain/ItemTest.java
+++ b/src/test/java/com/sseulang/domain/item/domain/ItemTest.java
@@ -244,6 +244,81 @@ class ItemTest {
         assertThat(item.getHashtags()).isEmpty();
     }
 
+    @Test
+    @DisplayName("markAsReserved 정상_판매중→예약")
+    void markAsReserved_정상() {
+        Item item = saleItem();
+        item.markAsReserved();
+        assertThat(item.getStatus()).isEqualTo(ItemStatus.예약);
+    }
+
+    @Test
+    @DisplayName("markAsReserved 이미 예약_TRANSACTION_RESERVED_BY_OTHER")
+    void markAsReserved_이미_예약_거부() {
+        Item item = saleItem();
+        item.markAsReserved();
+        assertThatThrownBy(item::markAsReserved)
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_RESERVED_BY_OTHER);
+    }
+
+    @Test
+    @DisplayName("markAsReserved 비공개/삭제_ITEM_INVALID_STATE")
+    void markAsReserved_비활성_거부() {
+        Item hidden = saleItem();
+        hidden.markAsHidden();
+        assertThatThrownBy(hidden::markAsReserved)
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_INVALID_STATE);
+
+        Item deleted = saleItem();
+        deleted.markAsDeleted();
+        assertThatThrownBy(deleted::markAsReserved)
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("markAsSold 예약→거래완료")
+    void markAsSold_정상() {
+        Item item = saleItem();
+        item.markAsReserved();
+        item.markAsSold();
+        assertThat(item.getStatus()).isEqualTo(ItemStatus.거래완료);
+    }
+
+    @Test
+    @DisplayName("markAsSold 판매중에서 직행_ITEM_INVALID_STATE")
+    void markAsSold_판매중에서_거부() {
+        Item item = saleItem();
+        assertThatThrownBy(item::markAsSold)
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("restoreFromReserved 예약→판매중")
+    void restoreFromReserved_정상() {
+        Item item = saleItem();
+        item.markAsReserved();
+        item.restoreFromReserved();
+        assertThat(item.getStatus()).isEqualTo(ItemStatus.판매중);
+    }
+
+    @Test
+    @DisplayName("restoreFromReserved 판매중에서_ITEM_INVALID_STATE")
+    void restoreFromReserved_거부() {
+        Item item = saleItem();
+        assertThatThrownBy(item::restoreFromReserved)
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_INVALID_STATE);
+    }
+
     private static Item saleItem() {
         return Item.create(SELLER, CATEGORY, "t", "d", 10_000L, null, null, TradeType.판매, "서울");
     }

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -1,0 +1,35 @@
+package com.sseulang.domain.transaction.application;
+
+import com.sseulang.domain.transaction.domain.Transaction;
+import com.sseulang.domain.transaction.domain.TransactionRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class InMemoryFakeTransactionRepository implements TransactionRepository {
+
+    private final Map<Long, Transaction> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public Optional<Transaction> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<Transaction> findByIdForUpdate(Long id) {
+        // fake — 락 의미 없음. 실제 동시성 검증은 IT 에서.
+        return findById(id);
+    }
+
+    @Override
+    public Transaction save(Transaction transaction) {
+        if (transaction.getId() == null) {
+            ReflectionTestUtils.setField(transaction, "id", ++sequence);
+        }
+        store.put(transaction.getId(), transaction);
+        return transaction;
+    }
+}

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -1,0 +1,225 @@
+package com.sseulang.domain.transaction.application;
+
+import com.sseulang.domain.category.application.CategoryApplicationService;
+import com.sseulang.domain.category.application.InMemoryFakeCategoryRepository;
+import com.sseulang.domain.item.application.InMemoryFakeItemRepository;
+import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
+import com.sseulang.domain.transaction.application.dto.TransactionResult;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TransactionApplicationServiceTest {
+
+    private static final Long SELLER = 100L;
+    private static final Long BUYER = 200L;
+    private static final Long OUTSIDER = 999L;
+
+    private InMemoryFakeTransactionRepository txRepo;
+    private InMemoryFakeItemRepository itemRepo;
+    private ItemApplicationService itemSvc;
+    private TransactionApplicationService service;
+    private Long itemId;
+
+    @BeforeEach
+    void setUp() {
+        txRepo = new InMemoryFakeTransactionRepository();
+        itemRepo = new InMemoryFakeItemRepository();
+        CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
+        itemSvc = new ItemApplicationService(itemRepo, catSvc);
+        service = new TransactionApplicationService(txRepo, itemSvc);
+
+        Item item = itemRepo.save(Item.create(
+                SELLER, null, "물건", "설명", 50_000L, null, null, TradeType.판매, "서울"
+        ));
+        itemId = item.getId();
+    }
+
+    @Test
+    @DisplayName("create 정상_status=채팅중")
+    void create_정상() {
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+
+        TransactionResult r = service.getById(txId, BUYER);
+        assertThat(r.itemId()).isEqualTo(itemId);
+        assertThat(r.sellerId()).isEqualTo(SELLER);
+        assertThat(r.buyerId()).isEqualTo(BUYER);
+        assertThat(r.status()).isEqualTo(TransactionStatus.채팅중);
+        assertThat(r.price()).isEqualTo(50_000L);
+    }
+
+    @Test
+    @DisplayName("create 본인 물품_TRANSACTION_SELF_NOT_ALLOWED")
+    void create_본인_거부() {
+        assertThatThrownBy(() ->
+                service.create(new TransactionCreateCommand(itemId, SELLER, null, null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_SELF_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("create 비활성 Item (예약 상태)_ITEM_INVALID_STATE")
+    void create_비활성_거부() {
+        Item item = itemRepo.findById(itemId).orElseThrow();
+        item.markAsReserved();
+        itemRepo.save(item);
+
+        assertThatThrownBy(() ->
+                service.create(new TransactionCreateCommand(itemId, BUYER, null, null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("create 없는 Item_ITEM_NOT_FOUND")
+    void create_없는_item() {
+        assertThatThrownBy(() ->
+                service.create(new TransactionCreateCommand(9999L, BUYER, null, null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("reserve seller 정상_Transaction.예약 + Item.예약")
+    void reserve_정상() {
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+
+        service.reserve(txId, SELLER);
+
+        assertThat(service.getById(txId, SELLER).status()).isEqualTo(TransactionStatus.예약);
+        assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.예약);
+    }
+
+    @Test
+    @DisplayName("reserve buyer 호출_TRANSACTION_FORBIDDEN")
+    void reserve_buyer_거부() {
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+
+        assertThatThrownBy(() -> service.reserve(txId, BUYER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("reserve 외부인_TRANSACTION_FORBIDDEN")
+    void reserve_외부인_거부() {
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+
+        assertThatThrownBy(() -> service.reserve(txId, OUTSIDER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("두 buyer 동시 거래_첫 reserve 만 성공_두 번째는 TRANSACTION_RESERVED_BY_OTHER")
+    void 동시_reserve_차단() {
+        Long buyer2 = 300L;
+        Long tx1 = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long tx2 = service.create(new TransactionCreateCommand(itemId, buyer2, null, null));
+
+        // 첫 reserve 성공
+        service.reserve(tx1, SELLER);
+
+        // 두 번째 reserve 는 Item.status=예약 으로 인해 거부
+        assertThatThrownBy(() -> service.reserve(tx2, SELLER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_RESERVED_BY_OTHER);
+    }
+
+    @Test
+    @DisplayName("complete 현재 비활성_TRANSACTION_COMPLETION_UNAVAILABLE")
+    void complete_비활성() {
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        service.reserve(txId, SELLER);
+
+        // Codex 게이트 1 Critical 2 — Day 7/8 결제·포인트 합류 전엔 503 으로 막음.
+        // 호출자(권한·상태 무관) 모두 동일 응답.
+        assertThatThrownBy(() -> service.complete(txId, SELLER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_COMPLETION_UNAVAILABLE);
+        assertThatThrownBy(() -> service.complete(txId, BUYER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_COMPLETION_UNAVAILABLE);
+
+        // Item 은 예약 상태 그대로 유지 — 거래완료 전이 일어나지 않음
+        assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.예약);
+    }
+
+    @Test
+    @DisplayName("cancel 채팅중 buyer_정상_Item 변경 없음")
+    void cancel_채팅중() {
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+
+        service.cancel(txId, BUYER, "변심");
+
+        assertThat(service.getById(txId, BUYER).status()).isEqualTo(TransactionStatus.취소);
+        assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.판매중);
+    }
+
+    @Test
+    @DisplayName("cancel 예약 상태_Item.판매중 으로 복원")
+    void cancel_예약_복원() {
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        service.reserve(txId, SELLER);
+
+        service.cancel(txId, SELLER, "물건 파손");
+
+        assertThat(service.getById(txId, SELLER).status()).isEqualTo(TransactionStatus.취소);
+        assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.판매중);
+    }
+
+    @Test
+    @DisplayName("cancel 외부인_TRANSACTION_FORBIDDEN")
+    void cancel_외부인_거부() {
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+
+        assertThatThrownBy(() -> service.cancel(txId, OUTSIDER, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("getById 비참여자_TRANSACTION_FORBIDDEN")
+    void getById_외부인_거부() {
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+
+        assertThatThrownBy(() -> service.getById(txId, OUTSIDER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("cancel 후 다른 buyer 가 같은 Item 으로 거래 시작 가능")
+    void cancel_후_새_거래() {
+        Long buyer2 = 300L;
+        Long tx1 = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        service.reserve(tx1, SELLER);
+        service.cancel(tx1, SELLER, "재예약 가능");
+
+        // Item 이 판매중으로 복원 → 새 거래 시작 OK
+        Long tx2 = service.create(new TransactionCreateCommand(itemId, buyer2, null, null));
+        service.reserve(tx2, SELLER);
+
+        assertThat(service.getById(tx2, SELLER).status()).isEqualTo(TransactionStatus.예약);
+    }
+}

--- a/src/test/java/com/sseulang/domain/transaction/domain/TransactionTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/domain/TransactionTest.java
@@ -1,0 +1,196 @@
+package com.sseulang.domain.transaction.domain;
+
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TransactionTest {
+
+    private static final Long ITEM = 10L;
+    private static final Long SELLER = 100L;
+    private static final Long BUYER = 200L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 1, 12, 0);
+
+    @Test
+    @DisplayName("create 판매_정상_status=채팅중, deposit/rental null")
+    void create_판매_정상() {
+        Transaction t = Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, 50_000L, null, null, null);
+
+        assertThat(t.getItemId()).isEqualTo(ITEM);
+        assertThat(t.getSellerId()).isEqualTo(SELLER);
+        assertThat(t.getBuyerId()).isEqualTo(BUYER);
+        assertThat(t.getTradeType()).isEqualTo(TradeType.판매);
+        assertThat(t.getPrice()).isEqualTo(50_000L);
+        assertThat(t.getStatus()).isEqualTo(TransactionStatus.채팅중);
+        assertThat(t.getReservedAt()).isNull();
+        assertThat(t.getCompletedAt()).isNull();
+        assertThat(t.getCanceledAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("create 대여_정상_deposit/rental 박힘")
+    void create_대여_정상() {
+        LocalDateTime start = NOW.plusDays(1);
+        LocalDateTime end = NOW.plusDays(7);
+        Transaction t = Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 5_000L, 50_000L, start, end);
+
+        assertThat(t.getDeposit()).isEqualTo(50_000L);
+        assertThat(t.getRentalStart()).isEqualTo(start);
+        assertThat(t.getRentalEnd()).isEqualTo(end);
+    }
+
+    @Test
+    @DisplayName("create seller==buyer_거부")
+    void create_self_거부() {
+        assertThatThrownBy(() ->
+                Transaction.create(ITEM, SELLER, SELLER, TradeType.판매, 1L, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create 대여인데 deposit/rental 누락_거부")
+    void create_대여_누락_거부() {
+        assertThatThrownBy(() ->
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, null, NOW, NOW.plusDays(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, 10_000L, null, NOW.plusDays(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create 판매인데 deposit/rental 박으면_거부")
+    void create_판매_보증금_거부() {
+        assertThatThrownBy(() ->
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, 1L, 10_000L, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, 1L, null, NOW, NOW.plusDays(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create 음수 price/deposit_거부")
+    void create_음수_거부() {
+        assertThatThrownBy(() ->
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, -1L, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, -1L, NOW, NOW.plusDays(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create rentalEnd <= rentalStart_거부")
+    void create_rental_역전_거부() {
+        assertThatThrownBy(() ->
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, 1_000L, NOW.plusDays(2), NOW.plusDays(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, 1_000L, NOW, NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("markAsReserved 정상_status=예약 + reservedAt")
+    void reserve_정상() {
+        Transaction t = sale();
+        t.markAsReserved(NOW);
+        assertThat(t.getStatus()).isEqualTo(TransactionStatus.예약);
+        assertThat(t.getReservedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("markAsReserved 채팅중 외_TRANSACTION_INVALID_STATE")
+    void reserve_상태_위반() {
+        Transaction t = sale();
+        t.markAsReserved(NOW);
+        assertThatThrownBy(() -> t.markAsReserved(NOW))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("markAsCompleted 정상_예약→거래완료")
+    void complete_정상() {
+        Transaction t = sale();
+        t.markAsReserved(NOW);
+        t.markAsCompleted(NOW.plusHours(1));
+        assertThat(t.getStatus()).isEqualTo(TransactionStatus.거래완료);
+        assertThat(t.getCompletedAt()).isEqualTo(NOW.plusHours(1));
+    }
+
+    @Test
+    @DisplayName("markAsCompleted 채팅중에서 직행_거부")
+    void complete_채팅중에서_거부() {
+        Transaction t = sale();
+        assertThatThrownBy(() -> t.markAsCompleted(NOW))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("cancel 채팅중에서 정상")
+    void cancel_채팅중() {
+        Transaction t = sale();
+        t.cancel(NOW, "사유");
+        assertThat(t.getStatus()).isEqualTo(TransactionStatus.취소);
+        assertThat(t.getCanceledAt()).isEqualTo(NOW);
+        assertThat(t.getCancelReason()).isEqualTo("사유");
+    }
+
+    @Test
+    @DisplayName("cancel 예약에서 정상")
+    void cancel_예약() {
+        Transaction t = sale();
+        t.markAsReserved(NOW);
+        t.cancel(NOW.plusHours(1), null);
+        assertThat(t.getStatus()).isEqualTo(TransactionStatus.취소);
+    }
+
+    @Test
+    @DisplayName("cancel 거래완료_거부")
+    void cancel_거래완료_거부() {
+        Transaction t = sale();
+        t.markAsReserved(NOW);
+        t.markAsCompleted(NOW.plusHours(1));
+        assertThatThrownBy(() -> t.cancel(NOW.plusHours(2), null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("cancel 이미 취소_거부")
+    void cancel_중복_거부() {
+        Transaction t = sale();
+        t.cancel(NOW, null);
+        assertThatThrownBy(() -> t.cancel(NOW.plusHours(1), null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("isSeller / isBuyer / isParticipant")
+    void participants() {
+        Transaction t = sale();
+        assertThat(t.isSeller(SELLER)).isTrue();
+        assertThat(t.isBuyer(BUYER)).isTrue();
+        assertThat(t.isParticipant(SELLER)).isTrue();
+        assertThat(t.isParticipant(BUYER)).isTrue();
+        assertThat(t.isParticipant(999L)).isFalse();
+        assertThat(t.isSeller(BUYER)).isFalse();
+    }
+
+    private static Transaction sale() {
+        return Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, 50_000L, null, null, null);
+    }
+}

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -1,0 +1,205 @@
+package com.sseulang.domain.transaction.integration;
+
+import com.sseulang.domain.category.application.CategoryApplicationService;
+import com.sseulang.domain.category.infrastructure.persistence.CategoryRepositoryImpl;
+import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.domain.item.infrastructure.persistence.ItemQuerydslRepository;
+import com.sseulang.domain.item.infrastructure.persistence.ItemRepositoryImpl;
+import com.sseulang.domain.transaction.application.TransactionApplicationService;
+import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+import com.sseulang.domain.transaction.infrastructure.persistence.TransactionRepositoryImpl;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.infrastructure.persistence.UserRepositoryImpl;
+import com.sseulang.global.config.JpaAuditingConfig;
+import com.sseulang.global.config.QuerydslConfig;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Transaction 동시 reserve race 검증 — 가이드 §5.2 / §7.6 강제 영역.
+ *
+ * <p>같은 Item 에 두 buyer 가 동시 reserve 호출 시 비관적 락(PESSIMISTIC_WRITE) 으로 첫 트랜잭션이
+ * Item 락 점유 → 두 번째는 대기 → 첫 commit 후 두 번째가 status=예약 보고 거부. 정확히 1건만 성공해야.</p>
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({
+        QuerydslConfig.class,
+        JpaAuditingConfig.class,
+        ItemQuerydslRepository.class,
+        ItemRepositoryImpl.class,
+        ItemApplicationService.class,
+        CategoryRepositoryImpl.class,
+        CategoryApplicationService.class,
+        UserRepositoryImpl.class,
+        TransactionRepositoryImpl.class,
+        TransactionApplicationService.class
+})
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class TransactionConcurrencyIT {
+
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("sseulang_test")
+            .withUsername("test")
+            .withPassword("testpw")
+            .withCommand("--character-set-server=utf8mb4",
+                    "--collation-server=utf8mb4_unicode_ci",
+                    "--ngram_token_size=2");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ItemApplicationService itemService;
+
+    @Autowired
+    private TransactionApplicationService transactionService;
+
+    @Autowired
+    private com.sseulang.domain.item.domain.ItemRepository itemRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate txTemplate;
+
+    private Long sellerId;
+    private Long buyer1Id;
+    private Long buyer2Id;
+    private Long itemId;
+    private Long tx1Id;
+    private Long tx2Id;
+
+    @BeforeEach
+    void setUp() {
+        txTemplate = new TransactionTemplate(transactionManager);
+        // setup 은 별도 트랜잭션 안에서 commit (기본 테스트 트랜잭션 X — @Commit 적용)
+        txTemplate.execute(status -> {
+            sellerId = persistUser("seller");
+            buyer1Id = persistUser("buyer1");
+            buyer2Id = persistUser("buyer2");
+
+            itemId = itemService.register(new ItemRegisterCommand(
+                    sellerId, null, "물건", "설명", 50_000L, null, null, TradeType.판매,
+                    "서울", null, null
+            ));
+
+            tx1Id = transactionService.create(new TransactionCreateCommand(itemId, buyer1Id, null, null));
+            tx2Id = transactionService.create(new TransactionCreateCommand(itemId, buyer2Id, null, null));
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("동시 reserve_정확히 1건 성공 + Item.status=예약")
+    void 동시_reserve() throws Exception {
+        ExecutorService exec = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicInteger success = new AtomicInteger();
+        AtomicInteger reservedByOther = new AtomicInteger();
+        AtomicInteger otherError = new AtomicInteger();
+
+        Runnable reserveTx1 = () -> tryReserve(tx1Id, start, done, success, reservedByOther, otherError);
+        Runnable reserveTx2 = () -> tryReserve(tx2Id, start, done, success, reservedByOther, otherError);
+
+        exec.submit(reserveTx1);
+        exec.submit(reserveTx2);
+
+        start.countDown();
+        boolean finished = done.await(10, TimeUnit.SECONDS);
+        exec.shutdown();
+
+        assertThat(finished).as("두 호출 모두 10초 안에 완료").isTrue();
+        assertThat(success.get()).as("정확히 1건만 reserve 성공").isEqualTo(1);
+        assertThat(reservedByOther.get()).as("나머지 1건은 TRANSACTION_RESERVED_BY_OTHER").isEqualTo(1);
+        assertThat(otherError.get()).as("그 외 에러 없음").isZero();
+
+        Item item = itemRepository.findById(itemId).orElseThrow();
+        assertThat(item.getStatus()).isEqualTo(ItemStatus.예약);
+
+        // cleanup — @Commit 으로 데이터 남으니 후속 테스트 충돌 방지 (현재 클래스 단일 테스트라 실효 X, 안전 차원)
+        txTemplate.execute(status -> {
+            em.createNativeQuery("DELETE FROM transactions").executeUpdate();
+            em.createNativeQuery("DELETE FROM items").executeUpdate();
+            em.createNativeQuery("DELETE FROM users").executeUpdate();
+            return null;
+        });
+    }
+
+    private void tryReserve(Long txId, CountDownLatch start, CountDownLatch done,
+                            AtomicInteger success, AtomicInteger reservedByOther, AtomicInteger otherError) {
+        try {
+            start.await();
+            transactionService.reserve(txId, sellerId);
+            success.incrementAndGet();
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == ErrorCode.TRANSACTION_RESERVED_BY_OTHER) {
+                reservedByOther.incrementAndGet();
+            } else {
+                otherError.incrementAndGet();
+            }
+        } catch (Exception e) {
+            otherError.incrementAndGet();
+        } finally {
+            done.countDown();
+        }
+    }
+
+    private Long persistUser(String suffix) {
+        User user = User.createSocialUser(
+                SocialProvider.KAKAO,
+                "kakao-" + suffix + "-" + System.nanoTime(),
+                new Email(suffix + "-" + System.nanoTime() + "@example.com"),
+                suffix,
+                null
+        );
+        em.persist(user);
+        em.flush();
+        return user.getId();
+    }
+}


### PR DESCRIPTION
## Summary

Day 5 Transaction 도메인 — 거래 상태 머신(채팅중 → 예약 → 거래완료/취소) + 동시 거래 차단. 가이드 §5.1 / §5.2 / §5.3 정합. **Codex 게이트 1 즉시 리뷰 + Critical 2 / Warning 1 모두 반영 완료**.

- **신규 도메인**: `transaction`
- **테스트**: 200 → **238 PASS / 0 FAIL** (+38 — 도메인 16 / 어플리케이션 14 / Item 거래 트리거 +7 / 통합 IT 1)
- **🔴 Critical 2개 fix**: Transaction 자체 락 + complete 비활성화 (포인트 도메인 합류 전 금전 정합성 결함 차단)
- **🟡 Warning 1개 fix**: create 시 Item 비관적 락 — reserve 동시 시 "예약 직후 새 채팅중 거래" 회귀 차단
- 후속 트래킹 [Issue #14](https://github.com/sseullaeng/sl-server/issues/14) — race latch IT 보강

## Commits

| | 의미 |
|---|---|
| `f5499ad` | docs: 트러블슈팅 §13 + 작업 흐름 §14 (PR #11 squash 직후 누락된 cause chain traversal cherry-pick) |
| `4f3baad` | **feat: Day 5 Transaction + 게이트 1 보강** |

## 핵심 설계

### 상태 머신 (가이드 §5.1)
- `채팅중 → 예약 → 거래완료` 또는 `취소`
- `Transaction.markAsReserved` / `markAsCompleted` / `cancel` — `canReserve` / `canComplete` / `canCancel` enum 가드
- 거래 도메인이 트리거하는 `Item.markAsReserved` / `markAsSold` / `restoreFromReserved`

### 동시성 (가이드 §5.2 / §5.3)
- **`Item.findByIdForUpdate`** (PESSIMISTIC_WRITE) — 다른 거래 reserve 직렬화
- **`Transaction.findByIdForUpdate`** — 같은 거래의 reserve vs cancel race 직렬화 (게이트 1 Critical 1)
- **락 순서 고정**: `Transaction → Item` (deadlock 회피)
- `create` 도 Item 락 — reserve 동시 시 새 채팅중 거래 회귀 차단 (게이트 1 Warning)

### 권한
- `reserve` / `complete`: seller 만
- `cancel`: 양쪽 참여자
- `getById`: 참여자만 → 그 외 `TRANSACTION_FORBIDDEN`
- 본인 물품 거래 거부 → `TRANSACTION_SELF_NOT_ALLOWED`

### complete 임시 비활성 (게이트 1 Critical 2)
- 결제·포인트 도메인 (Day 7/8) 합류 전 활성화 시 금전 정합성 결함
- 호출 시 `TRANSACTION_COMPLETION_UNAVAILABLE` (503) — Day 8 에서 본 가드 제거 + 정식 흐름

## 통합 테스트

`TransactionConcurrencyIT` — testcontainers MySQL + ExecutorService:
- 두 buyer 동시 reserve → 정확히 1건만 성공, 1건은 `TRANSACTION_RESERVED_BY_OTHER`
- `@Transactional(propagation = NOT_SUPPORTED)` 로 테스트 트랜잭션 무력화 → 멀티 스레드 별도 트랜잭션

## 게이트 1 처리 내역

🔴 **Critical**
- (1) Transaction 행에 락도 @Version 도 없어 reserve vs cancel 동시 진행 시 Transaction=취소, Item=예약 불일치 가능 → `findByIdForUpdate` 추가, 락 순서 Transaction → Item 고정
- (2) `complete` 가 포인트 이동 TODO 인 채로 머지되면 거래완료 확정되어도 돈이 안 움직임 → 503 으로 차단

🟡 **Warning**
- (1) `create` 가 non-locking read → reserve 와 동시 시 예약 직후 새 채팅중 거래 저장 가능 → Item 비관적 락 추가
- (2) IT 가 lock-wait race 강하게 재현 못 함, reserve vs cancel 시나리오 누락 → **Issue #14** 분리

🔵 **Suggestion** (별도 / 후순위)
- Item 도메인이 Transaction ErrorCode 직접 throw — `ITEM_ALREADY_RESERVED` 같은 item 측 에러 분리 평가
- self 거래 검증 snapshot read — owner 이전 확장 시 재평가

## Test plan

- [ ] CI build 통과
- [ ] 로컬 `./gradlew test` — 238 PASS / 0 FAIL 재현
- [ ] `TransactionConcurrencyIT` 단독 실행 (testcontainers MySQL pull 포함 ~15초)
- [ ] dev 머지 후 Swagger UI 에서:
  - `POST /api/v1/transactions`
  - `GET /api/v1/transactions/{id}`
  - `PATCH /api/v1/transactions/{id}` (action ∈ 예약/거래완료/취소). complete 는 503 반환 확인.
- [ ] 후속 트래킹: issue #14 (race latch IT)

## 위험 영역

이번 PR은 **🔴 게이트 1 영역** (거래 상태 머신, 동시 차단). Codex 게이트 1 즉시 리뷰 완료 + Critical 2개 closure. Day 8 결제·포인트 합류 시 `complete` 가드 제거 작업 필수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)