### PR TITLE
feat: Day 5 후반 — ChatRoom + Block + Report + Review (게이트 2 보강)

### DIFF
--- a/src/main/java/com/sseulang/domain/block/application/UserBlockApplicationService.java
+++ b/src/main/java/com/sseulang/domain/block/application/UserBlockApplicationService.java
@@ -1,0 +1,68 @@
+package com.sseulang.domain.block.application;
+
+import com.sseulang.domain.block.application.dto.UserBlockResult;
+import com.sseulang.domain.block.domain.UserBlock;
+import com.sseulang.domain.block.domain.UserBlockRepository;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UserBlockApplicationService {
+
+    private static final String UNIQUE_BLOCKER_BLOCKED = "uk_user_blocks";
+
+    private final UserBlockRepository repository;
+
+    public UserBlockApplicationService(UserBlockRepository repository) {
+        this.repository = repository;
+    }
+
+    /** 멱등 차단 추가. 자기 차단 거부, 이미 차단되어 있으면 무시. UNIQUE race 좁은 catch. */
+    @Transactional
+    public void block(Long blockerId, Long blockedId) {
+        if (blockerId.equals(blockedId)) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+        if (repository.existsByBlockerIdAndBlockedId(blockerId, blockedId)) {
+            return;
+        }
+        try {
+            repository.save(UserBlock.create(blockerId, blockedId));
+        } catch (DataIntegrityViolationException violation) {
+            if (isUniqueConflict(violation)) {
+                return;
+            }
+            throw violation;
+        }
+    }
+
+    @Transactional
+    public void unblock(Long blockerId, Long blockedId) {
+        repository.deleteByBlockerIdAndBlockedId(blockerId, blockedId);
+    }
+
+    public Page<UserBlockResult> listMine(Long blockerId, Pageable pageable) {
+        return repository.findByBlockerId(blockerId, pageable).map(UserBlockResult::from);
+    }
+
+    private static boolean isUniqueConflict(DataIntegrityViolationException violation) {
+        Throwable cause = violation;
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException cve
+                    && UNIQUE_BLOCKER_BLOCKED.equalsIgnoreCase(cve.getConstraintName())) {
+                return true;
+            }
+            Throwable next = cause.getCause();
+            if (next == cause) return false;
+            cause = next;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/sseulang/domain/block/application/dto/UserBlockResult.java
+++ b/src/main/java/com/sseulang/domain/block/application/dto/UserBlockResult.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.block.application.dto;
+
+import com.sseulang.domain.block.domain.UserBlock;
+
+import java.time.LocalDateTime;
+
+public record UserBlockResult(Long id, Long blockerId, Long blockedId, LocalDateTime createdAt) {
+    public static UserBlockResult from(UserBlock b) {
+        return new UserBlockResult(b.getId(), b.getBlockerId(), b.getBlockedId(), b.getCreatedAt());
+    }
+}

--- a/src/main/java/com/sseulang/domain/block/domain/UserBlock.java
+++ b/src/main/java/com/sseulang/domain/block/domain/UserBlock.java
@@ -1,0 +1,58 @@
+package com.sseulang.domain.block.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 차단 Aggregate. {@code user_blocks} 테이블 — UNIQUE(blocker_id, blocked_id),
+ * CHECK blocker != blocked.
+ */
+@Entity
+@Table(name = "user_blocks")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserBlock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "blocker_id", nullable = false)
+    private Long blockerId;
+
+    @Column(name = "blocked_id", nullable = false)
+    private Long blockedId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static UserBlock create(Long blockerId, Long blockedId) {
+        if (blockerId == null || blockerId <= 0) {
+            throw new IllegalArgumentException("blockerId 는 양수여야 합니다");
+        }
+        if (blockedId == null || blockedId <= 0) {
+            throw new IllegalArgumentException("blockedId 는 양수여야 합니다");
+        }
+        if (blockerId.equals(blockedId)) {
+            throw new IllegalArgumentException("자기 자신은 차단할 수 없습니다");
+        }
+        UserBlock b = new UserBlock();
+        b.blockerId = blockerId;
+        b.blockedId = blockedId;
+        return b;
+    }
+}

--- a/src/main/java/com/sseulang/domain/block/domain/UserBlockRepository.java
+++ b/src/main/java/com/sseulang/domain/block/domain/UserBlockRepository.java
@@ -1,0 +1,16 @@
+package com.sseulang.domain.block.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserBlockRepository {
+
+    boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    UserBlock save(UserBlock block);
+
+    /** 멱등 삭제. 영향 행 수 반환. */
+    int deleteByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    Page<UserBlock> findByBlockerId(Long blockerId, Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/block/infrastructure/persistence/UserBlockJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/block/infrastructure/persistence/UserBlockJpaRepository.java
@@ -1,0 +1,20 @@
+package com.sseulang.domain.block.infrastructure.persistence;
+
+import com.sseulang.domain.block.domain.UserBlock;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface UserBlockJpaRepository extends JpaRepository<UserBlock, Long> {
+
+    boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    @Modifying
+    @Query("DELETE FROM UserBlock b WHERE b.blockerId = :blocker AND b.blockedId = :blocked")
+    int deleteByBlockerAndBlocked(@Param("blocker") Long blockerId, @Param("blocked") Long blockedId);
+
+    Page<UserBlock> findByBlockerIdOrderByCreatedAtDesc(Long blockerId, Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/block/infrastructure/persistence/UserBlockRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/block/infrastructure/persistence/UserBlockRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.sseulang.domain.block.infrastructure.persistence;
+
+import com.sseulang.domain.block.domain.UserBlock;
+import com.sseulang.domain.block.domain.UserBlockRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserBlockRepositoryImpl implements UserBlockRepository {
+
+    private final UserBlockJpaRepository jpa;
+
+    public UserBlockRepositoryImpl(UserBlockJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId) {
+        return jpa.existsByBlockerIdAndBlockedId(blockerId, blockedId);
+    }
+
+    @Override
+    public UserBlock save(UserBlock block) {
+        return jpa.save(block);
+    }
+
+    @Override
+    public int deleteByBlockerIdAndBlockedId(Long blockerId, Long blockedId) {
+        return jpa.deleteByBlockerAndBlocked(blockerId, blockedId);
+    }
+
+    @Override
+    public Page<UserBlock> findByBlockerId(Long blockerId, Pageable pageable) {
+        return jpa.findByBlockerIdOrderByCreatedAtDesc(blockerId, pageable);
+    }
+}

--- a/src/main/java/com/sseulang/domain/block/presentation/UserBlockController.java
+++ b/src/main/java/com/sseulang/domain/block/presentation/UserBlockController.java
@@ -1,0 +1,66 @@
+package com.sseulang.domain.block.presentation;
+
+import com.sseulang.domain.block.application.UserBlockApplicationService;
+import com.sseulang.domain.block.presentation.dto.UserBlockRequest;
+import com.sseulang.domain.block.presentation.dto.UserBlockResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/blocks")
+public class UserBlockController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final UserBlockApplicationService blockService;
+
+    public UserBlockController(UserBlockApplicationService blockService) {
+        this.blockService = blockService;
+    }
+
+    @PostMapping
+    public ApiResponse<Void> block(
+            @AuthenticationPrincipal Long blockerId,
+            @Valid @RequestBody UserBlockRequest request
+    ) {
+        blockService.block(blockerId, request.userId());
+        return ApiResponse.ok();
+    }
+
+    @DeleteMapping("/{userId}")
+    public ApiResponse<Void> unblock(
+            @AuthenticationPrincipal Long blockerId,
+            @PathVariable("userId") Long blockedId
+    ) {
+        blockService.unblock(blockerId, blockedId);
+        return ApiResponse.ok();
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<UserBlockResponse>> listMine(
+            @AuthenticationPrincipal Long blockerId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+
+        Page<UserBlockResponse> result = blockService.listMine(blockerId, pageable)
+                .map(UserBlockResponse::from);
+        return ApiResponse.ok(PageResponse.from(result));
+    }
+}

--- a/src/main/java/com/sseulang/domain/block/presentation/dto/UserBlockRequest.java
+++ b/src/main/java/com/sseulang/domain/block/presentation/dto/UserBlockRequest.java
@@ -1,0 +1,6 @@
+package com.sseulang.domain.block.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record UserBlockRequest(@NotNull @Positive Long userId) { }

--- a/src/main/java/com/sseulang/domain/block/presentation/dto/UserBlockResponse.java
+++ b/src/main/java/com/sseulang/domain/block/presentation/dto/UserBlockResponse.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.block.presentation.dto;
+
+import com.sseulang.domain.block.application.dto.UserBlockResult;
+
+import java.time.LocalDateTime;
+
+public record UserBlockResponse(Long id, Long blockerId, Long blockedId, LocalDateTime createdAt) {
+    public static UserBlockResponse from(UserBlockResult r) {
+        return new UserBlockResponse(r.id(), r.blockerId(), r.blockedId(), r.createdAt());
+    }
+}

--- a/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
+++ b/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
@@ -1,0 +1,91 @@
+package com.sseulang.domain.chat.application;
+
+import com.sseulang.domain.chat.application.dto.ChatRoomResult;
+import com.sseulang.domain.chat.domain.ChatRoom;
+import com.sseulang.domain.chat.domain.ChatRoomRepository;
+import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ChatRoomApplicationService {
+
+    /** V1 스키마 {@code uk_chat_rooms_item_users} — 동시 openFor race 시 멱등 처리 (Codex 게이트 2 패턴). */
+    private static final String UNIQUE_ITEM_USERS = "uk_chat_rooms_item_users";
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ItemApplicationService itemApplicationService;
+
+    public ChatRoomApplicationService(
+            ChatRoomRepository chatRoomRepository,
+            ItemApplicationService itemApplicationService
+    ) {
+        this.chatRoomRepository = chatRoomRepository;
+        this.itemApplicationService = itemApplicationService;
+    }
+
+    /**
+     * 물품 ID 로 채팅방 생성 (가이드 §6.1). 멱등 — 이미 있으면 기존 반환.
+     * 본인 물품 거부 (자기 자신과 채팅 X). UNIQUE race 는 좁은 catch 후 재조회.
+     */
+    @Transactional
+    public ChatRoomResult openFor(Long requesterId, Long itemId) {
+        Long sellerId = itemApplicationService.findSellerOfActiveItem(itemId);
+        if (sellerId.equals(requesterId)) {
+            throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
+        }
+        return chatRoomRepository.findByItemAndUsers(itemId, requesterId, sellerId)
+                .map(ChatRoomResult::from)
+                .orElseGet(() -> createWithRaceGuard(itemId, requesterId, sellerId));
+    }
+
+    public Page<ChatRoomResult> listMine(Long userId, Pageable pageable) {
+        return chatRoomRepository.findMine(userId, pageable).map(ChatRoomResult::from);
+    }
+
+    public ChatRoomResult getOne(Long id, Long requesterId) {
+        ChatRoom room = chatRoomRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (!room.isParticipant(requesterId)) {
+            throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
+        }
+        return ChatRoomResult.from(room);
+    }
+
+    private ChatRoomResult createWithRaceGuard(Long itemId, Long requesterId, Long sellerId) {
+        ChatRoom newRoom = ChatRoom.openFor(itemId, requesterId, sellerId);
+        try {
+            return ChatRoomResult.from(chatRoomRepository.save(newRoom));
+        } catch (DataIntegrityViolationException violation) {
+            if (isUniqueConflict(violation)) {
+                return chatRoomRepository.findByItemAndUsers(itemId, requesterId, sellerId)
+                        .map(ChatRoomResult::from)
+                        .orElseThrow(() -> violation);
+            }
+            throw violation;
+        }
+    }
+
+    private static boolean isUniqueConflict(DataIntegrityViolationException violation) {
+        Throwable cause = violation;
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException cve
+                    && UNIQUE_ITEM_USERS.equalsIgnoreCase(cve.getConstraintName())) {
+                return true;
+            }
+            Throwable next = cause.getCause();
+            if (next == cause) {
+                return false;
+            }
+            cause = next;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
+++ b/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
@@ -1,0 +1,30 @@
+package com.sseulang.domain.chat.application.dto;
+
+import com.sseulang.domain.chat.domain.ChatRoom;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomResult(
+        Long id,
+        Long itemId,
+        Long user1Id,
+        Long user2Id,
+        String lastMessage,
+        LocalDateTime lastMessageAt,
+        int user1Unread,
+        int user2Unread,
+        boolean active,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ChatRoomResult from(ChatRoom c) {
+        return new ChatRoomResult(
+                c.getId(), c.getItemId(),
+                c.getUser1Id(), c.getUser2Id(),
+                c.getLastMessage(), c.getLastMessageAt(),
+                c.getUser1Unread(), c.getUser2Unread(),
+                c.isActive(),
+                c.getCreatedAt(), c.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoom.java
@@ -1,0 +1,89 @@
+package com.sseulang.domain.chat.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * ChatRoom Aggregate Root. V1 스키마 {@code chat_rooms} 매핑 — 메타데이터만 (메시지는 MongoDB, Day 6).
+ *
+ * <p>가이드 §4.10: 1:1 고정. UNIQUE(item_id, user1_id, user2_id) — 같은 두 사용자 + 같은 물품 은 단일 방.
+ * 정규화: 항상 {@code user1Id < user2Id} 강제 → 두 user 쌍이 어떤 순서로 들어와도 동일 행 매칭.</p>
+ *
+ * <p>last_message / last_message_at / unread 카운트 갱신은 메시지 도메인(Day 6)이 담당.
+ * 본 PR 은 채팅방 메타 + 멱등 생성/조회만.</p>
+ */
+@Entity
+@Table(name = "chat_rooms")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Column(name = "user1_id", nullable = false)
+    private Long user1Id;
+
+    @Column(name = "user2_id", nullable = false)
+    private Long user2Id;
+
+    @Column(name = "last_message", length = 500)
+    private String lastMessage;
+
+    @Column(name = "last_message_at")
+    private LocalDateTime lastMessageAt;
+
+    @Column(name = "user1_unread", nullable = false)
+    private int user1Unread;
+
+    @Column(name = "user2_unread", nullable = false)
+    private int user2Unread;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    /**
+     * {@code (itemId, requesterId, opponentId)} 로 채팅방 생성. {@code user1Id < user2Id} 강제 정규화.
+     */
+    public static ChatRoom openFor(Long itemId, Long requesterId, Long opponentId) {
+        if (itemId == null || itemId <= 0) {
+            throw new IllegalArgumentException("itemId 는 양수여야 합니다");
+        }
+        if (requesterId == null || requesterId <= 0) {
+            throw new IllegalArgumentException("requesterId 는 양수여야 합니다");
+        }
+        if (opponentId == null || opponentId <= 0) {
+            throw new IllegalArgumentException("opponentId 는 양수여야 합니다");
+        }
+        if (requesterId.equals(opponentId)) {
+            throw new IllegalArgumentException("requester 와 opponent 는 같을 수 없습니다");
+        }
+
+        ChatRoom cr = new ChatRoom();
+        cr.itemId = itemId;
+        cr.user1Id = Math.min(requesterId, opponentId);
+        cr.user2Id = Math.max(requesterId, opponentId);
+        cr.user1Unread = 0;
+        cr.user2Unread = 0;
+        cr.active = true;
+        return cr;
+    }
+
+    public boolean isParticipant(Long userId) {
+        return userId != null && (userId.equals(user1Id) || userId.equals(user2Id));
+    }
+}

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoomRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoomRepository.java
@@ -1,0 +1,21 @@
+package com.sseulang.domain.chat.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface ChatRoomRepository {
+
+    Optional<ChatRoom> findById(Long id);
+
+    /**
+     * 정규화된 (user1, user2) 쌍과 itemId 로 기존 방 조회. 인자는 정규화 전이어도 메서드가 정렬해 lookup.
+     */
+    Optional<ChatRoom> findByItemAndUsers(Long itemId, Long userA, Long userB);
+
+    /** 내가 참여자인 채팅방 목록 — last_message_at desc (null 은 후순위). */
+    Page<ChatRoom> findMine(Long userId, Pageable pageable);
+
+    ChatRoom save(ChatRoom chatRoom);
+}

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomJpaRepository.java
@@ -1,0 +1,35 @@
+package com.sseulang.domain.chat.infrastructure.persistence;
+
+import com.sseulang.domain.chat.domain.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, Long> {
+
+    @Query("""
+        SELECT c FROM ChatRoom c
+        WHERE c.itemId = :itemId
+          AND c.user1Id = :u1
+          AND c.user2Id = :u2
+    """)
+    Optional<ChatRoom> findByItemAndUsersNormalized(
+            @Param("itemId") Long itemId,
+            @Param("u1") Long u1,
+            @Param("u2") Long u2
+    );
+
+    @Query("""
+        SELECT c FROM ChatRoom c
+        WHERE c.user1Id = :userId OR c.user2Id = :userId
+        ORDER BY
+          CASE WHEN c.lastMessageAt IS NULL THEN 1 ELSE 0 END,
+          c.lastMessageAt DESC,
+          c.id DESC
+    """)
+    Page<ChatRoom> findMine(@Param("userId") Long userId, Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.sseulang.domain.chat.infrastructure.persistence;
+
+import com.sseulang.domain.chat.domain.ChatRoom;
+import com.sseulang.domain.chat.domain.ChatRoomRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class ChatRoomRepositoryImpl implements ChatRoomRepository {
+
+    private final ChatRoomJpaRepository jpa;
+
+    public ChatRoomRepositoryImpl(ChatRoomJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Optional<ChatRoom> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Optional<ChatRoom> findByItemAndUsers(Long itemId, Long userA, Long userB) {
+        long u1 = Math.min(userA, userB);
+        long u2 = Math.max(userA, userB);
+        return jpa.findByItemAndUsersNormalized(itemId, u1, u2);
+    }
+
+    @Override
+    public Page<ChatRoom> findMine(Long userId, Pageable pageable) {
+        return jpa.findMine(userId, pageable);
+    }
+
+    @Override
+    public ChatRoom save(ChatRoom chatRoom) {
+        return jpa.save(chatRoom);
+    }
+}

--- a/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
@@ -1,0 +1,65 @@
+package com.sseulang.domain.chat.presentation;
+
+import com.sseulang.domain.chat.application.ChatRoomApplicationService;
+import com.sseulang.domain.chat.presentation.dto.ChatRoomCreateRequest;
+import com.sseulang.domain.chat.presentation.dto.ChatRoomResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/chat-rooms")
+public class ChatRoomController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final ChatRoomApplicationService chatRoomService;
+
+    public ChatRoomController(ChatRoomApplicationService chatRoomService) {
+        this.chatRoomService = chatRoomService;
+    }
+
+    /** 멱등 — 같은 (요청자, 상대, 물품) 채팅방이 있으면 기존 반환, 없으면 생성. */
+    @PostMapping
+    public ApiResponse<ChatRoomResponse> openFor(
+            @AuthenticationPrincipal Long requesterId,
+            @Valid @RequestBody ChatRoomCreateRequest request
+    ) {
+        return ApiResponse.ok(ChatRoomResponse.from(
+                chatRoomService.openFor(requesterId, request.itemId())));
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<ChatRoomResponse>> listMine(
+            @AuthenticationPrincipal Long requesterId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+
+        Page<ChatRoomResponse> result = chatRoomService.listMine(requesterId, pageable)
+                .map(ChatRoomResponse::from);
+        return ApiResponse.ok(PageResponse.from(result));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<ChatRoomResponse> getOne(
+            @AuthenticationPrincipal Long requesterId,
+            @PathVariable("id") Long id
+    ) {
+        return ApiResponse.ok(ChatRoomResponse.from(chatRoomService.getOne(id, requesterId)));
+    }
+}

--- a/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomCreateRequest.java
@@ -1,0 +1,6 @@
+package com.sseulang.domain.chat.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record ChatRoomCreateRequest(@NotNull @Positive Long itemId) { }

--- a/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
@@ -1,0 +1,30 @@
+package com.sseulang.domain.chat.presentation.dto;
+
+import com.sseulang.domain.chat.application.dto.ChatRoomResult;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomResponse(
+        Long id,
+        Long itemId,
+        Long user1Id,
+        Long user2Id,
+        String lastMessage,
+        LocalDateTime lastMessageAt,
+        int user1Unread,
+        int user2Unread,
+        boolean active,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ChatRoomResponse from(ChatRoomResult r) {
+        return new ChatRoomResponse(
+                r.id(), r.itemId(),
+                r.user1Id(), r.user2Id(),
+                r.lastMessage(), r.lastMessageAt(),
+                r.user1Unread(), r.user2Unread(),
+                r.active(),
+                r.createdAt(), r.updatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -101,6 +101,21 @@ public class ItemApplicationService {
     }
 
     /**
+     * Chat / 거래 시작 등 다른 도메인이 Item 의 seller 를 알아야 할 때.
+     * 삭제: ITEM_NOT_FOUND, 비공개: ITEM_INVALID_STATE. 판매중/예약/거래완료 는 채팅 가능.
+     */
+    public Long findSellerOfActiveItem(Long id) {
+        Item item = findOrThrow(id);
+        if (item.getStatus() == ItemStatus.삭제) {
+            throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
+        }
+        if (item.getStatus() == ItemStatus.비공개) {
+            throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
+        }
+        return item.getSellerId();
+    }
+
+    /**
      * 거래 도메인이 거래 생성 시 호출. 비관적 락(PESSIMISTIC_WRITE)으로 Item 행을 잠근 뒤 활성(판매중) 검증.
      * 가이드 §5.2 — reserve 와 create 동시 시 락 직렬화로 "예약 직후 새 채팅중 거래 저장" 회귀 차단.
      * Codex 게이트 1 Warning 보강.

--- a/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
+++ b/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
@@ -1,0 +1,29 @@
+package com.sseulang.domain.report.application;
+
+import com.sseulang.domain.report.domain.UserReport;
+import com.sseulang.domain.report.domain.UserReportRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UserReportApplicationService {
+
+    private final UserReportRepository repository;
+
+    public UserReportApplicationService(UserReportRepository repository) {
+        this.repository = repository;
+    }
+
+    /** 사용자 신고. 자기 신고 거부는 도메인 invariant 에서. */
+    @Transactional
+    public Long reportUser(Long reporterId, Long reportedUserId, String reason, String detail) {
+        return repository.save(UserReport.reportUser(reporterId, reportedUserId, reason, detail)).getId();
+    }
+
+    /** 물품 신고. Item 존재 여부는 FK 가 잡음 (RESTRICT/CASCADE) — 별도 검증 생략. */
+    @Transactional
+    public Long reportItem(Long reporterId, Long itemId, String reason, String detail) {
+        return repository.save(UserReport.reportItem(reporterId, itemId, reason, detail)).getId();
+    }
+}

--- a/src/main/java/com/sseulang/domain/report/domain/ReportStatus.java
+++ b/src/main/java/com/sseulang/domain/report/domain/ReportStatus.java
@@ -1,0 +1,16 @@
+package com.sseulang.domain.report.domain;
+
+/**
+ * 신고 처리 상태. DB ENUM('접수','처리중','처리완료','반려') 1:1.
+ * 상태 전이는 관리자가 트리거 (Day 9 admin 도메인).
+ */
+public enum ReportStatus {
+    접수,
+    처리중,
+    처리완료,
+    반려;
+
+    public boolean isTerminal() {
+        return this == 처리완료 || this == 반려;
+    }
+}

--- a/src/main/java/com/sseulang/domain/report/domain/UserReport.java
+++ b/src/main/java/com/sseulang/domain/report/domain/UserReport.java
@@ -1,0 +1,101 @@
+package com.sseulang.domain.report.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자/물품 신고 Aggregate. {@code user_reports} 테이블 — CHECK reported_id XOR item_id (둘 중 하나는 NOT NULL).
+ * 관리자 처리 흐름(상태 전이)은 Day 9 admin 도메인.
+ */
+@Entity
+@Table(name = "user_reports")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserReport extends BaseEntity {
+
+    private static final int REASON_MAX_LENGTH = 50;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "reporter_id", nullable = false)
+    private Long reporterId;
+
+    @Column(name = "reported_id")
+    private Long reportedId;
+
+    @Column(name = "item_id")
+    private Long itemId;
+
+    @Column(name = "reason", nullable = false, length = REASON_MAX_LENGTH)
+    private String reason;
+
+    @Column(name = "detail", columnDefinition = "TEXT")
+    private String detail;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ReportStatus status;
+
+    @Column(name = "admin_id")
+    private Long adminId;
+
+    @Column(name = "admin_memo", length = 500)
+    private String adminMemo;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    public static UserReport reportUser(Long reporterId, Long reportedUserId, String reason, String detail) {
+        if (reportedUserId == null || reportedUserId <= 0) {
+            throw new IllegalArgumentException("reportedUserId 는 양수여야 합니다");
+        }
+        if (reporterId.equals(reportedUserId)) {
+            throw new IllegalArgumentException("자기 자신은 신고할 수 없습니다");
+        }
+        return create(reporterId, reportedUserId, null, reason, detail);
+    }
+
+    public static UserReport reportItem(Long reporterId, Long itemId, String reason, String detail) {
+        if (itemId == null || itemId <= 0) {
+            throw new IllegalArgumentException("itemId 는 양수여야 합니다");
+        }
+        return create(reporterId, null, itemId, reason, detail);
+    }
+
+    private static UserReport create(Long reporterId, Long reportedId, Long itemId, String reason, String detail) {
+        if (reporterId == null || reporterId <= 0) {
+            throw new IllegalArgumentException("reporterId 는 양수여야 합니다");
+        }
+        if (reportedId == null && itemId == null) {
+            throw new IllegalArgumentException("reportedId 또는 itemId 둘 중 하나는 필수입니다");
+        }
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException("reason 은 비어있을 수 없습니다");
+        }
+        if (reason.length() > REASON_MAX_LENGTH) {
+            throw new IllegalArgumentException("reason 은 " + REASON_MAX_LENGTH + "자를 초과할 수 없습니다");
+        }
+        UserReport r = new UserReport();
+        r.reporterId = reporterId;
+        r.reportedId = reportedId;
+        r.itemId = itemId;
+        r.reason = reason.strip();
+        r.detail = detail;
+        r.status = ReportStatus.접수;
+        return r;
+    }
+}

--- a/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
+++ b/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
@@ -1,0 +1,6 @@
+package com.sseulang.domain.report.domain;
+
+public interface UserReportRepository {
+
+    UserReport save(UserReport report);
+}

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
@@ -1,0 +1,7 @@
+package com.sseulang.domain.report.infrastructure.persistence;
+
+import com.sseulang.domain.report.domain.UserReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface UserReportJpaRepository extends JpaRepository<UserReport, Long> {
+}

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.sseulang.domain.report.infrastructure.persistence;
+
+import com.sseulang.domain.report.domain.UserReport;
+import com.sseulang.domain.report.domain.UserReportRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserReportRepositoryImpl implements UserReportRepository {
+
+    private final UserReportJpaRepository jpa;
+
+    public UserReportRepositoryImpl(UserReportJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public UserReport save(UserReport report) {
+        return jpa.save(report);
+    }
+}

--- a/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
@@ -1,0 +1,50 @@
+package com.sseulang.domain.report.presentation;
+
+import com.sseulang.domain.report.application.UserReportApplicationService;
+import com.sseulang.domain.report.presentation.dto.ReportIdResponse;
+import com.sseulang.domain.report.presentation.dto.ReportRequest;
+import com.sseulang.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 사용자/물품 신고 진입점. Item 신고는 가이드 §6.1 의 {@code POST /api/v1/items/{id}/report},
+ * User 신고는 별도 {@code POST /api/v1/users/{id}/report}.
+ */
+@RestController
+public class UserReportController {
+
+    private final UserReportApplicationService reportService;
+
+    public UserReportController(UserReportApplicationService reportService) {
+        this.reportService = reportService;
+    }
+
+    @PostMapping("/api/v1/items/{itemId}/report")
+    public ResponseEntity<ApiResponse<ReportIdResponse>> reportItem(
+            @AuthenticationPrincipal Long reporterId,
+            @PathVariable("itemId") Long itemId,
+            @Valid @RequestBody ReportRequest request
+    ) {
+        Long id = reportService.reportItem(reporterId, itemId, request.reason(), request.detail());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(new ReportIdResponse(id)));
+    }
+
+    @PostMapping("/api/v1/users/{userId}/report")
+    public ResponseEntity<ApiResponse<ReportIdResponse>> reportUser(
+            @AuthenticationPrincipal Long reporterId,
+            @PathVariable("userId") Long reportedUserId,
+            @Valid @RequestBody ReportRequest request
+    ) {
+        Long id = reportService.reportUser(reporterId, reportedUserId, request.reason(), request.detail());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(new ReportIdResponse(id)));
+    }
+}

--- a/src/main/java/com/sseulang/domain/report/presentation/dto/ReportIdResponse.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/dto/ReportIdResponse.java
@@ -1,0 +1,3 @@
+package com.sseulang.domain.report.presentation.dto;
+
+public record ReportIdResponse(Long id) { }

--- a/src/main/java/com/sseulang/domain/report/presentation/dto/ReportRequest.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/dto/ReportRequest.java
@@ -1,0 +1,9 @@
+package com.sseulang.domain.report.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ReportRequest(
+        @NotBlank @Size(max = 50) String reason,
+        @Size(max = 5000) String detail
+) { }

--- a/src/main/java/com/sseulang/domain/review/application/ReviewApplicationService.java
+++ b/src/main/java/com/sseulang/domain/review/application/ReviewApplicationService.java
@@ -1,0 +1,96 @@
+package com.sseulang.domain.review.application;
+
+import com.sseulang.domain.review.application.dto.ReviewResult;
+import com.sseulang.domain.review.application.dto.ReviewWriteCommand;
+import com.sseulang.domain.review.domain.Review;
+import com.sseulang.domain.review.domain.ReviewRepository;
+import com.sseulang.domain.transaction.application.TransactionApplicationService;
+import com.sseulang.domain.transaction.application.dto.ReviewableTransactionResult;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ReviewApplicationService {
+
+    /** V1 스키마 {@code uk_reviews_tx_reviewer} — 동일 reviewer 같은 거래 두 번 작성 시 race 보정. */
+    private static final String UNIQUE_TX_REVIEWER = "uk_reviews_tx_reviewer";
+
+    private final ReviewRepository reviewRepository;
+    private final TransactionApplicationService transactionApplicationService;
+    private final UserApplicationService userApplicationService;
+
+    public ReviewApplicationService(
+            ReviewRepository reviewRepository,
+            TransactionApplicationService transactionApplicationService,
+            UserApplicationService userApplicationService
+    ) {
+        this.reviewRepository = reviewRepository;
+        this.transactionApplicationService = transactionApplicationService;
+        this.userApplicationService = userApplicationService;
+    }
+
+    /**
+     * Review 작성. Transaction 검증(거래완료 + 7일 + 참여자) 은 TransactionApplicationService 가 수행.
+     * UNIQUE(tx, reviewer) race 는 좁은 catch → REVIEW_DUPLICATED. 작성 후 reviewee 의 trust_score atomic 갱신.
+     */
+    @Transactional
+    public Long write(ReviewWriteCommand cmd) {
+        ReviewableTransactionResult info = transactionApplicationService
+                .findCompletedForReview(cmd.transactionId(), cmd.reviewerId());
+
+        Review review = Review.create(
+                info.transactionId(),
+                info.reviewerId(),
+                info.revieweeId(),
+                cmd.rating(),
+                cmd.comment()
+        );
+
+        Long savedId;
+        try {
+            savedId = reviewRepository.save(review).getId();
+        } catch (DataIntegrityViolationException violation) {
+            if (isUniqueConflict(violation)) {
+                throw new BusinessException(ErrorCode.REVIEW_DUPLICATED);
+            }
+            throw violation;
+        }
+
+        // 가이드 §4.7 — 작성 시점 review_count / rating_sum 누적 + trust_score atomic 재계산.
+        // 단일 UPDATE 라 race 안전 (Codex 게이트 2 보강).
+        userApplicationService.recordReview(info.revieweeId(), cmd.rating());
+
+        return savedId;
+    }
+
+    /**
+     * 받은 리뷰 페이징. 한줄평은 작성자 본인만 보이도록 마스킹 (가이드 §4.7 "한줄평은 본인만").
+     */
+    public Page<ReviewResult> listReceived(Long revieweeId, Long requesterId, Pageable pageable) {
+        return reviewRepository.findByRevieweeId(revieweeId, pageable)
+                .map(ReviewResult::from)
+                .map(r -> r.masked(requesterId));
+    }
+
+    private static boolean isUniqueConflict(DataIntegrityViolationException violation) {
+        Throwable cause = violation;
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException cve
+                    && UNIQUE_TX_REVIEWER.equalsIgnoreCase(cve.getConstraintName())) {
+                return true;
+            }
+            Throwable next = cause.getCause();
+            if (next == cause) return false;
+            cause = next;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/sseulang/domain/review/application/dto/ReviewResult.java
+++ b/src/main/java/com/sseulang/domain/review/application/dto/ReviewResult.java
@@ -1,0 +1,32 @@
+package com.sseulang.domain.review.application.dto;
+
+import com.sseulang.domain.review.domain.Review;
+
+import java.time.LocalDateTime;
+
+public record ReviewResult(
+        Long id,
+        Long transactionId,
+        Long reviewerId,
+        Long revieweeId,
+        int rating,
+        String comment,
+        LocalDateTime createdAt
+) {
+    public static ReviewResult from(Review r) {
+        return new ReviewResult(
+                r.getId(), r.getTransactionId(),
+                r.getReviewerId(), r.getRevieweeId(),
+                r.getRating(), r.getComment(),
+                r.getCreatedAt()
+        );
+    }
+
+    /** 본인 한줄평만 노출 — 가이드 §4.7 "한줄평은 본인만". */
+    public ReviewResult masked(Long requesterId) {
+        if (reviewerId.equals(requesterId)) {
+            return this;
+        }
+        return new ReviewResult(id, transactionId, reviewerId, revieweeId, rating, null, createdAt);
+    }
+}

--- a/src/main/java/com/sseulang/domain/review/application/dto/ReviewWriteCommand.java
+++ b/src/main/java/com/sseulang/domain/review/application/dto/ReviewWriteCommand.java
@@ -1,0 +1,8 @@
+package com.sseulang.domain.review.application.dto;
+
+public record ReviewWriteCommand(
+        Long transactionId,
+        Long reviewerId,
+        int rating,
+        String comment
+) { }

--- a/src/main/java/com/sseulang/domain/review/domain/Review.java
+++ b/src/main/java/com/sseulang/domain/review/domain/Review.java
@@ -1,0 +1,87 @@
+package com.sseulang.domain.review.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * Review Aggregate Root. {@code reviews} 테이블. 거래 후 양방향 평가 — 가이드 §4.7.
+ *
+ * <p>UNIQUE(transaction_id, reviewer_id) — 같은 reviewer 같은 거래 두 번 X.
+ * CHECK rating 1~5, reviewer != reviewee.</p>
+ */
+@Entity
+@Table(name = "reviews")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review {
+
+    private static final int COMMENT_MAX_LENGTH = 500;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "transaction_id", nullable = false)
+    private Long transactionId;
+
+    @Column(name = "reviewer_id", nullable = false)
+    private Long reviewerId;
+
+    @Column(name = "reviewee_id", nullable = false)
+    private Long revieweeId;
+
+    /** DB {@code rating TINYINT}. Java int 와 매핑 mismatch 방지를 위해 명시 JDBC TINYINT 사용. */
+    @Column(name = "rating", nullable = false)
+    @JdbcTypeCode(SqlTypes.TINYINT)
+    private int rating;
+
+    @Column(name = "comment", length = COMMENT_MAX_LENGTH)
+    private String comment;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static Review create(Long transactionId, Long reviewerId, Long revieweeId, int rating, String comment) {
+        if (transactionId == null || transactionId <= 0) {
+            throw new IllegalArgumentException("transactionId 는 양수여야 합니다");
+        }
+        if (reviewerId == null || reviewerId <= 0) {
+            throw new IllegalArgumentException("reviewerId 는 양수여야 합니다");
+        }
+        if (revieweeId == null || revieweeId <= 0) {
+            throw new IllegalArgumentException("revieweeId 는 양수여야 합니다");
+        }
+        if (reviewerId.equals(revieweeId)) {
+            throw new IllegalArgumentException("자기 자신에게는 리뷰를 작성할 수 없습니다");
+        }
+        if (rating < 1 || rating > 5) {
+            throw new IllegalArgumentException("rating 은 1~5 범위여야 합니다");
+        }
+        if (comment != null && comment.length() > COMMENT_MAX_LENGTH) {
+            throw new IllegalArgumentException("comment 는 " + COMMENT_MAX_LENGTH + "자를 초과할 수 없습니다");
+        }
+        Review r = new Review();
+        r.transactionId = transactionId;
+        r.reviewerId = reviewerId;
+        r.revieweeId = revieweeId;
+        r.rating = rating;
+        r.comment = comment;
+        return r;
+    }
+}

--- a/src/main/java/com/sseulang/domain/review/domain/ReviewRepository.java
+++ b/src/main/java/com/sseulang/domain/review/domain/ReviewRepository.java
@@ -1,0 +1,12 @@
+package com.sseulang.domain.review.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewRepository {
+
+    Review save(Review review);
+
+    /** 특정 사용자가 받은 리뷰 페이징 (최신순). */
+    Page<Review> findByRevieweeId(Long revieweeId, Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/review/infrastructure/persistence/ReviewJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/review/infrastructure/persistence/ReviewJpaRepository.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.review.infrastructure.persistence;
+
+import com.sseulang.domain.review.domain.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface ReviewJpaRepository extends JpaRepository<Review, Long> {
+
+    Page<Review> findByRevieweeIdOrderByCreatedAtDesc(Long revieweeId, Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/review/infrastructure/persistence/ReviewRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/review/infrastructure/persistence/ReviewRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.sseulang.domain.review.infrastructure.persistence;
+
+import com.sseulang.domain.review.domain.Review;
+import com.sseulang.domain.review.domain.ReviewRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReviewRepositoryImpl implements ReviewRepository {
+
+    private final ReviewJpaRepository jpa;
+
+    public ReviewRepositoryImpl(ReviewJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Review save(Review review) {
+        return jpa.save(review);
+    }
+
+    @Override
+    public Page<Review> findByRevieweeId(Long revieweeId, Pageable pageable) {
+        return jpa.findByRevieweeIdOrderByCreatedAtDesc(revieweeId, pageable);
+    }
+}

--- a/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
@@ -1,0 +1,59 @@
+package com.sseulang.domain.review.presentation;
+
+import com.sseulang.domain.review.application.ReviewApplicationService;
+import com.sseulang.domain.review.presentation.dto.ReviewIdResponse;
+import com.sseulang.domain.review.presentation.dto.ReviewResponse;
+import com.sseulang.domain.review.presentation.dto.ReviewWriteRequest;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ReviewController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final ReviewApplicationService reviewService;
+
+    public ReviewController(ReviewApplicationService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @PostMapping("/api/v1/reviews")
+    public ResponseEntity<ApiResponse<ReviewIdResponse>> write(
+            @AuthenticationPrincipal Long reviewerId,
+            @Valid @RequestBody ReviewWriteRequest request
+    ) {
+        Long id = reviewService.write(request.toCommand(reviewerId));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(new ReviewIdResponse(id)));
+    }
+
+    @GetMapping("/api/v1/users/{userId}/reviews")
+    public ApiResponse<PageResponse<ReviewResponse>> listReceived(
+            @AuthenticationPrincipal Long requesterId,
+            @PathVariable("userId") Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+
+        Page<ReviewResponse> result = reviewService.listReceived(userId, requesterId, pageable)
+                .map(ReviewResponse::from);
+        return ApiResponse.ok(PageResponse.from(result));
+    }
+}

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewIdResponse.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewIdResponse.java
@@ -1,0 +1,3 @@
+package com.sseulang.domain.review.presentation.dto;
+
+public record ReviewIdResponse(Long id) { }

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewResponse.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewResponse.java
@@ -1,0 +1,24 @@
+package com.sseulang.domain.review.presentation.dto;
+
+import com.sseulang.domain.review.application.dto.ReviewResult;
+
+import java.time.LocalDateTime;
+
+public record ReviewResponse(
+        Long id,
+        Long transactionId,
+        Long reviewerId,
+        Long revieweeId,
+        int rating,
+        String comment,
+        LocalDateTime createdAt
+) {
+    public static ReviewResponse from(ReviewResult r) {
+        return new ReviewResponse(
+                r.id(), r.transactionId(),
+                r.reviewerId(), r.revieweeId(),
+                r.rating(), r.comment(),
+                r.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewWriteRequest.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewWriteRequest.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.review.presentation.dto;
+
+import com.sseulang.domain.review.application.dto.ReviewWriteCommand;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record ReviewWriteRequest(
+        @NotNull @Positive Long transactionId,
+        @Min(1) @Max(5) int rating,
+        @Size(max = 500) String comment
+) {
+    public ReviewWriteCommand toCommand(Long reviewerId) {
+        return new ReviewWriteCommand(transactionId, reviewerId, rating, comment);
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.transaction.application;
 
 import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.domain.item.application.dto.ItemForTransactionResult;
+import com.sseulang.domain.transaction.application.dto.ReviewableTransactionResult;
 import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
 import com.sseulang.domain.transaction.application.dto.TransactionResult;
 import com.sseulang.domain.transaction.domain.Transaction;
@@ -111,6 +112,32 @@ public class TransactionApplicationService {
             throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
         }
         return TransactionResult.from(tx);
+    }
+
+    /**
+     * Review 작성 시 호출. 가이드 §4.7:
+     * <ul>
+     *   <li>{@code status == 거래완료} 만 허용</li>
+     *   <li>거래 완료 후 7일 이내</li>
+     *   <li>requester 가 거래 참여자</li>
+     * </ul>
+     * reviewee 는 자동 결정 (seller 가 reviewer 면 buyer, 그 반대도). CLAUDE.md §3.3 — Review 도메인은
+     * 본 메서드만 의존, TransactionRepository 직접 접근 X.
+     */
+    public ReviewableTransactionResult findCompletedForReview(Long transactionId, Long requesterId) {
+        Transaction tx = findOrThrow(transactionId);
+        if (!tx.isParticipant(requesterId)) {
+            throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
+        }
+        if (tx.getStatus() != TransactionStatus.거래완료 || tx.getCompletedAt() == null) {
+            throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
+        }
+        // 7일 경계 정확 비교 — Duration.toDays() 는 내림이라 7일 23시간도 허용되는 회귀 (Codex 게이트 2).
+        if (LocalDateTime.now().isAfter(tx.getCompletedAt().plusDays(7))) {
+            throw new BusinessException(ErrorCode.REVIEW_PERIOD_EXPIRED);
+        }
+        Long revieweeId = tx.isSeller(requesterId) ? tx.getBuyerId() : tx.getSellerId();
+        return new ReviewableTransactionResult(tx.getId(), requesterId, revieweeId, tx.getCompletedAt());
     }
 
     private Transaction findOrThrow(Long id) {

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/ReviewableTransactionResult.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/ReviewableTransactionResult.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.transaction.application.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * Review 도메인이 거래 후 양방향 평가를 작성할 때 받는 정보. reviewer 권한·기한 검증은
+ * Transaction 도메인이 수행하고, reviewee 는 자동 결정 (참여자 중 reviewer 가 아닌 쪽).
+ */
+public record ReviewableTransactionResult(
+        Long transactionId,
+        Long reviewerId,
+        Long revieweeId,
+        LocalDateTime completedAt
+) { }

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -45,6 +45,17 @@ public class UserApplicationService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
+    /**
+     * 가이드 §4.7 — Review 작성 시점에 호출. review_count / rating_sum 누적 + trust_score 재계산.
+     * 단일 native UPDATE 라 동시 review 작성 race 안전 (Codex 게이트 2 보강 — 기존 AVG 서브쿼리
+     * 방식의 REPEATABLE_READ stale view 문제 차단). Review 도메인은 본 메서드만 의존
+     * (UserRepository 직접 호출 금지, CLAUDE.md §3.3).
+     */
+    @Transactional
+    public void recordReview(Long revieweeId, int rating) {
+        userRepository.recordReviewFor(revieweeId, rating);
+    }
+
     private User create(SocialProvider provider, String providerId, Email email, String nickname, String profileImage) {
         userRepository.findByEmail(email).ifPresent(existing -> {
             throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -13,6 +13,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 /**
  * User Aggregate Root. V1 스키마 {@code users} 매핑.
  *
@@ -56,6 +58,22 @@ public class User extends BaseEntity {
 
     @Column(name = "is_deleted", nullable = false)
     private boolean deleted;
+
+    /**
+     * 신뢰도(거래 후 받은 리뷰 평균). 가이드 §4.7 — 리뷰 작성 시점에 review_count + rating_sum 을
+     * 단일 atomic UPDATE 로 누적해 race 안전 (Codex 게이트 2 보강).
+     * 리뷰 0건이면 null ("신규" 표시용).
+     */
+    @Column(name = "trust_score", precision = 3, scale = 2)
+    private BigDecimal trustScore;
+
+    /** 누적 리뷰 수. trust_score 정합성을 위해 atomic 갱신 (V3 마이그). */
+    @Column(name = "review_count", nullable = false)
+    private int reviewCount;
+
+    /** 누적 별점 합계. trust_score = rating_sum / review_count (review_count > 0). */
+    @Column(name = "rating_sum", nullable = false)
+    private int ratingSum;
 
     /**
      * 소셜 가입 흐름의 정적 팩토리. (provider, providerId) 가 비어있을 수 없으며 LOCAL 은 거부.

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -15,4 +15,11 @@ public interface UserRepository {
     Optional<User> findByEmail(Email email);
 
     User save(User user);
+
+    /**
+     * 가이드 §4.7 — 리뷰 작성 시점에 review_count / rating_sum 을 단일 원자 UPDATE 로 누적하고
+     * trust_score 를 즉시 재계산. Codex 게이트 2 (2026-04-29) 보강 — REPEATABLE_READ + AVG 서브쿼리
+     * 의 stale read view 회귀를 누적 컬럼으로 차단.
+     */
+    int recordReviewFor(Long revieweeId, int rating);
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -3,6 +3,9 @@ package com.sseulang.domain.user.infrastructure.persistence;
 import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +15,21 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialProviderAndSocialId(SocialProvider provider, String socialId);
 
     Optional<User> findByEmail(String email);
+
+    /**
+     * 단일 atomic UPDATE — review_count / rating_sum 누적 + trust_score 즉시 재계산.
+     * 같은 reviewee 에 대한 동시 review 작성 race 안전 (각 트랜잭션은 본인 행 락 점유 시 직렬화 + 누적).
+     * 가이드 §5.3 동시성 처리 정합. Codex 게이트 2 보강.
+     *
+     * <p>trust_score 정밀도: DECIMAL(3,2) → CAST 로 분수 결과 보존.</p>
+     */
+    @Modifying
+    @Query(value = """
+        UPDATE users
+        SET review_count = review_count + 1,
+            rating_sum = rating_sum + :rating,
+            trust_score = CAST((rating_sum + :rating) AS DECIMAL(10,4)) / (review_count + 1)
+        WHERE id = :userId
+    """, nativeQuery = true)
+    int recordReviewFor(@Param("userId") Long userId, @Param("rating") int rating);
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -36,4 +36,9 @@ public class UserRepositoryImpl implements UserRepository {
     public User save(User user) {
         return jpa.save(user);
     }
+
+    @Override
+    public int recordReviewFor(Long revieweeId, int rating) {
+        return jpa.recordReviewFor(revieweeId, rating);
+    }
 }

--- a/src/main/resources/db/migration/V3__add_user_review_aggregates.sql
+++ b/src/main/resources/db/migration/V3__add_user_review_aggregates.sql
@@ -1,0 +1,8 @@
+-- =============================================================================
+-- 신뢰도(trust_score) 동시성 안전을 위한 누적 합계 컬럼 추가 — Codex 게이트 2 (Day 5 후반).
+-- 단일 SELECT AVG + UPDATE 는 REPEATABLE_READ read view 경계로 race 발생 가능.
+-- review_count(V1 부터 존재) + rating_sum(본 마이그) 누적 + 원자 UPDATE 로 정합성 확보.
+-- =============================================================================
+
+ALTER TABLE users
+    ADD COLUMN rating_sum INT NOT NULL DEFAULT 0 AFTER review_count;

--- a/src/test/java/com/sseulang/domain/block/application/InMemoryFakeUserBlockRepository.java
+++ b/src/test/java/com/sseulang/domain/block/application/InMemoryFakeUserBlockRepository.java
@@ -1,0 +1,60 @@
+package com.sseulang.domain.block.application;
+
+import com.sseulang.domain.block.domain.UserBlock;
+import com.sseulang.domain.block.domain.UserBlockRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class InMemoryFakeUserBlockRepository implements UserBlockRepository {
+
+    private final Map<String, UserBlock> store = new HashMap<>();
+    private long sequence = 0;
+
+    private static String key(Long blocker, Long blocked) {
+        return blocker + "|" + blocked;
+    }
+
+    @Override
+    public boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId) {
+        return store.containsKey(key(blockerId, blockedId));
+    }
+
+    @Override
+    public UserBlock save(UserBlock block) {
+        if (block.getId() == null) {
+            ReflectionTestUtils.setField(block, "id", ++sequence);
+            ReflectionTestUtils.setField(block, "createdAt", LocalDateTime.now());
+        }
+        store.put(key(block.getBlockerId(), block.getBlockedId()), block);
+        return block;
+    }
+
+    @Override
+    public int deleteByBlockerIdAndBlockedId(Long blockerId, Long blockedId) {
+        return store.remove(key(blockerId, blockedId)) != null ? 1 : 0;
+    }
+
+    @Override
+    public Page<UserBlock> findByBlockerId(Long blockerId, Pageable pageable) {
+        List<UserBlock> mine = store.values().stream()
+                .filter(b -> b.getBlockerId().equals(blockerId))
+                .sorted(Comparator.comparing(UserBlock::getCreatedAt,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .toList();
+        int start = Math.min((int) pageable.getOffset(), mine.size());
+        int end = Math.min(start + pageable.getPageSize(), mine.size());
+        return new PageImpl<>(mine.subList(start, end), pageable, mine.size());
+    }
+
+    public int size() {
+        return store.size();
+    }
+}

--- a/src/test/java/com/sseulang/domain/block/application/UserBlockApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/block/application/UserBlockApplicationServiceTest.java
@@ -1,0 +1,78 @@
+package com.sseulang.domain.block.application;
+
+import com.sseulang.domain.block.application.dto.UserBlockResult;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserBlockApplicationServiceTest {
+
+    private InMemoryFakeUserBlockRepository repo;
+    private UserBlockApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        repo = new InMemoryFakeUserBlockRepository();
+        service = new UserBlockApplicationService(repo);
+    }
+
+    @Test
+    @DisplayName("block 정상")
+    void block_정상() {
+        service.block(1L, 2L);
+        assertThat(repo.existsByBlockerIdAndBlockedId(1L, 2L)).isTrue();
+    }
+
+    @Test
+    @DisplayName("block 자기 차단_INVALID_REQUEST")
+    void block_self_거부() {
+        assertThatThrownBy(() -> service.block(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
+    @DisplayName("block 중복_idempotent")
+    void block_중복() {
+        service.block(1L, 2L);
+        service.block(1L, 2L);
+        service.block(1L, 2L);
+        assertThat(repo.size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("unblock 정상")
+    void unblock_정상() {
+        service.block(1L, 2L);
+        service.unblock(1L, 2L);
+        assertThat(repo.existsByBlockerIdAndBlockedId(1L, 2L)).isFalse();
+    }
+
+    @Test
+    @DisplayName("unblock 없는 항목_idempotent")
+    void unblock_없음() {
+        service.unblock(1L, 2L);
+        assertThat(repo.size()).isZero();
+    }
+
+    @Test
+    @DisplayName("listMine 본인 차단만")
+    void listMine() {
+        service.block(1L, 2L);
+        service.block(1L, 3L);
+        service.block(99L, 4L);  // 다른 사람 차단
+
+        Page<UserBlockResult> mine = service.listMine(1L, PageRequest.of(0, 10));
+        assertThat(mine.getTotalElements()).isEqualTo(2);
+        assertThat(mine.getContent()).extracting(UserBlockResult::blockedId)
+                .containsExactlyInAnyOrder(2L, 3L);
+    }
+}

--- a/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
@@ -1,0 +1,154 @@
+package com.sseulang.domain.chat.application;
+
+import com.sseulang.domain.category.application.CategoryApplicationService;
+import com.sseulang.domain.category.application.InMemoryFakeCategoryRepository;
+import com.sseulang.domain.chat.application.dto.ChatRoomResult;
+import com.sseulang.domain.item.application.InMemoryFakeItemRepository;
+import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ChatRoomApplicationServiceTest {
+
+    private static final Long SELLER = 100L;
+    private static final Long BUYER = 200L;
+    private static final Long OTHER = 300L;
+
+    private InMemoryFakeChatRoomRepository roomRepo;
+    private InMemoryFakeItemRepository itemRepo;
+    private ChatRoomApplicationService service;
+    private Long itemId;
+
+    @BeforeEach
+    void setUp() {
+        roomRepo = new InMemoryFakeChatRoomRepository();
+        itemRepo = new InMemoryFakeItemRepository();
+        CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc);
+        service = new ChatRoomApplicationService(roomRepo, itemSvc);
+
+        Item item = itemRepo.save(Item.create(
+                SELLER, null, "물건", "설명", 50_000L, null, null, TradeType.판매, null
+        ));
+        itemId = item.getId();
+    }
+
+    @Test
+    @DisplayName("openFor 정상_방 생성 + 정규화 user1<user2")
+    void openFor_정상() {
+        ChatRoomResult r = service.openFor(BUYER, itemId);
+
+        assertThat(r.itemId()).isEqualTo(itemId);
+        assertThat(r.user1Id()).isEqualTo(SELLER);  // 100 < 200 → SELLER 가 user1
+        assertThat(r.user2Id()).isEqualTo(BUYER);
+        assertThat(r.active()).isTrue();
+    }
+
+    @Test
+    @DisplayName("openFor 멱등_같은 (요청자, item) 두 번 호출_같은 방")
+    void openFor_멱등() {
+        ChatRoomResult first = service.openFor(BUYER, itemId);
+        ChatRoomResult second = service.openFor(BUYER, itemId);
+
+        assertThat(first.id()).isEqualTo(second.id());
+    }
+
+    @Test
+    @DisplayName("openFor 본인 item_CHAT_FORBIDDEN")
+    void openFor_self_거부() {
+        assertThatThrownBy(() -> service.openFor(SELLER, itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHAT_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("openFor 삭제된 item_ITEM_NOT_FOUND")
+    void openFor_삭제_item_거부() {
+        Item item = itemRepo.findById(itemId).orElseThrow();
+        item.markAsDeleted();
+        itemRepo.save(item);
+
+        assertThatThrownBy(() -> service.openFor(BUYER, itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("openFor 비공개 item_ITEM_INVALID_STATE")
+    void openFor_비공개_거부() {
+        Item item = itemRepo.findById(itemId).orElseThrow();
+        item.markAsHidden();
+        itemRepo.save(item);
+
+        assertThatThrownBy(() -> service.openFor(BUYER, itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ITEM_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("openFor 예약/거래완료 item_채팅 가능")
+    void openFor_예약_허용() {
+        Item item = itemRepo.findById(itemId).orElseThrow();
+        item.markAsReserved();
+        itemRepo.save(item);
+
+        // 예약 상태에선 새 채팅 가능 (이미 예약된 buyer 외에도 다른 시점에 채팅 가능 가정)
+        ChatRoomResult r = service.openFor(BUYER, itemId);
+        assertThat(r).isNotNull();
+    }
+
+    @Test
+    @DisplayName("getOne 참여자 정상 / 외부인 거부")
+    void getOne_권한() {
+        Long roomId = service.openFor(BUYER, itemId).id();
+
+        assertThat(service.getOne(roomId, SELLER).id()).isEqualTo(roomId);
+        assertThat(service.getOne(roomId, BUYER).id()).isEqualTo(roomId);
+
+        assertThatThrownBy(() -> service.getOne(roomId, OTHER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHAT_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("getOne 없는 방_CHAT_ROOM_NOT_FOUND")
+    void getOne_없음() {
+        assertThatThrownBy(() -> service.getOne(9999L, BUYER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHAT_ROOM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("listMine 내가 참여한 방만")
+    void listMine() {
+        // BUYER 가 SELLER 의 item 으로 방 생성
+        Long room1 = service.openFor(BUYER, itemId).id();
+
+        // OTHER 가 SELLER 의 다른 item 으로 방 생성 — BUYER 와 무관
+        Item another = itemRepo.save(Item.create(
+                SELLER, null, "다른물건", "d", 1L, null, null, TradeType.판매, null
+        ));
+        Long room2 = service.openFor(OTHER, another.getId()).id();
+
+        Page<ChatRoomResult> mine = service.listMine(BUYER, PageRequest.of(0, 10));
+
+        assertThat(mine.getContent()).extracting(ChatRoomResult::id)
+                .containsExactly(room1)
+                .doesNotContain(room2);
+    }
+}

--- a/src/test/java/com/sseulang/domain/chat/application/InMemoryFakeChatRoomRepository.java
+++ b/src/test/java/com/sseulang/domain/chat/application/InMemoryFakeChatRoomRepository.java
@@ -1,0 +1,58 @@
+package com.sseulang.domain.chat.application;
+
+import com.sseulang.domain.chat.domain.ChatRoom;
+import com.sseulang.domain.chat.domain.ChatRoomRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class InMemoryFakeChatRoomRepository implements ChatRoomRepository {
+
+    private final Map<Long, ChatRoom> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public Optional<ChatRoom> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<ChatRoom> findByItemAndUsers(Long itemId, Long userA, Long userB) {
+        long u1 = Math.min(userA, userB);
+        long u2 = Math.max(userA, userB);
+        return store.values().stream()
+                .filter(c -> c.getItemId().equals(itemId)
+                        && c.getUser1Id() == u1 && c.getUser2Id() == u2)
+                .findFirst();
+    }
+
+    @Override
+    public Page<ChatRoom> findMine(Long userId, Pageable pageable) {
+        List<ChatRoom> mine = store.values().stream()
+                .filter(c -> c.isParticipant(userId))
+                .sorted(Comparator
+                        .comparing((ChatRoom c) -> c.getLastMessageAt() == null ? 1 : 0)
+                        .thenComparing(c -> c.getLastMessageAt(), Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparingLong(ChatRoom::getId).reversed())
+                .toList();
+        int start = Math.min((int) pageable.getOffset(), mine.size());
+        int end = Math.min(start + pageable.getPageSize(), mine.size());
+        return new PageImpl<>(mine.subList(start, end), pageable, mine.size());
+    }
+
+    @Override
+    public ChatRoom save(ChatRoom chatRoom) {
+        if (chatRoom.getId() == null) {
+            ReflectionTestUtils.setField(chatRoom, "id", ++sequence);
+        }
+        store.put(chatRoom.getId(), chatRoom);
+        return chatRoom;
+    }
+}

--- a/src/test/java/com/sseulang/domain/chat/domain/ChatRoomTest.java
+++ b/src/test/java/com/sseulang/domain/chat/domain/ChatRoomTest.java
@@ -1,0 +1,57 @@
+package com.sseulang.domain.chat.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ChatRoomTest {
+
+    @Test
+    @DisplayName("openFor 정상_user1<user2 정규화")
+    void openFor_정규화() {
+        ChatRoom a = ChatRoom.openFor(10L, 200L, 100L);
+        assertThat(a.getUser1Id()).isEqualTo(100L);
+        assertThat(a.getUser2Id()).isEqualTo(200L);
+
+        // 인자 순서 반대로 와도 동일
+        ChatRoom b = ChatRoom.openFor(10L, 100L, 200L);
+        assertThat(b.getUser1Id()).isEqualTo(100L);
+        assertThat(b.getUser2Id()).isEqualTo(200L);
+
+        assertThat(a.isActive()).isTrue();
+        assertThat(a.getUser1Unread()).isZero();
+        assertThat(a.getUser2Unread()).isZero();
+    }
+
+    @Test
+    @DisplayName("openFor 자기 자신_거부")
+    void openFor_self_거부() {
+        assertThatThrownBy(() -> ChatRoom.openFor(10L, 100L, 100L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("openFor null/비양수_거부")
+    void openFor_invalid_거부() {
+        assertThatThrownBy(() -> ChatRoom.openFor(null, 1L, 2L))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ChatRoom.openFor(0L, 1L, 2L))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ChatRoom.openFor(1L, null, 2L))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ChatRoom.openFor(1L, 1L, -1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("isParticipant")
+    void isParticipant() {
+        ChatRoom c = ChatRoom.openFor(10L, 100L, 200L);
+        assertThat(c.isParticipant(100L)).isTrue();
+        assertThat(c.isParticipant(200L)).isTrue();
+        assertThat(c.isParticipant(300L)).isFalse();
+        assertThat(c.isParticipant(null)).isFalse();
+    }
+}

--- a/src/test/java/com/sseulang/domain/report/domain/UserReportTest.java
+++ b/src/test/java/com/sseulang/domain/report/domain/UserReportTest.java
@@ -1,0 +1,64 @@
+package com.sseulang.domain.report.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserReportTest {
+
+    @Test
+    @DisplayName("reportUser 정상_status=접수")
+    void reportUser_정상() {
+        UserReport r = UserReport.reportUser(1L, 2L, "스팸", "광고 메시지 반복");
+        assertThat(r.getReporterId()).isEqualTo(1L);
+        assertThat(r.getReportedId()).isEqualTo(2L);
+        assertThat(r.getItemId()).isNull();
+        assertThat(r.getReason()).isEqualTo("스팸");
+        assertThat(r.getStatus()).isEqualTo(ReportStatus.접수);
+    }
+
+    @Test
+    @DisplayName("reportItem 정상_reportedId null + itemId 박힘")
+    void reportItem_정상() {
+        UserReport r = UserReport.reportItem(1L, 99L, "허위매물", "사진과 다름");
+        assertThat(r.getItemId()).isEqualTo(99L);
+        assertThat(r.getReportedId()).isNull();
+    }
+
+    @Test
+    @DisplayName("reportUser 자기 신고_거부")
+    void reportUser_self_거부() {
+        assertThatThrownBy(() -> UserReport.reportUser(1L, 1L, "x", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("reportUser null/비양수 reportedId_거부")
+    void reportUser_null_거부() {
+        assertThatThrownBy(() -> UserReport.reportUser(1L, null, "x", null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> UserReport.reportUser(1L, 0L, "x", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create 빈 reason_거부")
+    void create_빈_reason_거부() {
+        assertThatThrownBy(() -> UserReport.reportUser(1L, 2L, "", null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> UserReport.reportUser(1L, 2L, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> UserReport.reportUser(1L, 2L, "   ", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create reason 50자 초과_거부")
+    void create_reason_길이초과_거부() {
+        String tooLong = "가".repeat(51);
+        assertThatThrownBy(() -> UserReport.reportUser(1L, 2L, tooLong, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/sseulang/domain/review/application/InMemoryFakeReviewRepository.java
+++ b/src/test/java/com/sseulang/domain/review/application/InMemoryFakeReviewRepository.java
@@ -1,0 +1,42 @@
+package com.sseulang.domain.review.application;
+
+import com.sseulang.domain.review.domain.Review;
+import com.sseulang.domain.review.domain.ReviewRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class InMemoryFakeReviewRepository implements ReviewRepository {
+
+    private final Map<Long, Review> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public Review save(Review review) {
+        if (review.getId() == null) {
+            ReflectionTestUtils.setField(review, "id", ++sequence);
+            ReflectionTestUtils.setField(review, "createdAt", LocalDateTime.now());
+        }
+        store.put(review.getId(), review);
+        return review;
+    }
+
+    @Override
+    public Page<Review> findByRevieweeId(Long revieweeId, Pageable pageable) {
+        List<Review> filtered = store.values().stream()
+                .filter(r -> r.getRevieweeId().equals(revieweeId))
+                .sorted(Comparator.comparing(Review::getCreatedAt,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .toList();
+        int start = Math.min((int) pageable.getOffset(), filtered.size());
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
+    }
+}

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -1,0 +1,139 @@
+package com.sseulang.domain.review.application;
+
+import com.sseulang.domain.category.application.CategoryApplicationService;
+import com.sseulang.domain.category.application.InMemoryFakeCategoryRepository;
+import com.sseulang.domain.item.application.InMemoryFakeItemRepository;
+import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.domain.review.application.dto.ReviewWriteCommand;
+import com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository;
+import com.sseulang.domain.transaction.application.TransactionApplicationService;
+import com.sseulang.domain.transaction.domain.Transaction;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+import com.sseulang.domain.user.application.InMemoryFakeUserRepository;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReviewApplicationServiceTest {
+
+    private static final Long SELLER = 100L;
+    private static final Long BUYER = 200L;
+    private static final Long OUTSIDER = 999L;
+
+    private InMemoryFakeReviewRepository reviewRepo;
+    private InMemoryFakeTransactionRepository txRepo;
+    private InMemoryFakeUserRepository userRepo;
+    private ReviewApplicationService service;
+    private Long completedTxId;
+
+    @BeforeEach
+    void setUp() {
+        reviewRepo = new InMemoryFakeReviewRepository();
+        txRepo = new InMemoryFakeTransactionRepository();
+        userRepo = new InMemoryFakeUserRepository();
+        InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
+        CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc);
+        TransactionApplicationService txSvc = new TransactionApplicationService(txRepo, itemSvc);
+        UserApplicationService userSvc = new UserApplicationService(userRepo);
+        service = new ReviewApplicationService(reviewRepo, txSvc, userSvc);
+
+        Item item = itemRepo.save(Item.create(
+                SELLER, null, "물건", "설명", 50_000L, null, null, TradeType.판매, null
+        ));
+        completedTxId = persistCompletedTransaction(item.getId(), LocalDateTime.now().minusDays(1));
+    }
+
+    @Test
+    @DisplayName("write 정상_review 저장 + trust_score 갱신 호출")
+    void write_정상() {
+        Long reviewId = service.write(new ReviewWriteCommand(completedTxId, BUYER, 5, "친절"));
+
+        assertThat(reviewId).isNotNull();
+        assertThat(userRepo.recomputeCallCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("write 거래중인 tx_TRANSACTION_INVALID_STATE")
+    void write_거래중_거부() {
+        Long ongoingTxId = persistTransaction(1L, TransactionStatus.예약, null);
+
+        assertThatThrownBy(() -> service.write(new ReviewWriteCommand(ongoingTxId, BUYER, 5, null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("write 비참여자_TRANSACTION_FORBIDDEN")
+    void write_비참여자_거부() {
+        assertThatThrownBy(() -> service.write(new ReviewWriteCommand(completedTxId, OUTSIDER, 5, null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("write 7일 초과_REVIEW_PERIOD_EXPIRED")
+    void write_7일_초과_거부() {
+        Long oldTxId = persistCompletedTransaction(1L, LocalDateTime.now().minusDays(8));
+
+        assertThatThrownBy(() -> service.write(new ReviewWriteCommand(oldTxId, BUYER, 5, null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.REVIEW_PERIOD_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("write 7일 정확히 경계_허용")
+    void write_7일_경계_허용() {
+        Long sevenDaysTxId = persistCompletedTransaction(1L, LocalDateTime.now().minusDays(7).plusMinutes(1));
+
+        Long reviewId = service.write(new ReviewWriteCommand(sevenDaysTxId, BUYER, 5, null));
+        assertThat(reviewId).isNotNull();
+    }
+
+    @Test
+    @DisplayName("write 양방향_seller / buyer 모두 작성 가능")
+    void write_양방향() {
+        Long buyerReview = service.write(new ReviewWriteCommand(completedTxId, BUYER, 5, "buyer 측"));
+        Long sellerReview = service.write(new ReviewWriteCommand(completedTxId, SELLER, 4, "seller 측"));
+
+        assertThat(buyerReview).isNotEqualTo(sellerReview);
+        // trust_score recompute 가 양쪽 모두 호출됨 (BUYER 가 SELLER 평가, SELLER 가 BUYER 평가)
+        assertThat(userRepo.recomputeCallCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("write 없는 tx_TRANSACTION_NOT_FOUND")
+    void write_없는_tx() {
+        assertThatThrownBy(() -> service.write(new ReviewWriteCommand(9999L, BUYER, 5, null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_NOT_FOUND);
+    }
+
+    private Long persistCompletedTransaction(Long itemId, LocalDateTime completedAt) {
+        return persistTransaction(itemId, TransactionStatus.거래완료, completedAt);
+    }
+
+    private Long persistTransaction(Long itemId, TransactionStatus status, LocalDateTime completedAt) {
+        Transaction tx = Transaction.create(itemId, SELLER, BUYER, TradeType.판매, 50_000L, null, null, null);
+        ReflectionTestUtils.setField(tx, "status", status);
+        if (completedAt != null) {
+            ReflectionTestUtils.setField(tx, "completedAt", completedAt);
+        }
+        return txRepo.save(tx).getId();
+    }
+}

--- a/src/test/java/com/sseulang/domain/review/domain/ReviewTest.java
+++ b/src/test/java/com/sseulang/domain/review/domain/ReviewTest.java
@@ -1,0 +1,58 @@
+package com.sseulang.domain.review.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReviewTest {
+
+    @Test
+    @DisplayName("create 정상")
+    void create_정상() {
+        Review r = Review.create(10L, 100L, 200L, 5, "친절했어요");
+        assertThat(r.getTransactionId()).isEqualTo(10L);
+        assertThat(r.getReviewerId()).isEqualTo(100L);
+        assertThat(r.getRevieweeId()).isEqualTo(200L);
+        assertThat(r.getRating()).isEqualTo(5);
+        assertThat(r.getComment()).isEqualTo("친절했어요");
+    }
+
+    @Test
+    @DisplayName("create rating 0/6_거부")
+    void create_rating_범위_거부() {
+        assertThatThrownBy(() -> Review.create(10L, 100L, 200L, 0, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Review.create(10L, 100L, 200L, 6, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Review.create(10L, 100L, 200L, -1, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create reviewer == reviewee_거부")
+    void create_self_거부() {
+        assertThatThrownBy(() -> Review.create(10L, 100L, 100L, 5, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create comment 500자 초과_거부")
+    void create_comment_길이초과_거부() {
+        String tooLong = "가".repeat(501);
+        assertThatThrownBy(() -> Review.create(10L, 100L, 200L, 5, tooLong))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("create null/비양수 ID_거부")
+    void create_id_거부() {
+        assertThatThrownBy(() -> Review.create(null, 100L, 200L, 5, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Review.create(10L, 0L, 200L, 5, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Review.create(10L, 100L, -1L, 5, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
+++ b/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
@@ -1,0 +1,58 @@
+package com.sseulang.domain.user.application;
+
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InMemoryFakeUserRepository implements UserRepository {
+
+    private final Map<Long, User> store = new HashMap<>();
+    private long sequence = 0;
+    private final AtomicInteger recomputeCalls = new AtomicInteger();
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<User> findBySocial(SocialProvider provider, String socialId) {
+        return store.values().stream()
+                .filter(u -> u.getSocialProvider() == provider && socialId.equals(u.getSocialId()))
+                .findFirst();
+    }
+
+    @Override
+    public Optional<User> findByEmail(Email email) {
+        return store.values().stream()
+                .filter(u -> email.value().equals(u.getEmail()))
+                .findFirst();
+    }
+
+    @Override
+    public User save(User user) {
+        if (user.getId() == null) {
+            ReflectionTestUtils.setField(user, "id", ++sequence);
+        }
+        store.put(user.getId(), user);
+        return user;
+    }
+
+    @Override
+    public int recordReviewFor(Long revieweeId, int rating) {
+        recomputeCalls.incrementAndGet();
+        // fake — 실제 누적은 단위 테스트에서 검증 안 함 (호출 카운트만). 통합 IT 에서 prod SQL 실행 검증.
+        return store.containsKey(revieweeId) ? 1 : 0;
+    }
+
+    public int recomputeCallCount() {
+        return recomputeCalls.get();
+    }
+}


### PR DESCRIPTION
## Summary

Day 5 후반 4개 도메인 — ChatRoom (1:1 메타), UserBlock (멱등 차단), UserReport (사용자/물품 신고), Review (양방향 평가 + trust_score atomic). **Codex 게이트 2 (Review 영역 좁게) Critical 2 / Warning 처리 완료**.

- **신규 도메인**: chat / block / report / review
- **테스트**: 238 → **275 PASS / 0 FAIL** (+37)
- **🔴 Critical 2 fix**: 7일 경계 정확 계산, trust_score 누적 컬럼 atomic UPDATE (V3 마이그)
- **🟡 Warning** 트래킹 [Issue #16](https://github.com/sseullaeng/sl-server/issues/16)

## 핵심 설계

### ChatRoom
- `user1<user2` 정규화 → UNIQUE(item, u1, u2) 일관 매칭
- POST /api/v1/chat-rooms (itemId) — 멱등, 본인 item 거부
- 메시지·unread 갱신은 Day 6 (MongoDB + WebSocket) 영역

### UserBlock
- POST/DELETE /api/v1/blocks — 멱등 add/remove, UNIQUE race 좁은 catch

### UserReport
- POST /api/v1/items/{id}/report (item 신고) + /api/v1/users/{id}/report (사용자 신고)
- reportedId XOR itemId, status=접수

### Review (가이드 §4.7)
- 거래완료 후 7일 양방향 평가, rating 1-5, comment 500자
- UNIQUE(tx, reviewer) — REVIEW_DUPLICATED race 보정
- trust_score 갱신: review_count + rating_sum 누적 + 단일 atomic UPDATE
- 한줄평 마스킹 (본인만)

## 게이트 2 처리

🔴 **Critical 2개 모두 fix**

### (1) 7일 경계 회귀
- 기존: `Duration.between().toDays() > 7` — 내림 처리로 7일 23시간까지 허용
- 수정: `LocalDateTime.now().isAfter(completedAt.plusDays(7))` 정확 비교

### (2) trust_score race
- 기존: `UPDATE users SET trust_score = (SELECT AVG(rating) FROM reviews WHERE reviewee_id = :id)` — REPEATABLE_READ + read view 경계로 동시 review 작성 시 stale view 의 AVG 가 늦은 commit 으로 덮어씀
- 수정: V3 마이그로 `rating_sum` 컬럼 추가 (V1 의 `review_count` 와 결합) + 단일 atomic UPDATE
  ```sql
  UPDATE users
  SET review_count = review_count + 1,
      rating_sum = rating_sum + :rating,
      trust_score = CAST((rating_sum + :rating) AS DECIMAL(10,4)) / (review_count + 1)
  WHERE id = :userId
  ```

🟡 **Warning** (별도 [#16](https://github.com/sseullaeng/sl-server/issues/16) 트래킹)
- 응답 공개 범위 PM 합의 (가이드 §4.7 vs 현 응답 노출 항목)
- Clock 빈 주입 (현재 LocalDateTime.now() 하드코딩)
- pending reviews API 미구현 — Transaction + Review 결합 query 필요

🔵 Suggestion (별도)
- 7일 경계 추가 단위 테스트 (exactly / +1초 / -1초)
- 동시 review 작성 IT (testcontainers MySQL)

## 변경 사항 요약

| 영역 | 추가/변경 |
|---|---|
| 신규 도메인 | chat / block / report / review (4개) |
| User 도메인 | trust_score / review_count / rating_sum 매핑 + recordReview atomic |
| Item ApplicationService | findSellerOfActiveItem (Chat 진입) |
| Transaction ApplicationService | findCompletedForReview (거래완료/7일/참여자 검증) |
| ErrorCode | (기존 REVIEW_*, CHAT_*, INVALID_REQUEST 활용) |
| 마이그 | V3__add_user_review_aggregates.sql (rating_sum 컬럼) |

본 브랜치는 PR #11 squash 머지 직후 누락된 cause chain traversal + 트러블슈팅 §13/§14 (`f5499ad`) 도 cherry-pick 으로 합류.

## Test plan

- [ ] CI build 통과
- [ ] 로컬 `./gradlew test` — 275 PASS / 0 FAIL 재현
- [ ] dev 머지 후 Swagger UI 에서 새 endpoint 노출 확인:
  - `POST/GET /api/v1/chat-rooms(/{id})`
  - `POST/DELETE/GET /api/v1/blocks(/{userId})`
  - `POST /api/v1/items/{id}/report` / `POST /api/v1/users/{id}/report`
  - `POST /api/v1/reviews` / `GET /api/v1/users/{id}/reviews`
- [ ] V3 마이그 적용 후 users.rating_sum / review_count / trust_score 값 정합성 (운영 DB)
- [ ] 후속 트래킹: issue #16

## 위험 영역

본 PR 의 보안/돈 영역은 **Review trust_score 동시성** — Codex 게이트 2 보류 후 누적 컬럼 + atomic UPDATE 로 close. 나머지 ChatRoom / Block / Report 는 단순 CRUD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)