### PR TITLE
feat: Day 8 PR-b — 출금/관리자 + RT 격리 (게이트 1·2 통과)

### DIFF
--- a/docs/AUTH_SECURITY.md
+++ b/docs/AUTH_SECURITY.md
@@ -15,6 +15,9 @@
 - 게이트 1 thread: `019dd299-d74b-7ec0-99b5-90d6922df8d4`
 - mini 게이트 2 thread: `019dd2af-c49e-7621-b486-2b541121fe0f`
 
+### Day 8 PR-b (출금 도메인 + 관리자 로그인 + RT role 격리)
+- 게이트 1 thread: `019ddc22-822c-72d0-a563-1139b2dfac2e` (4묶음 리뷰: RT role / AdminLogin / Withdrawal / 테스트)
+
 `.logs/codex-review.log` 참고. 보안 영역 작업 직후엔 비울 것.
 
 | 항목 | 분류 | 처리 | 커밋/이슈 |
@@ -34,6 +37,15 @@
 | **Day 3 mini 게이트 2** Warning: race catch 광범위 | 🟡 | **적용** — UNIQUE race 만 보정, 그 외 제약 위반(닉네임 등) 은 원본 예외 그대로 throw | (Day 3 PR) |
 | **Day 3 mini 게이트 2** Warning: oauth2 엔드포인트 traceId 통합 검증 부재 | 🟡 | **적용** — `AuthOAuthFlowIT` (TraceIdFilter + X-Trace-Id 헤더 ↔ 본문 traceId 일관성, header relay 검증) | (Day 3 PR) |
 | **Day 3 mini 게이트 2** Suggestion: OAuthProvider javadoc | 🟢 | **적용** — 예외 계약(ExternalApiException + BusinessException) 명시 | (Day 3 PR) |
+| **Day 8 게이트 1** A: revokeAll SCAN→DEL race (동시 save 살아남음) | 🟡 → 🔴 채택 | **적용** — tokenVersion (RT claim `tv` + Redis `auth:rtv:{ROLE}:{userId}`, INCR 으로 한 방 무효화, consume 은 Lua 원자) | Day 8 PR-b |
+| **Day 8 게이트 1** A: role normalize default Locale 의존 | 🟡 | **적용** — `Locale.ROOT` 강제 (Redis store + InMemoryFake 양쪽) | Day 8 PR-b |
+| **Day 8 게이트 1** B: AdminLogin BCrypt timing leak (missing/inactive 단락 평가) | 🟡 | **적용** — `DUMMY_PASSWORD_HASH` 로 모든 분기에서 `matches()` 강제 호출 | Day 8 PR-b |
+| **Day 8 게이트 1** C: user chain `.authenticated()` 만 → ADMIN AT 로 출금 API 진입 가능 | 🔴 Critical | **적용** — `.hasRole("USER")` 강제 + `AuthSecurityFlowIT` 격리 테스트 추가 | Day 8 PR-b |
+| **Day 8 게이트 1** C: 출금 신청 멱등성 부재 (네트워크 재시도 → 중복 차감) | 🔴 Critical | **적용** — `WithdrawalRequest.idempotencyKey` (UUID 권장) + V4 `UNIQUE(user_id, idempotency_key)` + select-then-insert dedup + UNIQUE race 패배자 보정 (REQUIRES_NEW 재조회) | Day 8 PR-b |
+| **Day 8 게이트 1** C: cancel 의 `FOR UPDATE` 가 권한 검증 전 → 타인 id 로 lock-DoS | 🟡 | **적용** — `findByIdAndUserIdForUpdate(id, userId)` 한 쿼리로 권한+락 동시 획득 (응답은 `WITHDRAWAL_NOT_FOUND` 로 자원 존재 leak X) | Day 8 PR-b |
+| **Day 8 게이트 1** D: ADMIN AT → user 엔드포인트 격리 회귀 테스트 부재 | 🔴 Critical | **적용** — `adminAT_user엔드포인트_403`, `roleMissingAT_user엔드포인트_403` | Day 8 PR-b |
+| **Day 8 게이트 1** D: legacy RT / lowercase role / 7vs70 SCAN 회귀 | 🟡 | **적용** — `RedisRefreshTokenStoreIT` 에 case 추가 (기존 SCAN 회귀 + role 정규화 + tv mismatch + revokeAll race) | Day 8 PR-b |
+| **Day 8 게이트 1** D: 동시 동일 idempotencyKey IT 부재 | 🔴 Critical | **적용** — `WithdrawalSettlementIT.동시_동일_idempotencyKey_1건만` (행 1건 + history 1건만 검증) | Day 8 PR-b |
 
 ---
 
@@ -93,10 +105,12 @@ Codex MCP 호출 입출력에 토큰 / 비밀키 / 코드가 그대로 남는다
 
 ## 4. 후속 이슈 (트래킹)
 
-| ID | 대응 | 시점 |
-|----|------|------|
-| C1-a | user-level token version (User 엔티티 + AT/RT payload 에 ver claim + Filter 비교) | Day 3 OAuth 작업 ~ 직후 |
-| W2 | `RedisRefreshTokenStore.revokeAll` 의 SCAN → user 별 SET 인덱스 (`auth:rt-idx:{userId}`) | 5/6 이후 |
+| ID | 대응 | 시점 | 상태 |
+|----|------|------|------|
+| C1-a | user-level token version (User 엔티티 + AT/RT payload 에 ver claim + Filter 비교) | Day 3 OAuth 작업 ~ 직후 | ✅ Day 8 PR-b 에서 RT 단에 tokenVersion 도입으로 해결 (AT 는 30분 짧아 revoke 부담 적음) |
+| W2 | `RedisRefreshTokenStore.revokeAll` 의 SCAN → user 별 SET 인덱스 | 5/6 이후 | ✅ Day 8 PR-b 에서 INCR 한 방으로 변경 — SCAN 자체 제거 |
+| Cluster-1 | Redis Cluster 도입 시 multi-key Lua 슬롯 일치를 위한 hash tag `{ROLE:userId}` 적용 | 5/6 이후 (현재 standalone) | 📌 미진행 |
+| Withdrawal-1 | 외부 은행 이체 실연동 (현재 `adminComplete` 는 mock 로그만) | 5/6 이후 | 📌 미진행 |
 
 ---
 
@@ -125,6 +139,17 @@ SecurityConfig (3-chain: ADMIN / USER / PUBLIC)
    └─> JwtAccessDeniedHandler        (403 → ApiResponse)
 ```
 
+### 5.1 Day 8 보강 후 키 패턴
+
+```
+auth:rt:{ROLE}:{userId}:{jti}    → marker, TTL = RT 유효기간 (7일)
+auth:rtv:{ROLE}:{userId}         → 현재 tokenVersion (Long, INCR-only)
+auth:atbl:{jti}                  → AT 블랙리스트, TTL = AT 잔여 만료시간
+```
+
+- **role 차원**: USER / ADMIN 동일 숫자 id 공존 시 격리 (예: User#7 ≠ Admin#7).
+- **tokenVersion**: revokeAll 은 `INCR rtv` 한 방. 이후 발급된 RT 의 claim.tv 와 mismatch → consume 거부. SCAN race 제거.
+
 ---
 
 ## 6. 관련 문서 / 컨벤션
@@ -132,3 +157,123 @@ SecurityConfig (3-chain: ADMIN / USER / PUBLIC)
 - `.claude/CLAUDE.md` §4 (보안/인증 핵심 룰), §7.2 (TDD 강제 영역), §9 (Codex 게이트)
 - `.claude/AGENTS.md` §3.1 (보안 체크), §6.1 (게이트 1)
 - `docs/SSEULANG_BACKEND_GUIDE.md` §4.1 (인증/인가 결정 사항)
+
+---
+
+## 7. 트러블슈팅 (개발 중 만난 문제 + 해결)
+
+> 코드 보면 결과만 보이고 _왜 이렇게 됐는지_ 안 보이는 결정들. 후속 작업자가 같은 함정 안 밟도록 정리.
+
+### 7.1 RT user/admin 동일 숫자 id 격리 (Day 8 PR-b)
+
+**증상**: User#7 과 Admin#7 가 동시 존재할 수 있는데 Redis 키가 `auth:rt:7:{jti}` 로만 되어 있어 한 쪽 revokeAll 이 다른 쪽 RT 까지 무효화 위험.
+
+**원인**: 초기 설계가 user 도메인만 가정. 관리자 로그인 추가하며 동일 숫자 id 충돌이 가능해짐.
+
+**해결**: `RefreshTokenStore` 인터페이스의 모든 메서드에 `String role` 차원 추가 → 키 `auth:rt:{ROLE}:{userId}:{jti}`. JWT claim 의 role 이 권위 있는 출처. 호출부(OAuthLoginService / AdminLoginService / RefreshTokenRotationService) 전부 갱신.
+
+### 7.2 revokeAll SCAN→DEL race (Day 8 PR-b — Codex 지적)
+
+**증상**: `revokeAll` 이 SCAN 으로 키 목록을 모은 뒤 DEL. 그 사이에 동시 `consume` → `save` 가 끼어들어 새 RT 가 살아남는 race.
+
+**원인**: SCAN 은 atomic 이지만 SCAN 이후 새로 SET 되는 키는 보지 못함.
+
+**해결**: tokenVersion 도입.
+- 각 (role, userId) 마다 단조 증가 정수 `tv` 를 Redis 에 보관 (`auth:rtv:{ROLE}:{userId}`)
+- RT 발급 시 현재 tv 를 JWT claim `tv` 에 박음
+- `revokeAll` = `INCR rtv` 한 방 — SCAN 제거
+- `consume` 은 Lua 로 `(claim.tv == GET rtv)` 검증 + DEL jti 원자 실행
+- 이전 SCAN 중 끼어들었어도 INCR 이후엔 모든 RT 가 mismatch → 거부
+
+**부수 효과**: 기존 RT (tv claim 없음) 전부 무효화. dev 단계라 backward compat 미고려.
+
+**회귀 방지**: `RedisRefreshTokenStoreIT.revokeAll_race_새로_save된_RT도_무효화` — revokeAll 진행 중 동시 save 들이 모두 거부됨을 검증.
+
+### 7.3 user chain `.authenticated()` 만 → ADMIN AT 권한 누수 (Day 8 PR-b)
+
+**증상**: SecurityConfig 의 user chain 이 `.anyRequest().authenticated()` 만 요구. ADMIN AT 도 인증된 상태라 통과 — 출금/결제 같은 user 영역에 ADMIN AT 로 접근 가능.
+
+**위험**: adminId 와 userId 가 같은 숫자면 `@AuthenticationPrincipal Long userId` 본인 검증도 통과해 사용자 자원 조작 가능.
+
+**해결**: `.anyRequest().hasRole("USER")` 강제. ADMIN AT 는 admin chain 만 통과. 회귀: `AuthSecurityFlowIT.adminAT_user엔드포인트_403`.
+
+### 7.4 출금 신청 멱등성 부재 (Day 8 PR-b)
+
+**증상**: 더블클릭/네트워크 재시도로 같은 출금이 두 번 신청 → 잔액 두 번 차감.
+
+**해결**: 클라이언트 발급 `idempotencyKey` (UUID 권장) + DB 제약 `UNIQUE(user_id, idempotency_key)`. ApplicationService 에서 select-then-insert dedup 로직 + UNIQUE 제약 race 패배자는 catch 후 기존 row id 반환.
+
+**구현 중 만난 추가 함정 3가지** (멱등성 구현 자체보다 더 많은 시간 소비):
+
+#### 7.4.1 MySQL InnoDB: duplicate-key vs deadlock 모두 발생
+
+**증상**: 동시 INSERT 가 같은 UNIQUE 키를 노릴 때 MySQL 이 (a) `Duplicate entry` 또는 (b) `Deadlock found` 둘 중 하나를 던짐. 어느 쪽인지는 타이밍에 따라 달라짐.
+
+**원인**: InnoDB 의 next-key 락이 같은 UNIQUE 키 영역에 gap 락을 걸면서 두 트랜잭션이 서로의 lock 을 기다리면 deadlock 으로 처리. 그렇지 않으면 immediate duplicate-key.
+
+**해결**: catch 절에서 `DataIntegrityViolationException | CannotAcquireLockException` 두 타입 모두 처리. 둘 다 dedup 시그널로 동일 취급.
+
+#### 7.4.2 Hibernate: 같은 tx 안에서 INSERT 실패 catch → session dirty
+
+**증상**: `try { repo.save(entity) } catch (...) { ... }` 패턴이 `org.hibernate.AssertionFailure: null id ... (don't flush the Session after an exception occurs)` 로 깨짐.
+
+**원인**: JPA persistence context 에 entity 가 이미 추가된 상태에서 flush 가 실패. 이후 같은 tx 가 commit 되며 다시 flush 를 시도 → entity 가 여전히 dirty 상태 → 실패.
+
+**해결**: INSERT 시도를 별도 트랜잭션(`@Transactional(propagation = REQUIRES_NEW)`)으로 격리. 실패해도 그 inner tx 만 롤백되고 outer 의 persistence context 는 영향 없음. 같은 클래스 안의 자기 호출은 Spring AOP 가 가로채지 못하므로 `@Lazy WithdrawalApplicationService self` 자기 주입 패턴 사용.
+
+#### 7.4.3 REPEATABLE_READ: 패배자가 winner commit 못 봄
+
+**증상**: race 패배자가 catch 후 `findByUserIdAndIdempotencyKey` 로 winner 의 row 를 찾으려 하지만 빈 결과 → 원본 예외 재throw.
+
+**원인**: outer 트랜잭션이 MySQL 기본 isolation `REPEATABLE_READ` 라서 tx 시작 시점의 snapshot 을 고수. winner 가 catch 시점 이후에 commit 하더라도 outer tx 의 snapshot 에는 없음.
+
+**해결**: 복구 SELECT 도 `REQUIRES_NEW` 로 새 트랜잭션 열어서 fresh snapshot 받음. `findIdempotentInFreshTx(cmd, originalException)` 메서드로 분리.
+
+**최종 구조**:
+```
+request(cmd)                                       ← outer tx (readonly, class default)
+  ├─ findByUserIdAndIdempotencyKey (fast path)    ← outer 에서 1회 조회
+  ├─ self.insertWithDeduct(cmd)                   ← REQUIRES_NEW write tx
+  │    ├─ save(Withdrawal)
+  │    └─ pointApplicationService.deduct
+  └─ catch DataIntegrity|CannotAcquireLock
+       └─ self.findIdempotentInFreshTx(cmd, e)    ← REQUIRES_NEW readonly, fresh snapshot
+```
+
+### 7.5 cancel 의 lock-DoS (Day 8 PR-b — Codex 지적)
+
+**증상**: `cancel(id, requesterId)` 가 `findByIdForUpdate(id)` 로 락 먼저 잡고 `isOwnedBy` 검증을 나중에 함. 공격자가 임의 id 로 cancel 호출하면 잠깐이지만 모두에게 락 걸 수 있음.
+
+**해결**: `findByIdAndUserIdForUpdate(id, userId)` 로 권한 검증과 락을 한 쿼리에 묶음. 타인 자원이면 빈 결과 → 락 미획득. 응답은 `WITHDRAWAL_NOT_FOUND` 로 자원 존재 여부도 leak 안 되게.
+
+### 7.6 AdminLogin BCrypt timing leak (Day 8 PR-b — Codex 지적)
+
+**증상**: `if (!admin.isActive() || !passwordEncoder.matches(...))` 단락 평가 → username 미존재면 BCrypt 안 돌고, inactive 면 matches 도 안 돎. 응답 시간 차이로 username 존재 여부 / active 여부 leak.
+
+**해결**: `DUMMY_PASSWORD_HASH` 상수 도입. 미존재여도 dummy hash 로 항상 `passwordEncoder.matches(password, hash)` 호출 → 모든 분기에서 ~50ms BCrypt 비용 균일. 회귀: `AdminLoginServiceTest.login_미존재` / `login_비활성` 에 `verify(passwordEncoder).matches(...)` 추가.
+
+### 7.7 InMemoryFakeRefreshTokenStore 의미 변경으로 기존 테스트 깨짐
+
+**증상**: tokenVersion 도입 후 기존 `RefreshTokenRotationServiceTest.rotate_재사용탐지` 가 `store.contains(jti)` 로 무효화 검증하던 게 false positive (jti 키는 살아있고 tv mismatch 로 거부됨).
+
+**원인**: 새 의미상 `revokeAll` 은 INCR 만 — jti 키는 TTL 만료까지 잔존하지만 의미상 무효. raw key existence 와 logical validity 가 분리됨.
+
+**해결**: 테스트도 의미 기반으로 변경. `service.rotate(rt)` 가 `AUTH_REFRESH_TOKEN_INVALID` 로 거부되는지를 검증 — 추상화 누수 제거.
+
+### 7.8 role normalize default Locale 의존 (Day 8 PR-b — Codex 지적)
+
+**증상**: `role.toUpperCase()` 가 default Locale 사용. 터키어 등 일부 locale 에서 `i` ↔ `İ` 변환이 ASCII 와 달라 키 정규화가 깨질 수 있음.
+
+**해결**: `role.toUpperCase(Locale.ROOT)` 강제 (Redis store + InMemoryFake 양쪽).
+
+---
+
+## 8. 운영 plays (auth/withdrawal 사고 나면)
+
+| 증상 | 1차 확인 | 보정 |
+|------|----------|------|
+| 특정 사용자 "로그인 풀림" 신고 폭주 | `auth:rtv:USER:{userId}` INCR 이력 (Redis log) — 누군가 RT 재사용 탐지로 revokeAll 트리거됐는지 | 본인 재로그인 안내. 의심되면 잠시 active=false 후 조사 |
+| 출금 중복 차감 신고 | `withdrawals` 테이블에서 (user_id, idempotency_key) 페어 — 같은 key 로 행 2개면 UNIQUE 누락 의심 | V4 마이그레이션 적용 여부 확인. 행 1개면 신고자 오해 / 다른 트랜잭션 |
+| Admin chain 으로 user API 접근 가능 신고 | `SecurityConfig.userFilterChain` 의 `.hasRole("USER")` 회귀 여부 | 빠진 경우 즉시 핫픽스. 회귀 IT 추가 |
+| 출금 신청이 자꾸 NOT_FOUND 응답 | `findByIdAndUserIdForUpdate` 가 본인 자원만 조회 — 클라이언트가 잘못된 id 보내거나 다른 사용자 id 사용 중 | 클라이언트 로깅 확인 |
+| Withdrawal IT deadlock 빈발 | 동시 INSERT 패턴 — UNIQUE race 패배자 catch 가 정상 동작하는지 | `WithdrawalApplicationService.request` 의 catch 절에 `DataIntegrityViolationException` 와 `CannotAcquireLockException` 두 타입 모두 살아있는지 |

--- a/src/main/java/com/sseulang/domain/admin/application/AdminLoginService.java
+++ b/src/main/java/com/sseulang/domain/admin/application/AdminLoginService.java
@@ -1,0 +1,84 @@
+package com.sseulang.domain.admin.application;
+
+import com.sseulang.domain.admin.domain.Admin;
+import com.sseulang.domain.admin.domain.AdminRepository;
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.auth.domain.RefreshTokenStore;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.security.JwtProperties;
+import com.sseulang.global.security.JwtProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+/**
+ * 관리자 로그인 — username + BCrypt password 검증 → JWT 발급 (subject=admin.id, role=ADMIN).
+ *
+ * <p>일반 사용자 로그인 ({@link com.sseulang.domain.auth.application.OAuthLoginService}) 와 별도로
+ * 관리하지만, JWT 발급 / RefreshTokenStore 인프라는 공유. 관리자가 발급받은 토큰의 subject 는
+ * {@code admin.id}, role 은 {@code ADMIN} — admin chain 의 ROLE_ADMIN 가드와 정합.</p>
+ *
+ * <p>실패 응답은 {@link ErrorCode#AUTH_LOGIN_FAILED} 로 통일 (username 존재 여부 노출 X, CLAUDE.md §4 보안 룰).</p>
+ */
+@Service
+public class AdminLoginService {
+
+    private static final String ADMIN_ROLE = "ADMIN";
+
+    /**
+     * username enumeration timing 공격 방어용 sentinel 평문.
+     * <p>실제 admin password 와 충돌 가능성을 사실상 0 으로 만들기 위해 긴 random sentinel 사용.
+     * 충돌하더라도 admin 측에서 isActive() 체크 + role 차원 격리로 부수 피해 없음.</p>
+     */
+    private static final String DUMMY_PASSWORD_PLAINTEXT = "__sseulang_dummy_admin_sentinel_v1__";
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenStore refreshTokenStore;
+    private final Duration refreshTokenTtl;
+    /**
+     * username 미존재 / inactive 분기에서도 동일 비용으로 {@code matches()} 를 강제하기 위한 dummy hash.
+     * 생성자에서 주입된 {@link PasswordEncoder} 로 직접 encode — 하드코딩 시 인코더 종류 / 형식 어긋남
+     * 위험을 제거하고 항상 유효 형식 보장 (게이트 2 보강). 시작 시 1회 BCrypt 비용 ~50ms.
+     */
+    private final String dummyPasswordHash;
+
+    public AdminLoginService(
+            AdminRepository adminRepository,
+            PasswordEncoder passwordEncoder,
+            JwtProvider jwtProvider,
+            RefreshTokenStore refreshTokenStore,
+            JwtProperties jwtProperties
+    ) {
+        this.adminRepository = adminRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtProvider = jwtProvider;
+        this.refreshTokenStore = refreshTokenStore;
+        this.refreshTokenTtl = Duration.ofSeconds(jwtProperties.refreshTokenValiditySeconds());
+        this.dummyPasswordHash = passwordEncoder.encode(DUMMY_PASSWORD_PLAINTEXT);
+    }
+
+    public TokenPair login(String username, String password) {
+        if (username == null || username.isBlank() || password == null || password.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
+        }
+        Admin admin = adminRepository.findByUsername(username).orElse(null);
+        // 미존재여도 dummy hash 로 항상 BCrypt 를 돌려 timing 균일화 (단락 평가 X).
+        String hashToCompare = (admin != null) ? admin.getPassword() : dummyPasswordHash;
+        boolean passwordOk = passwordEncoder.matches(password, hashToCompare);
+
+        if (admin == null || !admin.isActive() || !passwordOk) {
+            throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
+        }
+
+        String at = jwtProvider.issueAccessToken(admin.getId(), ADMIN_ROLE);
+        long tv = refreshTokenStore.currentTokenVersion(ADMIN_ROLE, admin.getId());
+        String rt = jwtProvider.issueRefreshToken(admin.getId(), ADMIN_ROLE, tv);
+        String rtJti = jwtProvider.parse(rt).jti();
+        refreshTokenStore.save(ADMIN_ROLE, admin.getId(), rtJti, refreshTokenTtl);
+        return new TokenPair(at, rt);
+    }
+}

--- a/src/main/java/com/sseulang/domain/admin/domain/Admin.java
+++ b/src/main/java/com/sseulang/domain/admin/domain/Admin.java
@@ -1,0 +1,63 @@
+package com.sseulang.domain.admin.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Admin Aggregate Root. V1 스키마 {@code admins} 매핑.
+ *
+ * <p>일반 사용자 ({@code users}) 와 별도 테이블로 관리. 관리자 인증 흐름은
+ * {@code AdminLoginService} 가 username + BCrypt password 검증 + JWT 발급 (subject=admin.id, role=ADMIN).</p>
+ */
+@Entity
+@Table(name = "admins")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Admin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "username", nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "role", nullable = false, length = 20)
+    private String role;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    public static Admin create(String username, String hashedPassword, String name) {
+        if (username == null || username.isBlank()) {
+            throw new IllegalArgumentException("username 은 필수입니다");
+        }
+        if (hashedPassword == null || hashedPassword.isBlank()) {
+            throw new IllegalArgumentException("hashedPassword 는 필수입니다");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name 은 필수입니다");
+        }
+        Admin admin = new Admin();
+        admin.username = username;
+        admin.password = hashedPassword;
+        admin.name = name;
+        admin.role = "ADMIN";
+        admin.active = true;
+        return admin;
+    }
+}

--- a/src/main/java/com/sseulang/domain/admin/domain/AdminRepository.java
+++ b/src/main/java/com/sseulang/domain/admin/domain/AdminRepository.java
@@ -1,0 +1,12 @@
+package com.sseulang.domain.admin.domain;
+
+import java.util.Optional;
+
+public interface AdminRepository {
+
+    Admin save(Admin admin);
+
+    Optional<Admin> findByUsername(String username);
+
+    Optional<Admin> findById(Long id);
+}

--- a/src/main/java/com/sseulang/domain/admin/infrastructure/persistence/AdminJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/admin/infrastructure/persistence/AdminJpaRepository.java
@@ -1,0 +1,10 @@
+package com.sseulang.domain.admin.infrastructure.persistence;
+
+import com.sseulang.domain.admin.domain.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+interface AdminJpaRepository extends JpaRepository<Admin, Long> {
+    Optional<Admin> findByUsername(String username);
+}

--- a/src/main/java/com/sseulang/domain/admin/infrastructure/persistence/AdminRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/admin/infrastructure/persistence/AdminRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.sseulang.domain.admin.infrastructure.persistence;
+
+import com.sseulang.domain.admin.domain.Admin;
+import com.sseulang.domain.admin.domain.AdminRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class AdminRepositoryImpl implements AdminRepository {
+
+    private final AdminJpaRepository jpa;
+
+    public AdminRepositoryImpl(AdminJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Admin save(Admin admin) {
+        return jpa.save(admin);
+    }
+
+    @Override
+    public Optional<Admin> findByUsername(String username) {
+        return jpa.findByUsername(username);
+    }
+
+    @Override
+    public Optional<Admin> findById(Long id) {
+        return jpa.findById(id);
+    }
+}

--- a/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
+++ b/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
@@ -1,0 +1,44 @@
+package com.sseulang.domain.admin.presentation;
+
+import com.sseulang.domain.admin.application.AdminLoginService;
+import com.sseulang.domain.admin.presentation.dto.AdminLoginRequest;
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.security.CookieUtil;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 로그인 진입점. SecurityConfig 의 {@code /api/v1/auth/**} permitAll 영역.
+ * 일반 사용자 OAuth 흐름 ({@link com.sseulang.domain.auth.presentation.AuthController}) 와 분리.
+ */
+@RestController
+@RequestMapping("/api/v1/auth/admin")
+public class AdminAuthController {
+
+    private final AdminLoginService adminLoginService;
+    private final CookieUtil cookieUtil;
+
+    public AdminAuthController(AdminLoginService adminLoginService, CookieUtil cookieUtil) {
+        this.adminLoginService = adminLoginService;
+        this.cookieUtil = cookieUtil;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody AdminLoginRequest request) {
+        TokenPair pair = adminLoginService.login(request.username(), request.password());
+
+        ResponseCookie at = cookieUtil.accessTokenCookie(pair.accessToken());
+        ResponseCookie rt = cookieUtil.refreshTokenCookie(pair.refreshToken());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, at.toString())
+                .header(HttpHeaders.SET_COOKIE, rt.toString())
+                .body(ApiResponse.ok());
+    }
+}

--- a/src/main/java/com/sseulang/domain/admin/presentation/dto/AdminLoginRequest.java
+++ b/src/main/java/com/sseulang/domain/admin/presentation/dto/AdminLoginRequest.java
@@ -1,0 +1,8 @@
+package com.sseulang.domain.admin.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginRequest(
+        @NotBlank String username,
+        @NotBlank String password
+) {}

--- a/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
@@ -87,9 +87,11 @@ public class OAuthLoginService {
         }
 
         String at = jwtProvider.issueAccessToken(user.getId(), DEFAULT_ROLE);
-        String rt = jwtProvider.issueRefreshToken(user.getId(), DEFAULT_ROLE);
+        // tv: store 의 현재 버전을 RT claim 에 박는다. 이후 revokeAll → INCR 시 본 RT 는 mismatch 로 거부됨.
+        long tv = refreshTokenStore.currentTokenVersion(DEFAULT_ROLE, user.getId());
+        String rt = jwtProvider.issueRefreshToken(user.getId(), DEFAULT_ROLE, tv);
         String rtJti = jwtProvider.parse(rt).jti();
-        refreshTokenStore.save(user.getId(), rtJti, refreshTokenTtl);
+        refreshTokenStore.save(DEFAULT_ROLE, user.getId(), rtJti, refreshTokenTtl);
 
         return new TokenPair(at, rt);
     }

--- a/src/main/java/com/sseulang/domain/auth/application/RefreshTokenRotationService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/RefreshTokenRotationService.java
@@ -52,18 +52,24 @@ public class RefreshTokenRotationService {
         Long userId = claims.userId();
         String role = claims.role();
         String oldJti = claims.jti();
+        Long claimTv = claims.tokenVersion();
+        if (role == null || role.isBlank() || claimTv == null) {
+            // RT 에 role / tv 누락 — 토큰 변조 또는 구버전 토큰. 보수적으로 INVALID 응답.
+            throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
+        }
 
-        // atomic: 동시 rotate 요청 중 단 하나만 true 를 받는다.
-        // false = (a) 처음부터 없는 jti 또는 (b) 이미 누가 사용함 → 탈취 의심
-        if (!refreshTokenStore.consume(userId, oldJti)) {
-            refreshTokenStore.revokeAll(userId);
+        // atomic Lua: (1) claimTv == currentTv 검증, (2) jti DEL.
+        // false = (a) 버전 mismatch (revokeAll 이후) 또는 (b) 이미 사용된 jti → 탈취 의심.
+        if (!refreshTokenStore.consume(role, userId, oldJti, claimTv)) {
+            refreshTokenStore.revokeAll(role, userId);
             throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
         }
 
         String newAccessToken = jwtProvider.issueAccessToken(userId, role);
-        String newRefreshToken = jwtProvider.issueRefreshToken(userId, role);
+        long newTv = refreshTokenStore.currentTokenVersion(role, userId);
+        String newRefreshToken = jwtProvider.issueRefreshToken(userId, role, newTv);
         String newJti = jwtProvider.parse(newRefreshToken).jti();
-        refreshTokenStore.save(userId, newJti, refreshTokenTtl);
+        refreshTokenStore.save(role, userId, newJti, refreshTokenTtl);
 
         return new TokenPair(newAccessToken, newRefreshToken);
     }
@@ -79,7 +85,11 @@ public class RefreshTokenRotationService {
         }
         try {
             JwtClaims claims = jwtProvider.parse(refreshToken);
-            refreshTokenStore.revoke(claims.userId(), claims.jti());
+            String role = claims.role();
+            if (role == null || role.isBlank()) {
+                return;  // role 누락 토큰은 어차피 rotate 거부됨
+            }
+            refreshTokenStore.revoke(role, claims.userId(), claims.jti());
         } catch (BusinessException ignored) {
             // 만료/변조 토큰은 어차피 사용 불가 — 조용히 흘려보냄
         }

--- a/src/main/java/com/sseulang/domain/auth/domain/RefreshTokenStore.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/RefreshTokenStore.java
@@ -6,27 +6,53 @@ import java.time.Duration;
  * Refresh Token 저장소 인터페이스. 도메인 layer 순수 POJO — Spring/JPA/Redis 의존 X.
  * 구현은 {@code domain/auth/infrastructure/persistence}.
  *
- * Rotation 정책:
- *  - 토큰 발급 시 {@link #save} (TTL = 7일)
- *  - Rotation 시 {@link #consume} 으로 atomic 폐기 (반환 false 면 재사용 탐지)
- *  - 명시적 logout 시 {@link #revoke}
- *  - 재사용 탐지 시 {@link #revokeAll} 로 해당 사용자 전체 토큰 무효화
+ * <p>Key 차원: {@code (role, userId, jti)} — 일반 사용자(role=USER) 와 관리자(role=ADMIN) 가
+ * 동일 숫자 id 를 가질 수 있으므로 role 도 포함해야 세션 격리가 보장된다.</p>
+ *
+ * <h2>Token Version (게이트 1 race 보강)</h2>
+ * 각 (role, userId) 마다 단조 증가 정수 {@code tokenVersion} 을 둔다.
+ * <ul>
+ *   <li>RT 발급 직전 {@link #currentTokenVersion} 으로 현재 값 조회 → JWT claim {@code tv} 로 박는다.</li>
+ *   <li>{@link #revokeAll} 은 INCR 한 번으로 종료 (SCAN 없음). 이후 발급된 RT 의 claim.tv 와
+ *       mismatch → consume 단계에서 즉시 거부.</li>
+ *   <li>{@link #consume} 은 (claimTv == currentTv) 검증 + jti 폐기를 원자 실행 (Redis Lua).</li>
+ * </ul>
+ *
+ * <p>이전 SCAN→DEL 구현은 revokeAll 도중 동시 save 된 RT 가 살아남는 race 가 있었다.
+ * tokenVersion 은 키 검사 자체를 무력화하므로 race-free.</p>
+ *
+ * <h2>Rotation 정책</h2>
+ * <ul>
+ *   <li>발급: {@link #currentTokenVersion} → JWT 발급 → {@link #save}</li>
+ *   <li>Rotation: {@link #consume} 으로 atomic 검증·폐기 (false 면 재사용 탐지)</li>
+ *   <li>logout: {@link #revoke}</li>
+ *   <li>재사용 탐지·강제 로그아웃: {@link #revokeAll} (INCR)</li>
+ * </ul>
  */
 public interface RefreshTokenStore {
 
-    /** 발급 시 호출 — jti 를 지정 TTL 로 저장. */
-    void save(Long userId, String jti, Duration ttl);
+    /**
+     * 현재 (role, userId) 의 tokenVersion 조회. 한 번도 revokeAll 호출되지 않았으면 0 반환.
+     * RT 발급 직전 호출하여 JWT claim {@code tv} 로 박는다.
+     */
+    long currentTokenVersion(String role, Long userId);
+
+    /** 발급 시 호출 — (role, userId, jti) 를 지정 TTL 로 저장. tv 는 JWT claim 에만 보관. */
+    void save(String role, Long userId, String jti, Duration ttl);
 
     /**
-     * Rotation 의 핵심 — atomic 하게 jti 를 검증·폐기한다.
-     * 저장돼 있던 jti 면 즉시 삭제하고 true. 없거나 이미 폐기됐으면 false.
-     * isValid+revoke 두 단계를 race 없이 합친 형태.
+     * Rotation 의 핵심 — atomic 하게 (1) claimTv==currentTv 검증, (2) jti 폐기.
+     * 둘 다 통과하면 true. 아니면 false (= 버전 mismatch 또는 이미 폐기된 jti).
+     * isValid+revoke 두 단계를 Redis Lua 로 race 없이 합친 형태.
      */
-    boolean consume(Long userId, String jti);
+    boolean consume(String role, Long userId, String jti, long claimTv);
 
     /** 명시적 logout 등 — 단일 jti 폐기. 없어도 무방. */
-    void revoke(Long userId, String jti);
+    void revoke(String role, Long userId, String jti);
 
-    /** 해당 사용자의 모든 Refresh Token 폐기 — 재사용 탐지·전체 로그아웃. */
-    void revokeAll(Long userId);
+    /**
+     * 해당 (role, userId) 의 모든 Refresh Token 폐기 — INCR tokenVersion 한 번.
+     * 진행 중 동시 save 가 있어도 이후 consume 에서 모두 mismatch 로 거부됨.
+     */
+    void revokeAll(String role, Long userId);
 }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStore.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStore.java
@@ -1,25 +1,59 @@
 package com.sseulang.domain.auth.infrastructure.persistence;
 
 import com.sseulang.domain.auth.domain.RefreshTokenStore;
-import org.springframework.data.redis.core.Cursor;
-import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
+import java.util.Locale;
 
 /**
- * Redis 백엔드. Key 패턴: {@code auth:rt:{userId}:{jti}} → marker "1", TTL = 토큰 유효기간.
- * revokeAll 은 SCAN 으로 점진 검색 (KEYS 명령 회피).
+ * Redis 백엔드.
+ *
+ * <h2>키 패턴</h2>
+ * <ul>
+ *   <li>{@code auth:rt:{ROLE}:{userId}:{jti}} → marker "1", TTL = RT 유효기간</li>
+ *   <li>{@code auth:rtv:{ROLE}:{userId}} → 현재 tokenVersion (Long). 단조 증가, 부재 시 0 으로 간주.</li>
+ * </ul>
+ *
+ * <h2>race-free 보장</h2>
+ * <p>이전 SCAN→DEL 구현은 revokeAll 도중 동시 save 가 슬그머니 끼어들면 새 RT 가 살아남는 race
+ * 가 있었다. 본 구현은 {@code consume} 을 Lua 로 (1) tokenVersion 검증, (2) jti DEL 한 번에
+ * 묶어 race 를 제거한다. {@code revokeAll} 은 단순 INCR — 이후 발급된 RT 의 claim.tv 와
+ * mismatch → consume 단계 즉시 거부. (게이트 1 보강)</p>
+ *
+ * <p>role 차원 격리는 동일 — user/admin 동일 숫자 id 공존 시 키 충돌 방지.</p>
+ *
+ * <p>TODO(Cluster): 추후 Redis Cluster 도입 시 multi-key Lua 가 같은 슬롯에 떨어지도록
+ * hash tag {@code {ROLE:userId}} 적용 필요. 현재 standalone 사용으로 미적용.</p>
  */
 @Repository
 public class RedisRefreshTokenStore implements RefreshTokenStore {
 
     private static final String KEY_PREFIX = "auth:rt:";
+    private static final String VERSION_KEY_PREFIX = "auth:rtv:";
     private static final String MARKER = "1";
-    private static final long SCAN_BATCH = 100L;
+
+    /**
+     * Lua: (1) currentTv 조회 (없으면 "0"), (2) claimTv 와 비교, (3) 일치하면 DEL jti 시도.
+     * <ul>
+     *   <li>반환 -1 = 버전 mismatch (revokeAll 이후 발급된 RT 가 아닌 구버전)</li>
+     *   <li>반환 0  = 버전은 맞지만 jti 가 이미 폐기됨 (재사용 탐지 시그널)</li>
+     *   <li>반환 1  = 정상 consume</li>
+     * </ul>
+     */
+    private static final RedisScript<Long> CONSUME_SCRIPT = new DefaultRedisScript<>(
+            """
+            local cur = redis.call('GET', KEYS[1])
+            if cur == false then cur = '0' end
+            if cur ~= ARGV[1] then return -1 end
+            return redis.call('DEL', KEYS[2])
+            """,
+            Long.class
+    );
 
     private final StringRedisTemplate redis;
 
@@ -28,42 +62,59 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
     }
 
     @Override
-    public void save(Long userId, String jti, Duration ttl) {
-        redis.opsForValue().set(key(userId, jti), MARKER, ttl);
-    }
-
-    @Override
-    public boolean consume(Long userId, String jti) {
-        // DEL 의 반환값 = 삭제된 키 개수. 1 이면 이번 호출이 jti 를 가진 첫 호출자.
-        // 같은 jti 에 대한 동시 호출 중 단 하나만 true 를 받는다 (Redis 가 단일 스레드).
-        Long deleted = redis.delete(java.util.List.of(key(userId, jti)));
-        return deleted != null && deleted > 0L;
-    }
-
-    @Override
-    public void revoke(Long userId, String jti) {
-        redis.delete(key(userId, jti));
-    }
-
-    @Override
-    public void revokeAll(Long userId) {
-        // TODO(5/6 이후): 토큰 수 증가 시 SCAN 비효율. user 별 SET 인덱스(`auth:rt-idx:{userId}`)로 변경.
-        ScanOptions opts = ScanOptions.scanOptions()
-                .match(KEY_PREFIX + userId + ":*")
-                .count(SCAN_BATCH)
-                .build();
-        Set<String> keys = new HashSet<>();
-        try (Cursor<String> cursor = redis.scan(opts)) {
-            while (cursor.hasNext()) {
-                keys.add(cursor.next());
-            }
+    public long currentTokenVersion(String role, Long userId) {
+        String v = redis.opsForValue().get(versionKey(role, userId));
+        if (v == null) {
+            return 0L;
         }
-        if (!keys.isEmpty()) {
-            redis.delete(keys);
+        try {
+            return Long.parseLong(v);
+        } catch (NumberFormatException e) {
+            // 손상된 값 — 보수적으로 0 처리 (다음 revokeAll 호출이 INCR 로 정상화).
+            return 0L;
         }
     }
 
-    private static String key(Long userId, String jti) {
-        return KEY_PREFIX + userId + ":" + jti;
+    @Override
+    public void save(String role, Long userId, String jti, Duration ttl) {
+        redis.opsForValue().set(jtiKey(role, userId, jti), MARKER, ttl);
+    }
+
+    @Override
+    public boolean consume(String role, Long userId, String jti, long claimTv) {
+        Long result = redis.execute(
+                CONSUME_SCRIPT,
+                List.of(versionKey(role, userId), jtiKey(role, userId, jti)),
+                Long.toString(claimTv)
+        );
+        // result == 1 → consume 성공. -1 / 0 / null 모두 false (호출자가 revokeAll + INVALID 처리).
+        return result != null && result == 1L;
+    }
+
+    @Override
+    public void revoke(String role, Long userId, String jti) {
+        redis.delete(jtiKey(role, userId, jti));
+    }
+
+    @Override
+    public void revokeAll(String role, Long userId) {
+        // INCR 한 방. 진행 중 동시 save 가 있어도 이후 consume 의 tv 검증에서 mismatch 로 거부.
+        // 폐기된 jti 키들은 TTL 만료까지 잔존하지만 의미상 무효 (consume 단계에서 막힘).
+        redis.opsForValue().increment(versionKey(role, userId));
+    }
+
+    private static String jtiKey(String role, Long userId, String jti) {
+        return KEY_PREFIX + normalize(role) + ":" + userId + ":" + jti;
+    }
+
+    private static String versionKey(String role, Long userId) {
+        return VERSION_KEY_PREFIX + normalize(role) + ":" + userId;
+    }
+
+    private static String normalize(String role) {
+        if (role == null || role.isBlank()) {
+            throw new IllegalArgumentException("role 은 필수입니다");
+        }
+        return role.toUpperCase(Locale.ROOT);
     }
 }

--- a/src/main/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationService.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationService.java
@@ -1,0 +1,226 @@
+package com.sseulang.domain.withdrawal.application;
+
+import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.point.domain.PointHistoryType;
+import com.sseulang.domain.point.domain.PointReferenceType;
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalRequestCommand;
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalResult;
+import com.sseulang.domain.withdrawal.domain.Withdrawal;
+import com.sseulang.domain.withdrawal.domain.WithdrawalRepository;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 가이드 §4.8 출금 흐름:
+ *
+ * <ol>
+ *   <li>{@link #request} — 사용자 신청. 잔액 차감 ({@code PointApplicationService.deduct(type=출금, refType=WITHDRAWAL)})
+ *       + Withdrawal 저장 (status=신청). 잔액 부족 → INSUFFICIENT_POINT 트랜잭션 롤백.</li>
+ *   <li>{@link #cancel} — 사용자 본인 취소. 신청 상태만 허용. 잔액 원복 (환불 history 적재).</li>
+ *   <li>{@link #adminApprove} — 관리자 승인. 신청 → 승인. 외부 이체는 후속 {@link #adminComplete} 가 처리.</li>
+ *   <li>{@link #adminReject} — 관리자 거부. 잔액 원복.</li>
+ *   <li>{@link #adminComplete} — 관리자 외부 이체 완료. 승인 → 완료.</li>
+ * </ol>
+ *
+ * <p>모든 상태 전이는 {@code findByIdForUpdate} 비관적 락으로 직렬화 (가이드 §5.3).</p>
+ */
+@Service
+@Transactional(readOnly = true)
+public class WithdrawalApplicationService {
+
+    private static final Logger log = LoggerFactory.getLogger(WithdrawalApplicationService.class);
+
+    private final WithdrawalRepository withdrawalRepository;
+    private final PointApplicationService pointApplicationService;
+    /**
+     * 자기 자신 proxy — {@link #request} 가 {@link #insertWithDeduct} 를 별도 트랜잭션으로 호출하기 위해
+     * 사용한다. 직접 {@code this.insertWithDeduct(...)} 로 호출하면 Spring AOP 가 가로채지 못해
+     * REQUIRES_NEW 의미가 깨진다. {@code @Lazy} 로 순환 의존 회피.
+     */
+    private final WithdrawalApplicationService self;
+
+    @Autowired
+    public WithdrawalApplicationService(
+            WithdrawalRepository withdrawalRepository,
+            PointApplicationService pointApplicationService,
+            @Lazy WithdrawalApplicationService self
+    ) {
+        this.withdrawalRepository = withdrawalRepository;
+        this.pointApplicationService = pointApplicationService;
+        this.self = self;
+    }
+
+    /**
+     * 출금 신청 — 멱등성 보장.
+     *
+     * <p>흐름:
+     * <ol>
+     *   <li>같은 (userId, idempotencyKey) 가 이미 있으면 그 id 즉시 반환 (no-op).</li>
+     *   <li>없으면 {@link #insertWithDeduct} 를 REQUIRES_NEW 로 호출. INSERT 가 동시 race 로
+     *       실패(unique 위반 / deadlock)하면 그 트랜잭션만 롤백되고 본 readonly 외부 tx 는 영향 없음.</li>
+     *   <li>패배자 경로: 다시 조회 → winner 가 commit 한 row 의 id 반환.</li>
+     * </ol>
+     *
+     * <p>왜 REQUIRES_NEW 인가: 같은 tx 안에서 INSERT 실패를 catch 하면 Hibernate persistence
+     * context 가 dirty 상태로 남아 후속 flush 가 깨진다 (AssertionFailure: don't flush after exception).
+     * 별도 tx 로 격리해 winner 와 loser 각자 깔끔하게 commit/rollback 하도록 처리.</p>
+     */
+    public Long request(WithdrawalRequestCommand cmd) {
+        if (cmd.amount() <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+
+        // 1) Fast path — 기존 신청 dedup. payload 가 다르면 클라이언트 버그 시그널 → 명시 거부.
+        var existing = withdrawalRepository.findByUserIdAndIdempotencyKey(cmd.userId(), cmd.idempotencyKey());
+        if (existing.isPresent()) {
+            assertSamePayload(existing.get(), cmd);
+            return existing.get().getId();
+        }
+
+        // 2) 새 행 + 차감을 별 tx 에서. 동시 INSERT 가 UNIQUE 제약을 노릴 때 던질 수 있는 모든
+        //    예외를 dedup 시그널로 처리:
+        //    - DataIntegrityViolationException: duplicate-key (가장 일반)
+        //    - PessimisticLockingFailureException 계열 (CannotAcquireLockException /
+        //      DeadlockLoserDataAccessException 포함): InnoDB gap lock + deadlock 패턴
+        try {
+            return self.insertWithDeduct(cmd);
+        } catch (DataIntegrityViolationException | PessimisticLockingFailureException race) {
+            // 3) 패배자 — winner 가 commit 한 상태에서 재조회. 단, 본 outer tx 가 REPEATABLE_READ
+            //    snapshot 을 쥐고 있으면 winner 의 새 row 가 보이지 않으므로 REQUIRES_NEW 로 fresh
+            //    스냅샷을 받아서 조회 (fix #2).
+            return self.findIdempotentInFreshTx(cmd, race);
+        }
+    }
+
+    /**
+     * race 패배자 보정 — outer tx 의 snapshot 으로는 winner 의 새 row 가 보이지 않을 수 있어
+     * 새 트랜잭션으로 재조회한다 (REPEATABLE_READ 환경에서도 안전).
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
+    public Long findIdempotentInFreshTx(WithdrawalRequestCommand cmd, RuntimeException original) {
+        Withdrawal w = withdrawalRepository.findByUserIdAndIdempotencyKey(cmd.userId(), cmd.idempotencyKey())
+                .orElseThrow(() -> original);
+        assertSamePayload(w, cmd);
+        return w.getId();
+    }
+
+    /**
+     * 같은 idempotencyKey 로 다른 내용(amount/계좌)이 들어오면 클라이언트 버그 가능성 — 조용히
+     * 기존 id 반환하는 대신 명시적으로 거부 (게이트 2: silent pass 방지).
+     */
+    private static void assertSamePayload(Withdrawal existing, WithdrawalRequestCommand cmd) {
+        if (existing.getAmount() != cmd.amount()
+                || !existing.getBankName().equals(cmd.bankName())
+                || !existing.getAccountNumber().equals(cmd.accountNumber())
+                || !existing.getAccountHolder().equals(cmd.accountHolder())) {
+            throw new BusinessException(ErrorCode.WITHDRAWAL_IDEMPOTENCY_MISMATCH);
+        }
+    }
+
+    /**
+     * 신규 INSERT + 잔액 차감을 한 트랜잭션으로 묶는다. 잔액 부족 시 INSUFFICIENT_POINT → 본 tx 만
+     * 롤백 (Withdrawal save 도 함께 원복). UNIQUE race 패배 시도 본 tx 만 롤백되어 외부에 영향 없음.
+     *
+     * <p>Spring AOP 통과를 위해 반드시 {@link #self} 경유로만 호출.</p>
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Long insertWithDeduct(WithdrawalRequestCommand cmd) {
+        Withdrawal saved = withdrawalRepository.save(Withdrawal.request(
+                cmd.userId(), cmd.idempotencyKey(), cmd.amount(),
+                cmd.bankName(), cmd.accountNumber(), cmd.accountHolder(),
+                LocalDateTime.now()
+        ));
+        pointApplicationService.deduct(
+                cmd.userId(), cmd.amount(),
+                PointHistoryType.출금,
+                PointReferenceType.WITHDRAWAL,
+                saved.getId(),
+                "출금 신청"
+        );
+        return saved.getId();
+    }
+
+    @Transactional
+    public void cancel(Long withdrawalId, Long requesterId) {
+        // 본인 자원만 락 + 권한 검증을 한 쿼리로 — 타인 id 로는 락이 잡히지 않아 lock-DoS 차단 (게이트 1).
+        // 행이 존재하지만 소유자가 다른 경우와, 행 자체가 없는 경우를 클라이언트에 동일하게 응답 (존재 여부 leak X).
+        Withdrawal w = withdrawalRepository.findByIdAndUserIdForUpdate(withdrawalId, requesterId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WITHDRAWAL_NOT_FOUND));
+        // 신청 상태만 허용 (Aggregate 가 가드). 신청 → 취소 + 잔액 원복.
+        w.cancel(LocalDateTime.now());
+        refund(w, "출금 신청 취소");
+    }
+
+    @Transactional
+    public void adminApprove(Long withdrawalId, Long adminId, String memo) {
+        Withdrawal w = findOrThrowForUpdate(withdrawalId);
+        w.approve(adminId, memo, LocalDateTime.now());
+        // 잔액은 신청 시점에 이미 차감되어 있으므로 별도 변동 X. 외부 이체는 adminComplete 단계.
+    }
+
+    @Transactional
+    public void adminReject(Long withdrawalId, Long adminId, String memo) {
+        Withdrawal w = findOrThrowForUpdate(withdrawalId);
+        w.reject(adminId, memo, LocalDateTime.now());
+        refund(w, "출금 신청 거부");
+    }
+
+    /**
+     * 관리자 외부 이체 완료 처리. 본 PR 에선 이체 자체는 mock — 외부 은행 API 연동은 5/6 이후 후속.
+     * 승인 → 완료 단순 상태 전이.
+     */
+    @Transactional
+    public void adminComplete(Long withdrawalId, Long adminId) {
+        Withdrawal w = findOrThrowForUpdate(withdrawalId);
+        w.markAsCompleted(LocalDateTime.now());
+        log.info("[withdrawal-complete] id={} amount={} adminId={} (external transfer mock)",
+                w.getId(), w.getAmount(), adminId);
+    }
+
+    public WithdrawalResult getById(Long id, Long requesterId) {
+        Withdrawal w = withdrawalRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WITHDRAWAL_NOT_FOUND));
+        if (!w.isOwnedBy(requesterId)) {
+            throw new BusinessException(ErrorCode.WITHDRAWAL_FORBIDDEN);
+        }
+        return WithdrawalResult.from(w);
+    }
+
+    public Page<WithdrawalResult> findMyWithdrawals(Long userId, Pageable pageable) {
+        return withdrawalRepository.findByUserId(userId, pageable).map(WithdrawalResult::from);
+    }
+
+    public Page<WithdrawalResult> adminFindByStatus(WithdrawalStatus status, Pageable pageable) {
+        return withdrawalRepository.findByStatus(status, pageable).map(WithdrawalResult::from);
+    }
+
+    private void refund(Withdrawal w, String description) {
+        // 신청 시점 차감과 동일 트랜잭션 안에서 환불. 잔액 변경 + history 적재 (type=환불, refType=WITHDRAWAL).
+        pointApplicationService.credit(
+                w.getUserId(), w.getAmount(),
+                PointHistoryType.환불,
+                PointReferenceType.WITHDRAWAL,
+                w.getId(),
+                description
+        );
+    }
+
+    private Withdrawal findOrThrowForUpdate(Long id) {
+        return withdrawalRepository.findByIdForUpdate(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WITHDRAWAL_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalRequestCommand.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalRequestCommand.java
@@ -1,0 +1,33 @@
+package com.sseulang.domain.withdrawal.application.dto;
+
+/**
+ * 출금 신청 Command. 모든 문자열 필드(idempotencyKey + 계좌 정보)는 compact constructor 에서
+ * 한 번만 정규화 (trim) — Withdrawal 저장 / 멱등성 비교 / 복구 조회 모두 동일 값을 보고
+ * trim 위치 불일치로 dedup 이 거짓 거부되는 회귀 차단 (게이트 2 round 2).
+ */
+public record WithdrawalRequestCommand(
+        Long userId,
+        String idempotencyKey,
+        long amount,
+        String bankName,
+        String accountNumber,
+        String accountHolder
+) {
+    public WithdrawalRequestCommand {
+        idempotencyKey = normalize(idempotencyKey, "idempotencyKey", 64);
+        bankName = normalize(bankName, "bankName", 50);
+        accountNumber = normalize(accountNumber, "accountNumber", 50);
+        accountHolder = normalize(accountHolder, "accountHolder", 50);
+    }
+
+    private static String normalize(String value, String name, int maxLength) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " 는 필수입니다");
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() > maxLength) {
+            throw new IllegalArgumentException(name + " 는 " + maxLength + "자 이하여야 합니다");
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalResult.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalResult.java
@@ -1,0 +1,29 @@
+package com.sseulang.domain.withdrawal.application.dto;
+
+import com.sseulang.domain.withdrawal.domain.Withdrawal;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+
+import java.time.LocalDateTime;
+
+public record WithdrawalResult(
+        Long id,
+        Long userId,
+        long amount,
+        String bankName,
+        String accountNumber,
+        String accountHolder,
+        WithdrawalStatus status,
+        Long adminId,
+        String adminMemo,
+        LocalDateTime requestedAt,
+        LocalDateTime processedAt
+) {
+    public static WithdrawalResult from(Withdrawal w) {
+        return new WithdrawalResult(
+                w.getId(), w.getUserId(), w.getAmount(),
+                w.getBankName(), w.getAccountNumber(), w.getAccountHolder(),
+                w.getStatus(), w.getAdminId(), w.getAdminMemo(),
+                w.getRequestedAt(), w.getProcessedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/domain/Withdrawal.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/domain/Withdrawal.java
@@ -1,0 +1,181 @@
+package com.sseulang.domain.withdrawal.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Withdrawal Aggregate Root. V1 스키마 {@code withdrawals} 매핑.
+ *
+ * <p>가이드 §4.8 출금: 사용자 신청 → 관리자 승인 → 외부 계좌 이체 (시뮬). 잔액 정합성은
+ * ApplicationService 가 PointApplicationService 와 한 트랜잭션으로 묶어 처리. 본 Aggregate 는
+ * 상태 머신만 책임.</p>
+ *
+ * <p>Setter 없음. 상태 변경은 명시 비즈니스 메서드만.</p>
+ */
+@Entity
+@Table(name = "withdrawals")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Withdrawal extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    /**
+     * 멱등성 키 — 클라이언트가 신청 단위마다 발급. 동일 (user_id, idempotency_key) 재요청 시
+     * ApplicationService 가 기존 row 를 그대로 반환 (DB UNIQUE 가 race 의 마지막 가드).
+     * nullable — V4 마이그레이션 이전 데이터(없음) 호환 여지지만 실제로는 항상 채워서 들어옴.
+     */
+    @Column(name = "idempotency_key", length = 64)
+    private String idempotencyKey;
+
+    @Column(name = "amount", nullable = false)
+    private long amount;
+
+    @Column(name = "bank_name", nullable = false, length = 50)
+    private String bankName;
+
+    @Column(name = "account_number", nullable = false, length = 50)
+    private String accountNumber;
+
+    @Column(name = "account_holder", nullable = false, length = 50)
+    private String accountHolder;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private WithdrawalStatus status;
+
+    @Column(name = "admin_id")
+    private Long adminId;
+
+    @Column(name = "admin_memo", length = 500)
+    private String adminMemo;
+
+    @Column(name = "requested_at", nullable = false, updatable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    public static Withdrawal request(
+            Long userId,
+            String idempotencyKey,
+            long amount,
+            String bankName,
+            String accountNumber,
+            String accountHolder,
+            LocalDateTime now
+    ) {
+        if (userId == null || userId <= 0) {
+            throw new IllegalArgumentException("userId 는 양수여야 합니다");
+        }
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        validateText(idempotencyKey, "idempotencyKey", 64);
+        validateText(bankName, "bankName", 50);
+        validateText(accountNumber, "accountNumber", 50);
+        validateText(accountHolder, "accountHolder", 50);
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+
+        Withdrawal w = new Withdrawal();
+        w.userId = userId;
+        // 모든 문자열 필드는 Command compact constructor 에서 이미 trim/검증됨 — 여기서 다시 trim 하면
+        // 조회/저장 값 불일치로 멱등성 dedup 이 거짓 거부될 수 있어 그대로 저장 (게이트 2 round 2).
+        w.idempotencyKey = idempotencyKey;
+        w.amount = amount;
+        w.bankName = bankName;
+        w.accountNumber = accountNumber;
+        w.accountHolder = accountHolder;
+        w.status = WithdrawalStatus.신청;
+        w.requestedAt = now;
+        return w;
+    }
+
+    /**
+     * 사용자가 직접 취소. 신청 상태만 허용. 호출자가 잔액 원복 적용.
+     */
+    public void cancel(LocalDateTime now) {
+        if (!status.canUserCancel()) {
+            throw new BusinessException(ErrorCode.WITHDRAWAL_NOT_CANCELABLE);
+        }
+        this.status = WithdrawalStatus.취소;
+        this.processedAt = now;
+    }
+
+    /**
+     * 관리자 승인 — 신청 → 승인. 외부 이체는 후속 {@link #markAsCompleted} 가 처리.
+     */
+    public void approve(Long adminId, String memo, LocalDateTime now) {
+        if (adminId == null || adminId <= 0) {
+            throw new IllegalArgumentException("adminId 는 양수여야 합니다");
+        }
+        if (!status.canAdminProcess()) {
+            throw new BusinessException(ErrorCode.WITHDRAWAL_INVALID_STATE);
+        }
+        this.status = WithdrawalStatus.승인;
+        this.adminId = adminId;
+        this.adminMemo = memo;
+        this.processedAt = now;
+    }
+
+    /**
+     * 관리자 거부 — 신청 → 거부. 호출자가 잔액 원복 적용.
+     */
+    public void reject(Long adminId, String memo, LocalDateTime now) {
+        if (adminId == null || adminId <= 0) {
+            throw new IllegalArgumentException("adminId 는 양수여야 합니다");
+        }
+        if (!status.canAdminProcess()) {
+            throw new BusinessException(ErrorCode.WITHDRAWAL_INVALID_STATE);
+        }
+        this.status = WithdrawalStatus.거부;
+        this.adminId = adminId;
+        this.adminMemo = memo;
+        this.processedAt = now;
+    }
+
+    /**
+     * 관리자 외부 이체 완료 처리 — 승인 → 완료. 외부 이체 mock 후 호출.
+     */
+    public void markAsCompleted(LocalDateTime now) {
+        if (!status.canComplete()) {
+            throw new BusinessException(ErrorCode.WITHDRAWAL_INVALID_STATE);
+        }
+        this.status = WithdrawalStatus.완료;
+        this.processedAt = now;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return userId != null && userId.equals(this.userId);
+    }
+
+    private static void validateText(String value, String name, int max) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " 는 필수입니다");
+        }
+        if (value.length() > max) {
+            throw new IllegalArgumentException(name + " 는 " + max + "자 이하여야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalRepository.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalRepository.java
@@ -1,0 +1,39 @@
+package com.sseulang.domain.withdrawal.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+/**
+ * Withdrawal Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
+ * 구현은 {@code domain/withdrawal/infrastructure/persistence}.
+ */
+public interface WithdrawalRepository {
+
+    Withdrawal save(Withdrawal withdrawal);
+
+    Optional<Withdrawal> findById(Long id);
+
+    /**
+     * 가이드 §5.3 — 출금 처리 시 비관적 락. 동시 승인/거부/취소 race 차단.
+     */
+    Optional<Withdrawal> findByIdForUpdate(Long id);
+
+    /**
+     * 권한 검증 + 락을 한 번에. 사용자 본인 자원만 락을 잡는다 — 타인 id 로 시도하면 빈 결과만 받고
+     * 락은 획득되지 않음. 게이트 1: cancel 흐름의 lock-DoS 방지.
+     */
+    Optional<Withdrawal> findByIdAndUserIdForUpdate(Long id, Long userId);
+
+    /**
+     * 멱등성 — 동일 (userId, idempotencyKey) 의 기존 신청 조회. 같은 key 재요청 시 새 행 만들지 않고
+     * 기존 행을 그대로 반환하기 위해 사용. UNIQUE(user_id, idempotency_key) 와 짝.
+     */
+    Optional<Withdrawal> findByUserIdAndIdempotencyKey(Long userId, String idempotencyKey);
+
+    Page<Withdrawal> findByUserId(Long userId, Pageable pageable);
+
+    /** 관리자 — 상태별 페이징 (status null 이면 전체). */
+    Page<Withdrawal> findByStatus(WithdrawalStatus status, Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalStatus.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalStatus.java
@@ -1,0 +1,42 @@
+package com.sseulang.domain.withdrawal.domain;
+
+/**
+ * 출금 상태. V1 스키마 ENUM 1:1 매핑. 가이드 §4.8 출금 흐름.
+ *
+ * <pre>
+ *   신청 → 승인 → 완료
+ *     ├── 거부 (관리자)
+ *     └── 취소 (사용자, 신청 상태만)
+ * </pre>
+ */
+public enum WithdrawalStatus {
+    신청,
+    승인,
+    거부,
+    완료,
+    취소;
+
+    public boolean isTerminal() {
+        return this == 거부 || this == 완료 || this == 취소;
+    }
+
+    /** 관리자가 처리할 수 있는 상태 (승인/거부의 진입). */
+    public boolean canAdminProcess() {
+        return this == 신청;
+    }
+
+    /** 외부 이체 완료 처리 가능한 상태 (승인 → 완료). */
+    public boolean canComplete() {
+        return this == 승인;
+    }
+
+    /** 사용자가 직접 취소 가능한 상태 (신청 상태만). */
+    public boolean canUserCancel() {
+        return this == 신청;
+    }
+
+    /** 잔액 원복이 필요한 상태 (거부/취소 진입 시 호출). */
+    public boolean requiresRefundOnExit() {
+        return this == 신청;
+    }
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/infrastructure/persistence/WithdrawalJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/infrastructure/persistence/WithdrawalJpaRepository.java
@@ -1,0 +1,37 @@
+package com.sseulang.domain.withdrawal.infrastructure.persistence;
+
+import com.sseulang.domain.withdrawal.domain.Withdrawal;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+/** Spring Data JPA — {@link WithdrawalRepositoryImpl} 가 wrapping. 외부 직접 import 금지. */
+interface WithdrawalJpaRepository extends JpaRepository<Withdrawal, Long> {
+
+    /** 가이드 §5.3 — 비관적 락 (SELECT FOR UPDATE) 으로 동시 승인/거부/취소 직렬화. */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT w FROM Withdrawal w WHERE w.id = :id")
+    Optional<Withdrawal> findByIdForUpdate(@Param("id") Long id);
+
+    /**
+     * 본인 소유 + 락 동시 획득. 타인 id 로 시도 시 빈 결과 → 락 미획득 (cancel 의 lock-DoS 방지).
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT w FROM Withdrawal w WHERE w.id = :id AND w.userId = :userId")
+    Optional<Withdrawal> findByIdAndUserIdForUpdate(@Param("id") Long id, @Param("userId") Long userId);
+
+    Optional<Withdrawal> findByUserIdAndIdempotencyKey(Long userId, String idempotencyKey);
+
+    Page<Withdrawal> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    Page<Withdrawal> findByStatusOrderByCreatedAtDesc(WithdrawalStatus status, Pageable pageable);
+
+    Page<Withdrawal> findAllByOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/infrastructure/persistence/WithdrawalRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/infrastructure/persistence/WithdrawalRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.sseulang.domain.withdrawal.infrastructure.persistence;
+
+import com.sseulang.domain.withdrawal.domain.Withdrawal;
+import com.sseulang.domain.withdrawal.domain.WithdrawalRepository;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class WithdrawalRepositoryImpl implements WithdrawalRepository {
+
+    private final WithdrawalJpaRepository jpa;
+
+    public WithdrawalRepositoryImpl(WithdrawalJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Withdrawal save(Withdrawal withdrawal) {
+        return jpa.save(withdrawal);
+    }
+
+    @Override
+    public Optional<Withdrawal> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Optional<Withdrawal> findByIdForUpdate(Long id) {
+        return jpa.findByIdForUpdate(id);
+    }
+
+    @Override
+    public Optional<Withdrawal> findByIdAndUserIdForUpdate(Long id, Long userId) {
+        return jpa.findByIdAndUserIdForUpdate(id, userId);
+    }
+
+    @Override
+    public Optional<Withdrawal> findByUserIdAndIdempotencyKey(Long userId, String idempotencyKey) {
+        return jpa.findByUserIdAndIdempotencyKey(userId, idempotencyKey);
+    }
+
+    @Override
+    public Page<Withdrawal> findByUserId(Long userId, Pageable pageable) {
+        return jpa.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+    }
+
+    @Override
+    public Page<Withdrawal> findByStatus(WithdrawalStatus status, Pageable pageable) {
+        return status == null
+                ? jpa.findAllByOrderByCreatedAtDesc(pageable)
+                : jpa.findByStatusOrderByCreatedAtDesc(status, pageable);
+    }
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
@@ -1,0 +1,57 @@
+package com.sseulang.domain.withdrawal.presentation;
+
+import com.sseulang.domain.withdrawal.application.WithdrawalApplicationService;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import com.sseulang.domain.withdrawal.presentation.dto.AdminWithdrawalDecisionRequest;
+import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 출금 처리 — SecurityConfig 의 admin chain 이 ROLE_ADMIN 강제. AuthenticationPrincipal 은
+ * adminId (현재 SecurityFilter 정책 그대로 사용).
+ */
+@RestController
+@RequestMapping("/api/v1/admin/withdrawals")
+public class AdminWithdrawalController {
+
+    private final WithdrawalApplicationService withdrawalService;
+
+    public AdminWithdrawalController(WithdrawalApplicationService withdrawalService) {
+        this.withdrawalService = withdrawalService;
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<WithdrawalResponse>> list(
+            @RequestParam(value = "status", required = false) WithdrawalStatus status,
+            Pageable pageable
+    ) {
+        return ApiResponse.ok(PageResponse.from(
+                withdrawalService.adminFindByStatus(status, pageable).map(WithdrawalResponse::from)
+        ));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<Void> decide(
+            @AuthenticationPrincipal Long adminId,
+            @PathVariable("id") Long id,
+            @Valid @RequestBody AdminWithdrawalDecisionRequest request
+    ) {
+        switch (request.action()) {
+            case APPROVE -> withdrawalService.adminApprove(id, adminId, request.memo());
+            case REJECT -> withdrawalService.adminReject(id, adminId, request.memo());
+            case COMPLETE -> withdrawalService.adminComplete(id, adminId);
+        }
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/WithdrawalController.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/WithdrawalController.java
@@ -1,0 +1,66 @@
+package com.sseulang.domain.withdrawal.presentation;
+
+import com.sseulang.domain.withdrawal.application.WithdrawalApplicationService;
+import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalRequest;
+import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/withdrawals")
+public class WithdrawalController {
+
+    private final WithdrawalApplicationService withdrawalService;
+
+    public WithdrawalController(WithdrawalApplicationService withdrawalService) {
+        this.withdrawalService = withdrawalService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> request(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody WithdrawalRequest request
+    ) {
+        Long id = withdrawalService.request(request.toCommand(userId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(id));
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<WithdrawalResponse>> getMyWithdrawals(
+            @AuthenticationPrincipal Long userId,
+            Pageable pageable
+    ) {
+        return ApiResponse.ok(PageResponse.from(
+                withdrawalService.findMyWithdrawals(userId, pageable).map(WithdrawalResponse::from)
+        ));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<WithdrawalResponse> getOne(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable("id") Long id
+    ) {
+        return ApiResponse.ok(WithdrawalResponse.from(withdrawalService.getById(id, userId)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> cancel(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable("id") Long id
+    ) {
+        withdrawalService.cancel(id, userId);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/AdminWithdrawalDecisionRequest.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/AdminWithdrawalDecisionRequest.java
@@ -1,0 +1,21 @@
+package com.sseulang.domain.withdrawal.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 관리자 출금 처리 요청 — action: APPROVE / REJECT / COMPLETE.
+ */
+public record AdminWithdrawalDecisionRequest(
+        @NotNull(message = "action 은 필수입니다")
+        Action action,
+
+        @Size(max = 500)
+        String memo
+) {
+    public enum Action {
+        APPROVE,
+        REJECT,
+        COMPLETE
+    }
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalRequest.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalRequest.java
@@ -1,0 +1,35 @@
+package com.sseulang.domain.withdrawal.presentation.dto;
+
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalRequestCommand;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record WithdrawalRequest(
+        /**
+         * 클라이언트 발급 멱등성 키 (UUID 권장). 같은 (사용자, 키) 재요청 시 새 출금 행 생성하지 않고
+         * 기존 행을 그대로 반환 — 더블클릭/네트워크 재시도로 잔액 중복 차감 방지 (게이트 1).
+         */
+        @NotBlank(message = "idempotencyKey 는 필수입니다")
+        @Size(max = 64)
+        String idempotencyKey,
+
+        @Min(value = 1, message = "amount 는 1 이상이어야 합니다")
+        long amount,
+
+        @NotBlank(message = "bankName 은 필수입니다")
+        @Size(max = 50)
+        String bankName,
+
+        @NotBlank(message = "accountNumber 는 필수입니다")
+        @Size(max = 50)
+        String accountNumber,
+
+        @NotBlank(message = "accountHolder 는 필수입니다")
+        @Size(max = 50)
+        String accountHolder
+) {
+    public WithdrawalRequestCommand toCommand(Long userId) {
+        return new WithdrawalRequestCommand(userId, idempotencyKey, amount, bankName, accountNumber, accountHolder);
+    }
+}

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalResponse.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalResponse.java
@@ -1,0 +1,29 @@
+package com.sseulang.domain.withdrawal.presentation.dto;
+
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalResult;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+
+import java.time.LocalDateTime;
+
+public record WithdrawalResponse(
+        Long id,
+        Long userId,
+        long amount,
+        String bankName,
+        String accountNumber,
+        String accountHolder,
+        WithdrawalStatus status,
+        Long adminId,
+        String adminMemo,
+        LocalDateTime requestedAt,
+        LocalDateTime processedAt
+) {
+    public static WithdrawalResponse from(WithdrawalResult r) {
+        return new WithdrawalResponse(
+                r.id(), r.userId(), r.amount(),
+                r.bankName(), r.accountNumber(), r.accountHolder(),
+                r.status(), r.adminId(), r.adminMemo(),
+                r.requestedAt(), r.processedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/global/config/SecurityConfig.java
+++ b/src/main/java/com/sseulang/global/config/SecurityConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
@@ -81,6 +83,12 @@ public class SecurityConfig {
         return handler;
     }
 
+    /** 관리자 비밀번호 BCrypt 인코더. AdminLoginService 가 password 검증에 사용. */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
     @Bean
     @Order(1)
     public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
@@ -115,7 +123,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/items/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/categories/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/payments/webhook/**").permitAll()
-                        .anyRequest().authenticated())
+                        // ROLE_USER 강제 — ADMIN AT 가 user 영역(특히 출금/결제) 진입하지 못하도록 차단.
+                        // adminId 와 userId 가 동일 숫자면 본인 검사도 통과해버리는 격리 누수 방지 (게이트 1).
+                        .anyRequest().hasRole("USER"))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(csrfCookieFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/sseulang/global/dev/DevAuthController.java
+++ b/src/main/java/com/sseulang/global/dev/DevAuthController.java
@@ -75,7 +75,8 @@ public class DevAuthController {
         );
         String role = "USER";
         String at = jwtProvider.issueAccessToken(user.getId(), role);
-        String rt = jwtProvider.issueRefreshToken(user.getId(), role);
+        // dev 우회 — RefreshTokenStore 등록 없이 발급. tv=0 으로 박지만 어차피 rotate 는 store 미등록으로 실패함.
+        String rt = jwtProvider.issueRefreshToken(user.getId(), role, 0L);
 
         // CSRF 토큰을 응답 쿠키로 강제 박기 — Spring Security 6 deferred load 회피.
         // 후속 POST/PATCH 요청에서 X-XSRF-TOKEN 헤더로 echo 가능하도록.

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -53,6 +53,9 @@ public enum ErrorCode {
     INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
     WITHDRAWAL_NOT_FOUND(HttpStatus.NOT_FOUND, "출금 신청을 찾을 수 없습니다."),
     WITHDRAWAL_NOT_CANCELABLE(HttpStatus.BAD_REQUEST, "취소할 수 없는 상태입니다."),
+    WITHDRAWAL_INVALID_STATE(HttpStatus.BAD_REQUEST, "현재 상태에서 수행할 수 없는 동작입니다."),
+    WITHDRAWAL_FORBIDDEN(HttpStatus.FORBIDDEN, "출금 신청에 대한 권한이 없습니다."),
+    WITHDRAWAL_IDEMPOTENCY_MISMATCH(HttpStatus.CONFLICT, "동일 idempotencyKey 로 다른 내용의 신청이 들어왔습니다."),
 
     // 채팅 / 알림
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),

--- a/src/main/java/com/sseulang/global/security/JwtClaims.java
+++ b/src/main/java/com/sseulang/global/security/JwtClaims.java
@@ -3,12 +3,18 @@ package com.sseulang.global.security;
 import java.time.Instant;
 
 /**
- * JWT 파싱 결과. AccessToken 의 경우 role 채워짐, RefreshToken 의 경우 role 은 null.
+ * JWT 파싱 결과. AT/RT 모두 issue 시 role 클레임이 포함되므로 parse 시 role 채워진다
+ * (RT 도 user/admin 격리에 사용되므로 role 필수).
+ *
+ * <p>{@code tokenVersion} 은 RT 에만 존재 (AT 는 null). (role,userId) 별 단조 증가 정수로,
+ * {@code RefreshTokenStore.revokeAll} 시 INCR 되어 이전 발급분 RT 를 한 번에 무효화한다.
+ * 기존 SCAN→DEL 의 race 를 제거하기 위한 보강 (게이트 1).</p>
  */
 public record JwtClaims(
         Long userId,
         String role,
         String jti,
+        Long tokenVersion,
         Instant issuedAt,
         Instant expiresAt
 ) {

--- a/src/main/java/com/sseulang/global/security/JwtProvider.java
+++ b/src/main/java/com/sseulang/global/security/JwtProvider.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 public class JwtProvider {
 
     private static final String CLAIM_ROLE = "role";
+    private static final String CLAIM_TOKEN_VERSION = "tv";
 
     private final JwtProperties props;
     private final Clock clock;
@@ -51,12 +52,18 @@ public class JwtProvider {
                 .compact();
     }
 
-    public String issueRefreshToken(Long userId, String role) {
+    /**
+     * RT 발급. {@code tokenVersion} 은 호출 직전에 {@code RefreshTokenStore.currentTokenVersion}
+     * 으로 조회한 값. (role,userId) 의 revokeAll 시 store 측 tv 가 INCR 되어, 이 RT 의
+     * claim.tv 와 mismatch → 다음 rotate 에서 거부된다.
+     */
+    public String issueRefreshToken(Long userId, String role, long tokenVersion) {
         Instant now = clock.instant();
         Instant exp = now.plusSeconds(props.refreshTokenValiditySeconds());
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim(CLAIM_ROLE, role)
+                .claim(CLAIM_TOKEN_VERSION, tokenVersion)
                 .id(UUID.randomUUID().toString())
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(exp))
@@ -75,6 +82,7 @@ public class JwtProvider {
                     Long.valueOf(c.getSubject()),
                     c.get(CLAIM_ROLE, String.class),
                     c.getId(),
+                    extractTokenVersion(c),
                     c.getIssuedAt().toInstant(),
                     c.getExpiration().toInstant()
             );
@@ -83,5 +91,20 @@ public class JwtProvider {
         } catch (JwtException | IllegalArgumentException e) {
             throw new BusinessException(ErrorCode.AUTH_TOKEN_INVALID);
         }
+    }
+
+    /**
+     * tv claim 추출 — RT 에는 항상 존재, AT 에는 없음 (null). 정수형이면 Number 로,
+     * 누락이면 null 반환. 호출자(RotationService) 가 null 인 RT 를 INVALID 로 처리한다.
+     */
+    private static Long extractTokenVersion(Claims c) {
+        Object v = c.get(CLAIM_TOKEN_VERSION);
+        if (v == null) {
+            return null;
+        }
+        if (v instanceof Number n) {
+            return n.longValue();
+        }
+        return null;
     }
 }

--- a/src/main/resources/db/migration/V4__add_withdrawal_idempotency_key.sql
+++ b/src/main/resources/db/migration/V4__add_withdrawal_idempotency_key.sql
@@ -1,0 +1,11 @@
+-- =====================================================
+-- V4: withdrawals 멱등성 키 추가 (게이트 1 보강)
+-- =====================================================
+-- 출금 신청 중복 차단 — 클라이언트가 보낸 idempotencyKey 와 user_id 의 조합으로 1건만 허용.
+-- 동시 더블클릭 / 네트워크 재시도로 잔액이 두 번 차감되는 시나리오 방지.
+-- 동일 (user_id, idempotency_key) 재요청은 ApplicationService 가 기존 withdrawal 을 그대로 반환.
+-- =====================================================
+
+ALTER TABLE withdrawals
+    ADD COLUMN idempotency_key VARCHAR(64) NULL AFTER user_id,
+    ADD UNIQUE KEY uk_withdrawals_user_idem (user_id, idempotency_key);

--- a/src/test/java/com/sseulang/domain/admin/application/AdminLoginServiceTest.java
+++ b/src/test/java/com/sseulang/domain/admin/application/AdminLoginServiceTest.java
@@ -1,0 +1,176 @@
+package com.sseulang.domain.admin.application;
+
+import com.sseulang.domain.admin.domain.Admin;
+import com.sseulang.domain.admin.domain.AdminRepository;
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.auth.domain.RefreshTokenStore;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.security.JwtClaims;
+import com.sseulang.global.security.JwtProperties;
+import com.sseulang.global.security.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminLoginServiceTest {
+
+    @Mock private AdminRepository adminRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private RefreshTokenStore refreshTokenStore;
+
+    private AdminLoginService service;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties props = new JwtProperties("0123456789012345678901234567890123", 1800L, 604800L);
+        // mock encoder 의 encode("...") 는 기본 null 반환 — dummyPasswordHash 가 null 이라도
+        // matches(null) 호출은 실제 verify 대상 (mock 이라 boolean 반환만 봄). 게이트 2 dummy hash
+        // 형식 회귀는 별도 테스트 (real_BCrypt_*)에서 검증.
+        service = new AdminLoginService(adminRepository, passwordEncoder, jwtProvider, refreshTokenStore, props);
+    }
+
+    private Admin existing() {
+        Admin a = Admin.create("admin1", "$2a$10$hashed", "관리자");
+        ReflectionTestUtils.setField(a, "id", 7L);
+        return a;
+    }
+
+    @Test
+    @DisplayName("login 정상_AT/RT 발급 + RT 저장 (subject=admin.id, role=ADMIN)")
+    void login_정상() {
+        Admin admin = existing();
+        when(adminRepository.findByUsername("admin1")).thenReturn(Optional.of(admin));
+        when(passwordEncoder.matches("pw", admin.getPassword())).thenReturn(true);
+        when(jwtProvider.issueAccessToken(7L, "ADMIN")).thenReturn("at-token");
+        when(refreshTokenStore.currentTokenVersion("ADMIN", 7L)).thenReturn(0L);
+        when(jwtProvider.issueRefreshToken(7L, "ADMIN", 0L)).thenReturn("rt-token");
+        when(jwtProvider.parse("rt-token")).thenReturn(new JwtClaims(7L, "ADMIN", "rt-jti", 0L, null, null));
+
+        TokenPair pair = service.login("admin1", "pw");
+
+        assertThat(pair.accessToken()).isEqualTo("at-token");
+        assertThat(pair.refreshToken()).isEqualTo("rt-token");
+        verify(refreshTokenStore, times(1)).save(eq("ADMIN"), eq(7L), eq("rt-jti"), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("login 잘못된 username_AUTH_LOGIN_FAILED + dummy hash 로 BCrypt 강제 실행 (timing leak 방어)")
+    void login_미존재() {
+        when(adminRepository.findByUsername("none")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.login("none", "pw"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_LOGIN_FAILED);
+        verify(refreshTokenStore, never()).save(any(), any(), any(), any());
+        // 핵심: 미존재 케이스에서도 passwordEncoder.matches 가 1회 호출되어야 함
+        // (정상 admin 분기와 동일 비용 → username 존재 여부 timing leak 차단).
+        verify(passwordEncoder, times(1)).matches(eq("pw"), any());
+    }
+
+    @Test
+    @DisplayName("login 잘못된 password_AUTH_LOGIN_FAILED")
+    void login_password_불일치() {
+        Admin admin = existing();
+        when(adminRepository.findByUsername("admin1")).thenReturn(Optional.of(admin));
+        when(passwordEncoder.matches("wrong", admin.getPassword())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.login("admin1", "wrong"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_LOGIN_FAILED);
+        verify(jwtProvider, never()).issueAccessToken(any(), any());
+    }
+
+    @Test
+    @DisplayName("login 비활성 admin_AUTH_LOGIN_FAILED + BCrypt 강제 실행 (active 여부 timing leak 방어)")
+    void login_비활성() {
+        Admin admin = Admin.create("admin1", "$2a$10$hashed", "관리자");
+        ReflectionTestUtils.setField(admin, "id", 7L);
+        ReflectionTestUtils.setField(admin, "active", false);
+        when(adminRepository.findByUsername("admin1")).thenReturn(Optional.of(admin));
+
+        assertThatThrownBy(() -> service.login("admin1", "pw"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_LOGIN_FAILED);
+        // 핵심: inactive admin 도 active admin 과 동일하게 BCrypt 가 호출되어야 함
+        // (이전 단락 평가는 active 여부 timing leak 였음).
+        verify(passwordEncoder, times(1)).matches(eq("pw"), eq(admin.getPassword()));
+    }
+
+    @Test
+    @DisplayName("login null/blank 입력_AUTH_LOGIN_FAILED")
+    void login_blank() {
+        assertThatThrownBy(() -> service.login(null, "pw"))
+                .isInstanceOf(BusinessException.class);
+        assertThatThrownBy(() -> service.login("admin1", ""))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    // ───────── 게이트 2 회귀: dummy hash 가 진짜 BCrypt 형식 + 실 비교 비용 ─────────
+
+    @Test
+    @DisplayName("dummyPasswordHash 가 BCrypt 패턴이고 matches() 가 정상 작동 (게이트 2 회귀: 형식 깨짐 차단)")
+    void dummyHash_실제_BCrypt_패턴() {
+        BCryptPasswordEncoder real = new BCryptPasswordEncoder();
+        JwtProperties props = new JwtProperties("0123456789012345678901234567890123", 1800L, 604800L);
+        AdminLoginService realSvc = new AdminLoginService(
+                adminRepository, real, jwtProvider, refreshTokenStore, props
+        );
+
+        String dummyHash = (String) ReflectionTestUtils.getField(realSvc, "dummyPasswordHash");
+        // BCrypt 표준 패턴: $2[ayb]$cost$22salt + 31hash = 총 60자
+        assertThat(dummyHash)
+                .as("dummy hash 가 BCrypt 표준 형식 — 깨지면 matches 가 cost 안 태우고 즉시 실패해 timing leak 부활")
+                .matches("^\\$2[ayb]\\$\\d{2}\\$[./A-Za-z0-9]{53}$");
+        // sentinel 평문이 정말 이 hash 와 매칭되는지 — 양성 검증
+        String sentinel = (String) ReflectionTestUtils.getField(
+                AdminLoginService.class, "DUMMY_PASSWORD_PLAINTEXT"
+        );
+        assertThat(real.matches(sentinel, dummyHash))
+                .as("encode 결과가 같은 plaintext 로 다시 matches 통과 — BCrypt 정상 동작")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("미존재 username 도 실제 BCryptEncoder 로 비교 비용 태움 (timing 균일 회귀)")
+    void login_미존재_BCrypt_실비교() {
+        BCryptPasswordEncoder real = new BCryptPasswordEncoder();
+        JwtProperties props = new JwtProperties("0123456789012345678901234567890123", 1800L, 604800L);
+        when(adminRepository.findByUsername("nonexistent")).thenReturn(Optional.empty());
+        AdminLoginService realSvc = new AdminLoginService(
+                adminRepository, real, jwtProvider, refreshTokenStore, props
+        );
+
+        long t0 = System.nanoTime();
+        assertThatThrownBy(() -> realSvc.login("nonexistent", "any-pw"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_LOGIN_FAILED);
+        long elapsedMs = (System.nanoTime() - t0) / 1_000_000L;
+
+        // BCrypt cost=10 은 현대 HW 에서 ~30~80ms. 머신 분산 고려해 lower bound 만 검증 — flaky 회피.
+        // 이 lower bound 가 통과해야 미존재 username 분기에서도 실 BCrypt 비용이 났다는 증거.
+        assertThat(elapsedMs)
+                .as("미존재 username 분기에서도 실 BCrypt 비용 ≥10ms — dummy hash 형식 깨지면 1ms 이내 실패")
+                .isGreaterThanOrEqualTo(10L);
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/application/InMemoryFakeRefreshTokenStore.java
+++ b/src/test/java/com/sseulang/domain/auth/application/InMemoryFakeRefreshTokenStore.java
@@ -3,46 +3,71 @@ package com.sseulang.domain.auth.application;
 import com.sseulang.domain.auth.domain.RefreshTokenStore;
 
 import java.time.Duration;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 단위 테스트용 in-memory fake. TTL 무시 (테스트 시간 짧음).
+ *
+ * <p>(role, userId, jti) 격리 + tokenVersion 의미 보장 — Redis 구현과 동일한 race-free 의미.
+ * revokeAll = INCR. consume 은 (claimTv == currentTv) 검증 후 jti 폐기.</p>
  */
 class InMemoryFakeRefreshTokenStore implements RefreshTokenStore {
 
-    private final Set<String> store = ConcurrentHashMap.newKeySet();
+    private final Set<String> jtiStore = ConcurrentHashMap.newKeySet();
+    private final Map<String, Long> versionStore = new ConcurrentHashMap<>();
 
     @Override
-    public void save(Long userId, String jti, Duration ttl) {
-        store.add(key(userId, jti));
+    public long currentTokenVersion(String role, Long userId) {
+        return versionStore.getOrDefault(versionKey(role, userId), 0L);
     }
 
     @Override
-    public boolean consume(Long userId, String jti) {
-        return store.remove(key(userId, jti));  // ConcurrentHashMap.newKeySet() → atomic remove
+    public void save(String role, Long userId, String jti, Duration ttl) {
+        jtiStore.add(jtiKey(role, userId, jti));
     }
 
     @Override
-    public void revoke(Long userId, String jti) {
-        store.remove(key(userId, jti));
-    }
-
-    boolean contains(Long userId, String jti) {
-        return store.contains(key(userId, jti));
+    public boolean consume(String role, Long userId, String jti, long claimTv) {
+        // tv mismatch 면 jti 가 살아있어도 consume 실패 — Redis Lua 와 동일 의미.
+        if (currentTokenVersion(role, userId) != claimTv) {
+            return false;
+        }
+        return jtiStore.remove(jtiKey(role, userId, jti));
     }
 
     @Override
-    public void revokeAll(Long userId) {
-        String prefix = userId + "::";
-        store.removeIf(k -> k.startsWith(prefix));
+    public void revoke(String role, Long userId, String jti) {
+        jtiStore.remove(jtiKey(role, userId, jti));
+    }
+
+    @Override
+    public void revokeAll(String role, Long userId) {
+        versionStore.merge(versionKey(role, userId), 1L, Long::sum);
+    }
+
+    boolean contains(String role, Long userId, String jti) {
+        return jtiStore.contains(jtiKey(role, userId, jti));
     }
 
     int size() {
-        return store.size();
+        return jtiStore.size();
     }
 
-    private static String key(Long userId, String jti) {
-        return userId + "::" + jti;
+    private static String jtiKey(String role, Long userId, String jti) {
+        return normalize(role) + "::" + userId + "::" + jti;
+    }
+
+    private static String versionKey(String role, Long userId) {
+        return normalize(role) + "::" + userId;
+    }
+
+    private static String normalize(String role) {
+        if (role == null || role.isBlank()) {
+            throw new IllegalArgumentException("role 은 필수입니다");
+        }
+        return role.toUpperCase(Locale.ROOT);
     }
 }

--- a/src/test/java/com/sseulang/domain/auth/application/OAuthLoginServiceTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/OAuthLoginServiceTest.java
@@ -103,7 +103,7 @@ class OAuthLoginServiceTest {
 
         // RT jti 가 store 에 저장됨
         String rtJti = jwtProvider.parse(pair.refreshToken()).jti();
-        assertThat(store.contains(USER_ID, rtJti)).isTrue();
+        assertThat(store.contains("USER", USER_ID, rtJti)).isTrue();
 
         // 다른 provider 호출 X
         verify(googleProvider, never()).verifyAndFetch(any());
@@ -188,8 +188,8 @@ class OAuthLoginServiceTest {
         String j1 = jwtProvider.parse(p1.refreshToken()).jti();
         String j2 = jwtProvider.parse(p2.refreshToken()).jti();
         assertThat(j1).isNotEqualTo(j2);
-        assertThat(store.contains(USER_ID, j1)).isTrue();
-        assertThat(store.contains(USER_ID, j2)).isTrue();
+        assertThat(store.contains("USER", USER_ID, j1)).isTrue();
+        assertThat(store.contains("USER", USER_ID, j2)).isTrue();
 
         verify(userService, times(2)).findOrCreateBySocial(any(), any(), any(), any(), any());
     }

--- a/src/test/java/com/sseulang/domain/auth/application/RefreshTokenRotationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/RefreshTokenRotationServiceTest.java
@@ -44,10 +44,11 @@ class RefreshTokenRotationServiceTest {
         service = new RefreshTokenRotationService(jwt, store, blacklist, fixedClock, props);
     }
 
-    /** login 시점 시뮬레이션: 토큰 발급 + store 등록. */
+    /** login 시점 시뮬레이션: tv 조회 → 토큰 발급 + store 등록. */
     private String issueAndRegister(Long userId, String role) {
-        String rt = jwt.issueRefreshToken(userId, role);
-        store.save(userId, jwt.parse(rt).jti(), Duration.ofSeconds(RT_VALIDITY));
+        long tv = store.currentTokenVersion(role, userId);
+        String rt = jwt.issueRefreshToken(userId, role, tv);
+        store.save(role, userId, jwt.parse(rt).jti(), Duration.ofSeconds(RT_VALIDITY));
         return rt;
     }
 
@@ -65,10 +66,10 @@ class RefreshTokenRotationServiceTest {
                 .isNotEqualTo(oldRt);
 
         // old jti 무효화
-        assertThat(store.contains(USER_ID, oldJti)).isFalse();
+        assertThat(store.contains("USER", USER_ID, oldJti)).isFalse();
         // 새 jti 등록
         JwtClaims newClaims = jwt.parse(pair.refreshToken());
-        assertThat(store.contains(USER_ID, newClaims.jti())).isTrue();
+        assertThat(store.contains("USER", USER_ID, newClaims.jti())).isTrue();
         assertThat(newClaims.role()).isEqualTo("USER");
     }
 
@@ -83,27 +84,32 @@ class RefreshTokenRotationServiceTest {
     }
 
     @Test
-    @DisplayName("rotate_재사용 탐지_AUTH_REFRESH_TOKEN_INVALID + 해당 사용자 전체 폐기")
+    @DisplayName("rotate_재사용 탐지_AUTH_REFRESH_TOKEN_INVALID + 해당 사용자 RT 전체 무효화")
     void rotate_재사용탐지() {
         // 정상 발급 + store 등록 후 한 번 사용해서 폐기된 상태 가정
         String reusedRt = issueAndRegister(USER_ID, "USER");
         TokenPair first = service.rotate(reusedRt);  // 정상 회전 — old 폐기
         // 다른 디바이스에서도 토큰 등록되어 있다고 가정 (동일 사용자)
         String otherDeviceRt = issueAndRegister(USER_ID, "USER");
-        String otherJti = jwt.parse(otherDeviceRt).jti();
         // first 후 새 RT 도 store 에 있음
-        String firstNewJti = jwt.parse(first.refreshToken()).jti();
-        assertThat(store.contains(USER_ID, firstNewJti)).isTrue();
-        assertThat(store.contains(USER_ID, otherJti)).isTrue();
+        assertThat(store.contains("USER", USER_ID, jwt.parse(first.refreshToken()).jti())).isTrue();
+        assertThat(store.contains("USER", USER_ID, jwt.parse(otherDeviceRt).jti())).isTrue();
 
-        // 이미 폐기된 reusedRt 를 다시 들고 옴 → 탈취 의심 → 전체 폐기
+        // 이미 폐기된 reusedRt 를 다시 들고 옴 → 탈취 의심 → revokeAll (INCR tv)
         assertThatThrownBy(() -> service.rotate(reusedRt))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
 
-        // 해당 사용자의 모든 jti 가 사라져야 함
-        assertThat(store.contains(USER_ID, firstNewJti)).isFalse();
-        assertThat(store.contains(USER_ID, otherJti)).isFalse();
+        // tokenVersion 시맨틱: revokeAll 은 INCR 한 방. jti 키는 TTL 만료까지 잔존하지만 의미상 무효.
+        // 무효화 검증은 "rotate 시도 시 거부" 로 — 해당 사용자의 어떤 RT 든 더이상 rotate 불가.
+        assertThatThrownBy(() -> service.rotate(first.refreshToken()))
+                .as("first 의 새 RT 도 무효화되어야 함")
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
+        assertThatThrownBy(() -> service.rotate(otherDeviceRt))
+                .as("다른 디바이스 RT 도 무효화되어야 함")
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
     }
 
     @Test
@@ -135,11 +141,11 @@ class RefreshTokenRotationServiceTest {
     void revoke_정상() {
         String rt = issueAndRegister(USER_ID, "USER");
         String jti = jwt.parse(rt).jti();
-        assertThat(store.contains(USER_ID, jti)).isTrue();
+        assertThat(store.contains("USER", USER_ID, jti)).isTrue();
 
         service.revoke(rt);
 
-        assertThat(store.contains(USER_ID, jti)).isFalse();
+        assertThat(store.contains("USER", USER_ID, jti)).isFalse();
     }
 
     @Test
@@ -174,7 +180,7 @@ class RefreshTokenRotationServiceTest {
         service.logout(at, rt);
 
         assertThat(blacklist.isBlacklisted(atJti)).isTrue();
-        assertThat(store.contains(USER_ID, rtJti)).isFalse();
+        assertThat(store.contains("USER", USER_ID, rtJti)).isFalse();
     }
 
     @Test
@@ -205,7 +211,7 @@ class RefreshTokenRotationServiceTest {
 
         assertThat(blacklist.size()).isZero();
         // RT 는 정상이라 폐기됨
-        assertThat(store.contains(USER_ID, rtJti)).isFalse();
+        assertThat(store.contains("USER", USER_ID, rtJti)).isFalse();
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStoreIT.java
+++ b/src/test/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStoreIT.java
@@ -31,72 +31,157 @@ class RedisRefreshTokenStoreIT extends RedisIntegrationTestBase {
         store = new RedisRefreshTokenStore(redisTemplate());
     }
 
+    /** 헬퍼 — 현재 tv 로 발급된 RT consume 시뮬레이션. */
+    private boolean consumeAtCurrentVersion(String role, Long userId, String jti) {
+        return store.consume(role, userId, jti, store.currentTokenVersion(role, userId));
+    }
+
     @Test
     @DisplayName("save 후 consume_true 반환 (atomic 폐기)")
     void consume_save된jti_true() {
         String jti = UUID.randomUUID().toString();
-        store.save(USER_ID, jti, TTL);
+        store.save("USER", USER_ID, jti, TTL);
 
-        boolean consumed = store.consume(USER_ID, jti);
+        boolean consumed = consumeAtCurrentVersion("USER", USER_ID, jti);
 
         assertThat(consumed).isTrue();
         // 같은 jti 다시 consume → false (one-time)
-        assertThat(store.consume(USER_ID, jti)).isFalse();
+        assertThat(consumeAtCurrentVersion("USER", USER_ID, jti)).isFalse();
     }
 
     @Test
     @DisplayName("save 안 한 jti consume_false")
     void consume_save안한jti_false() {
-        assertThat(store.consume(USER_ID, UUID.randomUUID().toString())).isFalse();
+        assertThat(consumeAtCurrentVersion("USER", USER_ID, UUID.randomUUID().toString())).isFalse();
     }
 
     @Test
-    @DisplayName("revokeAll_해당 user 의 모든 jti 사라짐")
+    @DisplayName("currentTokenVersion_초기 0 → revokeAll 후 INCR (단조 증가)")
+    void tokenVersion_INCR() {
+        assertThat(store.currentTokenVersion("USER", USER_ID)).isZero();
+
+        store.revokeAll("USER", USER_ID);
+        assertThat(store.currentTokenVersion("USER", USER_ID)).isEqualTo(1L);
+
+        store.revokeAll("USER", USER_ID);
+        assertThat(store.currentTokenVersion("USER", USER_ID)).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("consume_claimTv 가 currentTv 와 mismatch → false (revokeAll 이후 구버전 RT 거부)")
+    void consume_tv_mismatch_false() {
+        String jti = UUID.randomUUID().toString();
+        long oldTv = store.currentTokenVersion("USER", USER_ID);  // 0
+        store.save("USER", USER_ID, jti, TTL);
+
+        store.revokeAll("USER", USER_ID);  // tv: 0 → 1
+
+        // 구버전 tv(=0)로 발급된 RT 는 거부되어야 함
+        assertThat(store.consume("USER", USER_ID, jti, oldTv)).isFalse();
+        // 그리고 jti 키는 살아있다 (DEL 자체가 안 일어남) — TTL 만료까지 잔존하지만 의미상 무효
+        // 다음 호출에서도 mismatch 라 여전히 false
+        assertThat(store.consume("USER", USER_ID, jti, oldTv)).isFalse();
+    }
+
+    @Test
+    @DisplayName("revokeAll_해당 (role,user) 의 모든 RT 무효화 (다른 사용자/role 영향 X)")
     void revokeAll_user전체폐기() {
         List<String> jtis = IntStream.range(0, 5)
                 .mapToObj(i -> UUID.randomUUID().toString())
                 .toList();
-        jtis.forEach(jti -> store.save(USER_ID, jti, TTL));
-        // 다른 user 의 jti — 영향받지 않아야 함
+        long tv0 = store.currentTokenVersion("USER", USER_ID);
+        jtis.forEach(jti -> store.save("USER", USER_ID, jti, TTL));
+        // 다른 user — 영향받지 않아야 함
         Long otherUser = 99L;
         String otherJti = UUID.randomUUID().toString();
-        store.save(otherUser, otherJti, TTL);
+        long otherTv = store.currentTokenVersion("USER", otherUser);
+        store.save("USER", otherUser, otherJti, TTL);
 
-        store.revokeAll(USER_ID);
+        store.revokeAll("USER", USER_ID);
 
-        jtis.forEach(jti -> assertThat(store.consume(USER_ID, jti)).isFalse());
-        // 다른 user 의 jti 는 살아있어야 함
-        assertThat(store.consume(otherUser, otherJti)).isTrue();
+        // 해당 user 의 기존 RT 는 모두 mismatch → false
+        jtis.forEach(jti -> assertThat(store.consume("USER", USER_ID, jti, tv0)).isFalse());
+        // 다른 user 의 RT 는 자기 tv 로 정상 consume
+        assertThat(store.consume("USER", otherUser, otherJti, otherTv)).isTrue();
+    }
+
+    @Test
+    @DisplayName("user/admin 동일 id 격리 — role 차원으로 RT 키 분리")
+    void user_admin_동일id_격리() {
+        Long sharedId = 7L;
+        String userJti = UUID.randomUUID().toString();
+        String adminJti = UUID.randomUUID().toString();
+        long userTv = store.currentTokenVersion("USER", sharedId);
+        long adminTv = store.currentTokenVersion("ADMIN", sharedId);
+        store.save("USER", sharedId, userJti, TTL);
+        store.save("ADMIN", sharedId, adminJti, TTL);
+
+        // user 측 revokeAll → admin 측은 살아있어야 함
+        store.revokeAll("USER", sharedId);
+
+        assertThat(store.consume("USER", sharedId, userJti, userTv)).as("user RT 무효화").isFalse();
+        assertThat(store.consume("ADMIN", sharedId, adminJti, adminTv)).as("admin RT 살아있음").isTrue();
+    }
+
+    @Test
+    @DisplayName("role 정규화 — 소문자/대문자 입력이 동일 키로 매핑")
+    void role_정규화_대소문자무관() {
+        String jti = UUID.randomUUID().toString();
+        long tv = store.currentTokenVersion("user", USER_ID);
+        store.save("user", USER_ID, jti, TTL);
+
+        // 대문자로 조회해도 같은 슬롯
+        assertThat(store.currentTokenVersion("USER", USER_ID)).isEqualTo(tv);
+        assertThat(store.consume("USER", USER_ID, jti, tv)).isTrue();
+    }
+
+    @Test
+    @DisplayName("키 충돌 회귀 — userId=7 의 revokeAll 이 userId=70 의 RT 를 건드리지 않음")
+    void revokeAll_id접두사_충돌없음() {
+        String jti7 = UUID.randomUUID().toString();
+        String jti70 = UUID.randomUUID().toString();
+        long tv7 = store.currentTokenVersion("USER", 7L);
+        long tv70 = store.currentTokenVersion("USER", 70L);
+        store.save("USER", 7L, jti7, TTL);
+        store.save("USER", 70L, jti70, TTL);
+
+        store.revokeAll("USER", 7L);
+
+        assertThat(store.consume("USER", 7L, jti7, tv7)).as("userId=7 무효화").isFalse();
+        assertThat(store.consume("USER", 70L, jti70, tv70)).as("userId=70 영향 없음").isTrue();
     }
 
     @Test
     @DisplayName("revoke_단일 jti 폐기")
     void revoke_단일폐기() {
         String jti = UUID.randomUUID().toString();
-        store.save(USER_ID, jti, TTL);
+        long tv = store.currentTokenVersion("USER", USER_ID);
+        store.save("USER", USER_ID, jti, TTL);
 
-        store.revoke(USER_ID, jti);
+        store.revoke("USER", USER_ID, jti);
 
-        assertThat(store.consume(USER_ID, jti)).isFalse();
+        assertThat(store.consume("USER", USER_ID, jti, tv)).isFalse();
     }
 
     @Test
     @DisplayName("TTL 만료_자동 정리")
     void save_TTL_만료시_사라짐() {
         String jti = UUID.randomUUID().toString();
-        store.save(USER_ID, jti, Duration.ofSeconds(1));
+        long tv = store.currentTokenVersion("USER", USER_ID);
+        store.save("USER", USER_ID, jti, Duration.ofSeconds(1));
 
         Awaitility.await()
                 .atMost(Duration.ofSeconds(3))
                 .pollInterval(Duration.ofMillis(200))
-                .until(() -> !store.consume(USER_ID, jti));
+                .until(() -> !store.consume("USER", USER_ID, jti, tv));
     }
 
     @Test
-    @DisplayName("동시 consume race_정확히 1개 스레드만 true")
+    @DisplayName("동시 consume race_정확히 1개 스레드만 true (Lua 원자성)")
     void consume_race_one_winner() throws Exception {
         String jti = UUID.randomUUID().toString();
-        store.save(USER_ID, jti, TTL);
+        long tv = store.currentTokenVersion("USER", USER_ID);
+        store.save("USER", USER_ID, jti, TTL);
 
         int threadCount = 16;
         ExecutorService pool = Executors.newFixedThreadPool(threadCount);
@@ -114,7 +199,7 @@ class RedisRefreshTokenStoreIT extends RedisIntegrationTestBase {
                             Thread.currentThread().interrupt();
                             return false;
                         }
-                        boolean ok = store.consume(USER_ID, jti);
+                        boolean ok = store.consume("USER", USER_ID, jti, tv);
                         if (ok) trueCount.incrementAndGet();
                         return ok;
                     }, pool))
@@ -129,7 +214,66 @@ class RedisRefreshTokenStoreIT extends RedisIntegrationTestBase {
         }
 
         assertThat(trueCount.get())
-                .as("Redis DEL 의 atomic 보장으로 정확히 1개 스레드만 consume=true 를 받아야 한다")
+                .as("Lua DEL 의 atomic 보장으로 정확히 1개 스레드만 consume=true 를 받아야 한다")
                 .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("revokeAll race 회귀 — revokeAll 진행 중 동시 save 된 RT 도 무효화 (이전 SCAN 구현 race 제거)")
+    void revokeAll_race_새로_save된_RT도_무효화() throws Exception {
+        // 시나리오: revokeAll 직전에 Tv=0 으로 발급된 RT 한 다발 + revokeAll 실행 중 새 save 시도.
+        // 새 RT 도 발급 시점 tv=0 이라면 revokeAll 의 INCR 직후 모두 mismatch 로 거부되어야 함.
+        long tv0 = store.currentTokenVersion("USER", USER_ID);  // 0
+        int preCount = 10;
+        List<String> preJtis = IntStream.range(0, preCount)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .toList();
+        preJtis.forEach(j -> store.save("USER", USER_ID, j, TTL));
+
+        int concurrentCount = 10;
+        ExecutorService pool = Executors.newFixedThreadPool(concurrentCount + 1);
+        CountDownLatch ready = new CountDownLatch(concurrentCount + 1);
+        CountDownLatch start = new CountDownLatch(1);
+
+        try {
+            // 동시 save 들 — 모두 tv=0 가정으로 발급된 RT.
+            List<String> raceJtis = IntStream.range(0, concurrentCount)
+                    .mapToObj(i -> UUID.randomUUID().toString())
+                    .toList();
+            List<CompletableFuture<Void>> saves = raceJtis.stream()
+                    .map(j -> CompletableFuture.runAsync(() -> {
+                        ready.countDown();
+                        try { start.await(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); return; }
+                        store.save("USER", USER_ID, j, TTL);
+                    }, pool))
+                    .toList();
+
+            CompletableFuture<Void> revoke = CompletableFuture.runAsync(() -> {
+                ready.countDown();
+                try { start.await(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); return; }
+                store.revokeAll("USER", USER_ID);
+            }, pool);
+
+            ready.await(5, TimeUnit.SECONDS);
+            start.countDown();
+            CompletableFuture.allOf(
+                    CompletableFuture.allOf(saves.toArray(CompletableFuture[]::new)),
+                    revoke
+            ).get(5, TimeUnit.SECONDS);
+
+            // 검증: tv 가 INCR 되었으므로 tv0 으로 발급된 모든 RT 는 consume 거부.
+            assertThat(store.currentTokenVersion("USER", USER_ID))
+                    .as("revokeAll 한 번이라도 실행되었으니 tv >= 1")
+                    .isGreaterThanOrEqualTo(1L);
+
+            preJtis.forEach(j -> assertThat(store.consume("USER", USER_ID, j, tv0))
+                    .as("revokeAll 이전 발급 RT 거부")
+                    .isFalse());
+            raceJtis.forEach(j -> assertThat(store.consume("USER", USER_ID, j, tv0))
+                    .as("revokeAll 와 race 한 RT 도 tv=0 이면 거부 (이전 SCAN 구현은 살아남았음)")
+                    .isFalse());
+        } finally {
+            pool.shutdown();
+        }
     }
 }

--- a/src/test/java/com/sseulang/domain/withdrawal/application/InMemoryFakeWithdrawalRepository.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/application/InMemoryFakeWithdrawalRepository.java
@@ -1,0 +1,72 @@
+package com.sseulang.domain.withdrawal.application;
+
+import com.sseulang.domain.withdrawal.domain.Withdrawal;
+import com.sseulang.domain.withdrawal.domain.WithdrawalRepository;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class InMemoryFakeWithdrawalRepository implements WithdrawalRepository {
+
+    private final Map<Long, Withdrawal> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public Withdrawal save(Withdrawal withdrawal) {
+        if (withdrawal.getId() == null) {
+            ReflectionTestUtils.setField(withdrawal, "id", ++sequence);
+        }
+        store.put(withdrawal.getId(), withdrawal);
+        return withdrawal;
+    }
+
+    @Override
+    public Optional<Withdrawal> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<Withdrawal> findByIdForUpdate(Long id) {
+        // fake — 락 의미 X. prod 동시성 IT 에서 실제 PESSIMISTIC_WRITE 검증.
+        return findById(id);
+    }
+
+    @Override
+    public Optional<Withdrawal> findByIdAndUserIdForUpdate(Long id, Long userId) {
+        return findById(id).filter(w -> userId != null && userId.equals(w.getUserId()));
+    }
+
+    @Override
+    public Optional<Withdrawal> findByUserIdAndIdempotencyKey(Long userId, String idempotencyKey) {
+        if (idempotencyKey == null) return Optional.empty();
+        return store.values().stream()
+                .filter(w -> userId.equals(w.getUserId()) && idempotencyKey.equals(w.getIdempotencyKey()))
+                .findFirst();
+    }
+
+    @Override
+    public Page<Withdrawal> findByUserId(Long userId, Pageable pageable) {
+        List<Withdrawal> filtered = store.values().stream()
+                .filter(w -> userId.equals(w.getUserId()))
+                .sorted(Comparator.comparing(Withdrawal::getId).reversed())
+                .toList();
+        return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+
+    @Override
+    public Page<Withdrawal> findByStatus(WithdrawalStatus status, Pageable pageable) {
+        List<Withdrawal> filtered = store.values().stream()
+                .filter(w -> status == null || w.getStatus() == status)
+                .sorted(Comparator.comparing(Withdrawal::getId).reversed())
+                .toList();
+        return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+}

--- a/src/test/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationServiceTest.java
@@ -1,0 +1,307 @@
+package com.sseulang.domain.withdrawal.application;
+
+import com.sseulang.domain.point.application.InMemoryFakePointHistoryRepository;
+import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.point.domain.PointHistoryType;
+import com.sseulang.domain.point.domain.PointReferenceType;
+import com.sseulang.domain.user.application.InMemoryFakeUserRepository;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalRequestCommand;
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalResult;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WithdrawalApplicationServiceTest {
+
+    private static final long ADMIN = 99L;
+
+    private InMemoryFakeWithdrawalRepository withdrawalRepo;
+    private InMemoryFakeUserRepository userRepo;
+    private InMemoryFakePointHistoryRepository historyRepo;
+    private WithdrawalApplicationService service;
+    private Long userId;
+    private Long otherUserId;
+
+    @BeforeEach
+    void setUp() {
+        withdrawalRepo = new InMemoryFakeWithdrawalRepository();
+        userRepo = new InMemoryFakeUserRepository();
+        historyRepo = new InMemoryFakePointHistoryRepository();
+        UserApplicationService userSvc = new UserApplicationService(userRepo);
+        PointApplicationService pointSvc = new PointApplicationService(userSvc, historyRepo);
+        // self 는 REQUIRES_NEW proxy 용 — 단위 테스트엔 Spring 컨텍스트 없으니 자기 자신을 주입.
+        // 단위 테스트의 InMemoryFake 는 deadlock/duplicate 던지지 않으므로 catch 경로 미진입.
+        service = new WithdrawalApplicationService(withdrawalRepo, pointSvc, null);
+        ReflectionTestUtils.setField(service, "self", service);
+
+        userId = userRepo.save(User.createSocialUser(
+                SocialProvider.KAKAO, "k-1", new Email("u1@x.com"), "u1", null
+        )).getId();
+        otherUserId = userRepo.save(User.createSocialUser(
+                SocialProvider.KAKAO, "k-2", new Email("u2@x.com"), "u2", null
+        )).getId();
+        userRepo.creditPointBalance(userId, 100_000L);  // 잔액 시드
+    }
+
+    /** 매 호출마다 새 idempotencyKey 발급 — 멱등 dedup 영향 없는 일반 신청 시나리오용. */
+    private WithdrawalRequestCommand cmd(long amount) {
+        return cmd(amount, "idem-" + java.util.UUID.randomUUID());
+    }
+
+    private WithdrawalRequestCommand cmd(long amount, String idempotencyKey) {
+        return new WithdrawalRequestCommand(userId, idempotencyKey, amount, "신한", "110-123-456789", "홍길동");
+    }
+
+    // ───────── request ─────────
+
+    @Test
+    @DisplayName("request 정상_status=신청 + 잔액 차감 + 출금 history 적재")
+    void request_정상() {
+        Long id = service.request(cmd(50_000L));
+
+        WithdrawalResult r = service.getById(id, userId);
+        assertThat(r.status()).isEqualTo(WithdrawalStatus.신청);
+        assertThat(r.amount()).isEqualTo(50_000L);
+        assertThat(userRepo.findPointBalance(userId)).isEqualTo(50_000L);  // 100000 - 50000
+        assertThat(historyRepo.size()).isEqualTo(1);
+        assertThat(historyRepo.all().get(0).getPointType()).isEqualTo(PointHistoryType.출금);
+        assertThat(historyRepo.all().get(0).getReferenceType()).isEqualTo(PointReferenceType.WITHDRAWAL);
+        assertThat(historyRepo.all().get(0).getReferenceId()).isEqualTo(id);
+        assertThat(historyRepo.all().get(0).getAmount()).isEqualTo(-50_000L);
+    }
+
+    @Test
+    @DisplayName("request 잔액 부족_INSUFFICIENT_POINT_history 미적재")
+    void request_잔액부족() {
+        assertThatThrownBy(() -> service.request(cmd(150_000L)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INSUFFICIENT_POINT);
+        // fake 는 트랜잭션 롤백 시뮬 X — Withdrawal 행은 남을 수 있음 (실 prod IT 에서 정합성 보장)
+        // 잔액은 변동 X
+        assertThat(userRepo.findPointBalance(userId)).isEqualTo(100_000L);
+        assertThat(historyRepo.size()).isZero();
+    }
+
+    @Test
+    @DisplayName("request amount<=0_INVALID_REQUEST")
+    void request_invalid_amount() {
+        assertThatThrownBy(() -> service.request(cmd(0L)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REQUEST);
+    }
+
+    // ───────── cancel ─────────
+
+    @Test
+    @DisplayName("cancel 정상_status=취소 + 잔액 원복 + 환불 history")
+    void cancel_정상() {
+        Long id = service.request(cmd(50_000L));
+
+        service.cancel(id, userId);
+
+        assertThat(service.getById(id, userId).status()).isEqualTo(WithdrawalStatus.취소);
+        assertThat(userRepo.findPointBalance(userId)).isEqualTo(100_000L);  // 원복
+        assertThat(historyRepo.size()).isEqualTo(2);
+        assertThat(historyRepo.all().get(1).getPointType()).isEqualTo(PointHistoryType.환불);
+        assertThat(historyRepo.all().get(1).getAmount()).isEqualTo(50_000L);
+    }
+
+    @Test
+    @DisplayName("cancel 외부인_WITHDRAWAL_NOT_FOUND (락+권한 동시 검증 → 자원 존재 leak X) + 상태/잔액 변동 X")
+    void cancel_외부인() {
+        Long id = service.request(cmd(50_000L));
+
+        // 게이트 1 보강: cancel 은 findByIdAndUserIdForUpdate 로 본인 자원만 락+조회.
+        // 타인 id 로는 빈 결과 → NOT_FOUND. FORBIDDEN 으로 자원 존재 여부가 새는 것 차단.
+        assertThatThrownBy(() -> service.cancel(id, otherUserId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_NOT_FOUND);
+        assertThat(service.getById(id, userId).status()).isEqualTo(WithdrawalStatus.신청);
+        assertThat(userRepo.findPointBalance(userId)).isEqualTo(50_000L);
+    }
+
+    // ───────── 멱등성 ─────────
+
+    @Test
+    @DisplayName("request 동일 idempotencyKey 재요청_같은 id 반환 + 차감/저장 1회 (no-op)")
+    void request_idempotent_같은key_재요청() {
+        Long id1 = service.request(cmd(30_000L, "idem-X"));
+        Long id2 = service.request(cmd(30_000L, "idem-X"));  // 두 번째 호출 — 같은 key
+
+        assertThat(id2).as("같은 key 재요청 → 같은 row id").isEqualTo(id1);
+        assertThat(withdrawalRepo.findByUserId(userId, PageRequest.of(0, 10)).getContent())
+                .as("withdrawal 행은 1개만").hasSize(1);
+        assertThat(historyRepo.size()).as("차감 history 도 1회만").isEqualTo(1);
+        assertThat(userRepo.findPointBalance(userId)).isEqualTo(70_000L);  // 100k - 30k 한 번
+    }
+
+    @Test
+    @DisplayName("request 같은 key + 계좌 필드에 trailing 공백만 다름_dedup 통과 (Command 정규화로 mismatch 거짓 거부 차단)")
+    void request_같은key_공백차이_dedup() {
+        Long id1 = service.request(new WithdrawalRequestCommand(
+                userId, "idem-Z", 10_000L, "신한", "110-123-456789", "홍길동"));
+
+        // 두 번째 요청은 계좌 필드 끝에 공백 — Command compact constructor 가 trim 하므로 같은 값
+        Long id2 = service.request(new WithdrawalRequestCommand(
+                userId, "idem-Z", 10_000L, "신한 ", "110-123-456789  ", "홍길동 "));
+
+        assertThat(id2).as("공백만 다른 payload 는 정규화 후 동일 → dedup").isEqualTo(id1);
+        assertThat(historyRepo.size()).as("차감 1회만").isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("request 같은 key + 다른 payload_WITHDRAWAL_IDEMPOTENCY_MISMATCH (silent pass 차단)")
+    void request_같은key_다른payload_거부() {
+        Long id1 = service.request(cmd(30_000L, "idem-Y"));
+
+        // 같은 key 인데 amount 가 다름 → 클라이언트 버그 가능성, 명시 거부
+        assertThatThrownBy(() -> service.request(
+                new WithdrawalRequestCommand(userId, "idem-Y", 50_000L, "신한", "110-123-456789", "홍길동")))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_IDEMPOTENCY_MISMATCH);
+
+        // 잔액/withdrawal 행은 첫 호출 그대로
+        assertThat(userRepo.findPointBalance(userId)).isEqualTo(70_000L);
+    }
+
+    @Test
+    @DisplayName("request 같은 key + 다른 사용자_각자 별개 row (격리)")
+    void request_같은key_다른사용자_별개() {
+        userRepo.creditPointBalance(otherUserId, 100_000L);
+
+        Long id1 = service.request(new WithdrawalRequestCommand(userId, "shared", 10_000L, "신한", "1", "홍"));
+        Long id2 = service.request(new WithdrawalRequestCommand(otherUserId, "shared", 10_000L, "신한", "1", "홍"));
+
+        assertThat(id1).isNotEqualTo(id2);
+        assertThat(historyRepo.size()).isEqualTo(2);  // 각자 차감
+    }
+
+    @Test
+    @DisplayName("cancel 승인 상태_WITHDRAWAL_NOT_CANCELABLE")
+    void cancel_승인_거부() {
+        Long id = service.request(cmd(50_000L));
+        service.adminApprove(id, ADMIN, null);
+
+        assertThatThrownBy(() -> service.cancel(id, userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_NOT_CANCELABLE);
+    }
+
+    // ───────── adminApprove ─────────
+
+    @Test
+    @DisplayName("adminApprove 정상_status=승인 + 잔액 변동 X")
+    void adminApprove_정상() {
+        Long id = service.request(cmd(50_000L));
+
+        service.adminApprove(id, ADMIN, "확인 완료");
+
+        WithdrawalResult r = service.getById(id, userId);
+        assertThat(r.status()).isEqualTo(WithdrawalStatus.승인);
+        assertThat(r.adminId()).isEqualTo(ADMIN);
+        assertThat(r.adminMemo()).isEqualTo("확인 완료");
+        assertThat(userRepo.findPointBalance(userId)).isEqualTo(50_000L);  // 신청 시점 차감 그대로
+    }
+
+    @Test
+    @DisplayName("adminApprove 신청 외 상태_WITHDRAWAL_INVALID_STATE")
+    void adminApprove_상태_거부() {
+        Long id = service.request(cmd(50_000L));
+        service.adminApprove(id, ADMIN, null);
+
+        assertThatThrownBy(() -> service.adminApprove(id, ADMIN, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_INVALID_STATE);
+    }
+
+    // ───────── adminReject ─────────
+
+    @Test
+    @DisplayName("adminReject 정상_status=거부 + 잔액 원복")
+    void adminReject_정상() {
+        Long id = service.request(cmd(50_000L));
+
+        service.adminReject(id, ADMIN, "계좌 오류");
+
+        WithdrawalResult r = service.getById(id, userId);
+        assertThat(r.status()).isEqualTo(WithdrawalStatus.거부);
+        assertThat(r.adminMemo()).isEqualTo("계좌 오류");
+        assertThat(userRepo.findPointBalance(userId)).isEqualTo(100_000L);  // 원복
+        assertThat(historyRepo.size()).isEqualTo(2);
+    }
+
+    // ───────── adminComplete ─────────
+
+    @Test
+    @DisplayName("adminComplete 승인 → 완료")
+    void adminComplete_정상() {
+        Long id = service.request(cmd(50_000L));
+        service.adminApprove(id, ADMIN, null);
+
+        service.adminComplete(id, ADMIN);
+
+        assertThat(service.getById(id, userId).status()).isEqualTo(WithdrawalStatus.완료);
+        // 외부 이체 mock — 잔액 변동 없음 (신청 시점 차감 유지)
+        assertThat(userRepo.findPointBalance(userId)).isEqualTo(50_000L);
+    }
+
+    @Test
+    @DisplayName("adminComplete 신청 상태_WITHDRAWAL_INVALID_STATE")
+    void adminComplete_상태_거부() {
+        Long id = service.request(cmd(50_000L));
+
+        assertThatThrownBy(() -> service.adminComplete(id, ADMIN))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_INVALID_STATE);
+    }
+
+    // ───────── 조회 ─────────
+
+    @Test
+    @DisplayName("getById 외부인_WITHDRAWAL_FORBIDDEN")
+    void getById_외부인() {
+        Long id = service.request(cmd(50_000L));
+
+        assertThatThrownBy(() -> service.getById(id, otherUserId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("findMyWithdrawals 페이징")
+    void findMyWithdrawals() {
+        service.request(cmd(10_000L));
+        service.request(cmd(20_000L));
+
+        Page<WithdrawalResult> page = service.findMyWithdrawals(userId, PageRequest.of(0, 10));
+        assertThat(page.getContent()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("adminFindByStatus 신청만 필터")
+    void adminFindByStatus() {
+        Long id1 = service.request(cmd(10_000L));
+        Long id2 = service.request(cmd(20_000L));
+        service.adminApprove(id2, ADMIN, null);
+
+        Page<WithdrawalResult> 신청 = service.adminFindByStatus(WithdrawalStatus.신청, PageRequest.of(0, 10));
+        assertThat(신청.getContent()).hasSize(1);
+        assertThat(신청.getContent().get(0).id()).isEqualTo(id1);
+
+        Page<WithdrawalResult> 전체 = service.adminFindByStatus(null, PageRequest.of(0, 10));
+        assertThat(전체.getContent()).hasSize(2);
+    }
+}

--- a/src/test/java/com/sseulang/domain/withdrawal/domain/WithdrawalTest.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/domain/WithdrawalTest.java
@@ -1,0 +1,141 @@
+package com.sseulang.domain.withdrawal.domain;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WithdrawalTest {
+
+    private static final Long USER = 1L;
+    private static final Long ADMIN = 99L;
+    private static final String IDEM = "idem-key-1";
+    private static final long AMOUNT = 50_000L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 30, 12, 0);
+
+    private Withdrawal newWithdrawal() {
+        return Withdrawal.request(USER, IDEM, AMOUNT, "신한", "110-123-456789", "홍길동", NOW);
+    }
+
+    @Test
+    @DisplayName("request 정상_status=신청, idempotencyKey/requestedAt 설정")
+    void request_정상() {
+        Withdrawal w = newWithdrawal();
+
+        assertThat(w.getUserId()).isEqualTo(USER);
+        assertThat(w.getIdempotencyKey()).isEqualTo(IDEM);
+        assertThat(w.getAmount()).isEqualTo(AMOUNT);
+        assertThat(w.getStatus()).isEqualTo(WithdrawalStatus.신청);
+        assertThat(w.getRequestedAt()).isEqualTo(NOW);
+        assertThat(w.getProcessedAt()).isNull();
+        assertThat(w.getAdminId()).isNull();
+    }
+
+    @Test
+    @DisplayName("request invalid 인자 거부 (idempotencyKey 누락 포함)")
+    void request_invalid() {
+        assertThatThrownBy(() -> Withdrawal.request(null, IDEM, AMOUNT, "a", "b", "c", NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Withdrawal.request(USER, IDEM, 0L, "a", "b", "c", NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Withdrawal.request(USER, "", AMOUNT, "a", "b", "c", NOW))
+                .as("idempotencyKey 빈값 거부")
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Withdrawal.request(USER, null, AMOUNT, "a", "b", "c", NOW))
+                .as("idempotencyKey null 거부")
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Withdrawal.request(USER, IDEM, AMOUNT, "", "b", "c", NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Withdrawal.request(USER, IDEM, AMOUNT, "a", null, "c", NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Withdrawal.request(USER, IDEM, AMOUNT, "a", "b", "", NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("cancel 신청 상태_status=취소")
+    void cancel_정상() {
+        Withdrawal w = newWithdrawal();
+        w.cancel(NOW.plusMinutes(5));
+
+        assertThat(w.getStatus()).isEqualTo(WithdrawalStatus.취소);
+        assertThat(w.getProcessedAt()).isEqualTo(NOW.plusMinutes(5));
+    }
+
+    @Test
+    @DisplayName("cancel 승인 상태_WITHDRAWAL_NOT_CANCELABLE")
+    void cancel_승인상태_거부() {
+        Withdrawal w = newWithdrawal();
+        w.approve(ADMIN, "ok", NOW.plusMinutes(1));
+        assertThatThrownBy(() -> w.cancel(NOW.plusMinutes(2)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_NOT_CANCELABLE);
+    }
+
+    @Test
+    @DisplayName("approve 신청 → 승인_adminId/memo 기록")
+    void approve_정상() {
+        Withdrawal w = newWithdrawal();
+        w.approve(ADMIN, "확인 완료", NOW.plusMinutes(1));
+
+        assertThat(w.getStatus()).isEqualTo(WithdrawalStatus.승인);
+        assertThat(w.getAdminId()).isEqualTo(ADMIN);
+        assertThat(w.getAdminMemo()).isEqualTo("확인 완료");
+    }
+
+    @Test
+    @DisplayName("approve 신청 외 상태_WITHDRAWAL_INVALID_STATE")
+    void approve_상태_거부() {
+        Withdrawal w = newWithdrawal();
+        w.approve(ADMIN, null, NOW.plusMinutes(1));
+        assertThatThrownBy(() -> w.approve(ADMIN, null, NOW.plusMinutes(2)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("reject 신청 → 거부_상태 기록")
+    void reject_정상() {
+        Withdrawal w = newWithdrawal();
+        w.reject(ADMIN, "계좌 오류", NOW.plusMinutes(1));
+
+        assertThat(w.getStatus()).isEqualTo(WithdrawalStatus.거부);
+        assertThat(w.getAdminId()).isEqualTo(ADMIN);
+        assertThat(w.getAdminMemo()).isEqualTo("계좌 오류");
+    }
+
+    @Test
+    @DisplayName("markAsCompleted 승인 → 완료")
+    void markAsCompleted_정상() {
+        Withdrawal w = newWithdrawal();
+        w.approve(ADMIN, null, NOW.plusMinutes(1));
+        w.markAsCompleted(NOW.plusMinutes(10));
+
+        assertThat(w.getStatus()).isEqualTo(WithdrawalStatus.완료);
+        assertThat(w.getProcessedAt()).isEqualTo(NOW.plusMinutes(10));
+    }
+
+    @Test
+    @DisplayName("markAsCompleted 승인 외 상태_WITHDRAWAL_INVALID_STATE")
+    void markAsCompleted_상태_거부() {
+        Withdrawal w = newWithdrawal();
+        // 신청 상태에서 바로 complete 불가
+        assertThatThrownBy(() -> w.markAsCompleted(NOW))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("isOwnedBy")
+    void isOwnedBy() {
+        Withdrawal w = newWithdrawal();
+        assertThat(w.isOwnedBy(USER)).isTrue();
+        assertThat(w.isOwnedBy(USER + 1)).isFalse();
+        assertThat(w.isOwnedBy(null)).isFalse();
+    }
+}

--- a/src/test/java/com/sseulang/domain/withdrawal/integration/WithdrawalSettlementIT.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/integration/WithdrawalSettlementIT.java
@@ -1,0 +1,344 @@
+package com.sseulang.domain.withdrawal.integration;
+
+import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.point.domain.PointHistory;
+import com.sseulang.domain.point.domain.PointHistoryRepository;
+import com.sseulang.domain.point.domain.PointHistoryType;
+import com.sseulang.domain.point.infrastructure.persistence.PointHistoryRepositoryImpl;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserRepository;
+import com.sseulang.domain.user.infrastructure.persistence.UserRepositoryImpl;
+import com.sseulang.domain.withdrawal.application.WithdrawalApplicationService;
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalRequestCommand;
+import com.sseulang.domain.withdrawal.domain.Withdrawal;
+import com.sseulang.domain.withdrawal.domain.WithdrawalRepository;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import com.sseulang.domain.withdrawal.infrastructure.persistence.WithdrawalRepositoryImpl;
+import com.sseulang.global.config.JpaAuditingConfig;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Day 8 PR-b 게이트 1 — 출금 잔액 정합성 DB-backed IT.
+ *
+ * <ol>
+ *   <li>{@code request 잔액 부족} — Withdrawal 행 / point_histories / 잔액 모두 원복 (트랜잭션 롤백)</li>
+ *   <li>{@code cancel 잔액 원복} — 신청 차감 → 취소 시 잔액 +amount 환불 + 환불 history 적재</li>
+ *   <li>{@code adminReject 잔액 원복} — 관리자 거부 시 잔액 환불</li>
+ *   <li>{@code adminComplete} — 외부 이체 mock 후 status=완료, 잔액 변동 없음</li>
+ * </ol>
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({
+        JpaAuditingConfig.class,
+        UserRepositoryImpl.class,
+        UserApplicationService.class,
+        PointHistoryRepositoryImpl.class,
+        PointApplicationService.class,
+        WithdrawalRepositoryImpl.class,
+        WithdrawalApplicationService.class
+})
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class WithdrawalSettlementIT {
+
+    private long adminId;
+
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("sseulang_test")
+            .withUsername("test")
+            .withPassword("testpw")
+            .withCommand("--character-set-server=utf8mb4",
+                    "--collation-server=utf8mb4_unicode_ci",
+                    "--ngram_token_size=2");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    @Autowired private EntityManager em;
+    @Autowired private WithdrawalApplicationService withdrawalService;
+    @Autowired private WithdrawalRepository withdrawalRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private PointHistoryRepository pointHistoryRepository;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate txTemplate;
+    private Long userId;
+
+    @BeforeEach
+    void setUp() {
+        txTemplate = new TransactionTemplate(transactionManager);
+        txTemplate.execute(s -> {
+            em.createNativeQuery("DELETE FROM point_histories").executeUpdate();
+            em.createNativeQuery("DELETE FROM withdrawals").executeUpdate();
+            em.createNativeQuery("DELETE FROM users").executeUpdate();
+            em.createNativeQuery("DELETE FROM admins").executeUpdate();
+            return null;
+        });
+        userId = txTemplate.execute(s -> persistUser());
+        adminId = txTemplate.execute(s -> persistAdmin());
+        txTemplate.execute(s -> {
+            userRepository.creditPointBalance(userId, 100_000L);
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("request 잔액 부족_Withdrawal/point_histories/잔액 모두 롤백")
+    void request_잔액부족_롤백() {
+        assertThatThrownBy(() -> txTemplate.execute(s -> {
+            withdrawalService.request(new WithdrawalRequestCommand(
+                    userId, idemKey(), 200_000L, "신한", "110-123-456789", "홍길동"
+            ));
+            return null;
+        }))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INSUFFICIENT_POINT);
+
+        // verify — Withdrawal 행 미생성 (트랜잭션 롤백) / point_history 미적재 / 잔액 변동 X
+        assertThat(withdrawalRepository.findByStatus(null,
+                org.springframework.data.domain.PageRequest.of(0, 10)).getContent())
+                .as("Withdrawal 행 롤백").isEmpty();
+        assertThat(pointHistoryRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .as("history 미적재").isEmpty();
+        assertThat(userRepository.findPointBalance(userId)).isEqualTo(100_000L);
+    }
+
+    @Test
+    @DisplayName("cancel 정상_잔액 원복 + 출금/환불 history 두 건")
+    void cancel_정상() {
+        Long id = txTemplate.execute(s -> withdrawalService.request(new WithdrawalRequestCommand(
+                userId, idemKey(), 50_000L, "신한", "110-123-456789", "홍길동"
+        )));
+        // 신청 직후 잔액 50000
+        assertThat(userRepository.findPointBalance(userId)).isEqualTo(50_000L);
+
+        txTemplate.execute(s -> {
+            withdrawalService.cancel(id, userId);
+            return null;
+        });
+
+        Withdrawal w = withdrawalRepository.findById(id).orElseThrow();
+        assertThat(w.getStatus()).isEqualTo(WithdrawalStatus.취소);
+        assertThat(userRepository.findPointBalance(userId)).isEqualTo(100_000L);  // 원복
+        var histories = pointHistoryRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        assertThat(histories).hasSize(2);
+        // 같은 트랜잭션 안에서 생성되어 created_at 동일할 수 있음 — 매칭 기반 검증.
+        PointHistory withdrawHistory = histories.stream()
+                .filter(h -> h.getPointType() == PointHistoryType.출금).findFirst().orElseThrow();
+        PointHistory refundHistory = histories.stream()
+                .filter(h -> h.getPointType() == PointHistoryType.환불).findFirst().orElseThrow();
+        assertThat(withdrawHistory.getAmount()).isEqualTo(-50_000L);
+        assertThat(withdrawHistory.getBalanceAfter()).isEqualTo(50_000L);
+        assertThat(refundHistory.getAmount()).isEqualTo(50_000L);
+        assertThat(refundHistory.getBalanceAfter()).isEqualTo(100_000L);
+    }
+
+    @Test
+    @DisplayName("adminReject 정상_잔액 원복")
+    void adminReject_정상() {
+        Long id = txTemplate.execute(s -> withdrawalService.request(new WithdrawalRequestCommand(
+                userId, idemKey(), 30_000L, "신한", "110-123-456789", "홍길동"
+        )));
+
+        txTemplate.execute(s -> {
+            withdrawalService.adminReject(id, adminId, "계좌 검증 실패");
+            return null;
+        });
+
+        assertThat(withdrawalRepository.findById(id).orElseThrow().getStatus())
+                .isEqualTo(WithdrawalStatus.거부);
+        assertThat(userRepository.findPointBalance(userId)).isEqualTo(100_000L);
+    }
+
+    @Test
+    @DisplayName("동시 cancel vs adminApprove_정확히 1건만 처리 + 다른 1건은 상태 가드로 거부")
+    void 동시_cancel_vs_adminApprove() throws Exception {
+        Long id = txTemplate.execute(s -> withdrawalService.request(new WithdrawalRequestCommand(
+                userId, idemKey(), 30_000L, "신한", "110-123-456789", "홍길동"
+        )));
+
+        java.util.concurrent.ExecutorService exec = java.util.concurrent.Executors.newFixedThreadPool(2);
+        java.util.concurrent.CountDownLatch start = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(2);
+        java.util.concurrent.atomic.AtomicInteger cancelOk = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.atomic.AtomicInteger approveOk = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.atomic.AtomicInteger stateErr = new java.util.concurrent.atomic.AtomicInteger();
+
+        exec.submit(() -> {
+            try {
+                start.await();
+                txTemplate.execute(s -> { withdrawalService.cancel(id, userId); return null; });
+                cancelOk.incrementAndGet();
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.WITHDRAWAL_NOT_CANCELABLE
+                        || e.getErrorCode() == ErrorCode.WITHDRAWAL_INVALID_STATE) {
+                    stateErr.incrementAndGet();
+                }
+            } catch (Exception ignore) {
+            } finally { done.countDown(); }
+        });
+        exec.submit(() -> {
+            try {
+                start.await();
+                txTemplate.execute(s -> { withdrawalService.adminApprove(id, adminId, "ok"); return null; });
+                approveOk.incrementAndGet();
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.WITHDRAWAL_NOT_CANCELABLE
+                        || e.getErrorCode() == ErrorCode.WITHDRAWAL_INVALID_STATE) {
+                    stateErr.incrementAndGet();
+                }
+            } catch (Exception ignore) {
+            } finally { done.countDown(); }
+        });
+        start.countDown();
+        boolean finished = done.await(10, java.util.concurrent.TimeUnit.SECONDS);
+        exec.shutdown();
+
+        assertThat(finished).as("두 호출 모두 10초 안에 완료").isTrue();
+        // 두 흐름 중 정확히 1개 성공, 다른 1개는 상태 가드로 거부 (락 직렬화).
+        assertThat(cancelOk.get() + approveOk.get()).as("성공 1건").isEqualTo(1);
+        assertThat(stateErr.get()).as("거부 1건").isEqualTo(1);
+
+        Withdrawal w = withdrawalRepository.findById(id).orElseThrow();
+        assertThat(w.getStatus()).isIn(WithdrawalStatus.취소, WithdrawalStatus.승인);
+    }
+
+    @Test
+    @DisplayName("adminApprove → adminComplete_status=완료, 잔액 변동 없음")
+    void adminApproveComplete() {
+        Long id = txTemplate.execute(s -> withdrawalService.request(new WithdrawalRequestCommand(
+                userId, idemKey(), 30_000L, "신한", "110-123-456789", "홍길동"
+        )));
+
+        txTemplate.execute(s -> { withdrawalService.adminApprove(id, adminId, "ok"); return null; });
+        txTemplate.execute(s -> { withdrawalService.adminComplete(id, adminId); return null; });
+
+        Withdrawal w = withdrawalRepository.findById(id).orElseThrow();
+        assertThat(w.getStatus()).isEqualTo(WithdrawalStatus.완료);
+        assertThat(w.getAdminId()).isEqualTo(adminId);
+        // 신청 시점 차감만 유지 (외부 이체 mock — 추가 잔액 변동 X)
+        assertThat(userRepository.findPointBalance(userId)).isEqualTo(70_000L);
+        // 출금 history 한 건 (환불 없음)
+        var histories = pointHistoryRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        assertThat(histories).hasSize(1);
+        assertThat(histories.get(0).getPointType()).isEqualTo(PointHistoryType.출금);
+    }
+
+    @Test
+    @DisplayName("동시 동일 idempotencyKey 신청_정확히 1건만 생성, 1번만 차감 (게이트 1 멱등성)")
+    void 동시_동일_idempotencyKey_1건만() throws Exception {
+        String key = idemKey();
+        long amount = 30_000L;
+
+        java.util.concurrent.ExecutorService exec = java.util.concurrent.Executors.newFixedThreadPool(2);
+        java.util.concurrent.CountDownLatch start = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(2);
+        java.util.concurrent.atomic.AtomicReference<Long> id1 = new java.util.concurrent.atomic.AtomicReference<>();
+        java.util.concurrent.atomic.AtomicReference<Long> id2 = new java.util.concurrent.atomic.AtomicReference<>();
+        java.util.concurrent.atomic.AtomicReference<Throwable> err = new java.util.concurrent.atomic.AtomicReference<>();
+
+        Runnable submit = () -> {
+            try {
+                start.await();
+                Long id = txTemplate.execute(s -> withdrawalService.request(new WithdrawalRequestCommand(
+                        userId, key, amount, "신한", "110-123-456789", "홍길동"
+                )));
+                if (id1.get() == null) id1.set(id); else id2.set(id);
+            } catch (Throwable t) {
+                err.set(t);
+            } finally {
+                done.countDown();
+            }
+        };
+        exec.submit(submit);
+        exec.submit(submit);
+        start.countDown();
+        boolean finished = done.await(10, java.util.concurrent.TimeUnit.SECONDS);
+        exec.shutdown();
+
+        assertThat(finished).as("두 호출 모두 10초 안에 완료").isTrue();
+        assertThat(err.get()).as("두 호출 모두 BusinessException 없이 완료 — 한 쪽은 dedup, 한 쪽은 신규").isNull();
+        // 두 호출이 같은 id 반환해야 멱등 (DB UNIQUE 또는 select-then-insert dedup 둘 중 하나로 처리됨)
+        assertThat(id1.get()).as("호출 1 id").isNotNull();
+        assertThat(id2.get()).as("호출 2 id").isNotNull();
+        assertThat(id1.get()).as("두 호출 같은 withdrawal id 반환").isEqualTo(id2.get());
+
+        // withdrawal 행은 1건만, point_history 도 1건만 (=차감 1번)
+        assertThat(withdrawalRepository.findByUserId(userId,
+                org.springframework.data.domain.PageRequest.of(0, 10)).getContent())
+                .as("withdrawal 행 1건").hasSize(1);
+        var histories = pointHistoryRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        assertThat(histories).as("출금 history 1건만 — 잔액 중복 차감 X").hasSize(1);
+        assertThat(histories.get(0).getAmount()).isEqualTo(-amount);
+        assertThat(userRepository.findPointBalance(userId)).isEqualTo(100_000L - amount);
+    }
+
+    private static String idemKey() {
+        return "idem-" + java.util.UUID.randomUUID();
+    }
+
+    private Long persistUser() {
+        User user = User.createSocialUser(
+                SocialProvider.KAKAO,
+                "kakao-" + System.nanoTime(),
+                new Email("u-" + System.nanoTime() + "@example.com"),
+                "user",
+                null
+        );
+        em.persist(user);
+        em.flush();
+        return user.getId();
+    }
+
+    private Long persistAdmin() {
+        // admins 테이블에 직접 native INSERT — admin 도메인 엔티티가 본 모듈에 노출 안 되어 있음
+        String username = "admin-" + System.nanoTime();
+        em.createNativeQuery("""
+                INSERT INTO admins (username, password, name, role, is_active)
+                VALUES (?, ?, ?, ?, ?)
+                """)
+                .setParameter(1, username)
+                .setParameter(2, "$2a$10$dummyHashForITTestUseOnlyXX")
+                .setParameter(3, "tester")
+                .setParameter(4, "ADMIN")
+                .setParameter(5, true)
+                .executeUpdate();
+        Object id = em.createNativeQuery("SELECT id FROM admins WHERE username = ?")
+                .setParameter(1, username)
+                .getSingleResult();
+        return ((Number) id).longValue();
+    }
+}

--- a/src/test/java/com/sseulang/global/security/AuthSecurityFlowIT.java
+++ b/src/test/java/com/sseulang/global/security/AuthSecurityFlowIT.java
@@ -76,7 +76,7 @@ class AuthSecurityFlowIT {
     @Test
     @DisplayName("유효한 AT 쿠키_보호된 엔드포인트 200")
     void 유효AT_보호된엔드포인트_200() throws Exception {
-        JwtClaims claims = new JwtClaims(1L, "USER", "jti-1",
+        JwtClaims claims = new JwtClaims(1L, "USER", "jti-1", null,
                 Instant.parse("2026-04-28T03:00:00Z"),
                 Instant.parse("2026-04-28T03:30:00Z"));
         when(jwtProvider.parse(any())).thenReturn(claims);
@@ -90,6 +90,42 @@ class AuthSecurityFlowIT {
                         }))
                 .andExpect(status().isOk())
                 .andExpect(header().exists(TraceIdFilter.HEADER));
+    }
+
+    @Test
+    @DisplayName("ADMIN AT_user 영역 접근_403 (권한 격리: hasRole(\"USER\") 강제)")
+    void adminAT_user엔드포인트_403() throws Exception {
+        // 시나리오: adminId=1 인 ADMIN AT 가 /api/v1/test/protected (user chain) 접근 시도.
+        // 이전 .authenticated() 정책에선 인증만 됐다고 통과 — 본인 검사가 숫자 id 충돌하면 사용자 자원 접근 가능.
+        // 게이트 1 보강: hasRole("USER") 강제로 ADMIN AT 는 차단된다.
+        JwtClaims adminClaims = new JwtClaims(1L, "ADMIN", "admin-jti", null,
+                Instant.parse("2026-04-28T03:00:00Z"),
+                Instant.parse("2026-04-28T03:30:00Z"));
+        when(jwtProvider.parse(any())).thenReturn(adminClaims);
+        when(accessTokenBlacklist.isBlacklisted("admin-jti")).thenReturn(false);
+
+        mvc.perform(get("/api/v1/test/protected")
+                        .cookie(new Cookie(CookieUtil.ACCESS_TOKEN_COOKIE, "ADMIN_AT")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.FORBIDDEN.name()));
+    }
+
+    @Test
+    @DisplayName("role 누락 AT_user 영역 접근_403 (변조 / 구버전 토큰 방어)")
+    void roleMissingAT_user엔드포인트_403() throws Exception {
+        // role=null 로 발급된 토큰은 어떤 역할도 받지 못해 ROLE_null 부여 → hasRole("USER") fail.
+        // 명시적으로 권한 결과 검증해서 회귀 시 즉시 실패하도록.
+        JwtClaims noRoleClaims = new JwtClaims(1L, null, "jti-x", null,
+                Instant.parse("2026-04-28T03:00:00Z"),
+                Instant.parse("2026-04-28T03:30:00Z"));
+        when(jwtProvider.parse(any())).thenReturn(noRoleClaims);
+        when(accessTokenBlacklist.isBlacklisted("jti-x")).thenReturn(false);
+
+        mvc.perform(get("/api/v1/test/protected")
+                        .cookie(new Cookie(CookieUtil.ACCESS_TOKEN_COOKIE, "NOROLE_AT")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.FORBIDDEN.name()));
     }
 
     @Test

--- a/src/test/java/com/sseulang/global/security/JwtProviderTest.java
+++ b/src/test/java/com/sseulang/global/security/JwtProviderTest.java
@@ -45,15 +45,25 @@ class JwtProviderTest {
     }
 
     @Test
-    @DisplayName("RefreshToken 발급_정상_userId/role/jti 포함되고 7일 뒤 만료")
+    @DisplayName("RefreshToken 발급_정상_userId/role/jti/tv 포함되고 7일 뒤 만료")
     void issueRefreshToken_정상_payload포함_7일만료() {
-        String token = provider.issueRefreshToken(42L, "USER");
+        String token = provider.issueRefreshToken(42L, "USER", 3L);
 
         JwtClaims claims = provider.parse(token);
         assertThat(claims.userId()).isEqualTo(42L);
         assertThat(claims.role()).isEqualTo("USER");
         assertThat(claims.jti()).isNotBlank();
+        assertThat(claims.tokenVersion()).isEqualTo(3L);
         assertThat(claims.expiresAt()).isEqualTo(FIXED_NOW.plusSeconds(RT_VALIDITY));
+    }
+
+    @Test
+    @DisplayName("AccessToken parse 결과_tokenVersion은 null (RT 전용 claim)")
+    void accessToken_tokenVersion_null() {
+        String token = provider.issueAccessToken(42L, "USER");
+
+        JwtClaims claims = provider.parse(token);
+        assertThat(claims.tokenVersion()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## 한 줄 요약

출금 신청·승인 흐름 + 관리자 로그인 + RT (role, tokenVersion) 격리. 게이트 1 두 번, 게이트 2 한 번의 코덱스 리뷰 반영 후 머지 가능 판정.

## 무엇이 바뀌었는지

### 새 기능
- **출금 도메인** — 사용자 신청 → 관리자 승인/거부/완료/취소 상태머신. 잔액은 신청 시점에 차감, 거부/취소 시 환불.
- **관리자 로그인** — username + BCrypt password. JWT는 USER 토큰과 분리된 ADMIN 토큰 발급.

### 보안 보강 (코덱스 게이트 리뷰 반영)
- **출금 멱등성** — 클라이언트 발급 `idempotencyKey` (UUID 권장) + DB UNIQUE 제약. 더블클릭/네트워크 재시도로 잔액이 두 번 차감되는 사고 차단.
- **권한 격리** — 그동안 user API가 "인증만 됐으면 통과" 였는데, 이제 `ROLE_USER` 강제. ADMIN 토큰으로 출금/결제 같은 user 영역 진입 불가.
- **RT race-free 무효화** — 기존엔 강제 로그아웃 시 SCAN→DEL 패턴이라 동시 발급된 새 RT가 살아남는 race. 이제 (role, userId)별 tokenVersion을 INCR 하나로 무효화 (Redis Lua 원자 처리).
- **AdminLogin timing leak 방어** — username 미존재여도 dummy hash로 BCrypt 강제 실행. 응답 시간 차이로 username 존재 여부 enumeration 방지.
- **출금 cancel lock-DoS 방지** — 권한 검증과 락 획득을 한 쿼리로 묶음. 타인 id로 락만 걸어두는 공격 차단.

### 의도한 결정 (트러블슈팅 docs에 정리)
- 멱등성 구현 중 만난 함정 3건 처리:
  1. MySQL InnoDB가 동시 INSERT 충돌을 duplicate-key 또는 deadlock 둘 다로 던질 수 있음 → 두 예외 모두 catch
  2. Hibernate에서 같은 트랜잭션 안에서 INSERT 실패 catch 시 session이 dirty 상태로 깨짐 → INSERT를 별도 트랜잭션(`REQUIRES_NEW`)으로 분리, `@Lazy` self-injection
  3. REPEATABLE_READ snapshot 때문에 race 패배자가 winner의 commit을 못 봄 → 복구 SELECT도 별도 트랜잭션에서 fresh snapshot

## 영향 범위

- 신규 도메인 2개 (`domain/admin`, `domain/withdrawal`)
- `auth/RefreshTokenStore` 인터페이스 변경 (role + tokenVersion 추가) — 호출부(OAuthLoginService / RefreshTokenRotationService / AdminLoginService) 모두 갱신
- `SecurityConfig` user chain `.hasRole("USER")` 강제
- DB 마이그레이션 V4 추가 (withdrawals.idempotency_key + UNIQUE)

## 테스트

- [x] 425 PASS / 0 FAIL (`./gradlew test`)
- [x] 신규 시나리오: 동시 동일 idempotencyKey → 1건만 / revokeAll race / ADMIN AT user 엔드포인트 403 / dummy BCrypt 패턴 검증 / 미존재 username의 BCrypt 비교 비용 ≥10ms
- [x] 기존 테스트 회귀 없음

## 코덱스 리뷰

- 게이트 1 round 1 (RT role 격리): thread `019dd...`
- 게이트 1 round 2 (출금 흐름 + AdminLogin): thread `019ddc22-...` — Critical 4건 + Should-fix 8건 모두 반영
- 게이트 2 (PR 풀 리뷰): thread `019ddc56-...` — round 2까지 거쳐 **머지 가능 판정**

## 머지 후 후속 (별도 이슈로 트래킹 권장)

- V4 마이그레이션 prod 배포 절차 문서화 (UNIQUE index 빌드 시 metadata lock)
- Redis Cluster 도입 시 Lua multi-key를 `{ROLE:userId}` hash tag로 같은 슬롯에 묶기
- `auth:rtv:{ROLE}:{userId}` TTL 추가 검토 (현재 무TTL — 비활성 사용자도 영원히 잔존)
- 외부 은행 이체 실연동 (현재 `adminComplete` 는 mock 로그)

## 관련 문서

- `docs/AUTH_SECURITY.md` §1 (게이트 결과 표 갱신), §5.1 (Day 8 키 패턴), §7 (트러블슈팅 8건), §8 (운영 plays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)