### PR TITLE
feat: Day 9 — Notice/Banner + 관리자 회원관리/신고처리

### DIFF
--- a/src/main/java/com/sseulang/domain/banner/application/BannerApplicationService.java
+++ b/src/main/java/com/sseulang/domain/banner/application/BannerApplicationService.java
@@ -1,0 +1,82 @@
+package com.sseulang.domain.banner.application;
+
+import com.sseulang.domain.banner.application.dto.BannerResult;
+import com.sseulang.domain.banner.application.dto.BannerUpsertCommand;
+import com.sseulang.domain.banner.domain.Banner;
+import com.sseulang.domain.banner.domain.BannerRepository;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 배너 흐름 — 관리자 CRUD + activate/deactivate, 사용자는 활성 + 윈도우 안 배너만 sort_order 순으로.
+ */
+@Service
+@Transactional(readOnly = true)
+public class BannerApplicationService {
+
+    private final BannerRepository bannerRepository;
+    private final Clock clock;
+
+    public BannerApplicationService(BannerRepository bannerRepository, Clock clock) {
+        this.bannerRepository = bannerRepository;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public Long create(Long adminId, BannerUpsertCommand cmd) {
+        Banner b = Banner.create(
+                adminId, cmd.title(), cmd.imageUrl(), cmd.linkUrl(),
+                cmd.sortOrder(), cmd.startsAt(), cmd.endsAt()
+        );
+        return bannerRepository.save(b).getId();
+    }
+
+    @Transactional
+    public void update(Long bannerId, BannerUpsertCommand cmd) {
+        Banner b = findOrThrow(bannerId);
+        b.update(cmd.title(), cmd.imageUrl(), cmd.linkUrl(),
+                cmd.sortOrder(), cmd.startsAt(), cmd.endsAt());
+    }
+
+    @Transactional
+    public void setActive(Long bannerId, boolean active) {
+        Banner b = findOrThrow(bannerId);
+        if (active) b.activate(); else b.deactivate();
+    }
+
+    @Transactional
+    public void delete(Long bannerId) {
+        if (bannerRepository.findById(bannerId).isEmpty()) {
+            throw new BusinessException(ErrorCode.BANNER_NOT_FOUND);
+        }
+        bannerRepository.deleteById(bannerId);
+    }
+
+    public List<BannerResult> findVisible() {
+        LocalDateTime now = LocalDateTime.now(clock);
+        return bannerRepository.findVisibleSorted(now).stream()
+                .map(BannerResult::from)
+                .toList();
+    }
+
+    public Page<BannerResult> adminFindAll(Pageable pageable) {
+        return bannerRepository.findAllForAdmin(pageable).map(BannerResult::from);
+    }
+
+    public BannerResult adminFindById(Long bannerId) {
+        return BannerResult.from(findOrThrow(bannerId));
+    }
+
+    private Banner findOrThrow(Long id) {
+        return bannerRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.BANNER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/sseulang/domain/banner/application/dto/BannerResult.java
+++ b/src/main/java/com/sseulang/domain/banner/application/dto/BannerResult.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.banner.application.dto;
+
+import com.sseulang.domain.banner.domain.Banner;
+
+import java.time.LocalDateTime;
+
+public record BannerResult(
+        Long id,
+        Long adminId,
+        String title,
+        String imageUrl,
+        String linkUrl,
+        int sortOrder,
+        boolean active,
+        LocalDateTime startsAt,
+        LocalDateTime endsAt,
+        LocalDateTime createdAt
+) {
+    public static BannerResult from(Banner b) {
+        return new BannerResult(
+                b.getId(), b.getAdminId(), b.getTitle(), b.getImageUrl(), b.getLinkUrl(),
+                b.getSortOrder(), b.isActive(), b.getStartsAt(), b.getEndsAt(), b.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/banner/application/dto/BannerUpsertCommand.java
+++ b/src/main/java/com/sseulang/domain/banner/application/dto/BannerUpsertCommand.java
@@ -1,0 +1,12 @@
+package com.sseulang.domain.banner.application.dto;
+
+import java.time.LocalDateTime;
+
+public record BannerUpsertCommand(
+        String title,
+        String imageUrl,
+        String linkUrl,
+        int sortOrder,
+        LocalDateTime startsAt,
+        LocalDateTime endsAt
+) {}

--- a/src/main/java/com/sseulang/domain/banner/domain/Banner.java
+++ b/src/main/java/com/sseulang/domain/banner/domain/Banner.java
@@ -1,0 +1,147 @@
+package com.sseulang.domain.banner.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Banner Aggregate Root. V1 스키마 {@code banners} 매핑.
+ *
+ * <p>배너는 {@code is_active} + 게시 윈도우 (startsAt/endsAt) 두 축으로 노출 결정.
+ * sort_order 가 작을수록 먼저 노출.</p>
+ */
+@Entity
+@Table(name = "banners")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Banner extends BaseEntity {
+
+    private static final int TITLE_MAX_LENGTH = 200;
+    private static final int URL_MAX_LENGTH = 500;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "admin_id")
+    private Long adminId;
+
+    @Column(name = "title", nullable = false, length = TITLE_MAX_LENGTH)
+    private String title;
+
+    @Column(name = "image_url", nullable = false, length = URL_MAX_LENGTH)
+    private String imageUrl;
+
+    @Column(name = "link_url", length = URL_MAX_LENGTH)
+    private String linkUrl;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    @Column(name = "starts_at")
+    private LocalDateTime startsAt;
+
+    @Column(name = "ends_at")
+    private LocalDateTime endsAt;
+
+    public static Banner create(
+            Long adminId,
+            String title,
+            String imageUrl,
+            String linkUrl,
+            int sortOrder,
+            LocalDateTime startsAt,
+            LocalDateTime endsAt
+    ) {
+        validateText(title, "title", TITLE_MAX_LENGTH);
+        validateText(imageUrl, "imageUrl", URL_MAX_LENGTH);
+        validateOptional(linkUrl, "linkUrl", URL_MAX_LENGTH);
+        validatePeriod(startsAt, endsAt);
+
+        Banner b = new Banner();
+        b.adminId = adminId;
+        b.title = title.trim();
+        b.imageUrl = imageUrl.trim();
+        b.linkUrl = linkUrl == null ? null : linkUrl.trim();
+        b.sortOrder = sortOrder;
+        b.active = true;
+        b.startsAt = startsAt;
+        b.endsAt = endsAt;
+        return b;
+    }
+
+    public void update(
+            String title,
+            String imageUrl,
+            String linkUrl,
+            int sortOrder,
+            LocalDateTime startsAt,
+            LocalDateTime endsAt
+    ) {
+        validateText(title, "title", TITLE_MAX_LENGTH);
+        validateText(imageUrl, "imageUrl", URL_MAX_LENGTH);
+        validateOptional(linkUrl, "linkUrl", URL_MAX_LENGTH);
+        validatePeriod(startsAt, endsAt);
+        this.title = title.trim();
+        this.imageUrl = imageUrl.trim();
+        this.linkUrl = linkUrl == null ? null : linkUrl.trim();
+        this.sortOrder = sortOrder;
+        this.startsAt = startsAt;
+        this.endsAt = endsAt;
+    }
+
+    public void activate() {
+        this.active = true;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+    /** 사용자 노출 — active + 게시 윈도우 안. */
+    public boolean isVisibleAt(LocalDateTime now) {
+        if (!active || now == null) {
+            return false;
+        }
+        if (startsAt != null && now.isBefore(startsAt)) {
+            return false;
+        }
+        if (endsAt != null && !now.isBefore(endsAt)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static void validateText(String value, String name, int maxLength) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " 은 필수입니다");
+        }
+        if (value.trim().length() > maxLength) {
+            throw new IllegalArgumentException(name + " 은 " + maxLength + "자 이하여야 합니다");
+        }
+    }
+
+    private static void validateOptional(String value, String name, int maxLength) {
+        if (value != null && value.length() > maxLength) {
+            throw new IllegalArgumentException(name + " 은 " + maxLength + "자 이하여야 합니다");
+        }
+    }
+
+    private static void validatePeriod(LocalDateTime startsAt, LocalDateTime endsAt) {
+        if (startsAt != null && endsAt != null && !startsAt.isBefore(endsAt)) {
+            throw new IllegalArgumentException("startsAt 은 endsAt 보다 이전이어야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/banner/domain/BannerRepository.java
+++ b/src/main/java/com/sseulang/domain/banner/domain/BannerRepository.java
@@ -1,0 +1,23 @@
+package com.sseulang.domain.banner.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface BannerRepository {
+
+    Banner save(Banner banner);
+
+    Optional<Banner> findById(Long id);
+
+    void deleteById(Long id);
+
+    /** 사용자 — 활성 + 윈도우 안 배너, sort_order ASC 정렬. */
+    List<Banner> findVisibleSorted(LocalDateTime now);
+
+    /** 관리자 — 전체 페이징. created_at DESC. */
+    Page<Banner> findAllForAdmin(Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/banner/infrastructure/persistence/BannerJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/banner/infrastructure/persistence/BannerJpaRepository.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.banner.infrastructure.persistence;
+
+import com.sseulang.domain.banner.domain.Banner;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+interface BannerJpaRepository extends JpaRepository<Banner, Long> {
+
+    @Query("""
+            SELECT b FROM Banner b
+             WHERE b.active = true
+               AND (b.startsAt IS NULL OR b.startsAt <= :now)
+               AND (b.endsAt IS NULL OR b.endsAt > :now)
+             ORDER BY b.sortOrder ASC, b.id ASC
+            """)
+    List<Banner> findVisibleSorted(@Param("now") LocalDateTime now);
+
+    Page<Banner> findAllByOrderByIdDesc(Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/banner/infrastructure/persistence/BannerRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/banner/infrastructure/persistence/BannerRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.sseulang.domain.banner.infrastructure.persistence;
+
+import com.sseulang.domain.banner.domain.Banner;
+import com.sseulang.domain.banner.domain.BannerRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class BannerRepositoryImpl implements BannerRepository {
+
+    private final BannerJpaRepository jpa;
+
+    public BannerRepositoryImpl(BannerJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Banner save(Banner banner) {
+        return jpa.save(banner);
+    }
+
+    @Override
+    public Optional<Banner> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jpa.deleteById(id);
+    }
+
+    @Override
+    public List<Banner> findVisibleSorted(LocalDateTime now) {
+        return jpa.findVisibleSorted(now);
+    }
+
+    @Override
+    public Page<Banner> findAllForAdmin(Pageable pageable) {
+        return jpa.findAllByOrderByIdDesc(pageable);
+    }
+}

--- a/src/main/java/com/sseulang/domain/banner/presentation/AdminBannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/AdminBannerController.java
@@ -1,0 +1,77 @@
+package com.sseulang.domain.banner.presentation;
+
+import com.sseulang.domain.banner.application.BannerApplicationService;
+import com.sseulang.domain.banner.presentation.dto.BannerActiveRequest;
+import com.sseulang.domain.banner.presentation.dto.BannerResponse;
+import com.sseulang.domain.banner.presentation.dto.BannerUpsertRequest;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/banners")
+public class AdminBannerController {
+
+    private final BannerApplicationService bannerService;
+
+    public AdminBannerController(BannerApplicationService bannerService) {
+        this.bannerService = bannerService;
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<BannerResponse>> list(Pageable pageable) {
+        return ApiResponse.ok(PageResponse.from(
+                bannerService.adminFindAll(pageable).map(BannerResponse::from)
+        ));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<BannerResponse> getOne(@PathVariable("id") Long id) {
+        return ApiResponse.ok(BannerResponse.from(bannerService.adminFindById(id)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> create(
+            @AuthenticationPrincipal Long adminId,
+            @Valid @RequestBody BannerUpsertRequest request
+    ) {
+        Long id = bannerService.create(adminId, request.toCommand());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(id));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<Void> update(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody BannerUpsertRequest request
+    ) {
+        bannerService.update(id, request.toCommand());
+        return ApiResponse.ok();
+    }
+
+    @PatchMapping("/{id}/active")
+    public ApiResponse<Void> setActive(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody BannerActiveRequest request
+    ) {
+        bannerService.setActive(id, request.active());
+        return ApiResponse.ok();
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(@PathVariable("id") Long id) {
+        bannerService.delete(id);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
@@ -1,0 +1,29 @@
+package com.sseulang.domain.banner.presentation;
+
+import com.sseulang.domain.banner.application.BannerApplicationService;
+import com.sseulang.domain.banner.presentation.dto.BannerResponse;
+import com.sseulang.global.common.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/** 사용자 활성 배너 목록 — sort_order 정렬. */
+@RestController
+@RequestMapping("/api/v1/banners")
+public class BannerController {
+
+    private final BannerApplicationService bannerService;
+
+    public BannerController(BannerApplicationService bannerService) {
+        this.bannerService = bannerService;
+    }
+
+    @GetMapping
+    public ApiResponse<List<BannerResponse>> list() {
+        return ApiResponse.ok(bannerService.findVisible().stream()
+                .map(BannerResponse::from)
+                .toList());
+    }
+}

--- a/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerActiveRequest.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerActiveRequest.java
@@ -1,0 +1,5 @@
+package com.sseulang.domain.banner.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record BannerActiveRequest(@NotNull Boolean active) {}

--- a/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerResponse.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerResponse.java
@@ -1,0 +1,23 @@
+package com.sseulang.domain.banner.presentation.dto;
+
+import com.sseulang.domain.banner.application.dto.BannerResult;
+
+import java.time.LocalDateTime;
+
+public record BannerResponse(
+        Long id,
+        Long adminId,
+        String title,
+        String imageUrl,
+        String linkUrl,
+        int sortOrder,
+        boolean active,
+        LocalDateTime startsAt,
+        LocalDateTime endsAt,
+        LocalDateTime createdAt
+) {
+    public static BannerResponse from(BannerResult r) {
+        return new BannerResponse(r.id(), r.adminId(), r.title(), r.imageUrl(), r.linkUrl(),
+                r.sortOrder(), r.active(), r.startsAt(), r.endsAt(), r.createdAt());
+    }
+}

--- a/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerUpsertRequest.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerUpsertRequest.java
@@ -1,0 +1,20 @@
+package com.sseulang.domain.banner.presentation.dto;
+
+import com.sseulang.domain.banner.application.dto.BannerUpsertCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record BannerUpsertRequest(
+        @NotBlank @Size(max = 200) String title,
+        @NotBlank @Size(max = 500) String imageUrl,
+        @Size(max = 500) String linkUrl,
+        int sortOrder,
+        LocalDateTime startsAt,
+        LocalDateTime endsAt
+) {
+    public BannerUpsertCommand toCommand() {
+        return new BannerUpsertCommand(title, imageUrl, linkUrl, sortOrder, startsAt, endsAt);
+    }
+}

--- a/src/main/java/com/sseulang/domain/notice/application/NoticeApplicationService.java
+++ b/src/main/java/com/sseulang/domain/notice/application/NoticeApplicationService.java
@@ -1,0 +1,107 @@
+package com.sseulang.domain.notice.application;
+
+import com.sseulang.domain.notice.application.dto.NoticeResult;
+import com.sseulang.domain.notice.application.dto.NoticeUpsertCommand;
+import com.sseulang.domain.notice.domain.Notice;
+import com.sseulang.domain.notice.domain.NoticeRepository;
+import com.sseulang.domain.notice.domain.NoticeType;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+/**
+ * 공지 흐름.
+ *
+ * <ul>
+ *   <li>관리자: CRUD + pin/publish 토글.</li>
+ *   <li>사용자: 노출 윈도우 ({@code Notice.isVisibleAt}) 조건 만족하는 공지만 조회.
+ *       단건 조회 시 view_count 증가.</li>
+ * </ul>
+ *
+ * <p>관리자 권한 검증은 SecurityConfig admin chain ({@code hasRole("ADMIN")}) 에 위임 — 본
+ * 서비스에서는 admin id 만 받아 작성자 정보로 기록.</p>
+ */
+@Service
+@Transactional(readOnly = true)
+public class NoticeApplicationService {
+
+    private final NoticeRepository noticeRepository;
+    private final Clock clock;
+
+    public NoticeApplicationService(NoticeRepository noticeRepository, Clock clock) {
+        this.noticeRepository = noticeRepository;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public Long create(Long adminId, NoticeUpsertCommand cmd) {
+        Notice n = Notice.create(
+                adminId, cmd.type(), cmd.title(), cmd.content(),
+                cmd.imageUrl(), cmd.startsAt(), cmd.endsAt()
+        );
+        return noticeRepository.save(n).getId();
+    }
+
+    @Transactional
+    public void update(Long noticeId, NoticeUpsertCommand cmd) {
+        Notice n = findOrThrow(noticeId);
+        n.update(cmd.type(), cmd.title(), cmd.content(),
+                cmd.imageUrl(), cmd.startsAt(), cmd.endsAt());
+    }
+
+    @Transactional
+    public void setPinned(Long noticeId, boolean pinned) {
+        Notice n = findOrThrow(noticeId);
+        if (pinned) n.pin(); else n.unpin();
+    }
+
+    @Transactional
+    public void setPublished(Long noticeId, boolean published) {
+        Notice n = findOrThrow(noticeId);
+        if (published) n.publish(); else n.unpublish();
+    }
+
+    @Transactional
+    public void delete(Long noticeId) {
+        if (noticeRepository.findById(noticeId).isEmpty()) {
+            throw new BusinessException(ErrorCode.NOTICE_NOT_FOUND);
+        }
+        noticeRepository.deleteById(noticeId);
+    }
+
+    /** 사용자 단건 조회 + 조회수 증가. 미공개·윈도우 외 공지는 NOT_FOUND 로 동일 응답 (존재 leak 차단). */
+    @Transactional
+    public NoticeResult viewById(Long noticeId) {
+        Notice n = findOrThrow(noticeId);
+        LocalDateTime now = LocalDateTime.now(clock);
+        if (!n.isVisibleAt(now)) {
+            throw new BusinessException(ErrorCode.NOTICE_NOT_FOUND);
+        }
+        n.incrementViewCount();
+        return NoticeResult.from(n);
+    }
+
+    public Page<NoticeResult> findVisible(NoticeType type, Pageable pageable) {
+        LocalDateTime now = LocalDateTime.now(clock);
+        return noticeRepository.findVisible(now, type, pageable).map(NoticeResult::from);
+    }
+
+    public Page<NoticeResult> adminFindAll(NoticeType type, Pageable pageable) {
+        return noticeRepository.findAllForAdmin(type, pageable).map(NoticeResult::from);
+    }
+
+    public NoticeResult adminFindById(Long noticeId) {
+        return NoticeResult.from(findOrThrow(noticeId));
+    }
+
+    private Notice findOrThrow(Long id) {
+        return noticeRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/sseulang/domain/notice/application/dto/NoticeResult.java
+++ b/src/main/java/com/sseulang/domain/notice/application/dto/NoticeResult.java
@@ -1,0 +1,42 @@
+package com.sseulang.domain.notice.application.dto;
+
+import com.sseulang.domain.notice.domain.Notice;
+import com.sseulang.domain.notice.domain.NoticeType;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공지 단건 Result — admin / user 공용. user 응답에서는 isPublished 가 항상 true 로 고정되지만
+ * 필드는 그대로 노출 (admin 화면 재사용성 + 디버깅 용이).
+ */
+public record NoticeResult(
+        Long id,
+        Long adminId,
+        NoticeType type,
+        String title,
+        String content,
+        String imageUrl,
+        boolean pinned,
+        boolean published,
+        int viewCount,
+        LocalDateTime startsAt,
+        LocalDateTime endsAt,
+        LocalDateTime createdAt
+) {
+    public static NoticeResult from(Notice n) {
+        return new NoticeResult(
+                n.getId(),
+                n.getAdminId(),
+                n.getType(),
+                n.getTitle(),
+                n.getContent(),
+                n.getImageUrl(),
+                n.isPinned(),
+                n.isPublished(),
+                n.getViewCount(),
+                n.getStartsAt(),
+                n.getEndsAt(),
+                n.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/notice/application/dto/NoticeUpsertCommand.java
+++ b/src/main/java/com/sseulang/domain/notice/application/dto/NoticeUpsertCommand.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.notice.application.dto;
+
+import com.sseulang.domain.notice.domain.NoticeType;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공지 생성·수정 Command. presentation 의 Request DTO 가 변환해 service 로 전달.
+ * 검증은 {@link com.sseulang.domain.notice.domain.Notice} 정적 팩토리 / update 가 책임.
+ */
+public record NoticeUpsertCommand(
+        NoticeType type,
+        String title,
+        String content,
+        String imageUrl,
+        LocalDateTime startsAt,
+        LocalDateTime endsAt
+) {}

--- a/src/main/java/com/sseulang/domain/notice/domain/Notice.java
+++ b/src/main/java/com/sseulang/domain/notice/domain/Notice.java
@@ -1,0 +1,186 @@
+package com.sseulang.domain.notice.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Notice Aggregate Root. V1 스키마 {@code notices} 매핑.
+ *
+ * <p>관리자가 작성하는 공지/이벤트. 게시 윈도우 ({@code startsAt}/{@code endsAt}) 와 게시 여부
+ * ({@code isPublished}) 두 축으로 사용자 노출 여부 결정.</p>
+ */
+@Entity
+@Table(name = "notices")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseEntity {
+
+    private static final int TITLE_MAX_LENGTH = 200;
+    private static final int IMAGE_URL_MAX_LENGTH = 500;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "admin_id")
+    private Long adminId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private NoticeType type;
+
+    @Column(name = "title", nullable = false, length = TITLE_MAX_LENGTH)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "image_url", length = IMAGE_URL_MAX_LENGTH)
+    private String imageUrl;
+
+    @Column(name = "is_pinned", nullable = false)
+    private boolean pinned;
+
+    @Column(name = "is_published", nullable = false)
+    private boolean published;
+
+    @Column(name = "view_count", nullable = false)
+    private int viewCount;
+
+    @Column(name = "starts_at")
+    private LocalDateTime startsAt;
+
+    @Column(name = "ends_at")
+    private LocalDateTime endsAt;
+
+    public static Notice create(
+            Long adminId,
+            NoticeType type,
+            String title,
+            String content,
+            String imageUrl,
+            LocalDateTime startsAt,
+            LocalDateTime endsAt
+    ) {
+        if (type == null) {
+            throw new IllegalArgumentException("type 은 필수입니다");
+        }
+        validateText(title, "title", TITLE_MAX_LENGTH);
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("content 는 필수입니다");
+        }
+        validateImageUrl(imageUrl);
+        validatePeriod(startsAt, endsAt);
+
+        Notice n = new Notice();
+        n.adminId = adminId;
+        n.type = type;
+        n.title = title.trim();
+        n.content = content;  // 본문은 trim 안 함 — 줄바꿈/공백 의미 보존
+        n.imageUrl = imageUrl;
+        n.startsAt = startsAt;
+        n.endsAt = endsAt;
+        n.pinned = false;
+        n.published = true;  // 기본 게시 — 작성 즉시 노출 가능
+        n.viewCount = 0;
+        return n;
+    }
+
+    public void update(
+            NoticeType type,
+            String title,
+            String content,
+            String imageUrl,
+            LocalDateTime startsAt,
+            LocalDateTime endsAt
+    ) {
+        if (type == null) {
+            throw new IllegalArgumentException("type 은 필수입니다");
+        }
+        validateText(title, "title", TITLE_MAX_LENGTH);
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("content 는 필수입니다");
+        }
+        validateImageUrl(imageUrl);
+        validatePeriod(startsAt, endsAt);
+        this.type = type;
+        this.title = title.trim();
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.startsAt = startsAt;
+        this.endsAt = endsAt;
+    }
+
+    public void pin() {
+        this.pinned = true;
+    }
+
+    public void unpin() {
+        this.pinned = false;
+    }
+
+    public void publish() {
+        this.published = true;
+    }
+
+    public void unpublish() {
+        this.published = false;
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
+
+    /**
+     * 사용자에게 노출되는지: published + 게시 윈도우 안. startsAt/endsAt null 이면 그쪽은 무제한.
+     */
+    public boolean isVisibleAt(LocalDateTime now) {
+        if (!published) {
+            return false;
+        }
+        if (now == null) {
+            return false;
+        }
+        if (startsAt != null && now.isBefore(startsAt)) {
+            return false;
+        }
+        // ends_at 은 exclusive 로 취급 — endsAt == now 이면 종료
+        if (endsAt != null && !now.isBefore(endsAt)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static void validateText(String value, String name, int maxLength) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " 은 필수입니다");
+        }
+        if (value.trim().length() > maxLength) {
+            throw new IllegalArgumentException(name + " 은 " + maxLength + "자 이하여야 합니다");
+        }
+    }
+
+    private static void validateImageUrl(String imageUrl) {
+        if (imageUrl != null && imageUrl.length() > IMAGE_URL_MAX_LENGTH) {
+            throw new IllegalArgumentException("imageUrl 은 " + IMAGE_URL_MAX_LENGTH + "자 이하여야 합니다");
+        }
+    }
+
+    private static void validatePeriod(LocalDateTime startsAt, LocalDateTime endsAt) {
+        if (startsAt != null && endsAt != null && !startsAt.isBefore(endsAt)) {
+            throw new IllegalArgumentException("startsAt 은 endsAt 보다 이전이어야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/notice/domain/NoticeRepository.java
+++ b/src/main/java/com/sseulang/domain/notice/domain/NoticeRepository.java
@@ -1,0 +1,29 @@
+package com.sseulang.domain.notice.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * Notice Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
+ * 구현은 {@code domain/notice/infrastructure/persistence}.
+ */
+public interface NoticeRepository {
+
+    Notice save(Notice notice);
+
+    Optional<Notice> findById(Long id);
+
+    void deleteById(Long id);
+
+    /**
+     * 사용자 노출 — published + 게시 윈도우 안 (startsAt 도달 + endsAt 미도달).
+     * is_pinned DESC, created_at DESC 정렬.
+     */
+    Page<Notice> findVisible(LocalDateTime now, NoticeType type, Pageable pageable);
+
+    /** 관리자 — 전체 또는 type 별 페이징 (created_at DESC). */
+    Page<Notice> findAllForAdmin(NoticeType type, Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/notice/domain/NoticeType.java
+++ b/src/main/java/com/sseulang/domain/notice/domain/NoticeType.java
@@ -1,0 +1,10 @@
+package com.sseulang.domain.notice.domain;
+
+/**
+ * V1 schema notices.type ENUM 매핑. 한글 enum 이름은 DB ENUM 값과 동일해야 한다 (Hibernate
+ * EnumType.STRING 으로 그대로 매핑).
+ */
+public enum NoticeType {
+    공지,
+    이벤트
+}

--- a/src/main/java/com/sseulang/domain/notice/infrastructure/persistence/NoticeJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/notice/infrastructure/persistence/NoticeJpaRepository.java
@@ -1,0 +1,40 @@
+package com.sseulang.domain.notice.infrastructure.persistence;
+
+import com.sseulang.domain.notice.domain.Notice;
+import com.sseulang.domain.notice.domain.NoticeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+
+/** Spring Data JPA — {@link NoticeRepositoryImpl} 가 wrapping. 외부 직접 import 금지. */
+interface NoticeJpaRepository extends JpaRepository<Notice, Long> {
+
+    /**
+     * 사용자 노출 쿼리. type null 이면 전체 type. 윈도우는 startsAt/endsAt 두 축으로 판정 —
+     * NULL 이면 그쪽 무제한. 정렬은 pinned 우선, 그다음 최신.
+     */
+    @Query("""
+            SELECT n FROM Notice n
+             WHERE n.published = true
+               AND (:type IS NULL OR n.type = :type)
+               AND (n.startsAt IS NULL OR n.startsAt <= :now)
+               AND (n.endsAt IS NULL OR n.endsAt > :now)
+             ORDER BY n.pinned DESC, n.id DESC
+            """)
+    Page<Notice> findVisible(
+            @Param("now") LocalDateTime now,
+            @Param("type") NoticeType type,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT n FROM Notice n
+             WHERE (:type IS NULL OR n.type = :type)
+             ORDER BY n.id DESC
+            """)
+    Page<Notice> findAllForAdmin(@Param("type") NoticeType type, Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/notice/infrastructure/persistence/NoticeRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/notice/infrastructure/persistence/NoticeRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.sseulang.domain.notice.infrastructure.persistence;
+
+import com.sseulang.domain.notice.domain.Notice;
+import com.sseulang.domain.notice.domain.NoticeRepository;
+import com.sseulang.domain.notice.domain.NoticeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public class NoticeRepositoryImpl implements NoticeRepository {
+
+    private final NoticeJpaRepository jpa;
+
+    public NoticeRepositoryImpl(NoticeJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Notice save(Notice notice) {
+        return jpa.save(notice);
+    }
+
+    @Override
+    public Optional<Notice> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jpa.deleteById(id);
+    }
+
+    @Override
+    public Page<Notice> findVisible(LocalDateTime now, NoticeType type, Pageable pageable) {
+        return jpa.findVisible(now, type, pageable);
+    }
+
+    @Override
+    public Page<Notice> findAllForAdmin(NoticeType type, Pageable pageable) {
+        return jpa.findAllForAdmin(type, pageable);
+    }
+}

--- a/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
@@ -1,0 +1,94 @@
+package com.sseulang.domain.notice.presentation;
+
+import com.sseulang.domain.notice.application.NoticeApplicationService;
+import com.sseulang.domain.notice.domain.NoticeType;
+import com.sseulang.domain.notice.presentation.dto.NoticeResponse;
+import com.sseulang.domain.notice.presentation.dto.NoticeToggleRequest;
+import com.sseulang.domain.notice.presentation.dto.NoticeUpsertRequest;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 공지 CRUD + 상태 토글. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
+ */
+@RestController
+@RequestMapping("/api/v1/admin/notices")
+public class AdminNoticeController {
+
+    private final NoticeApplicationService noticeService;
+
+    public AdminNoticeController(NoticeApplicationService noticeService) {
+        this.noticeService = noticeService;
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<NoticeResponse>> list(
+            @RequestParam(value = "type", required = false) NoticeType type,
+            Pageable pageable
+    ) {
+        return ApiResponse.ok(PageResponse.from(
+                noticeService.adminFindAll(type, pageable).map(NoticeResponse::from)
+        ));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<NoticeResponse> getOne(@PathVariable("id") Long id) {
+        return ApiResponse.ok(NoticeResponse.from(noticeService.adminFindById(id)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> create(
+            @AuthenticationPrincipal Long adminId,
+            @Valid @RequestBody NoticeUpsertRequest request
+    ) {
+        Long id = noticeService.create(adminId, request.toCommand());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(id));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<Void> update(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody NoticeUpsertRequest request
+    ) {
+        noticeService.update(id, request.toCommand());
+        return ApiResponse.ok();
+    }
+
+    @PatchMapping("/{id}/pin")
+    public ApiResponse<Void> setPinned(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody NoticeToggleRequest request
+    ) {
+        noticeService.setPinned(id, request.value());
+        return ApiResponse.ok();
+    }
+
+    @PatchMapping("/{id}/publish")
+    public ApiResponse<Void> setPublished(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody NoticeToggleRequest request
+    ) {
+        noticeService.setPublished(id, request.value());
+        return ApiResponse.ok();
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(@PathVariable("id") Long id) {
+        noticeService.delete(id);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
@@ -1,0 +1,43 @@
+package com.sseulang.domain.notice.presentation;
+
+import com.sseulang.domain.notice.application.NoticeApplicationService;
+import com.sseulang.domain.notice.domain.NoticeType;
+import com.sseulang.domain.notice.presentation.dto.NoticeResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 사용자 공지 조회 — 노출 윈도우 통과한 공지만. SecurityConfig user chain 으로 ROLE_USER 강제.
+ */
+@RestController
+@RequestMapping("/api/v1/notices")
+public class NoticeController {
+
+    private final NoticeApplicationService noticeService;
+
+    public NoticeController(NoticeApplicationService noticeService) {
+        this.noticeService = noticeService;
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<NoticeResponse>> list(
+            @RequestParam(value = "type", required = false) NoticeType type,
+            Pageable pageable
+    ) {
+        return ApiResponse.ok(PageResponse.from(
+                noticeService.findVisible(type, pageable).map(NoticeResponse::from)
+        ));
+    }
+
+    /** 단건 조회 시 view_count++. 미공개·윈도우 외 공지는 NOT_FOUND. */
+    @GetMapping("/{id}")
+    public ApiResponse<NoticeResponse> getOne(@PathVariable("id") Long id) {
+        return ApiResponse.ok(NoticeResponse.from(noticeService.viewById(id)));
+    }
+}

--- a/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeResponse.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeResponse.java
@@ -1,0 +1,28 @@
+package com.sseulang.domain.notice.presentation.dto;
+
+import com.sseulang.domain.notice.application.dto.NoticeResult;
+import com.sseulang.domain.notice.domain.NoticeType;
+
+import java.time.LocalDateTime;
+
+public record NoticeResponse(
+        Long id,
+        Long adminId,
+        NoticeType type,
+        String title,
+        String content,
+        String imageUrl,
+        boolean pinned,
+        boolean published,
+        int viewCount,
+        LocalDateTime startsAt,
+        LocalDateTime endsAt,
+        LocalDateTime createdAt
+) {
+    public static NoticeResponse from(NoticeResult r) {
+        return new NoticeResponse(
+                r.id(), r.adminId(), r.type(), r.title(), r.content(), r.imageUrl(),
+                r.pinned(), r.published(), r.viewCount(), r.startsAt(), r.endsAt(), r.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeToggleRequest.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeToggleRequest.java
@@ -1,0 +1,6 @@
+package com.sseulang.domain.notice.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/** pin / publish 토글 공용 — 단순 boolean payload. */
+public record NoticeToggleRequest(@NotNull Boolean value) {}

--- a/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeUpsertRequest.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeUpsertRequest.java
@@ -1,0 +1,22 @@
+package com.sseulang.domain.notice.presentation.dto;
+
+import com.sseulang.domain.notice.application.dto.NoticeUpsertCommand;
+import com.sseulang.domain.notice.domain.NoticeType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record NoticeUpsertRequest(
+        @NotNull NoticeType type,
+        @NotBlank @Size(max = 200) String title,
+        @NotBlank String content,
+        @Size(max = 500) String imageUrl,
+        LocalDateTime startsAt,
+        LocalDateTime endsAt
+) {
+    public NoticeUpsertCommand toCommand() {
+        return new NoticeUpsertCommand(type, title, content, imageUrl, startsAt, endsAt);
+    }
+}

--- a/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
+++ b/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
@@ -1,18 +1,28 @@
 package com.sseulang.domain.report.application;
 
+import com.sseulang.domain.report.domain.ReportStatus;
 import com.sseulang.domain.report.domain.UserReport;
 import com.sseulang.domain.report.domain.UserReportRepository;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
 
 @Service
 @Transactional(readOnly = true)
 public class UserReportApplicationService {
 
     private final UserReportRepository repository;
+    private final Clock clock;
 
-    public UserReportApplicationService(UserReportRepository repository) {
+    public UserReportApplicationService(UserReportRepository repository, Clock clock) {
         this.repository = repository;
+        this.clock = clock;
     }
 
     /** 사용자 신고. 자기 신고 거부는 도메인 invariant 에서. */
@@ -25,5 +35,38 @@ public class UserReportApplicationService {
     @Transactional
     public Long reportItem(Long reporterId, Long itemId, String reason, String detail) {
         return repository.save(UserReport.reportItem(reporterId, itemId, reason, detail)).getId();
+    }
+
+    // ───────── 관리자 처리 흐름 ─────────
+
+    @Transactional
+    public void adminMarkInProgress(Long reportId, Long adminId, String memo) {
+        UserReport r = findOrThrow(reportId);
+        r.markInProgress(adminId, memo, LocalDateTime.now(clock));
+    }
+
+    @Transactional
+    public void adminComplete(Long reportId, Long adminId, String memo) {
+        UserReport r = findOrThrow(reportId);
+        r.complete(adminId, memo, LocalDateTime.now(clock));
+    }
+
+    @Transactional
+    public void adminReject(Long reportId, Long adminId, String memo) {
+        UserReport r = findOrThrow(reportId);
+        r.reject(adminId, memo, LocalDateTime.now(clock));
+    }
+
+    public Page<UserReport> adminFindByStatus(ReportStatus status, Pageable pageable) {
+        return repository.findByStatus(status, pageable);
+    }
+
+    public UserReport adminFindById(Long reportId) {
+        return findOrThrow(reportId);
+    }
+
+    private UserReport findOrThrow(Long reportId) {
+        return repository.findById(reportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REPORT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/sseulang/domain/report/domain/UserReport.java
+++ b/src/main/java/com/sseulang/domain/report/domain/UserReport.java
@@ -1,6 +1,8 @@
 package com.sseulang.domain.report.domain;
 
 import com.sseulang.global.common.BaseEntity;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -97,5 +99,53 @@ public class UserReport extends BaseEntity {
         r.detail = detail;
         r.status = ReportStatus.접수;
         return r;
+    }
+
+    /**
+     * 관리자 처리 시작. 접수 → 처리중. processedAt 은 처리 시작 시점에 기록 (terminal 일 때
+     * 다시 갱신 가능).
+     */
+    public void markInProgress(Long adminId, String memo, LocalDateTime now) {
+        validateAdminAndNow(adminId, now);
+        if (status != ReportStatus.접수) {
+            throw new BusinessException(ErrorCode.REPORT_INVALID_STATE);
+        }
+        this.status = ReportStatus.처리중;
+        this.adminId = adminId;
+        this.adminMemo = memo;
+        this.processedAt = now;
+    }
+
+    /** 처리 완료 — 처리중 단계에서만 가능. */
+    public void complete(Long adminId, String memo, LocalDateTime now) {
+        validateAdminAndNow(adminId, now);
+        if (status != ReportStatus.처리중) {
+            throw new BusinessException(ErrorCode.REPORT_INVALID_STATE);
+        }
+        this.status = ReportStatus.처리완료;
+        this.adminId = adminId;
+        this.adminMemo = memo;
+        this.processedAt = now;
+    }
+
+    /** 반려 — 접수 또는 처리중에서만 가능 (terminal 상태 전이는 거부). */
+    public void reject(Long adminId, String memo, LocalDateTime now) {
+        validateAdminAndNow(adminId, now);
+        if (status.isTerminal()) {
+            throw new BusinessException(ErrorCode.REPORT_INVALID_STATE);
+        }
+        this.status = ReportStatus.반려;
+        this.adminId = adminId;
+        this.adminMemo = memo;
+        this.processedAt = now;
+    }
+
+    private static void validateAdminAndNow(Long adminId, LocalDateTime now) {
+        if (adminId == null || adminId <= 0) {
+            throw new IllegalArgumentException("adminId 는 양수여야 합니다");
+        }
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
     }
 }

--- a/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
+++ b/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
@@ -1,6 +1,16 @@
 package com.sseulang.domain.report.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
 public interface UserReportRepository {
 
     UserReport save(UserReport report);
+
+    Optional<UserReport> findById(Long id);
+
+    /** 관리자 — 상태별 페이징 (status null 이면 전체). created_at DESC. */
+    Page<UserReport> findByStatus(ReportStatus status, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
@@ -1,7 +1,19 @@
 package com.sseulang.domain.report.infrastructure.persistence;
 
+import com.sseulang.domain.report.domain.ReportStatus;
 import com.sseulang.domain.report.domain.UserReport;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface UserReportJpaRepository extends JpaRepository<UserReport, Long> {
+
+    @Query("""
+            SELECT r FROM UserReport r
+             WHERE (:status IS NULL OR r.status = :status)
+             ORDER BY r.id DESC
+            """)
+    Page<UserReport> findByStatusFilter(@Param("status") ReportStatus status, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
@@ -1,8 +1,13 @@
 package com.sseulang.domain.report.infrastructure.persistence;
 
+import com.sseulang.domain.report.domain.ReportStatus;
 import com.sseulang.domain.report.domain.UserReport;
 import com.sseulang.domain.report.domain.UserReportRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public class UserReportRepositoryImpl implements UserReportRepository {
@@ -16,5 +21,15 @@ public class UserReportRepositoryImpl implements UserReportRepository {
     @Override
     public UserReport save(UserReport report) {
         return jpa.save(report);
+    }
+
+    @Override
+    public Optional<UserReport> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Page<UserReport> findByStatus(ReportStatus status, Pageable pageable) {
+        return jpa.findByStatusFilter(status, pageable);
     }
 }

--- a/src/main/java/com/sseulang/domain/report/presentation/AdminReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/AdminReportController.java
@@ -1,0 +1,58 @@
+package com.sseulang.domain.report.presentation;
+
+import com.sseulang.domain.report.application.UserReportApplicationService;
+import com.sseulang.domain.report.domain.ReportStatus;
+import com.sseulang.domain.report.presentation.dto.AdminReportDecisionRequest;
+import com.sseulang.domain.report.presentation.dto.AdminReportResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/reports")
+public class AdminReportController {
+
+    private final UserReportApplicationService reportService;
+
+    public AdminReportController(UserReportApplicationService reportService) {
+        this.reportService = reportService;
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<AdminReportResponse>> list(
+            @RequestParam(value = "status", required = false) ReportStatus status,
+            Pageable pageable
+    ) {
+        return ApiResponse.ok(PageResponse.from(
+                reportService.adminFindByStatus(status, pageable).map(AdminReportResponse::from)
+        ));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<AdminReportResponse> getOne(@PathVariable("id") Long id) {
+        return ApiResponse.ok(AdminReportResponse.from(reportService.adminFindById(id)));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<Void> decide(
+            @AuthenticationPrincipal Long adminId,
+            @PathVariable("id") Long id,
+            @Valid @RequestBody AdminReportDecisionRequest request
+    ) {
+        switch (request.action()) {
+            case MARK_IN_PROGRESS -> reportService.adminMarkInProgress(id, adminId, request.memo());
+            case COMPLETE -> reportService.adminComplete(id, adminId, request.memo());
+            case REJECT -> reportService.adminReject(id, adminId, request.memo());
+        }
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/report/presentation/dto/AdminReportDecisionRequest.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/dto/AdminReportDecisionRequest.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.report.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record AdminReportDecisionRequest(
+        @NotNull Action action,
+        @Size(max = 500) String memo
+) {
+    public enum Action { MARK_IN_PROGRESS, COMPLETE, REJECT }
+}

--- a/src/main/java/com/sseulang/domain/report/presentation/dto/AdminReportResponse.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/dto/AdminReportResponse.java
@@ -1,0 +1,28 @@
+package com.sseulang.domain.report.presentation.dto;
+
+import com.sseulang.domain.report.domain.ReportStatus;
+import com.sseulang.domain.report.domain.UserReport;
+
+import java.time.LocalDateTime;
+
+public record AdminReportResponse(
+        Long id,
+        Long reporterId,
+        Long reportedId,
+        Long itemId,
+        String reason,
+        String detail,
+        ReportStatus status,
+        Long adminId,
+        String adminMemo,
+        LocalDateTime processedAt,
+        LocalDateTime createdAt
+) {
+    public static AdminReportResponse from(UserReport r) {
+        return new AdminReportResponse(
+                r.getId(), r.getReporterId(), r.getReportedId(), r.getItemId(),
+                r.getReason(), r.getDetail(), r.getStatus(),
+                r.getAdminId(), r.getAdminMemo(), r.getProcessedAt(), r.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -7,6 +7,8 @@ import com.sseulang.domain.user.domain.UserRepository;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -99,6 +101,23 @@ public class UserApplicationService {
             throw new BusinessException(ErrorCode.USER_NOT_FOUND);
         }
         return balance;
+    }
+
+    /**
+     * 관리자 회원 목록 — created_at DESC 페이징. 차단/삭제 상태 모두 포함.
+     */
+    public Page<User> adminFindAll(Pageable pageable) {
+        return userRepository.findAllForAdmin(pageable);
+    }
+
+    /**
+     * 관리자 차단/해제 — Aggregate {@code block()/unblock()} 위임. 미존재 userId → USER_NOT_FOUND.
+     * 멱등 (이미 차단된 사용자를 또 차단해도 OK).
+     */
+    @Transactional
+    public void adminSetBlocked(Long userId, boolean blocked) {
+        User u = getById(userId);
+        if (blocked) u.block(); else u.unblock();
     }
 
     private User create(SocialProvider provider, String providerId, Email email, String nickname, String profileImage) {

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -118,4 +118,14 @@ public class User extends BaseEntity {
     public Email email() {
         return new Email(email);
     }
+
+    /** 관리자 차단 — 이미 차단/삭제된 계정도 멱등 호출 가능 (true 보장). */
+    public void block() {
+        this.blocked = true;
+    }
+
+    /** 관리자 차단 해제 — 멱등 호출. */
+    public void unblock() {
+        this.blocked = false;
+    }
 }

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -1,5 +1,8 @@
 package com.sseulang.domain.user.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Optional;
 
 /**
@@ -15,6 +18,9 @@ public interface UserRepository {
     Optional<User> findByEmail(Email email);
 
     User save(User user);
+
+    /** 관리자 회원 목록 페이징. 차단/삭제 상태 필터는 후속, 일단 전체 노출. created_at DESC. */
+    Page<User> findAllForAdmin(Pageable pageable);
 
     /**
      * 가이드 §4.7 — 리뷰 작성 시점에 review_count / rating_sum 을 단일 원자 UPDATE 로 누적하고

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -2,6 +2,8 @@ package com.sseulang.domain.user.infrastructure.persistence;
 
 import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -55,4 +57,6 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
      */
     @Query("SELECT u.pointBalance FROM User u WHERE u.id = :userId")
     Long findPointBalanceById(@Param("userId") Long userId);
+
+    Page<User> findAllByOrderByIdDesc(Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.sseulang.domain.user.domain.Email;
 import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.domain.user.domain.User;
 import com.sseulang.domain.user.domain.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -35,6 +37,11 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public User save(User user) {
         return jpa.save(user);
+    }
+
+    @Override
+    public Page<User> findAllForAdmin(Pageable pageable) {
+        return jpa.findAllByOrderByIdDesc(pageable);
     }
 
     @Override

--- a/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
@@ -1,0 +1,50 @@
+package com.sseulang.domain.user.presentation;
+
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.presentation.dto.AdminUserResponse;
+import com.sseulang.domain.user.presentation.dto.UserBlockRequest;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 회원 관리. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
+ */
+@RestController
+@RequestMapping("/api/v1/admin/users")
+public class AdminUserController {
+
+    private final UserApplicationService userService;
+
+    public AdminUserController(UserApplicationService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<AdminUserResponse>> list(Pageable pageable) {
+        return ApiResponse.ok(PageResponse.from(
+                userService.adminFindAll(pageable).map(AdminUserResponse::from)
+        ));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<AdminUserResponse> getOne(@PathVariable("id") Long id) {
+        return ApiResponse.ok(AdminUserResponse.from(userService.getById(id)));
+    }
+
+    @PatchMapping("/{id}/block")
+    public ApiResponse<Void> setBlocked(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody UserBlockRequest request
+    ) {
+        userService.adminSetBlocked(id, request.blocked());
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
@@ -1,0 +1,38 @@
+package com.sseulang.domain.user.presentation.dto;
+
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/** 관리자용 회원 단건 응답 — 비밀번호/소셜 토큰 등 민감 정보는 제외. */
+public record AdminUserResponse(
+        Long id,
+        String email,
+        String nickname,
+        String profileImage,
+        SocialProvider socialProvider,
+        boolean blocked,
+        boolean deleted,
+        BigDecimal trustScore,
+        int reviewCount,
+        long pointBalance,
+        LocalDateTime createdAt
+) {
+    public static AdminUserResponse from(User u) {
+        return new AdminUserResponse(
+                u.getId(),
+                u.getEmail(),
+                u.getNickname(),
+                u.getProfileImage(),
+                u.getSocialProvider(),
+                u.isBlocked(),
+                u.isDeleted(),
+                u.getTrustScore(),
+                u.getReviewCount(),
+                u.getPointBalance(),
+                u.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/UserBlockRequest.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/UserBlockRequest.java
@@ -1,0 +1,5 @@
+package com.sseulang.domain.user.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserBlockRequest(@NotNull Boolean blocked) {}

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -65,6 +65,14 @@ public enum ErrorCode {
     REVIEW_DUPLICATED(HttpStatus.CONFLICT, "이미 작성한 리뷰입니다."),
     REVIEW_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "리뷰 작성 기간이 지났습니다."),
 
+    // 공지 / 배너
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "공지를 찾을 수 없습니다."),
+    BANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "배너를 찾을 수 없습니다."),
+
+    // 신고
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "신고를 찾을 수 없습니다."),
+    REPORT_INVALID_STATE(HttpStatus.BAD_REQUEST, "현재 상태에서 수행할 수 없는 동작입니다."),
+
     // 파일
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     FILE_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "파일 검증에 실패했습니다.");

--- a/src/test/java/com/sseulang/domain/banner/application/BannerApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/banner/application/BannerApplicationServiceTest.java
@@ -1,0 +1,89 @@
+package com.sseulang.domain.banner.application;
+
+import com.sseulang.domain.banner.application.dto.BannerResult;
+import com.sseulang.domain.banner.application.dto.BannerUpsertCommand;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BannerApplicationServiceTest {
+
+    private static final Long ADMIN = 7L;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 30, 12, 0);
+
+    private InMemoryFakeBannerRepository repo;
+    private BannerApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        repo = new InMemoryFakeBannerRepository();
+        Clock clock = Clock.fixed(NOW.atZone(KST).toInstant(), KST);
+        service = new BannerApplicationService(repo, clock);
+    }
+
+    private BannerUpsertCommand cmd(int sortOrder) {
+        return new BannerUpsertCommand("배너 " + sortOrder, "https://i/" + sortOrder, null, sortOrder, null, null);
+    }
+
+    @Test
+    @DisplayName("create 정상_active=true 기본")
+    void create_정상() {
+        Long id = service.create(ADMIN, cmd(1));
+        assertThat(service.adminFindById(id).active()).isTrue();
+    }
+
+    @Test
+    @DisplayName("setActive 토글")
+    void setActive_토글() {
+        Long id = service.create(ADMIN, cmd(1));
+        service.setActive(id, false);
+        assertThat(service.adminFindById(id).active()).isFalse();
+    }
+
+    @Test
+    @DisplayName("delete 미존재_BANNER_NOT_FOUND")
+    void delete_미존재_404() {
+        assertThatThrownBy(() -> service.delete(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.BANNER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("findVisible_active 만 + sortOrder 정렬")
+    void findVisible_정렬() {
+        Long b1 = service.create(ADMIN, cmd(2));
+        Long b2 = service.create(ADMIN, cmd(0));
+        Long b3 = service.create(ADMIN, cmd(1));
+        Long inactive = service.create(ADMIN, cmd(99));
+        service.setActive(inactive, false);
+
+        List<BannerResult> visible = service.findVisible();
+
+        assertThat(visible).extracting(BannerResult::id)
+                .as("sortOrder ASC, inactive 제외")
+                .containsExactly(b2, b3, b1);
+    }
+
+    @Test
+    @DisplayName("findVisible_window 외 제외")
+    void findVisible_window_외() {
+        Long future = service.create(ADMIN, new BannerUpsertCommand(
+                "future", "https://i", null, 0, NOW.plusDays(1), NOW.plusDays(7)
+        ));
+        Long current = service.create(ADMIN, cmd(1));
+
+        List<BannerResult> visible = service.findVisible();
+        assertThat(visible).extracting(BannerResult::id).containsExactly(current);
+    }
+}

--- a/src/test/java/com/sseulang/domain/banner/application/InMemoryFakeBannerRepository.java
+++ b/src/test/java/com/sseulang/domain/banner/application/InMemoryFakeBannerRepository.java
@@ -1,0 +1,61 @@
+package com.sseulang.domain.banner.application;
+
+import com.sseulang.domain.banner.domain.Banner;
+import com.sseulang.domain.banner.domain.BannerRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+class InMemoryFakeBannerRepository implements BannerRepository {
+
+    private final Map<Long, Banner> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public Banner save(Banner banner) {
+        if (banner.getId() == null) {
+            ReflectionTestUtils.setField(banner, "id", ++sequence);
+        }
+        store.put(banner.getId(), banner);
+        return banner;
+    }
+
+    @Override
+    public Optional<Banner> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        store.remove(id);
+    }
+
+    @Override
+    public List<Banner> findVisibleSorted(LocalDateTime now) {
+        return store.values().stream()
+                .filter(b -> b.isVisibleAt(now))
+                .sorted(Comparator.comparingInt(Banner::getSortOrder)
+                        .thenComparing(Banner::getId))
+                .toList();
+    }
+
+    @Override
+    public Page<Banner> findAllForAdmin(Pageable pageable) {
+        List<Banner> all = store.values().stream()
+                .sorted(Comparator.comparing(Banner::getId).reversed())
+                .toList();
+        return new PageImpl<>(all, pageable, all.size());
+    }
+
+    int size() {
+        return store.size();
+    }
+}

--- a/src/test/java/com/sseulang/domain/banner/domain/BannerTest.java
+++ b/src/test/java/com/sseulang/domain/banner/domain/BannerTest.java
@@ -1,0 +1,78 @@
+package com.sseulang.domain.banner.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BannerTest {
+
+    private static final Long ADMIN = 7L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 30, 12, 0);
+
+    private Banner newBanner() {
+        return Banner.create(ADMIN, "여름 세일", "https://i/u.png", "https://link", 0, null, null);
+    }
+
+    @Test
+    @DisplayName("create 정상_active=true / sortOrder 보존")
+    void create_정상() {
+        Banner b = Banner.create(ADMIN, "B", "https://i", null, 5, null, null);
+        assertThat(b.isActive()).isTrue();
+        assertThat(b.getSortOrder()).isEqualTo(5);
+        assertThat(b.getLinkUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("create_invalid 인자 거부")
+    void create_invalid() {
+        assertThatThrownBy(() -> Banner.create(ADMIN, "", "https://i", null, 0, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Banner.create(ADMIN, "t", " ", null, 0, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Banner.create(ADMIN, "t", "https://i", null, 0, NOW, NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("activate/deactivate 토글")
+    void state_토글() {
+        Banner b = newBanner();
+        b.deactivate();
+        assertThat(b.isActive()).isFalse();
+        b.activate();
+        assertThat(b.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("isVisibleAt_inactive 면 false")
+    void isVisibleAt_inactive() {
+        Banner b = newBanner();
+        b.deactivate();
+        assertThat(b.isVisibleAt(NOW)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isVisibleAt_window 검증")
+    void isVisibleAt_window() {
+        Banner b = Banner.create(ADMIN, "t", "https://i", null, 0, NOW, NOW.plusDays(7));
+
+        assertThat(b.isVisibleAt(NOW.minusMinutes(1))).isFalse();
+        assertThat(b.isVisibleAt(NOW)).isTrue();
+        assertThat(b.isVisibleAt(NOW.plusDays(7))).isFalse();
+    }
+
+    @Test
+    @DisplayName("update 필드 변경")
+    void update_정상() {
+        Banner b = newBanner();
+        b.update("새 제목", "https://new", "https://newlink", 9, NOW, NOW.plusDays(3));
+
+        assertThat(b.getTitle()).isEqualTo("새 제목");
+        assertThat(b.getSortOrder()).isEqualTo(9);
+        assertThat(b.getLinkUrl()).isEqualTo("https://newlink");
+    }
+}

--- a/src/test/java/com/sseulang/domain/notice/application/InMemoryFakeNoticeRepository.java
+++ b/src/test/java/com/sseulang/domain/notice/application/InMemoryFakeNoticeRepository.java
@@ -1,0 +1,66 @@
+package com.sseulang.domain.notice.application;
+
+import com.sseulang.domain.notice.domain.Notice;
+import com.sseulang.domain.notice.domain.NoticeRepository;
+import com.sseulang.domain.notice.domain.NoticeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+class InMemoryFakeNoticeRepository implements NoticeRepository {
+
+    private final Map<Long, Notice> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public Notice save(Notice notice) {
+        if (notice.getId() == null) {
+            ReflectionTestUtils.setField(notice, "id", ++sequence);
+        }
+        store.put(notice.getId(), notice);
+        return notice;
+    }
+
+    @Override
+    public Optional<Notice> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        store.remove(id);
+    }
+
+    @Override
+    public Page<Notice> findVisible(LocalDateTime now, NoticeType type, Pageable pageable) {
+        List<Notice> filtered = store.values().stream()
+                .filter(n -> n.isVisibleAt(now))
+                .filter(n -> type == null || n.getType() == type)
+                .sorted(Comparator
+                        .comparing(Notice::isPinned).reversed()
+                        .thenComparing(Comparator.comparing(Notice::getId).reversed()))
+                .toList();
+        return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+
+    @Override
+    public Page<Notice> findAllForAdmin(NoticeType type, Pageable pageable) {
+        List<Notice> filtered = store.values().stream()
+                .filter(n -> type == null || n.getType() == type)
+                .sorted(Comparator.comparing(Notice::getId).reversed())
+                .toList();
+        return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+
+    int size() {
+        return store.size();
+    }
+}

--- a/src/test/java/com/sseulang/domain/notice/application/NoticeApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/notice/application/NoticeApplicationServiceTest.java
@@ -1,0 +1,161 @@
+package com.sseulang.domain.notice.application;
+
+import com.sseulang.domain.notice.application.dto.NoticeResult;
+import com.sseulang.domain.notice.application.dto.NoticeUpsertCommand;
+import com.sseulang.domain.notice.domain.NoticeType;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NoticeApplicationServiceTest {
+
+    private static final Long ADMIN = 7L;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 30, 12, 0);
+
+    private InMemoryFakeNoticeRepository repo;
+    private NoticeApplicationService service;
+    private Clock clock;
+
+    @BeforeEach
+    void setUp() {
+        repo = new InMemoryFakeNoticeRepository();
+        clock = Clock.fixed(NOW.atZone(KST).toInstant(), KST);
+        service = new NoticeApplicationService(repo, clock);
+    }
+
+    private NoticeUpsertCommand cmd(NoticeType type) {
+        return new NoticeUpsertCommand(type, "제목", "본문", null, null, null);
+    }
+
+    @Test
+    @DisplayName("create 정상_id 반환 + 저장")
+    void create_정상() {
+        Long id = service.create(ADMIN, cmd(NoticeType.공지));
+
+        assertThat(id).isNotNull();
+        assertThat(repo.size()).isEqualTo(1);
+        NoticeResult r = service.adminFindById(id);
+        assertThat(r.adminId()).isEqualTo(ADMIN);
+        assertThat(r.type()).isEqualTo(NoticeType.공지);
+    }
+
+    @Test
+    @DisplayName("update 미존재_NOTICE_NOT_FOUND")
+    void update_미존재_404() {
+        assertThatThrownBy(() -> service.update(999L, cmd(NoticeType.공지)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NOTICE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("setPinned/setPublished 토글")
+    void state_토글() {
+        Long id = service.create(ADMIN, cmd(NoticeType.공지));
+
+        service.setPinned(id, true);
+        assertThat(service.adminFindById(id).pinned()).isTrue();
+
+        service.setPublished(id, false);
+        assertThat(service.adminFindById(id).published()).isFalse();
+    }
+
+    @Test
+    @DisplayName("delete 정상_저장소에서 사라짐")
+    void delete_정상() {
+        Long id = service.create(ADMIN, cmd(NoticeType.공지));
+        service.delete(id);
+        assertThat(repo.size()).isZero();
+    }
+
+    @Test
+    @DisplayName("delete 미존재_NOTICE_NOT_FOUND")
+    void delete_미존재_404() {
+        assertThatThrownBy(() -> service.delete(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NOTICE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("viewById 정상_view_count 1 증가 + Result 반환")
+    void viewById_view_증가() {
+        Long id = service.create(ADMIN, cmd(NoticeType.공지));
+        service.viewById(id);
+        service.viewById(id);
+
+        assertThat(service.adminFindById(id).viewCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("viewById 미공개_NOTICE_NOT_FOUND (존재 leak X)")
+    void viewById_미공개_404() {
+        Long id = service.create(ADMIN, cmd(NoticeType.공지));
+        service.setPublished(id, false);
+
+        assertThatThrownBy(() -> service.viewById(id))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NOTICE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("viewById 윈도우 외_NOTICE_NOT_FOUND")
+    void viewById_윈도우외_404() {
+        // 시작이 미래 — 아직 노출되면 안 됨
+        Long id = service.create(ADMIN, new NoticeUpsertCommand(
+                NoticeType.이벤트, "t", "c", null, NOW.plusDays(1), NOW.plusDays(7)
+        ));
+        assertThatThrownBy(() -> service.viewById(id))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NOTICE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("findVisible_pinned 우선 정렬 + 미공개/윈도우 외 제외")
+    void findVisible_정렬() {
+        Long pinnedId = service.create(ADMIN, cmd(NoticeType.공지));
+        service.setPinned(pinnedId, true);
+        Long normalId = service.create(ADMIN, cmd(NoticeType.공지));
+
+        Long hiddenId = service.create(ADMIN, cmd(NoticeType.공지));
+        service.setPublished(hiddenId, false);
+
+        Page<NoticeResult> page = service.findVisible(null, PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).extracting(NoticeResult::id)
+                .as("pinned 가 먼저, hidden 은 누락")
+                .containsExactly(pinnedId, normalId);
+    }
+
+    @Test
+    @DisplayName("findVisible_type 필터")
+    void findVisible_type_필터() {
+        Long noticeId = service.create(ADMIN, cmd(NoticeType.공지));
+        Long eventId = service.create(ADMIN, cmd(NoticeType.이벤트));
+
+        Page<NoticeResult> events = service.findVisible(NoticeType.이벤트, PageRequest.of(0, 10));
+        assertThat(events.getContent()).extracting(NoticeResult::id).containsExactly(eventId);
+    }
+
+    @Test
+    @DisplayName("adminFindAll_미공개도 포함")
+    void adminFindAll_미공개포함() {
+        Long publishedId = service.create(ADMIN, cmd(NoticeType.공지));
+        Long hiddenId = service.create(ADMIN, cmd(NoticeType.공지));
+        service.setPublished(hiddenId, false);
+
+        Page<NoticeResult> all = service.adminFindAll(null, PageRequest.of(0, 10));
+        assertThat(all.getContent()).extracting(NoticeResult::id).contains(publishedId, hiddenId);
+    }
+}

--- a/src/test/java/com/sseulang/domain/notice/domain/NoticeTest.java
+++ b/src/test/java/com/sseulang/domain/notice/domain/NoticeTest.java
@@ -1,0 +1,117 @@
+package com.sseulang.domain.notice.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NoticeTest {
+
+    private static final Long ADMIN = 7L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 30, 12, 0);
+
+    private Notice newNotice() {
+        return Notice.create(ADMIN, NoticeType.공지, "제목", "본문", null, null, null);
+    }
+
+    @Test
+    @DisplayName("create 정상_published=true / pinned=false / viewCount=0 default")
+    void create_정상_default() {
+        Notice n = newNotice();
+
+        assertThat(n.getAdminId()).isEqualTo(ADMIN);
+        assertThat(n.getType()).isEqualTo(NoticeType.공지);
+        assertThat(n.getTitle()).isEqualTo("제목");
+        assertThat(n.getContent()).isEqualTo("본문");
+        assertThat(n.isPinned()).isFalse();
+        assertThat(n.isPublished()).isTrue();
+        assertThat(n.getViewCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("create_invalid 인자 거부")
+    void create_invalid() {
+        assertThatThrownBy(() -> Notice.create(ADMIN, null, "t", "c", null, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Notice.create(ADMIN, NoticeType.공지, "", "c", null, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Notice.create(ADMIN, NoticeType.공지, "t", " ", null, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Notice.create(ADMIN, NoticeType.공지, "t", "c", null, NOW, NOW.minusDays(1)))
+                .as("startsAt > endsAt")
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Notice.create(ADMIN, NoticeType.공지, "t", "c", null, NOW, NOW))
+                .as("startsAt == endsAt")
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("pin/unpin/publish/unpublish 토글")
+    void state_toggle() {
+        Notice n = newNotice();
+        n.pin();
+        assertThat(n.isPinned()).isTrue();
+        n.unpin();
+        assertThat(n.isPinned()).isFalse();
+
+        n.unpublish();
+        assertThat(n.isPublished()).isFalse();
+        n.publish();
+        assertThat(n.isPublished()).isTrue();
+    }
+
+    @Test
+    @DisplayName("incrementViewCount_누적 증가")
+    void incrementViewCount_누적() {
+        Notice n = newNotice();
+        n.incrementViewCount();
+        n.incrementViewCount();
+        assertThat(n.getViewCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("isVisibleAt_unpublished 면 false")
+    void isVisibleAt_unpublished() {
+        Notice n = newNotice();
+        n.unpublish();
+        assertThat(n.isVisibleAt(NOW)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isVisibleAt_window 검증 — startsAt 이전이면 false, endsAt 도달 시 false")
+    void isVisibleAt_window() {
+        Notice n = Notice.create(ADMIN, NoticeType.이벤트, "t", "c", null,
+                NOW, NOW.plusDays(7));
+
+        assertThat(n.isVisibleAt(NOW.minusMinutes(1))).as("시작 전").isFalse();
+        assertThat(n.isVisibleAt(NOW)).as("시작 시점 포함").isTrue();
+        assertThat(n.isVisibleAt(NOW.plusDays(3))).as("기간 중").isTrue();
+        assertThat(n.isVisibleAt(NOW.plusDays(7))).as("종료 시점은 노출 X (exclusive)").isFalse();
+        assertThat(n.isVisibleAt(NOW.plusDays(8))).as("종료 후").isFalse();
+    }
+
+    @Test
+    @DisplayName("isVisibleAt_window null = 무제한")
+    void isVisibleAt_no_window() {
+        Notice n = newNotice();
+        assertThat(n.isVisibleAt(NOW)).isTrue();
+        assertThat(n.isVisibleAt(NOW.plusYears(10))).isTrue();
+    }
+
+    @Test
+    @DisplayName("update_필드 변경 + 검증")
+    void update_정상() {
+        Notice n = newNotice();
+        n.update(NoticeType.이벤트, "새 제목", "새 본문", "https://i/u.png", NOW, NOW.plusDays(3));
+
+        assertThat(n.getType()).isEqualTo(NoticeType.이벤트);
+        assertThat(n.getTitle()).isEqualTo("새 제목");
+        assertThat(n.getContent()).isEqualTo("새 본문");
+        assertThat(n.getImageUrl()).isEqualTo("https://i/u.png");
+        assertThat(n.getStartsAt()).isEqualTo(NOW);
+        assertThat(n.getEndsAt()).isEqualTo(NOW.plusDays(3));
+    }
+}

--- a/src/test/java/com/sseulang/domain/report/application/InMemoryFakeUserReportRepository.java
+++ b/src/test/java/com/sseulang/domain/report/application/InMemoryFakeUserReportRepository.java
@@ -1,0 +1,44 @@
+package com.sseulang.domain.report.application;
+
+import com.sseulang.domain.report.domain.ReportStatus;
+import com.sseulang.domain.report.domain.UserReport;
+import com.sseulang.domain.report.domain.UserReportRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+class InMemoryFakeUserReportRepository implements UserReportRepository {
+
+    private final Map<Long, UserReport> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public UserReport save(UserReport report) {
+        if (report.getId() == null) {
+            ReflectionTestUtils.setField(report, "id", ++sequence);
+        }
+        store.put(report.getId(), report);
+        return report;
+    }
+
+    @Override
+    public Optional<UserReport> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Page<UserReport> findByStatus(ReportStatus status, Pageable pageable) {
+        List<UserReport> filtered = store.values().stream()
+                .filter(r -> status == null || r.getStatus() == status)
+                .sorted(Comparator.comparing(UserReport::getId).reversed())
+                .toList();
+        return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+}

--- a/src/test/java/com/sseulang/domain/report/application/UserReportApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/report/application/UserReportApplicationServiceTest.java
@@ -1,0 +1,87 @@
+package com.sseulang.domain.report.application;
+
+import com.sseulang.domain.report.domain.ReportStatus;
+import com.sseulang.domain.report.domain.UserReport;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserReportApplicationServiceTest {
+
+    private static final Long ADMIN = 99L;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 30, 12, 0);
+
+    private InMemoryFakeUserReportRepository repo;
+    private UserReportApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        repo = new InMemoryFakeUserReportRepository();
+        Clock clock = Clock.fixed(NOW.atZone(KST).toInstant(), KST);
+        service = new UserReportApplicationService(repo, clock);
+    }
+
+    @Test
+    @DisplayName("adminMarkInProgress 정상_status=처리중")
+    void markInProgress_정상() {
+        Long id = service.reportUser(1L, 2L, "스팸", null);
+        service.adminMarkInProgress(id, ADMIN, "검토 시작");
+
+        UserReport r = service.adminFindById(id);
+        assertThat(r.getStatus()).isEqualTo(ReportStatus.처리중);
+        assertThat(r.getAdminId()).isEqualTo(ADMIN);
+    }
+
+    @Test
+    @DisplayName("adminMarkInProgress 미존재_REPORT_NOT_FOUND")
+    void markInProgress_미존재() {
+        assertThatThrownBy(() -> service.adminMarkInProgress(999L, ADMIN, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.REPORT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("adminComplete 정상_처리중 → 처리완료")
+    void complete_정상() {
+        Long id = service.reportUser(1L, 2L, "스팸", null);
+        service.adminMarkInProgress(id, ADMIN, null);
+        service.adminComplete(id, ADMIN, "처리 완료");
+
+        assertThat(service.adminFindById(id).getStatus()).isEqualTo(ReportStatus.처리완료);
+    }
+
+    @Test
+    @DisplayName("adminReject 정상_접수에서 바로 반려")
+    void reject_정상() {
+        Long id = service.reportUser(1L, 2L, "스팸", null);
+        service.adminReject(id, ADMIN, "근거 부족");
+
+        assertThat(service.adminFindById(id).getStatus()).isEqualTo(ReportStatus.반려);
+    }
+
+    @Test
+    @DisplayName("adminFindByStatus_status null = 전체, 필터 동작")
+    void findByStatus_필터() {
+        Long id1 = service.reportUser(1L, 2L, "스팸", null);
+        Long id2 = service.reportUser(1L, 3L, "허위", null);
+        service.adminReject(id2, ADMIN, null);
+
+        Page<UserReport> 접수만 = service.adminFindByStatus(ReportStatus.접수, PageRequest.of(0, 10));
+        assertThat(접수만.getContent()).extracting(UserReport::getId).containsExactly(id1);
+
+        Page<UserReport> 전체 = service.adminFindByStatus(null, PageRequest.of(0, 10));
+        assertThat(전체.getContent()).hasSize(2);
+    }
+}

--- a/src/test/java/com/sseulang/domain/report/domain/UserReportTest.java
+++ b/src/test/java/com/sseulang/domain/report/domain/UserReportTest.java
@@ -1,7 +1,11 @@
 package com.sseulang.domain.report.domain;
 
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -60,5 +64,78 @@ class UserReportTest {
         String tooLong = "가".repeat(51);
         assertThatThrownBy(() -> UserReport.reportUser(1L, 2L, tooLong, null))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ───────── 관리자 처리 흐름 ─────────
+    private static final Long ADMIN = 99L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 30, 12, 0);
+
+    private UserReport pending() {
+        return UserReport.reportUser(1L, 2L, "스팸", null);
+    }
+
+    @Test
+    @DisplayName("markInProgress 접수 → 처리중_adminId/processedAt 기록")
+    void markInProgress_정상() {
+        UserReport r = pending();
+        r.markInProgress(ADMIN, "검토 시작", NOW);
+
+        assertThat(r.getStatus()).isEqualTo(ReportStatus.처리중);
+        assertThat(r.getAdminId()).isEqualTo(ADMIN);
+        assertThat(r.getAdminMemo()).isEqualTo("검토 시작");
+        assertThat(r.getProcessedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("markInProgress 처리중·terminal 상태_REPORT_INVALID_STATE")
+    void markInProgress_상태_거부() {
+        UserReport r = pending();
+        r.markInProgress(ADMIN, null, NOW);
+        assertThatThrownBy(() -> r.markInProgress(ADMIN, null, NOW.plusMinutes(1)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.REPORT_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("complete 처리중 → 처리완료")
+    void complete_정상() {
+        UserReport r = pending();
+        r.markInProgress(ADMIN, null, NOW);
+        r.complete(ADMIN, "처리 완료", NOW.plusMinutes(10));
+
+        assertThat(r.getStatus()).isEqualTo(ReportStatus.처리완료);
+        assertThat(r.getStatus().isTerminal()).isTrue();
+    }
+
+    @Test
+    @DisplayName("complete 접수 상태_REPORT_INVALID_STATE")
+    void complete_접수_거부() {
+        UserReport r = pending();
+        assertThatThrownBy(() -> r.complete(ADMIN, null, NOW))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.REPORT_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("reject 접수 → 반려, 처리중 → 반려")
+    void reject_정상() {
+        UserReport r1 = pending();
+        r1.reject(ADMIN, "근거 부족", NOW);
+        assertThat(r1.getStatus()).isEqualTo(ReportStatus.반려);
+
+        UserReport r2 = pending();
+        r2.markInProgress(ADMIN, null, NOW);
+        r2.reject(ADMIN, "근거 부족", NOW.plusMinutes(1));
+        assertThat(r2.getStatus()).isEqualTo(ReportStatus.반려);
+    }
+
+    @Test
+    @DisplayName("reject terminal 상태_REPORT_INVALID_STATE")
+    void reject_terminal_거부() {
+        UserReport r = pending();
+        r.reject(ADMIN, null, NOW);
+        assertThatThrownBy(() -> r.reject(ADMIN, null, NOW.plusMinutes(1)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.REPORT_INVALID_STATE);
     }
 }

--- a/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
+++ b/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
@@ -4,9 +4,14 @@ import com.sseulang.domain.user.domain.Email;
 import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.domain.user.domain.User;
 import com.sseulang.domain.user.domain.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -77,5 +82,13 @@ public class InMemoryFakeUserRepository implements UserRepository {
     public Long findPointBalance(Long userId) {
         User user = store.get(userId);
         return user == null ? null : user.getPointBalance();
+    }
+
+    @Override
+    public Page<User> findAllForAdmin(Pageable pageable) {
+        List<User> all = store.values().stream()
+                .sorted(Comparator.comparing(User::getId).reversed())
+                .toList();
+        return new PageImpl<>(all, pageable, all.size());
     }
 }


### PR DESCRIPTION
## 한 줄 요약

공지·배너 도메인 신규 + 관리자 회원관리·신고처리 흐름 추가. 단순 CRUD 영역이라 코덱스 게이트 호출 없이 직접 PR.

## 무엇이 바뀌었는지

### 새 도메인 2개
- **Notice (공지)** — 관리자가 공지/이벤트 작성, 사용자는 게시 윈도우(`startsAt~endsAt`) 안의 공개 공지만 봄. 단건 조회 시 view_count 증가. pin/publish 토글 별도 엔드포인트.
- **Banner (배너)** — 관리자가 배너 등록·관리, 사용자는 활성(`is_active`)이고 윈도우 안인 배너만 sort_order 순으로 받음. activate/deactivate 토글.

### 기존 도메인 확장
- **User** — `block()`/`unblock()` 도메인 메서드 추가. UserApplicationService에 admin 회원 목록 + 차단 토글 메서드.
- **UserReport** — 상태 전이 메서드 신규 (접수→처리중→처리완료/반려). terminal 상태에서 재전이 불가 가드. UserReportApplicationService에 admin 처리 흐름.

### 새 컨트롤러 (모두 ROLE_ADMIN 강제 / user chain은 ROLE_USER)
- `GET /api/v1/notices`, `GET /api/v1/notices/{id}` (사용자)
- `/api/v1/admin/notices` (admin CRUD + pin/publish 토글)
- `GET /api/v1/banners` (사용자)
- `/api/v1/admin/banners` (admin CRUD + active 토글)
- `/api/v1/admin/users` (회원 목록 + block 토글)
- `/api/v1/admin/reports` (신고 목록 + status 전환)

### ErrorCode 추가
`NOTICE_NOT_FOUND`, `BANNER_NOT_FOUND`, `REPORT_NOT_FOUND`, `REPORT_INVALID_STATE`

## 의도한 결정

- **Notice/Banner 모두 시간 윈도우 + 활성 플래그 두 축으로 노출 제어** — 미래 게시 예약 / 이벤트 자동 종료 가능.
- **사용자 단건 조회에서 미공개·윈도우 외 공지는 NOT_FOUND** — 존재 여부 leak 방지.
- **`Clock` DI 주입** — 시간 의존 로직 (윈도우 판정, view_count 시점) 테스트 가능하게.
- **상태 전이는 모두 Aggregate 메서드로 캡슐화** — UserReport.markInProgress/complete/reject. ApplicationService는 락+위임만.

## 영향 범위

- 도메인 신규: `domain/notice/**`, `domain/banner/**`
- 도메인 확장: `domain/user/**` (admin 메서드), `domain/report/**` (admin 처리)
- DB 변경 없음 (V1에 이미 notices/banners 테이블 정의됨)

## 테스트

- [x] 466 PASS / 0 FAIL (`./gradlew test`)
- [x] Notice/Banner Aggregate 윈도우 판정, 상태 토글, view_count 증가
- [x] ApplicationService — 미존재 NOT_FOUND, fast path dedup, type 필터, sort 정렬
- [x] UserReport 상태 전이 — 정상 전이 + terminal 가드 (REPORT_INVALID_STATE)

## 코덱스 리뷰

게이트 면제 영역 (CLAUDE.md §9.5 — Notice/Banner/관리자 일반 기능). 호출 없이 직접 PR.

## 머지 후 후속 (Phase 3 — 별도 PR로 분리 예정)

- Admin 통계 대시보드 — 회원 수 / 거래 수 / 결제 합계 / 출금 합계 등 집계
- N+1 / 인덱스 검토 영역이라 게이트 2 PR 전 리뷰 영역

🤖 Generated with [Claude Code](https://claude.com/claude-code)