### PR TITLE
feat: Day 9 PR-b — 관리자 통계 dashboard

### DIFF
--- a/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.payment.application.dto.ChargeConfirmCommand;
 import com.sseulang.domain.payment.application.dto.ChargeStartCommand;
 import com.sseulang.domain.payment.application.dto.ChargeStartResult;
 import com.sseulang.domain.payment.application.dto.PaymentResult;
+import com.sseulang.domain.payment.application.dto.PaymentStatsResult;
 import com.sseulang.domain.payment.domain.Payment;
 import com.sseulang.domain.payment.domain.PaymentConfirmResult;
 import com.sseulang.domain.payment.domain.PaymentGateway;
@@ -154,6 +155,11 @@ public class PaymentApplicationService {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
         return PaymentResult.from(payment);
+    }
+
+    /** 관리자 결제 통계 — 완료 건수 + 누적 금액. 단일 SUM/COUNT 쿼리. */
+    public PaymentStatsResult adminGetStats() {
+        return new PaymentStatsResult(paymentRepository.countPaid(), paymentRepository.sumPaidAmount());
     }
 
     private static String generateMerchantUid() {

--- a/src/main/java/com/sseulang/domain/payment/application/dto/PaymentStatsResult.java
+++ b/src/main/java/com/sseulang/domain/payment/application/dto/PaymentStatsResult.java
@@ -1,0 +1,6 @@
+package com.sseulang.domain.payment.application.dto;
+
+/**
+ * 결제 통계 — 완료된 결제 건수 + 누적 금액. 미완료/실패/환불 결제는 제외.
+ */
+public record PaymentStatsResult(long paidCount, long totalPaidAmount) {}

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentRepository.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentRepository.java
@@ -12,4 +12,12 @@ public interface PaymentRepository {
     Optional<Payment> findByMerchantUidForUpdate(String merchantUid);
 
     Payment save(Payment payment);
+
+    // ───────── 관리자 통계 ─────────
+
+    /** status=완료 결제의 paid_amount 합계. 미완료 결제는 제외. */
+    long sumPaidAmount();
+
+    /** status=완료 결제 건수. */
+    long countPaid();
 }

--- a/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/PaymentJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/PaymentJpaRepository.java
@@ -16,4 +16,14 @@ interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Payment p WHERE p.merchantUid = :merchantUid")
     Optional<Payment> findByMerchantUidForUpdate(@Param("merchantUid") String merchantUid);
+
+    /**
+     * status=완료 결제의 amount 합계. COALESCE 로 빈 결과(완료 0건)에서도 0 반환 — Long null 회피.
+     * payments.status 인덱스 권장 (V1 schema 에 idx_payments_status 있음).
+     */
+    @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p WHERE p.status = com.sseulang.domain.payment.domain.PaymentStatus.완료")
+    long sumPaidAmount();
+
+    @Query("SELECT COUNT(p) FROM Payment p WHERE p.status = com.sseulang.domain.payment.domain.PaymentStatus.완료")
+    long countPaid();
 }

--- a/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -34,4 +34,14 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public Payment save(Payment payment) {
         return jpa.save(payment);
     }
+
+    @Override
+    public long sumPaidAmount() {
+        return jpa.sumPaidAmount();
+    }
+
+    @Override
+    public long countPaid() {
+        return jpa.countPaid();
+    }
 }

--- a/src/main/java/com/sseulang/domain/stats/application/AdminDashboardResult.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminDashboardResult.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.stats.application;
+
+import com.sseulang.domain.payment.application.dto.PaymentStatsResult;
+import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
+import com.sseulang.domain.user.application.dto.UserStatsResult;
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
+
+/** 4개 도메인 통계 묶음. 단순 wrapper — 각 도메인 stats result 는 그 도메인 dto 그대로 노출. */
+public record AdminDashboardResult(
+        UserStatsResult users,
+        TransactionStatsResult transactions,
+        PaymentStatsResult payments,
+        WithdrawalStatsResult withdrawals
+) {}

--- a/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
@@ -1,0 +1,52 @@
+package com.sseulang.domain.stats.application;
+
+import com.sseulang.domain.payment.application.PaymentApplicationService;
+import com.sseulang.domain.payment.application.dto.PaymentStatsResult;
+import com.sseulang.domain.transaction.application.TransactionApplicationService;
+import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.application.dto.UserStatsResult;
+import com.sseulang.domain.withdrawal.application.WithdrawalApplicationService;
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 관리자 dashboard 통계 — 4개 도메인 ApplicationService 를 호출하여 단순 조립.
+ *
+ * <p>본 서비스는 자체 상태/도메인 없음 — read-only orchestration. CLAUDE.md §3.3 준수:
+ * 다른 도메인 Repository 직접 호출 금지, 각 도메인 ApplicationService 만 의존.</p>
+ *
+ * <p>각 도메인 stats 호출은 단일 집계 쿼리 (GROUP BY / SUM / COUNT) 라 N+1 없음. 전체 dashboard
+ * 한 번 호출 시 SQL 9개 (User 4 [all/blocked/deleted/active] + Transaction 1 + Payment 2 +
+ * Withdrawal 2). prod 트래픽 스케일 커지면 schedule 캐싱 검토.</p>
+ */
+@Service
+@Transactional(readOnly = true)
+public class AdminStatsService {
+
+    private final UserApplicationService userService;
+    private final TransactionApplicationService transactionService;
+    private final PaymentApplicationService paymentService;
+    private final WithdrawalApplicationService withdrawalService;
+
+    public AdminStatsService(
+            UserApplicationService userService,
+            TransactionApplicationService transactionService,
+            PaymentApplicationService paymentService,
+            WithdrawalApplicationService withdrawalService
+    ) {
+        this.userService = userService;
+        this.transactionService = transactionService;
+        this.paymentService = paymentService;
+        this.withdrawalService = withdrawalService;
+    }
+
+    public AdminDashboardResult dashboard() {
+        UserStatsResult users = userService.adminGetStats();
+        TransactionStatsResult transactions = transactionService.adminGetStats();
+        PaymentStatsResult payments = paymentService.adminGetStats();
+        WithdrawalStatsResult withdrawals = withdrawalService.adminGetStats();
+        return new AdminDashboardResult(users, transactions, payments, withdrawals);
+    }
+}

--- a/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.stats.presentation;
+
+import com.sseulang.domain.stats.application.AdminStatsService;
+import com.sseulang.domain.stats.presentation.dto.AdminDashboardResponse;
+import com.sseulang.global.common.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 관리자 통계 dashboard. SecurityConfig admin chain 으로 ROLE_ADMIN 강제. */
+@RestController
+@RequestMapping("/api/v1/admin/stats")
+public class AdminStatsController {
+
+    private final AdminStatsService statsService;
+
+    public AdminStatsController(AdminStatsService statsService) {
+        this.statsService = statsService;
+    }
+
+    @GetMapping("/dashboard")
+    public ApiResponse<AdminDashboardResponse> dashboard() {
+        return ApiResponse.ok(AdminDashboardResponse.from(statsService.dashboard()));
+    }
+}

--- a/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardResponse.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardResponse.java
@@ -1,0 +1,22 @@
+package com.sseulang.domain.stats.presentation.dto;
+
+import com.sseulang.domain.payment.application.dto.PaymentStatsResult;
+import com.sseulang.domain.stats.application.AdminDashboardResult;
+import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
+import com.sseulang.domain.user.application.dto.UserStatsResult;
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
+
+/**
+ * 관리자 dashboard JSON 응답. presentation layer 응답 — application Result 를 그대로 노출하지만
+ * 향후 응답 shape 분리(예: 일부 필드 마스킹)에 대비해 wrapper 유지.
+ */
+public record AdminDashboardResponse(
+        UserStatsResult users,
+        TransactionStatsResult transactions,
+        PaymentStatsResult payments,
+        WithdrawalStatsResult withdrawals
+) {
+    public static AdminDashboardResponse from(AdminDashboardResult r) {
+        return new AdminDashboardResponse(r.users(), r.transactions(), r.payments(), r.withdrawals());
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -7,15 +7,19 @@ import com.sseulang.domain.point.domain.PointReferenceType;
 import com.sseulang.domain.transaction.application.dto.ReviewableTransactionResult;
 import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
 import com.sseulang.domain.transaction.application.dto.TransactionResult;
+import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
 import com.sseulang.domain.transaction.domain.Transaction;
 import com.sseulang.domain.transaction.domain.TransactionRepository;
 import com.sseulang.domain.transaction.domain.TransactionStatus;
+import com.sseulang.domain.transaction.domain.TransactionStatusCount;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.EnumMap;
+import java.util.Map;
 
 /**
  * Transaction 거래 흐름. 가이드 §5.1 / §5.2 정합:
@@ -160,6 +164,23 @@ public class TransactionApplicationService {
         }
         Long revieweeId = tx.isSeller(requesterId) ? tx.getBuyerId() : tx.getSellerId();
         return new ReviewableTransactionResult(tx.getId(), requesterId, revieweeId, tx.getCompletedAt());
+    }
+
+    /**
+     * 관리자 거래 통계 — total + status 별 카운트. byStatus 는 enum 모든 값 포함 (없는 status 는 0L).
+     * 단일 GROUP BY 쿼리 — N+1 없음.
+     */
+    public TransactionStatsResult adminGetStats() {
+        Map<TransactionStatus, Long> byStatus = new EnumMap<>(TransactionStatus.class);
+        for (TransactionStatus s : TransactionStatus.values()) {
+            byStatus.put(s, 0L);  // default 0
+        }
+        long total = 0;
+        for (TransactionStatusCount row : transactionRepository.countGroupByStatus()) {
+            byStatus.put(row.status(), row.count());
+            total += row.count();
+        }
+        return new TransactionStatsResult(total, byStatus);
     }
 
     private Transaction findOrThrow(Long id) {

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionStatsResult.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionStatsResult.java
@@ -1,0 +1,10 @@
+package com.sseulang.domain.transaction.application.dto;
+
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+
+import java.util.Map;
+
+/**
+ * 거래 통계 — total + status 별 카운트. byStatus 는 모든 enum 값 포함 (0 이면 0L).
+ */
+public record TransactionStatsResult(long total, Map<TransactionStatus, Long> byStatus) {}

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.transaction.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -19,4 +20,9 @@ public interface TransactionRepository {
     Optional<Transaction> findByIdForUpdate(Long id);
 
     Transaction save(Transaction transaction);
+
+    // ───────── 관리자 통계 ─────────
+
+    /** 단일 GROUP BY 집계 — (status, count) 행 리스트 (가능한 모든 status 행 포함, 0 인 status 는 없음). */
+    List<TransactionStatusCount> countGroupByStatus();
 }

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatusCount.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatusCount.java
@@ -1,0 +1,4 @@
+package com.sseulang.domain.transaction.domain;
+
+/** 거래 상태별 집계 결과 — Repository GROUP BY 응답을 받기 위한 record. */
+public record TransactionStatusCount(TransactionStatus status, long count) {}

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -1,12 +1,14 @@
 package com.sseulang.domain.transaction.infrastructure.persistence;
 
 import com.sseulang.domain.transaction.domain.Transaction;
+import com.sseulang.domain.transaction.domain.TransactionStatusCount;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 /** Spring Data JPA — {@link TransactionRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
@@ -15,4 +17,15 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT t FROM Transaction t WHERE t.id = :id")
     Optional<Transaction> findByIdForUpdate(@Param("id") Long id);
+
+    /**
+     * status 별 거래 건수 집계. 단일 쿼리 — N+1 없음. 결과는 status 가 한 번이라도 등장한 행만 옴
+     * (0 건인 status 는 application 단에서 0 으로 채움). status 컬럼 인덱스 권장.
+     */
+    @Query("""
+            SELECT new com.sseulang.domain.transaction.domain.TransactionStatusCount(t.status, COUNT(t))
+              FROM Transaction t
+             GROUP BY t.status
+            """)
+    List<TransactionStatusCount> countGroupByStatusJpql();
 }

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -2,8 +2,10 @@ package com.sseulang.domain.transaction.infrastructure.persistence;
 
 import com.sseulang.domain.transaction.domain.Transaction;
 import com.sseulang.domain.transaction.domain.TransactionRepository;
+import com.sseulang.domain.transaction.domain.TransactionStatusCount;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -28,5 +30,10 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     @Override
     public Transaction save(Transaction transaction) {
         return jpa.save(transaction);
+    }
+
+    @Override
+    public List<TransactionStatusCount> countGroupByStatus() {
+        return jpa.countGroupByStatusJpql();
     }
 }

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.user.application;
 
+import com.sseulang.domain.user.application.dto.UserStatsResult;
 import com.sseulang.domain.user.domain.Email;
 import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.domain.user.domain.User;
@@ -118,6 +119,20 @@ public class UserApplicationService {
     public void adminSetBlocked(Long userId, boolean blocked) {
         User u = getById(userId);
         if (blocked) u.block(); else u.unblock();
+    }
+
+    /**
+     * 관리자 회원 통계 — total / blocked / deleted / active 모두 직접 집계.
+     * active 는 별도 쿼리(`WHERE blocked=false AND deleted=false`) 로 정확 — 이중 차감(blocked &&
+     * deleted) 시나리오에서도 정확 (게이트 2 보강).
+     * stats 도메인이 본 메서드만 의존하도록 하여 UserRepository 직접 호출 차단 (CLAUDE.md §3.3).
+     */
+    public UserStatsResult adminGetStats() {
+        long total = userRepository.countAll();
+        long blocked = userRepository.countBlocked();
+        long deleted = userRepository.countDeleted();
+        long active = userRepository.countActive();
+        return new UserStatsResult(total, blocked, deleted, active);
     }
 
     private User create(SocialProvider provider, String providerId, Email email, String nickname, String profileImage) {

--- a/src/main/java/com/sseulang/domain/user/application/dto/UserStatsResult.java
+++ b/src/main/java/com/sseulang/domain/user/application/dto/UserStatsResult.java
@@ -1,0 +1,8 @@
+package com.sseulang.domain.user.application.dto;
+
+/**
+ * 회원 통계 — total / blocked / deleted 의 단순 카운트.
+ * active = total − (blocked + deleted) 는 derived. 단, blocked && deleted 인 사용자가 있으면
+ * active 계산에 음수가 나올 수 있어 service 에서 max(0, ...) 가드.
+ */
+public record UserStatsResult(long total, long blocked, long deleted, long active) {}

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -46,4 +46,21 @@ public interface UserRepository {
      * 잔액 단건 scalar 조회. atomic UPDATE 직후 balance_after 적재용 — 영속성 컨텍스트 stale 우회.
      */
     Long findPointBalance(Long userId);
+
+    // ───────── 관리자 통계 ─────────
+
+    /** 전체 사용자 수 (차단/삭제 포함). */
+    long countAll();
+
+    /** is_blocked=true 사용자 수. */
+    long countBlocked();
+
+    /** is_deleted=true 사용자 수. */
+    long countDeleted();
+
+    /**
+     * 정상(차단 X, 삭제 X) 사용자 수. blocked && deleted 동시 true 인 사용자가 있어도 정확.
+     * 게이트 2 보강 — total - blocked - deleted 의 이중 차감 회피.
+     */
+    long countActive();
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -59,4 +59,17 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
     Long findPointBalanceById(@Param("userId") Long userId);
 
     Page<User> findAllByOrderByIdDesc(Pageable pageable);
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.blocked = true")
+    long countBlocked();
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.deleted = true")
+    long countDeleted();
+
+    /**
+     * 정상 사용자 수 — blocked && deleted 동시 true 도 active 에서 제외. 복합 인덱스
+     * users(is_blocked, is_deleted) 사용 (V5 마이그레이션).
+     */
+    @Query("SELECT COUNT(u) FROM User u WHERE u.blocked = false AND u.deleted = false")
+    long countActive();
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -63,4 +63,24 @@ public class UserRepositoryImpl implements UserRepository {
     public Long findPointBalance(Long userId) {
         return jpa.findPointBalanceById(userId);
     }
+
+    @Override
+    public long countAll() {
+        return jpa.count();
+    }
+
+    @Override
+    public long countBlocked() {
+        return jpa.countBlocked();
+    }
+
+    @Override
+    public long countDeleted() {
+        return jpa.countDeleted();
+    }
+
+    @Override
+    public long countActive() {
+        return jpa.countActive();
+    }
 }

--- a/src/main/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationService.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationService.java
@@ -5,9 +5,11 @@ import com.sseulang.domain.point.domain.PointHistoryType;
 import com.sseulang.domain.point.domain.PointReferenceType;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalRequestCommand;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalResult;
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
 import com.sseulang.domain.withdrawal.domain.Withdrawal;
 import com.sseulang.domain.withdrawal.domain.WithdrawalRepository;
 import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatusCount;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import org.slf4j.Logger;
@@ -23,6 +25,8 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.EnumMap;
+import java.util.Map;
 
 /**
  * 가이드 §4.8 출금 흐름:
@@ -206,6 +210,21 @@ public class WithdrawalApplicationService {
 
     public Page<WithdrawalResult> adminFindByStatus(WithdrawalStatus status, Pageable pageable) {
         return withdrawalRepository.findByStatus(status, pageable).map(WithdrawalResult::from);
+    }
+
+    /** 관리자 출금 통계 — total + byStatus + 완료된 출금 누적 금액. 단일 GROUP BY + 단일 SUM. */
+    public WithdrawalStatsResult adminGetStats() {
+        Map<WithdrawalStatus, Long> byStatus = new EnumMap<>(WithdrawalStatus.class);
+        for (WithdrawalStatus s : WithdrawalStatus.values()) {
+            byStatus.put(s, 0L);
+        }
+        long total = 0;
+        for (WithdrawalStatusCount row : withdrawalRepository.countGroupByStatus()) {
+            byStatus.put(row.status(), row.count());
+            total += row.count();
+        }
+        long completedAmount = withdrawalRepository.sumCompletedAmount();
+        return new WithdrawalStatsResult(total, byStatus, completedAmount);
     }
 
     private void refund(Withdrawal w, String description) {

--- a/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalStatsResult.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalStatsResult.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.withdrawal.application.dto;
+
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+
+import java.util.Map;
+
+/**
+ * 출금 통계 — total + status 별 카운트 + 완료된 출금 누적 금액.
+ */
+public record WithdrawalStatsResult(
+        long total,
+        Map<WithdrawalStatus, Long> byStatus,
+        long completedAmount
+) {}

--- a/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalRepository.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalRepository.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.withdrawal.domain;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -36,4 +37,11 @@ public interface WithdrawalRepository {
 
     /** 관리자 — 상태별 페이징 (status null 이면 전체). */
     Page<Withdrawal> findByStatus(WithdrawalStatus status, Pageable pageable);
+
+    // ───────── 관리자 통계 ─────────
+
+    List<WithdrawalStatusCount> countGroupByStatus();
+
+    /** status=완료 출금의 amount 합계 (실제 외부 이체된 금액). */
+    long sumCompletedAmount();
 }

--- a/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalStatusCount.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalStatusCount.java
@@ -1,0 +1,4 @@
+package com.sseulang.domain.withdrawal.domain;
+
+/** 출금 상태별 집계 결과. */
+public record WithdrawalStatusCount(WithdrawalStatus status, long count) {}

--- a/src/main/java/com/sseulang/domain/withdrawal/infrastructure/persistence/WithdrawalJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/infrastructure/persistence/WithdrawalJpaRepository.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.withdrawal.infrastructure.persistence;
 
 import com.sseulang.domain.withdrawal.domain.Withdrawal;
 import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatusCount;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,6 +11,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 /** Spring Data JPA — {@link WithdrawalRepositoryImpl} 가 wrapping. 외부 직접 import 금지. */
@@ -34,4 +36,17 @@ interface WithdrawalJpaRepository extends JpaRepository<Withdrawal, Long> {
     Page<Withdrawal> findByStatusOrderByCreatedAtDesc(WithdrawalStatus status, Pageable pageable);
 
     Page<Withdrawal> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    /**
+     * status 별 출금 건수 집계. 단일 쿼리. withdrawals.status 인덱스 사용 (V1 idx_withdrawals_status).
+     */
+    @Query("""
+            SELECT new com.sseulang.domain.withdrawal.domain.WithdrawalStatusCount(w.status, COUNT(w))
+              FROM Withdrawal w
+             GROUP BY w.status
+            """)
+    List<WithdrawalStatusCount> countGroupByStatusJpql();
+
+    @Query("SELECT COALESCE(SUM(w.amount), 0) FROM Withdrawal w WHERE w.status = com.sseulang.domain.withdrawal.domain.WithdrawalStatus.완료")
+    long sumCompletedAmount();
 }

--- a/src/main/java/com/sseulang/domain/withdrawal/infrastructure/persistence/WithdrawalRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/infrastructure/persistence/WithdrawalRepositoryImpl.java
@@ -3,10 +3,12 @@ package com.sseulang.domain.withdrawal.infrastructure.persistence;
 import com.sseulang.domain.withdrawal.domain.Withdrawal;
 import com.sseulang.domain.withdrawal.domain.WithdrawalRepository;
 import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatusCount;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -53,5 +55,15 @@ public class WithdrawalRepositoryImpl implements WithdrawalRepository {
         return status == null
                 ? jpa.findAllByOrderByCreatedAtDesc(pageable)
                 : jpa.findByStatusOrderByCreatedAtDesc(status, pageable);
+    }
+
+    @Override
+    public List<WithdrawalStatusCount> countGroupByStatus() {
+        return jpa.countGroupByStatusJpql();
+    }
+
+    @Override
+    public long sumCompletedAmount() {
+        return jpa.sumCompletedAmount();
     }
 }

--- a/src/main/resources/db/migration/V5__add_user_status_index.sql
+++ b/src/main/resources/db/migration/V5__add_user_status_index.sql
@@ -1,0 +1,10 @@
+-- =====================================================
+-- V5: users (is_blocked, is_deleted) 복합 인덱스 (게이트 2 보강)
+-- =====================================================
+-- 관리자 dashboard 의 countBlocked / countDeleted / countActive 가 사용자 수 증가에 따라
+-- full table scan 되는 문제 회피. dashboard 쿼리는 두 컬럼 모두 WHERE 절에 등장하므로
+-- 단일 boolean 인덱스보다 복합 인덱스가 효율적.
+-- =====================================================
+
+ALTER TABLE users
+    ADD KEY idx_users_blocked_deleted (is_blocked, is_deleted);

--- a/src/test/java/com/sseulang/domain/payment/application/InMemoryFakePaymentRepository.java
+++ b/src/test/java/com/sseulang/domain/payment/application/InMemoryFakePaymentRepository.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.payment.application;
 
 import com.sseulang.domain.payment.domain.Payment;
 import com.sseulang.domain.payment.domain.PaymentRepository;
+import com.sseulang.domain.payment.domain.PaymentStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.HashMap;
@@ -38,5 +39,18 @@ public class InMemoryFakePaymentRepository implements PaymentRepository {
         }
         store.put(payment.getId(), payment);
         return payment;
+    }
+
+    @Override
+    public long sumPaidAmount() {
+        return store.values().stream()
+                .filter(p -> p.getStatus() == PaymentStatus.완료)
+                .mapToLong(Payment::getAmount)
+                .sum();
+    }
+
+    @Override
+    public long countPaid() {
+        return store.values().stream().filter(p -> p.getStatus() == PaymentStatus.완료).count();
     }
 }

--- a/src/test/java/com/sseulang/domain/stats/application/AdminStatsServiceTest.java
+++ b/src/test/java/com/sseulang/domain/stats/application/AdminStatsServiceTest.java
@@ -1,0 +1,72 @@
+package com.sseulang.domain.stats.application;
+
+import com.sseulang.domain.payment.application.PaymentApplicationService;
+import com.sseulang.domain.payment.application.dto.PaymentStatsResult;
+import com.sseulang.domain.transaction.application.TransactionApplicationService;
+import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.application.dto.UserStatsResult;
+import com.sseulang.domain.withdrawal.application.WithdrawalApplicationService;
+import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * AdminStatsService 단위 — 4개 도메인 ApplicationService 호출 + 응답 합성을 검증.
+ * 각 도메인의 stats 로직은 자체 ApplicationServiceTest 가 책임. 본 테스트는 orchestration 정확성만.
+ */
+class AdminStatsServiceTest {
+
+    private UserApplicationService userService;
+    private TransactionApplicationService transactionService;
+    private PaymentApplicationService paymentService;
+    private WithdrawalApplicationService withdrawalService;
+    private AdminStatsService statsService;
+
+    @BeforeEach
+    void setUp() {
+        userService = mock(UserApplicationService.class);
+        transactionService = mock(TransactionApplicationService.class);
+        paymentService = mock(PaymentApplicationService.class);
+        withdrawalService = mock(WithdrawalApplicationService.class);
+        statsService = new AdminStatsService(userService, transactionService, paymentService, withdrawalService);
+    }
+
+    @Test
+    @DisplayName("dashboard_4개 도메인 stats 합성 + 각 service 1회만 호출")
+    void dashboard_orchestration() {
+        UserStatsResult users = new UserStatsResult(100, 5, 2, 93);
+        TransactionStatsResult transactions = new TransactionStatsResult(50,
+                java.util.Map.of(TransactionStatus.채팅중, 10L, TransactionStatus.예약, 5L,
+                        TransactionStatus.거래완료, 30L, TransactionStatus.취소, 5L));
+        PaymentStatsResult payments = new PaymentStatsResult(20, 1_000_000L);
+        WithdrawalStatsResult withdrawals = new WithdrawalStatsResult(10,
+                java.util.Map.of(WithdrawalStatus.신청, 3L, WithdrawalStatus.완료, 7L), 700_000L);
+
+        when(userService.adminGetStats()).thenReturn(users);
+        when(transactionService.adminGetStats()).thenReturn(transactions);
+        when(paymentService.adminGetStats()).thenReturn(payments);
+        when(withdrawalService.adminGetStats()).thenReturn(withdrawals);
+
+        AdminDashboardResult result = statsService.dashboard();
+
+        assertThat(result.users()).isSameAs(users);
+        assertThat(result.transactions()).isSameAs(transactions);
+        assertThat(result.payments()).isSameAs(payments);
+        assertThat(result.withdrawals()).isSameAs(withdrawals);
+
+        // N+1 회피 — 각 도메인 ApplicationService 는 정확히 1회만 호출되어야 함
+        verify(userService).adminGetStats();
+        verify(transactionService).adminGetStats();
+        verify(paymentService).adminGetStats();
+        verify(withdrawalService).adminGetStats();
+    }
+}

--- a/src/test/java/com/sseulang/domain/stats/integration/AdminStatsAggregationIT.java
+++ b/src/test/java/com/sseulang/domain/stats/integration/AdminStatsAggregationIT.java
@@ -1,0 +1,222 @@
+package com.sseulang.domain.stats.integration;
+
+import com.sseulang.domain.payment.domain.Payment;
+import com.sseulang.domain.payment.domain.PaymentMethod;
+import com.sseulang.domain.payment.domain.PaymentRepository;
+import com.sseulang.domain.payment.infrastructure.persistence.PaymentRepositoryImpl;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserRepository;
+import com.sseulang.domain.user.infrastructure.persistence.UserRepositoryImpl;
+import com.sseulang.domain.withdrawal.domain.Withdrawal;
+import com.sseulang.domain.withdrawal.domain.WithdrawalRepository;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatusCount;
+import com.sseulang.domain.withdrawal.infrastructure.persistence.WithdrawalRepositoryImpl;
+import com.sseulang.global.config.JpaAuditingConfig;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Day 9 PR-b 게이트 2 — 관리자 통계 집계 쿼리 DB-backed IT.
+ *
+ * <p>회귀 가드 항목:
+ * <ul>
+ *   <li>User: countActive 가 blocked && deleted 사용자도 정확히 active 에서 제외</li>
+ *   <li>Withdrawal: GROUP BY constructor projection (record 매핑)</li>
+ *   <li>Withdrawal: COALESCE SUM 이 0건 상태에서도 0 반환 (NULL 회피)</li>
+ *   <li>Payment: SUM(amount) WHERE status = 완료 정확</li>
+ * </ul>
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({
+        JpaAuditingConfig.class,
+        UserRepositoryImpl.class,
+        WithdrawalRepositoryImpl.class,
+        PaymentRepositoryImpl.class
+})
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class AdminStatsAggregationIT {
+
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("sseulang_test")
+            .withUsername("test")
+            .withPassword("testpw")
+            .withCommand("--character-set-server=utf8mb4",
+                    "--collation-server=utf8mb4_unicode_ci",
+                    "--ngram_token_size=2");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    @Autowired private EntityManager em;
+    @Autowired private UserRepository userRepository;
+    @Autowired private WithdrawalRepository withdrawalRepository;
+    @Autowired private PaymentRepository paymentRepository;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate tx;
+
+    @BeforeEach
+    void setUp() {
+        tx = new TransactionTemplate(transactionManager);
+        tx.execute(s -> {
+            em.createNativeQuery("DELETE FROM withdrawals").executeUpdate();
+            em.createNativeQuery("DELETE FROM payments").executeUpdate();
+            em.createNativeQuery("DELETE FROM users").executeUpdate();
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("User countActive_blocked && deleted 사용자도 정확히 제외 (이중 차감 방지 회귀)")
+    void user_countActive_정확() {
+        // 시드: total 5, blocked-only 1, deleted-only 1, both 1, normal 2 → active 2
+        Long both = tx.execute(s -> persistUser("u-both", true, true));
+        Long blockedOnly = tx.execute(s -> persistUser("u-blocked", true, false));
+        Long deletedOnly = tx.execute(s -> persistUser("u-deleted", false, true));
+        tx.execute(s -> persistUser("u-normal-1", false, false));
+        tx.execute(s -> persistUser("u-normal-2", false, false));
+
+        assertThat(userRepository.countAll()).isEqualTo(5L);
+        assertThat(userRepository.countBlocked()).as("both 포함").isEqualTo(2L);
+        assertThat(userRepository.countDeleted()).as("both 포함").isEqualTo(2L);
+        assertThat(userRepository.countActive())
+                .as("blocked && deleted 도 active 에서 정확히 제외 — total - blocked - deleted = -1 이지만 실제 active = 2")
+                .isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("Withdrawal GROUP BY constructor projection_record 매핑 정상")
+    void withdrawal_groupBy_projection() {
+        Long userId = tx.execute(s -> persistUser("w-user", false, false));
+
+        // 시드: 신청 2, 승인 1, 완료 1, 거부 1
+        seedWithdrawal(userId, "k1", 10_000L, WithdrawalStatus.신청, null);
+        seedWithdrawal(userId, "k2", 20_000L, WithdrawalStatus.신청, null);
+        seedWithdrawal(userId, "k3", 30_000L, WithdrawalStatus.승인, null);
+        seedWithdrawal(userId, "k4", 40_000L, WithdrawalStatus.완료, null);
+        seedWithdrawal(userId, "k5", 50_000L, WithdrawalStatus.거부, null);
+
+        List<WithdrawalStatusCount> rows = withdrawalRepository.countGroupByStatus();
+        Map<WithdrawalStatus, Long> byStatus = rows.stream()
+                .collect(Collectors.toMap(WithdrawalStatusCount::status, WithdrawalStatusCount::count));
+
+        assertThat(byStatus)
+                .containsEntry(WithdrawalStatus.신청, 2L)
+                .containsEntry(WithdrawalStatus.승인, 1L)
+                .containsEntry(WithdrawalStatus.완료, 1L)
+                .containsEntry(WithdrawalStatus.거부, 1L);
+    }
+
+    @Test
+    @DisplayName("Withdrawal sumCompletedAmount_완료만 합산 + 0건일 때 0 반환 (COALESCE)")
+    void withdrawal_sum_completed() {
+        // 0건 상태 — COALESCE 가드 검증
+        assertThat(withdrawalRepository.sumCompletedAmount()).as("0건 → 0").isZero();
+
+        Long userId = tx.execute(s -> persistUser("ws-user", false, false));
+        seedWithdrawal(userId, "ks1", 30_000L, WithdrawalStatus.완료, null);
+        seedWithdrawal(userId, "ks2", 70_000L, WithdrawalStatus.완료, null);
+        seedWithdrawal(userId, "ks3", 99_999L, WithdrawalStatus.신청, null);  // 미완료 — 합산 X
+
+        assertThat(withdrawalRepository.sumCompletedAmount())
+                .as("완료된 출금만 합산 — 신청은 제외")
+                .isEqualTo(100_000L);
+    }
+
+    @Test
+    @DisplayName("Payment sumPaidAmount + countPaid_완료만 / 0건 → 0")
+    void payment_sum_paid() {
+        assertThat(paymentRepository.sumPaidAmount()).isZero();
+        assertThat(paymentRepository.countPaid()).isZero();
+
+        Long userId = tx.execute(s -> persistUser("p-user", false, false));
+        // 시드: 완료 2건 (50k + 30k), 실패 1건 (99k 합산 X)
+        seedPayment(userId, 50_000L, true);
+        seedPayment(userId, 30_000L, true);
+        seedPayment(userId, 99_999L, false);
+
+        assertThat(paymentRepository.countPaid()).isEqualTo(2L);
+        assertThat(paymentRepository.sumPaidAmount()).as("완료 결제만 합산").isEqualTo(80_000L);
+    }
+
+    // ───────── 시드 헬퍼 ─────────
+
+    /**
+     * User 시드 — createSocialUser 후 blocked/deleted 는 ReflectionTestUtils 로 강제 설정.
+     * 본 PR scope 에선 block/unblock 도메인 메서드 미존재 (PR-a 에서 추가됨, dev 머지 전).
+     */
+    private Long persistUser(String suffix, boolean blocked, boolean deleted) {
+        User u = User.createSocialUser(
+                SocialProvider.KAKAO,
+                "kakao-" + suffix + "-" + System.nanoTime(),
+                new Email(suffix + "@stats.test"),
+                "user-" + suffix,
+                null
+        );
+        if (blocked) ReflectionTestUtils.setField(u, "blocked", true);
+        if (deleted) ReflectionTestUtils.setField(u, "deleted", true);
+        em.persist(u);
+        em.flush();
+        return u.getId();
+    }
+
+    private void seedWithdrawal(Long userId, String key, long amount, WithdrawalStatus targetStatus, Object _ignored) {
+        tx.execute(s -> {
+            Withdrawal w = Withdrawal.request(userId, key, amount, "신한", "110-1", "홍길동", LocalDateTime.now());
+            // 상태 전이 — Aggregate 메서드는 invariant 가드가 있어 시드 시점엔 reflection 으로 직접 적용.
+            ReflectionTestUtils.setField(w, "status", targetStatus);
+            withdrawalRepository.save(w);
+            return null;
+        });
+    }
+
+    private void seedPayment(Long userId, long amount, boolean paid) {
+        tx.execute(s -> {
+            Payment p = Payment.startCharge(userId, "p-" + UUID.randomUUID(), amount);
+            if (paid) {
+                p.markAsPaid("pk-" + UUID.randomUUID(), PaymentMethod.CARD, LocalDateTime.now(), "{}");
+            } else {
+                p.markAsFailed("test failure");
+            }
+            paymentRepository.save(p);
+            return null;
+        });
+    }
+}

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -2,11 +2,14 @@ package com.sseulang.domain.transaction.application;
 
 import com.sseulang.domain.transaction.domain.Transaction;
 import com.sseulang.domain.transaction.domain.TransactionRepository;
+import com.sseulang.domain.transaction.domain.TransactionStatusCount;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class InMemoryFakeTransactionRepository implements TransactionRepository {
 
@@ -31,5 +34,14 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
         }
         store.put(transaction.getId(), transaction);
         return transaction;
+    }
+
+    @Override
+    public List<TransactionStatusCount> countGroupByStatus() {
+        return store.values().stream()
+                .collect(Collectors.groupingBy(Transaction::getStatus, Collectors.counting()))
+                .entrySet().stream()
+                .map(e -> new TransactionStatusCount(e.getKey(), e.getValue()))
+                .toList();
     }
 }

--- a/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
+++ b/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
@@ -91,4 +91,24 @@ public class InMemoryFakeUserRepository implements UserRepository {
                 .toList();
         return new PageImpl<>(all, pageable, all.size());
     }
+
+    @Override
+    public long countAll() {
+        return store.size();
+    }
+
+    @Override
+    public long countBlocked() {
+        return store.values().stream().filter(User::isBlocked).count();
+    }
+
+    @Override
+    public long countDeleted() {
+        return store.values().stream().filter(User::isDeleted).count();
+    }
+
+    @Override
+    public long countActive() {
+        return store.values().stream().filter(u -> !u.isBlocked() && !u.isDeleted()).count();
+    }
 }

--- a/src/test/java/com/sseulang/domain/user/application/UserApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/user/application/UserApplicationServiceTest.java
@@ -213,4 +213,36 @@ class UserApplicationServiceTest {
                 service.findOrCreateBySocial(SocialProvider.KAKAO, "k-1", EMAIL, "n", null))
                 .isSameAs(nicknameTooLong);
     }
+
+    // ───────── 관리자 통계 ─────────
+
+    @Test
+    @DisplayName("adminGetStats_total/blocked/deleted/active 모두 직접 집계")
+    void adminGetStats_정상() {
+        when(userRepository.countAll()).thenReturn(100L);
+        when(userRepository.countBlocked()).thenReturn(5L);
+        when(userRepository.countDeleted()).thenReturn(2L);
+        when(userRepository.countActive()).thenReturn(93L);
+
+        var stats = service.adminGetStats();
+        assertThat(stats.total()).isEqualTo(100L);
+        assertThat(stats.blocked()).isEqualTo(5L);
+        assertThat(stats.deleted()).isEqualTo(2L);
+        assertThat(stats.active()).isEqualTo(93L);
+    }
+
+    @Test
+    @DisplayName("adminGetStats_blocked && deleted 동시 사용자_active 별도 집계라 정확 (이중 차감 회귀 방지)")
+    void adminGetStats_이중_차감_없음() {
+        // 시나리오: 10명 중 blocked=7, deleted=7, blocked&&deleted=5. 정확한 active = 10 - (7 + 7 - 5) = 1
+        when(userRepository.countAll()).thenReturn(10L);
+        when(userRepository.countBlocked()).thenReturn(7L);
+        when(userRepository.countDeleted()).thenReturn(7L);
+        when(userRepository.countActive()).thenReturn(1L);
+
+        var stats = service.adminGetStats();
+        assertThat(stats.active())
+                .as("countActive 별도 쿼리라 이중 차감 없음 — 이전 (total - blocked - deleted) 방식이면 -4 였을 케이스")
+                .isEqualTo(1L);
+    }
 }

--- a/src/test/java/com/sseulang/domain/withdrawal/application/InMemoryFakeWithdrawalRepository.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/application/InMemoryFakeWithdrawalRepository.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.withdrawal.application;
 import com.sseulang.domain.withdrawal.domain.Withdrawal;
 import com.sseulang.domain.withdrawal.domain.WithdrawalRepository;
 import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import com.sseulang.domain.withdrawal.domain.WithdrawalStatusCount;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -68,5 +69,22 @@ public class InMemoryFakeWithdrawalRepository implements WithdrawalRepository {
                 .sorted(Comparator.comparing(Withdrawal::getId).reversed())
                 .toList();
         return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+
+    @Override
+    public List<WithdrawalStatusCount> countGroupByStatus() {
+        return store.values().stream()
+                .collect(java.util.stream.Collectors.groupingBy(Withdrawal::getStatus, java.util.stream.Collectors.counting()))
+                .entrySet().stream()
+                .map(e -> new WithdrawalStatusCount(e.getKey(), e.getValue()))
+                .toList();
+    }
+
+    @Override
+    public long sumCompletedAmount() {
+        return store.values().stream()
+                .filter(w -> w.getStatus() == WithdrawalStatus.완료)
+                .mapToLong(Withdrawal::getAmount)
+                .sum();
     }
 }


### PR DESCRIPTION
## 한 줄 요약

관리자 dashboard 통계 — 회원/거래/결제/출금 4개 도메인 집계. 게이트 2 두 라운드 거쳐 머지 가능 판정.

## 무엇이 바뀌었는지 (사람 말로)

### 새 도메인 1개
- **stats** — read-only orchestration. 자체 도메인 layer 없이 4개 도메인 ApplicationService를 호출해 dashboard 응답만 합성.

### 각 도메인에 통계 메서드 추가 (단일 집계 쿼리, N+1 없음)
- **User** — 전체/차단/삭제/정상 카운트. **정상은 별도 쿼리로 직접 집계** (이전 `total - blocked - deleted` 방식은 blocked && deleted 사용자를 이중 차감하는 정확도 버그)
- **Transaction** — status별 GROUP BY, JPQL constructor projection으로 record 매핑
- **Payment** — 완료된 결제 건수 + 누적 금액 (`COALESCE SUM`으로 0건 NULL 회피)
- **Withdrawal** — status별 GROUP BY + 완료 출금 누적 금액

### V5 마이그레이션
- `users (is_blocked, is_deleted)` 복합 인덱스 — countActive/Blocked/Deleted 풀스캔 방지

### 새 엔드포인트
- `GET /api/v1/admin/stats/dashboard` — admin chain `ROLE_ADMIN` 강제

## 의도한 결정

- **각 도메인 ApplicationService 경유** — stats가 다른 도메인 Repository를 직접 호출하지 않음 (CLAUDE.md §3.3 준수). 도메인 경계 유지.
- **byStatus는 enum 모든 값 포함** — GROUP BY 결과에 빠진 status도 0으로 채워서 클라이언트 응답 안정성 확보.
- **dashboard 1회 호출 = SQL 9개** — N+1 없는 단일 집계만. 트래픽 커지면 캐싱/scheduler 검토 (후속).

## 테스트

- [x] 432 PASS / 0 FAIL (`./gradlew test`)
- [x] AdminStatsServiceTest — orchestration mock 검증
- [x] UserApplicationServiceTest — countActive 직접 집계 + 이중 차감 회귀 가드
- [x] **AdminStatsAggregationIT** (Testcontainers MySQL slice IT)
  - User countActive 정확도 (blocked && deleted 시나리오)
  - Withdrawal GROUP BY constructor projection 매핑
  - Withdrawal/Payment SUM 0건 → 0 (COALESCE)

## 코덱스 게이트 2 (CLAUDE.md §9.6 — 검색/필터/aggregation 영역)

- **Round 1**: critical 0 + should-fix 3 (countActive 직접 집계 / V5 인덱스 / JpaRepository slice IT)
- **Round 2**: 모두 반영 → **OK 머지 가능** 판정
- 비차단 메모 2건만 후속 옵션으로 남김:
  - Transaction GROUP BY projection도 IT에 직접 포함하면 더 좋음 (Withdrawal과 패턴 동일)
  - countDeleted 단독 seek가 필요해지면 (is_deleted) 별도 인덱스 추가 검토

## 머지 후 후속 (별도 이슈 트래킹 권장)

- 트래픽 증가 시 dashboard 응답 캐싱 (Redis ttl) 또는 materialized view
- Day별 시계열 통계 (가입 추이 / 일별 거래 등)
- prod V5 마이그레이션 적용 영향 (`ADD KEY` online DDL 가능 — MySQL 8 inplace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)