### PR TITLE
feat: Day 9 — 로컬 가입/로그인 + 이메일 인증 + OAuth 계정 연동

### DIFF
--- a/src/main/java/com/sseulang/domain/auth/application/EmailVerificationService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/EmailVerificationService.java
@@ -1,0 +1,127 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.domain.EmailSender;
+import com.sseulang.domain.auth.domain.EmailVerification;
+import com.sseulang.domain.auth.domain.EmailVerificationRepository;
+import com.sseulang.domain.auth.domain.VerificationPurpose;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 이메일 인증 토큰 발급 + 검증.
+ *
+ * <p>흐름:
+ * <ol>
+ *   <li>{@link #issueSignupToken} — 가입 직후 또는 재발송. 토큰 생성 → DB 저장 → 메일 발송.</li>
+ *   <li>{@link #verifyToken} — 사용자가 메일 링크 클릭. 토큰 매칭 → 만료/재사용 가드 → user.markEmailVerified.</li>
+ * </ol>
+ *
+ * <p>토큰: 32자 UUID (충돌/brute-force 안전). 만료: 24시간. 새 토큰 발급 시 같은 user 의 기존
+ * 미사용 SIGNUP 토큰 모두 invalidate — 메일 폭탄 / 토큰 누적 차단 (게이트 1 round 2).
+ * 재발송은 60초 cooldown.</p>
+ */
+@Service
+@Transactional(readOnly = true)
+public class EmailVerificationService {
+
+    private static final Duration TOKEN_TTL = Duration.ofHours(24);
+    /** 동일 user 의 인증 메일 재발송 최소 간격 — 메일 폭탄 방어 (게이트 1 round 2). */
+    private static final Duration RESEND_COOLDOWN = Duration.ofSeconds(60);
+
+    /**
+     * userId → 마지막 발송 시각. in-memory 단일 인스턴스 가정. 다중 인스턴스 배포 시 Redis-backed
+     * counter 로 교체 권장 (5/6 이후 후속). prod 1대 운영 기준 충분.
+     */
+    private final Map<Long, LocalDateTime> lastIssuedAt = new ConcurrentHashMap<>();
+
+    private final EmailVerificationRepository verificationRepository;
+    private final UserApplicationService userService;
+    private final EmailSender emailSender;
+    private final Clock clock;
+    private final String verificationUrlBase;
+
+    public EmailVerificationService(
+            EmailVerificationRepository verificationRepository,
+            UserApplicationService userService,
+            EmailSender emailSender,
+            Clock clock,
+            @Value("${app.email.verification-url-base:http://localhost:8080/api/v1/auth/verify-email}")
+            String verificationUrlBase
+    ) {
+        this.verificationRepository = verificationRepository;
+        this.userService = userService;
+        this.emailSender = emailSender;
+        this.clock = clock;
+        this.verificationUrlBase = verificationUrlBase;
+    }
+
+    /**
+     * SIGNUP 토큰 발급 + 메일 발송. 호출 시:
+     * <ol>
+     *   <li>해당 user 의 기존 미사용 SIGNUP 토큰 모두 무효화 (구 토큰 누적 차단).</li>
+     *   <li>새 토큰 생성/저장/메일 발송.</li>
+     *   <li>userId 별 마지막 발송 시각 기록 — 재발송 cooldown 가드 기준.</li>
+     * </ol>
+     * 가입 직후 흐름 (LocalAuthService.signup) 에서도 호출되며, 가입 시점엔 기존 토큰이 없어 invalidate 는 no-op.
+     */
+    @Transactional
+    public void issueSignupToken(Long userId, String email) {
+        LocalDateTime now = LocalDateTime.now(clock);
+        verificationRepository.invalidateUnusedSignupTokens(userId, now);
+        String token = generateToken();
+        LocalDateTime expiresAt = now.plus(TOKEN_TTL);
+        verificationRepository.save(EmailVerification.issue(userId, token, VerificationPurpose.SIGNUP, expiresAt));
+        emailSender.sendVerificationEmail(email, verificationUrlBase + "?token=" + token);
+        lastIssuedAt.put(userId, now);
+    }
+
+    /** 토큰 검증 + user.markEmailVerified. 만료/재사용/없음 모두 명시 ErrorCode. */
+    @Transactional
+    public void verifyToken(String token) {
+        if (token == null || token.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID);
+        }
+        EmailVerification ver = verificationRepository.findByToken(token)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID));
+        ver.markUsed(LocalDateTime.now(clock));  // 만료/재사용 시 throw
+        User user = userService.getById(ver.getUserId());
+        user.markEmailVerified();
+    }
+
+    /**
+     * 인증 메일 재발송 — 본인 user 만 호출. 이미 verified 면 no-op (멱등).
+     * 직전 발송 후 {@link #RESEND_COOLDOWN} 이내 재호출은 {@code AUTH_VERIFICATION_RESEND_TOO_SOON} 거부 —
+     * 메일 폭탄 방어 (게이트 1 round 2).
+     */
+    @Transactional
+    public void resendForUser(Long userId) {
+        User user = userService.getById(userId);
+        if (user.isEmailVerified()) {
+            return;  // 이미 인증된 사용자 — 토큰 발급/메일 발송 모두 skip
+        }
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime last = lastIssuedAt.get(userId);
+        if (last != null && Duration.between(last, now).compareTo(RESEND_COOLDOWN) < 0) {
+            throw new com.sseulang.global.exception.BusinessException(
+                    com.sseulang.global.exception.ErrorCode.AUTH_VERIFICATION_RESEND_TOO_SOON);
+        }
+        issueSignupToken(user.getId(), user.getEmail());
+    }
+
+    private static String generateToken() {
+        // 32자 UUID hex (대시 제거) — brute-force 안전한 충분한 entropy.
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/application/LocalAuthService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/LocalAuthService.java
@@ -1,0 +1,152 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.auth.domain.RefreshTokenStore;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserRepository;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.security.JwtProperties;
+import com.sseulang.global.security.JwtProvider;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/**
+ * LOCAL (email + password) 가입/로그인 흐름. OAuth 와 분리된 별도 service.
+ *
+ * <p>보안 정책:
+ * <ul>
+ *   <li>가입: BCrypt 해싱 후 저장. 사전 email 중복 체크 + UNIQUE race 패배자 보정.</li>
+ *   <li>로그인: 미존재 user / 차단 / 비밀번호 불일치 모두 {@link ErrorCode#AUTH_LOGIN_FAILED} 통합 응답
+ *       (email 존재 여부 leak 방지). dummy hash 로 timing 균일화 (미존재 user 분기에서도 BCrypt 비용
+ *       태움 — username enumeration timing 공격 방어, AdminLogin 패턴과 동일).</li>
+ *   <li>비밀번호 정책: 8자 이상, 72자 이하 (BCrypt 72-byte limit).</li>
+ * </ul>
+ *
+ * <p>가입 직후 자동 JWT 발급 — 별도 로그인 호출 없이 즉시 인증된 세션. OAuth 흐름과 동일.</p>
+ */
+@Service
+public class LocalAuthService {
+
+    private static final String DEFAULT_ROLE = "USER";
+    private static final int MIN_PASSWORD_LENGTH = 8;
+    private static final int MAX_PASSWORD_LENGTH = 72;
+
+    /**
+     * username enumeration timing 공격 방어용 sentinel. 미존재 user 분기에서도 BCrypt cost 를
+     * 강제 태우기 위해 항상 호출. AdminLoginService 와 동일 패턴.
+     */
+    private static final String DUMMY_PASSWORD_PLAINTEXT = "__sseulang_dummy_user_sentinel_v1__";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenStore refreshTokenStore;
+    private final EmailVerificationService verificationService;
+    private final Duration refreshTokenTtl;
+    /**
+     * 생성자 시점에 실제 인코더로 encode — 하드코딩 시 인코더 변경/형식 깨짐 위험 제거 (게이트 2 보강).
+     */
+    private final String dummyPasswordHash;
+
+    public LocalAuthService(
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            JwtProvider jwtProvider,
+            RefreshTokenStore refreshTokenStore,
+            EmailVerificationService verificationService,
+            JwtProperties jwtProperties
+    ) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtProvider = jwtProvider;
+        this.refreshTokenStore = refreshTokenStore;
+        this.verificationService = verificationService;
+        this.refreshTokenTtl = Duration.ofSeconds(jwtProperties.refreshTokenValiditySeconds());
+        this.dummyPasswordHash = passwordEncoder.encode(DUMMY_PASSWORD_PLAINTEXT);
+    }
+
+    /**
+     * LOCAL 가입 + 자동 로그인. email 중복 시 {@link ErrorCode#USER_EMAIL_DUPLICATED} (다른 provider
+     * 로 이미 가입돼있어도 동일 — 가이드 §12 정책).
+     */
+    public TokenPair signup(Email email, String rawPassword, String nickname) {
+        validatePassword(rawPassword);
+
+        // 사전 중복 체크 (fast path) — UNIQUE race 의 1차 가드. 마지막 가드는 DB UNIQUE.
+        userRepository.findByEmail(email).ifPresent(u -> {
+            throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);
+        });
+
+        String hashed = passwordEncoder.encode(rawPassword);
+        User saved;
+        try {
+            saved = userRepository.save(User.createLocalUser(email, hashed, nickname));
+        } catch (DataIntegrityViolationException race) {
+            // UNIQUE race 패배 — 다른 트랜잭션이 같은 email 로 먼저 가입. 명시 거부 (다른 제약 위반은 원본 throw).
+            if (userRepository.findByEmail(email).isPresent()) {
+                throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);
+            }
+            throw race;
+        }
+        // 가입 직후 인증 메일 발송. 사용자는 verified=false 상태로 자동 로그인되며, 민감 기능은
+        // verified=true 가 될 때까지 차단 (UserApplicationService.requireVerified).
+        verificationService.issueSignupToken(saved.getId(), saved.getEmail());
+        return issueTokens(saved);
+    }
+
+    /**
+     * LOCAL 로그인. 미존재 user / 비밀번호 불일치 / 차단·삭제 계정 모두 동일 응답으로 통합 —
+     * email 존재 여부 / 계정 상태 leak 차단. dummy hash 로 BCrypt timing 균일.
+     */
+    public TokenPair login(Email email, String rawPassword) {
+        if (rawPassword == null || rawPassword.isEmpty()) {
+            throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
+        }
+        // BCrypt 72-byte 초과 입력은 truncation 위험 — login 도 byte 가드 (signup 과 동일).
+        // 실패는 LOGIN_FAILED 통합 (이메일 존재 여부 leak 방지, AdminLogin 패턴).
+        if (rawPassword.length() > MAX_PASSWORD_LENGTH
+                || rawPassword.getBytes(StandardCharsets.UTF_8).length > MAX_PASSWORD_LENGTH) {
+            throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
+        }
+        User user = userRepository.findByEmail(email).orElse(null);
+        // 미존재 / 비번 미보유(소셜 가입자) 계정에서도 dummy hash 로 BCrypt cost 강제.
+        String hashToCompare = (user != null && user.hasPassword()) ? user.getPassword() : dummyPasswordHash;
+        boolean passwordOk = passwordEncoder.matches(rawPassword, hashToCompare);
+
+        if (user == null || !user.hasPassword() || user.isBlocked() || user.isDeleted() || !passwordOk) {
+            throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
+        }
+        return issueTokens(user);
+    }
+
+    /**
+     * 비밀번호 길이 검증. BCrypt 는 평문을 UTF-8 인코딩한 byte 길이 72 까지만 처리하고 그 이상은
+     * 자동 truncation 됨 — char-length 만 보면 한글 등 multi-byte 문자가 통과되어 보안 약화 (게이트 1).
+     * char + UTF-8 byte 둘 다 검증.
+     */
+    private void validatePassword(String rawPassword) {
+        if (rawPassword == null
+                || rawPassword.length() < MIN_PASSWORD_LENGTH
+                || rawPassword.length() > MAX_PASSWORD_LENGTH) {
+            throw new BusinessException(ErrorCode.AUTH_PASSWORD_INVALID);
+        }
+        if (rawPassword.getBytes(StandardCharsets.UTF_8).length > MAX_PASSWORD_LENGTH) {
+            throw new BusinessException(ErrorCode.AUTH_PASSWORD_INVALID);
+        }
+    }
+
+    private TokenPair issueTokens(User user) {
+        String at = jwtProvider.issueAccessToken(user.getId(), DEFAULT_ROLE);
+        long tv = refreshTokenStore.currentTokenVersion(DEFAULT_ROLE, user.getId());
+        String rt = jwtProvider.issueRefreshToken(user.getId(), DEFAULT_ROLE, tv);
+        String rtJti = jwtProvider.parse(rt).jti();
+        refreshTokenStore.save(DEFAULT_ROLE, user.getId(), rtJti, refreshTokenTtl);
+        return new TokenPair(at, rt);
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/domain/EmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/EmailSender.java
@@ -1,0 +1,13 @@
+package com.sseulang.domain.auth.domain;
+
+/**
+ * 이메일 발송 추상화. 도메인 layer 인터페이스 — SMTP / SES / SendGrid 등 구현은 infrastructure.
+ *
+ * <p>본 PR scope: {@code LogEmailSender} (개발용 — 콘솔에 인증 URL 출력) 만 구현. prod SMTP
+ * 어댑터는 5/6 이후 후속.</p>
+ */
+public interface EmailSender {
+
+    /** 이메일 인증 토큰 발송. URL 은 호출자(EmailVerificationService) 가 token 으로 조립해 전달. */
+    void sendVerificationEmail(String toEmail, String verificationUrl);
+}

--- a/src/main/java/com/sseulang/domain/auth/domain/EmailVerification.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/EmailVerification.java
@@ -1,0 +1,96 @@
+package com.sseulang.domain.auth.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이메일 인증 토큰. 가입 직후 발급되고 사용자가 메일의 링크 클릭 시 verifyToken 으로 소진.
+ * 한 user 가 여러 토큰 보유 가능 (재발송 시) — 검증 시 가장 최근 미사용 토큰 매칭.
+ */
+@Entity
+@Table(name = "email_verifications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerification extends BaseEntity {
+
+    private static final int TOKEN_LENGTH_MIN = 32;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "token", nullable = false, length = 64, unique = true)
+    private String token;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "purpose", nullable = false, length = 30)
+    private VerificationPurpose purpose;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    public static EmailVerification issue(Long userId, String token, VerificationPurpose purpose, LocalDateTime expiresAt) {
+        if (userId == null || userId <= 0) {
+            throw new IllegalArgumentException("userId 는 양수여야 합니다");
+        }
+        if (token == null || token.length() < TOKEN_LENGTH_MIN) {
+            // 짧은 토큰은 brute-force 위험 — 32자 이상 강제 (UUID + extra entropy 조합).
+            throw new IllegalArgumentException("token 은 " + TOKEN_LENGTH_MIN + "자 이상이어야 합니다");
+        }
+        if (purpose == null) {
+            throw new IllegalArgumentException("purpose 는 필수입니다");
+        }
+        if (expiresAt == null) {
+            throw new IllegalArgumentException("expiresAt 은 필수입니다");
+        }
+        EmailVerification v = new EmailVerification();
+        v.userId = userId;
+        v.token = token;
+        v.purpose = purpose;
+        v.expiresAt = expiresAt;
+        return v;
+    }
+
+    /**
+     * 토큰 사용 처리. 만료 / 이미 사용된 토큰은 거부 (멱등 X — 재사용 차단).
+     */
+    public void markUsed(LocalDateTime now) {
+        if (usedAt != null) {
+            throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID);
+        }
+        // 만료 경계는 닫힘 — expiresAt 와 같은 시각도 만료된 것으로 간주 (Codex 게이트 1 round 2 nit).
+        if (now == null || !now.isBefore(expiresAt)) {
+            throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_EXPIRED);
+        }
+        this.usedAt = now;
+    }
+
+    public boolean isUsed() {
+        return usedAt != null;
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        // expiresAt 시각 자체가 만료 경계 — !isBefore 로 닫힘 처리.
+        return now != null && !now.isBefore(expiresAt);
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/domain/EmailVerificationRepository.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/EmailVerificationRepository.java
@@ -1,0 +1,16 @@
+package com.sseulang.domain.auth.domain;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository {
+
+    EmailVerification save(EmailVerification verification);
+
+    Optional<EmailVerification> findByToken(String token);
+
+    /**
+     * 해당 user 의 미사용 SIGNUP 토큰을 모두 used 처리. 새 토큰 발급 직전 호출 — 메일 폭탄/구토큰 누적 차단.
+     * 영향받은 행 수 반환.
+     */
+    int invalidateUnusedSignupTokens(Long userId, java.time.LocalDateTime now);
+}

--- a/src/main/java/com/sseulang/domain/auth/domain/VerificationPurpose.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/VerificationPurpose.java
@@ -1,0 +1,6 @@
+package com.sseulang.domain.auth.domain;
+
+/** 이메일 인증 토큰 용도. SIGNUP 만 본 PR scope, PASSWORD_RESET 등은 후속. */
+public enum VerificationPurpose {
+    SIGNUP
+}

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/email/LogEmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/email/LogEmailSender.java
@@ -1,0 +1,27 @@
+package com.sseulang.domain.auth.infrastructure.email;
+
+import com.sseulang.domain.auth.domain.EmailSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * 개발/테스트용 EmailSender — 실제 SMTP 호출 없이 로그에 인증 URL 만 출력.
+ * prod 환경에서는 별도 SMTP 어댑터(SES/SendGrid) 가 등록되어야 한다 (5/6 이후 후속).
+ *
+ * <p>{@code @Profile({"local","dev","test"})} — 명시 allowlist. {@code @Profile("!prod")} 는
+ * prod 프로필 누락(빈 active profile) 시 빈이 활성화돼 토큰 URL 이 운영 로그에 새는 회귀 위험.
+ * prod 는 SMTP 어댑터 미등록 시 부팅 실패하도록 둔다 (게이트 1 round 2).</p>
+ */
+@Component
+@Profile({"local", "dev", "test"})
+public class LogEmailSender implements EmailSender {
+
+    private static final Logger log = LoggerFactory.getLogger(LogEmailSender.class);
+
+    @Override
+    public void sendVerificationEmail(String toEmail, String verificationUrl) {
+        log.info("[email-verification] to={} url={}", toEmail, verificationUrl);
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/KakaoOAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/KakaoOAuthProvider.java
@@ -59,13 +59,20 @@ public class KakaoOAuthProvider implements OAuthProvider {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
 
-        String email = res.kakaoAccount() != null ? res.kakaoAccount().email() : null;
-        KakaoProfile profile = res.kakaoAccount() != null ? res.kakaoAccount().profile() : null;
+        KakaoAccount account = res.kakaoAccount();
+        String email = account != null ? account.email() : null;
+        KakaoProfile profile = account != null ? account.profile() : null;
         String nickname = profile != null ? profile.nickname() : null;
         String profileImage = profile != null ? profile.profileImageUrl() : null;
 
         if (email == null || nickname == null) {
             // 동의 항목 누락 — 사용자가 약관에서 거부했거나 개발자 콘솔 권한 미설정
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+        // 게이트 1 round 2 — 카카오 응답에 미인증 이메일이 포함될 수 있어 takeover/auto-verified 의
+        // 전제("provider 가 검증한 이메일") 가 깨질 수 있다. is_email_valid + is_email_verified 둘 다
+        // true 인 이메일만 허용 — 둘 중 하나라도 false/null 이면 OAuth 거부.
+        if (!Boolean.TRUE.equals(account.isEmailValid()) || !Boolean.TRUE.equals(account.isEmailVerified())) {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
 
@@ -88,7 +95,12 @@ public class KakaoOAuthProvider implements OAuthProvider {
             @JsonProperty("kakao_account") KakaoAccount kakaoAccount
     ) {}
 
-    record KakaoAccount(String email, KakaoProfile profile) {}
+    record KakaoAccount(
+            String email,
+            @JsonProperty("is_email_valid") Boolean isEmailValid,
+            @JsonProperty("is_email_verified") Boolean isEmailVerified,
+            KakaoProfile profile
+    ) {}
 
     record KakaoProfile(
             String nickname,

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/EmailVerificationJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/EmailVerificationJpaRepository.java
@@ -1,0 +1,28 @@
+package com.sseulang.domain.auth.infrastructure.persistence;
+
+import com.sseulang.domain.auth.domain.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+interface EmailVerificationJpaRepository extends JpaRepository<EmailVerification, Long> {
+
+    Optional<EmailVerification> findByToken(String token);
+
+    /**
+     * 단일 atomic UPDATE — 해당 user 의 미사용 SIGNUP 토큰 일괄 만료. 새 토큰 발급 직전 호출.
+     */
+    @Modifying
+    @Query("""
+            UPDATE EmailVerification v
+               SET v.usedAt = :now
+             WHERE v.userId = :userId
+               AND v.purpose = com.sseulang.domain.auth.domain.VerificationPurpose.SIGNUP
+               AND v.usedAt IS NULL
+            """)
+    int invalidateUnusedSignupTokens(@Param("userId") Long userId, @Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/EmailVerificationRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/EmailVerificationRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.sseulang.domain.auth.infrastructure.persistence;
+
+import com.sseulang.domain.auth.domain.EmailVerification;
+import com.sseulang.domain.auth.domain.EmailVerificationRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class EmailVerificationRepositoryImpl implements EmailVerificationRepository {
+
+    private final EmailVerificationJpaRepository jpa;
+
+    public EmailVerificationRepositoryImpl(EmailVerificationJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public EmailVerification save(EmailVerification verification) {
+        return jpa.save(verification);
+    }
+
+    @Override
+    public Optional<EmailVerification> findByToken(String token) {
+        return jpa.findByToken(token);
+    }
+
+    @Override
+    public int invalidateUnusedSignupTokens(Long userId, java.time.LocalDateTime now) {
+        return jpa.invalidateUnusedSignupTokens(userId, now);
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
@@ -1,8 +1,11 @@
 package com.sseulang.domain.auth.presentation;
 
+import com.sseulang.domain.auth.application.LocalAuthService;
 import com.sseulang.domain.auth.application.OAuthLoginService;
 import com.sseulang.domain.auth.application.RefreshTokenRotationService;
 import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.auth.presentation.dto.LocalLoginRequest;
+import com.sseulang.domain.auth.presentation.dto.LocalSignupRequest;
 import com.sseulang.domain.auth.presentation.dto.OAuthLoginRequest;
 import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.global.common.ApiResponse;
@@ -26,16 +29,42 @@ public class AuthController {
 
     private final RefreshTokenRotationService rotationService;
     private final OAuthLoginService oauthLoginService;
+    private final LocalAuthService localAuthService;
     private final CookieUtil cookieUtil;
 
     public AuthController(
             RefreshTokenRotationService rotationService,
             OAuthLoginService oauthLoginService,
+            LocalAuthService localAuthService,
             CookieUtil cookieUtil
     ) {
         this.rotationService = rotationService;
         this.oauthLoginService = oauthLoginService;
+        this.localAuthService = localAuthService;
         this.cookieUtil = cookieUtil;
+    }
+
+    /** LOCAL email/password 가입 — 가입 즉시 자동 로그인 (AT/RT 쿠키 발급). */
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody LocalSignupRequest request) {
+        TokenPair pair = localAuthService.signup(request.toEmailVO(), request.password(), request.nickname());
+        return setAuthCookies(pair);
+    }
+
+    /** LOCAL email/password 로그인. 미존재/차단/비밀번호 불일치 모두 동일 응답 (leak 방어). */
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody LocalLoginRequest request) {
+        TokenPair pair = localAuthService.login(request.toEmailVO(), request.password());
+        return setAuthCookies(pair);
+    }
+
+    private ResponseEntity<ApiResponse<Void>> setAuthCookies(TokenPair pair) {
+        ResponseCookie at = cookieUtil.accessTokenCookie(pair.accessToken());
+        ResponseCookie rt = cookieUtil.refreshTokenCookie(pair.refreshToken());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, at.toString())
+                .header(HttpHeaders.SET_COOKIE, rt.toString())
+                .body(ApiResponse.ok());
     }
 
     @PostMapping("/oauth2/{provider}")

--- a/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
@@ -1,0 +1,44 @@
+package com.sseulang.domain.auth.presentation;
+
+import com.sseulang.domain.auth.application.EmailVerificationService;
+import com.sseulang.domain.auth.presentation.dto.VerifyEmailRequest;
+import com.sseulang.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 이메일 인증 — verify (token 검증, 익명 호출) + resend (재발송, 인증 필수).
+ *
+ * <p>SecurityConfig 정책:
+ * <ul>
+ *   <li>{@code /verify-email} — PUBLIC_AUTH_ENDPOINTS, CSRF 면제 (사용자가 메일 링크 클릭하는 흐름)</li>
+ *   <li>{@code /resend-verification} — auth 필수 (hasRole("USER")) + CSRF 적용 (게이트 1 round 2 보강)</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/api/v1/auth")
+public class EmailVerificationController {
+
+    private final EmailVerificationService verificationService;
+
+    public EmailVerificationController(EmailVerificationService verificationService) {
+        this.verificationService = verificationService;
+    }
+
+    @PostMapping("/verify-email")
+    public ApiResponse<Void> verify(@Valid @RequestBody VerifyEmailRequest request) {
+        verificationService.verifyToken(request.token());
+        return ApiResponse.ok();
+    }
+
+    /** 본인 인증 메일 재발송 — 로그인 필수. 이미 verified 면 no-op. */
+    @PostMapping("/resend-verification")
+    public ApiResponse<Void> resend(@AuthenticationPrincipal Long userId) {
+        verificationService.resendForUser(userId);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/LocalLoginRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/LocalLoginRequest.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.auth.presentation.dto;
+
+import com.sseulang.domain.user.domain.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LocalLoginRequest(
+        @NotBlank @jakarta.validation.constraints.Email @Size(max = 100) String email,
+        @NotBlank @Size(max = 72) String password
+) {
+    public Email toEmailVO() {
+        return new Email(email);
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/LocalSignupRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/LocalSignupRequest.java
@@ -1,0 +1,19 @@
+package com.sseulang.domain.auth.presentation.dto;
+
+import com.sseulang.domain.user.domain.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * LOCAL 가입 요청. 비밀번호는 BCrypt 72-byte limit + 보안 정책으로 8~72자.
+ * 길이/형식 추가 검증은 LocalAuthService 가 도메인 룰로 한 번 더 가드.
+ */
+public record LocalSignupRequest(
+        @NotBlank @jakarta.validation.constraints.Email @Size(max = 100) String email,
+        @NotBlank @Size(min = 8, max = 72) String password,
+        @NotBlank @Size(max = 50) String nickname
+) {
+    public Email toEmailVO() {
+        return new Email(email);
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/VerifyEmailRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/VerifyEmailRequest.java
@@ -1,0 +1,8 @@
+package com.sseulang.domain.auth.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record VerifyEmailRequest(
+        @NotBlank @Size(min = 32, max = 64) String token
+) {}

--- a/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
+++ b/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
@@ -22,21 +22,26 @@ public class ChatRoomApplicationService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ItemApplicationService itemApplicationService;
+    private final com.sseulang.domain.user.application.UserApplicationService userApplicationService;
 
     public ChatRoomApplicationService(
             ChatRoomRepository chatRoomRepository,
-            ItemApplicationService itemApplicationService
+            ItemApplicationService itemApplicationService,
+            com.sseulang.domain.user.application.UserApplicationService userApplicationService
     ) {
         this.chatRoomRepository = chatRoomRepository;
         this.itemApplicationService = itemApplicationService;
+        this.userApplicationService = userApplicationService;
     }
 
     /**
      * 물품 ID 로 채팅방 생성 (가이드 §6.1). 멱등 — 이미 있으면 기존 반환.
      * 본인 물품 거부 (자기 자신과 채팅 X). UNIQUE race 는 좁은 catch 후 재조회.
+     * 미인증 사용자의 채팅 스팸 방지 — verified 가드 (게이트 1 round 2).
      */
     @Transactional
     public ChatRoomResult openFor(Long requesterId, Long itemId) {
+        userApplicationService.requireVerified(requesterId);
         Long sellerId = itemApplicationService.findSellerOfActiveItem(itemId);
         if (sellerId.equals(requesterId)) {
             throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);

--- a/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
+++ b/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
@@ -59,13 +59,19 @@ public class FileApplicationService {
     );
 
     private final PresignedUrlGenerator generator;
+    private final com.sseulang.domain.user.application.UserApplicationService userService;
 
-    public FileApplicationService(PresignedUrlGenerator generator) {
+    public FileApplicationService(
+            PresignedUrlGenerator generator,
+            com.sseulang.domain.user.application.UserApplicationService userService
+    ) {
         this.generator = generator;
+        this.userService = userService;
     }
 
     /**
      * 일반 사용자 진입점. {@link #USER_ALLOWED_PURPOSES} 외 purpose 는 거부한다.
+     * 미인증 이메일 사용자가 비용 큰 S3 업로드를 남용하지 못하도록 verified 가드 (게이트 1 round 2).
      */
     public List<PresignResult> issueForUser(FilePurpose purpose, Long ownerId, List<PresignRequestItem> files) {
         if (purpose == null) {
@@ -74,6 +80,7 @@ public class FileApplicationService {
         if (!USER_ALLOWED_PURPOSES.contains(purpose)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
+        userService.requireVerified(ownerId);
         return issue(purpose, ownerId, files);
     }
 

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -1,6 +1,7 @@
 package com.sseulang.domain.item.application;
 
 import com.sseulang.domain.category.application.CategoryApplicationService;
+import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.domain.item.application.dto.ItemDetailResult;
 import com.sseulang.domain.item.application.dto.ItemForTransactionResult;
 import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
@@ -25,17 +26,22 @@ public class ItemApplicationService {
 
     private final ItemRepository itemRepository;
     private final CategoryApplicationService categoryApplicationService;
+    private final UserApplicationService userApplicationService;
 
     public ItemApplicationService(
             ItemRepository itemRepository,
-            CategoryApplicationService categoryApplicationService
+            CategoryApplicationService categoryApplicationService,
+            UserApplicationService userApplicationService
     ) {
         this.itemRepository = itemRepository;
         this.categoryApplicationService = categoryApplicationService;
+        this.userApplicationService = userApplicationService;
     }
 
     @Transactional
     public Long register(ItemRegisterCommand cmd) {
+        // Item 등록 — 사기 방지 위해 이메일 인증 필수 (게이트 1).
+        userApplicationService.requireVerified(cmd.sellerId());
         categoryApplicationService.requireExists(cmd.categoryId());
         Item item = Item.create(
                 cmd.sellerId(), cmd.categoryId(),

--- a/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
@@ -12,6 +12,7 @@ import com.sseulang.domain.payment.domain.PaymentRepository;
 import com.sseulang.domain.point.application.PointApplicationService;
 import com.sseulang.domain.point.domain.PointHistoryType;
 import com.sseulang.domain.point.domain.PointReferenceType;
+import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import com.sseulang.global.infra.payment.TossProperties;
@@ -43,17 +44,20 @@ public class PaymentApplicationService {
     private final PaymentRepository paymentRepository;
     private final PaymentGateway paymentGateway;
     private final PointApplicationService pointApplicationService;
+    private final UserApplicationService userApplicationService;
     private final TossProperties tossProperties;
 
     public PaymentApplicationService(
             PaymentRepository paymentRepository,
             PaymentGateway paymentGateway,
             PointApplicationService pointApplicationService,
+            UserApplicationService userApplicationService,
             TossProperties tossProperties
     ) {
         this.paymentRepository = paymentRepository;
         this.paymentGateway = paymentGateway;
         this.pointApplicationService = pointApplicationService;
+        this.userApplicationService = userApplicationService;
         this.tossProperties = tossProperties;
     }
 
@@ -62,6 +66,8 @@ public class PaymentApplicationService {
         if (cmd.amount() <= 0) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST);
         }
+        // 자금 흐름 진입점 — 이메일 인증 미완료 사용자 차단 (게이트 1).
+        userApplicationService.requireVerified(cmd.userId());
         String merchantUid = generateMerchantUid();
         Payment payment = Payment.startCharge(cmd.userId(), merchantUid, cmd.amount());
         Payment saved = paymentRepository.save(payment);

--- a/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
+++ b/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
@@ -18,22 +18,33 @@ import java.time.LocalDateTime;
 public class UserReportApplicationService {
 
     private final UserReportRepository repository;
+    private final com.sseulang.domain.user.application.UserApplicationService userService;
     private final Clock clock;
 
-    public UserReportApplicationService(UserReportRepository repository, Clock clock) {
+    public UserReportApplicationService(
+            UserReportRepository repository,
+            com.sseulang.domain.user.application.UserApplicationService userService,
+            Clock clock
+    ) {
         this.repository = repository;
+        this.userService = userService;
         this.clock = clock;
     }
 
-    /** 사용자 신고. 자기 신고 거부는 도메인 invariant 에서. */
+    /**
+     * 사용자 신고. 자기 신고 거부는 도메인 invariant 에서.
+     * 미인증 사용자의 무차별 신고 스팸 방지 — verified 가드 (게이트 1 round 2).
+     */
     @Transactional
     public Long reportUser(Long reporterId, Long reportedUserId, String reason, String detail) {
+        userService.requireVerified(reporterId);
         return repository.save(UserReport.reportUser(reporterId, reportedUserId, reason, detail)).getId();
     }
 
     /** 물품 신고. Item 존재 여부는 FK 가 잡음 (RESTRICT/CASCADE) — 별도 검증 생략. */
     @Transactional
     public Long reportItem(Long reporterId, Long itemId, String reason, String detail) {
+        userService.requireVerified(reporterId);
         return repository.save(UserReport.reportItem(reporterId, itemId, reason, detail)).getId();
     }
 

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.domain.item.application.dto.ItemForTransactionResult;
 import com.sseulang.domain.point.application.PointApplicationService;
 import com.sseulang.domain.point.domain.PointReferenceType;
+import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.domain.transaction.application.dto.ReviewableTransactionResult;
 import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
 import com.sseulang.domain.transaction.application.dto.TransactionResult;
@@ -43,19 +44,24 @@ public class TransactionApplicationService {
     private final TransactionRepository transactionRepository;
     private final ItemApplicationService itemApplicationService;
     private final PointApplicationService pointApplicationService;
+    private final UserApplicationService userApplicationService;
 
     public TransactionApplicationService(
             TransactionRepository transactionRepository,
             ItemApplicationService itemApplicationService,
-            PointApplicationService pointApplicationService
+            PointApplicationService pointApplicationService,
+            UserApplicationService userApplicationService
     ) {
         this.transactionRepository = transactionRepository;
         this.itemApplicationService = itemApplicationService;
         this.pointApplicationService = pointApplicationService;
+        this.userApplicationService = userApplicationService;
     }
 
     @Transactional
     public Long create(TransactionCreateCommand cmd) {
+        // 거래 시작은 자금 영향 — 이메일 인증 필수 (게이트 1: 미인증 사용자 차단).
+        userApplicationService.requireVerified(cmd.buyerId());
         ItemForTransactionResult info = itemApplicationService.findActiveForTransaction(cmd.itemId());
         if (info.sellerId().equals(cmd.buyerId())) {
             throw new BusinessException(ErrorCode.TRANSACTION_SELF_NOT_ALLOWED);

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -26,10 +26,17 @@ public class UserApplicationService {
     }
 
     /**
-     * 소셜 가입 흐름 — (provider, providerId) 로 기존 user 조회, 없으면 신규 가입.
-     *
-     * <p>주의: 같은 email 이 다른 provider 로 이미 가입돼 있으면 {@code USER_EMAIL_DUPLICATED}.
-     * 이 정책은 가이드 §12 의 미결정 영역 — 추후 PM 협의로 "동일 이메일 다중 provider 연결" 허용 시 변경.</p>
+     * 소셜 가입/로그인 흐름 — (provider, providerId) 로 기존 user 조회. 없으면:
+     * <ol>
+     *   <li>같은 email 의 기존 user 가 있으면:
+     *     <ul>
+     *       <li>LOCAL 가입자 → <b>takeover</b>: linkSocial(provider, providerId), 기존 password 무효화 +
+     *           verified=true. 이메일 선점 공격 무력화 (게이트 1).</li>
+     *       <li>다른 provider OAuth 가입자 → AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER 거부</li>
+     *     </ul>
+     *   </li>
+     *   <li>같은 email user 없음 → 신규 OAuth user 생성 (verified=true).</li>
+     * </ol>
      */
     @Transactional
     public User findOrCreateBySocial(
@@ -40,12 +47,41 @@ public class UserApplicationService {
             String profileImage
     ) {
         return userRepository.findBySocial(provider, providerId)
-                .orElseGet(() -> create(provider, providerId, email, nickname, profileImage));
+                .orElseGet(() -> linkOrCreate(provider, providerId, email, nickname, profileImage));
+    }
+
+    /**
+     * 같은 email user 발견 분기 처리 (linking) + 없으면 신규 생성. {@code create} race 처리도 동일.
+     */
+    private User linkOrCreate(SocialProvider provider, String providerId, Email email, String nickname, String profileImage) {
+        Optional<User> sameEmail = userRepository.findByEmail(email);
+        if (sameEmail.isPresent()) {
+            User existing = sameEmail.get();
+            if (existing.getSocialProvider() == SocialProvider.LOCAL) {
+                // LOCAL 가입자 → OAuth takeover. 기존 password 무효화, social 정보 추가.
+                existing.linkSocial(provider, providerId);
+                return existing;
+            }
+            // 다른 OAuth provider — 본 PR scope 에선 multi-provider linking 미지원.
+            throw new BusinessException(ErrorCode.AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER);
+        }
+        return create(provider, providerId, email, nickname, profileImage);
     }
 
     public User getById(Long id) {
         return userRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * 민감 기능 진입 가드 — 이메일 인증 미완료 시 {@link ErrorCode#AUTH_EMAIL_NOT_VERIFIED} (FORBIDDEN).
+     * 거래 시작 / 결제 / 출금 / Item 등록 등 자금·신뢰 영향 흐름의 첫 진입점에서 호출.
+     */
+    public void requireVerified(Long userId) {
+        User user = getById(userId);
+        if (!user.isEmailVerified()) {
+            throw new BusinessException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
+        }
     }
 
     /**
@@ -136,9 +172,6 @@ public class UserApplicationService {
     }
 
     private User create(SocialProvider provider, String providerId, Email email, String nickname, String profileImage) {
-        userRepository.findByEmail(email).ifPresent(existing -> {
-            throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);
-        });
         User newUser = User.createSocialUser(provider, providerId, email, nickname, profileImage);
         try {
             return userRepository.save(newUser);
@@ -157,9 +190,15 @@ public class UserApplicationService {
         if (raceWinner.isPresent()) {
             return raceWinner.get();
         }
-        // 다른 user 가 같은 email 로 가입한 경우만 USER_EMAIL_DUPLICATED 로 변환
-        if (userRepository.findByEmail(email).isPresent()) {
-            throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);
+        // 다른 user 가 같은 email 로 가입했다면 linking 흐름 재진입 (takeover or 거부)
+        Optional<User> sameEmail = userRepository.findByEmail(email);
+        if (sameEmail.isPresent()) {
+            User existing = sameEmail.get();
+            if (existing.getSocialProvider() == SocialProvider.LOCAL) {
+                existing.linkSocial(provider, providerId);
+                return existing;
+            }
+            throw new BusinessException(ErrorCode.AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER);
         }
         // UNIQUE 충돌이 아닌 다른 제약 위반 — 시스템 에러로 그대로 노출
         throw race;

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -53,6 +54,22 @@ public class User extends BaseEntity {
     @Column(name = "social_id", length = 100)
     private String socialId;
 
+    /**
+     * BCrypt 해싱된 비밀번호. LOCAL 가입 사용자에게만 채워짐 (소셜 가입은 null).
+     * 평문 비밀번호 검증/해싱은 application layer 의 {@code LocalAuthService} 책임 — 도메인 layer 는
+     * Spring Security 의존 X (CLAUDE.md §3.3).
+     */
+    @Column(name = "password", length = 255)
+    private String password;
+
+    /**
+     * 이메일 소유 검증 여부. OAuth 가입자는 provider 가 검증한 이메일이라 자동 true,
+     * LOCAL 가입자는 인증 메일 클릭 후 true. 민감 기능 (거래/결제/출금/Item 등록) 가드의 기준.
+     * V6 마이그레이션에서 컬럼 추가 + OAuth 사용자 backfill.
+     */
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified;
+
     @Column(name = "is_blocked", nullable = false)
     private boolean blocked;
 
@@ -83,6 +100,15 @@ public class User extends BaseEntity {
     private long pointBalance;
 
     /**
+     * JPA optimistic lock — V7 마이그레이션. LOCAL takeover 처럼 read-modify-write 흐름에서 두
+     * 트랜잭션이 같은 user 를 동시 변경하면 OptimisticLockException 으로 한 쪽이 실패한다 (게이트 1).
+     * 단순 atomic UPDATE (point_balance 등) 는 본 컬럼을 갱신하지 않는다 — JPA dirty-check 시점에만 동작.
+     */
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
+
+    /**
      * 소셜 가입 흐름의 정적 팩토리. (provider, providerId) 가 비어있을 수 없으며 LOCAL 은 거부.
      * 일반 회원가입 흐름은 별도 팩토리(예: {@code createLocalUser})로 분리.
      */
@@ -109,9 +135,68 @@ public class User extends BaseEntity {
         u.profileImage = profileImage;
         u.socialProvider = provider;
         u.socialId = providerId;
+        u.emailVerified = true;  // OAuth provider 가 이메일 소유 검증 — 자동 verified
         u.blocked = false;
         u.deleted = false;
         return u;
+    }
+
+    /**
+     * LOCAL 가입 정적 팩토리. 비밀번호는 호출자(LocalAuthService) 가 BCrypt 해싱한 결과만 받음 —
+     * 도메인 layer 가 평문/해싱 전환 책임지지 않음 (Spring Security 의존성 회피, CLAUDE.md §3.3).
+     */
+    public static User createLocalUser(Email email, String hashedPassword, String nickname) {
+        if (email == null) {
+            throw new IllegalArgumentException("email 은 필수입니다");
+        }
+        if (hashedPassword == null || hashedPassword.isBlank()) {
+            throw new IllegalArgumentException("hashedPassword 는 필수입니다");
+        }
+        if (nickname == null || nickname.isBlank()) {
+            throw new IllegalArgumentException("nickname 은 필수입니다");
+        }
+
+        User u = new User();
+        u.email = email.value();
+        u.nickname = nickname;
+        u.socialProvider = SocialProvider.LOCAL;
+        u.socialId = null;
+        u.password = hashedPassword;
+        u.emailVerified = false;  // LOCAL 가입은 인증 메일 클릭 전까지 false
+        u.blocked = false;
+        u.deleted = false;
+        return u;
+    }
+
+    /** LOCAL 가입 사용자만 비밀번호 보유. 소셜 가입은 null 반환. */
+    public boolean hasPassword() {
+        return password != null && !password.isBlank();
+    }
+
+    /** 이메일 인증 완료. 멱등 호출 가능. */
+    public void markEmailVerified() {
+        this.emailVerified = true;
+    }
+
+    /**
+     * OAuth takeover — 기존 LOCAL user 가 점유한 email 에 진짜 owner 가 OAuth 로 가입 시도.
+     * 기존 user 의 password 무효화 + social 정보 추가 + verified=true. 공격자(LOCAL 가입자)는
+     * 더 이상 비밀번호로 로그인 불가. 게이트 1: 이메일 선점 공격 무력화.
+     *
+     * <p>호출 전제: 같은 user 가 다른 OAuth provider 와 연결되지 않은 상태 — 호출자가 검증.</p>
+     */
+    public void linkSocial(SocialProvider provider, String socialId) {
+        if (provider == null || provider == SocialProvider.LOCAL) {
+            throw new IllegalArgumentException("소셜 provider 는 LOCAL 외여야 합니다");
+        }
+        if (socialId == null || socialId.isBlank()) {
+            throw new IllegalArgumentException("socialId 는 필수입니다");
+        }
+        this.socialProvider = provider;
+        this.socialId = socialId;
+        // takeover — 기존 LOCAL 비밀번호 무효화 (공격자 차단)
+        this.password = null;
+        this.emailVerified = true;
     }
 
     /** 도메인 layer 외부에서 raw String 대신 VO 로 다루도록 의미적 wrapper. */

--- a/src/main/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationService.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationService.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.withdrawal.application;
 import com.sseulang.domain.point.application.PointApplicationService;
 import com.sseulang.domain.point.domain.PointHistoryType;
 import com.sseulang.domain.point.domain.PointReferenceType;
+import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalRequestCommand;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalResult;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
@@ -50,6 +51,7 @@ public class WithdrawalApplicationService {
 
     private final WithdrawalRepository withdrawalRepository;
     private final PointApplicationService pointApplicationService;
+    private final UserApplicationService userApplicationService;
     /**
      * 자기 자신 proxy — {@link #request} 가 {@link #insertWithDeduct} 를 별도 트랜잭션으로 호출하기 위해
      * 사용한다. 직접 {@code this.insertWithDeduct(...)} 로 호출하면 Spring AOP 가 가로채지 못해
@@ -61,10 +63,12 @@ public class WithdrawalApplicationService {
     public WithdrawalApplicationService(
             WithdrawalRepository withdrawalRepository,
             PointApplicationService pointApplicationService,
+            UserApplicationService userApplicationService,
             @Lazy WithdrawalApplicationService self
     ) {
         this.withdrawalRepository = withdrawalRepository;
         this.pointApplicationService = pointApplicationService;
+        this.userApplicationService = userApplicationService;
         this.self = self;
     }
 
@@ -87,6 +91,8 @@ public class WithdrawalApplicationService {
         if (cmd.amount() <= 0) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST);
         }
+        // 자금 인출 — 이메일 인증 필수 (게이트 1).
+        userApplicationService.requireVerified(cmd.userId());
 
         // 1) Fast path — 기존 신청 dedup. payload 가 다르면 클라이언트 버그 시그널 → 명시 거부.
         var existing = withdrawalRepository.findByUserIdAndIdempotencyKey(cmd.userId(), cmd.idempotencyKey());

--- a/src/main/java/com/sseulang/global/config/SecurityConfig.java
+++ b/src/main/java/com/sseulang/global/config/SecurityConfig.java
@@ -42,12 +42,29 @@ public class SecurityConfig {
             "/actuator/info"
     };
 
-    private static final String[] AUTH_ENDPOINTS = {
-            "/api/v1/auth/**"
+    /**
+     * 인증 없이 호출 가능한 auth endpoint 들. {@code /api/v1/auth/**} 통째로 permitAll 하지 않고
+     * 개별 명시 — {@code /api/v1/auth/resend-verification} 같은 인증 필수 endpoint 가 실수로
+     * permitAll 되는 회귀 차단 (게이트 1 round 2).
+     */
+    private static final String[] PUBLIC_AUTH_ENDPOINTS = {
+            "/api/v1/auth/oauth2/**",
+            "/api/v1/auth/signup",
+            "/api/v1/auth/login",
+            "/api/v1/auth/refresh",
+            "/api/v1/auth/logout",
+            "/api/v1/auth/verify-email"
     };
 
     private static final String[] CSRF_IGNORED_ENDPOINTS = {
-            "/api/v1/auth/**",
+            // 위 PUBLIC_AUTH_ENDPOINTS 와 동일한 정책 — 익명 호출 endpoint 만 CSRF 면제.
+            // resend-verification 은 인증 필수라 면제 X.
+            "/api/v1/auth/oauth2/**",
+            "/api/v1/auth/signup",
+            "/api/v1/auth/login",
+            "/api/v1/auth/refresh",
+            "/api/v1/auth/logout",
+            "/api/v1/auth/verify-email",
             // WebSocket handshake 는 SockJS 폴백 path 까지 포함해 CSRF 면제 — STOMP CONNECT 단계의
             // 인증·인가는 ChannelInterceptor 가 별도 검증.
             "/ws-stomp/**",
@@ -119,7 +136,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(AUTH_ENDPOINTS).permitAll()
+                        .requestMatchers(PUBLIC_AUTH_ENDPOINTS).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/items/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/categories/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/payments/webhook/**").permitAll()

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -21,6 +21,12 @@ public enum ErrorCode {
     AUTH_TOKEN_REVOKED(HttpStatus.UNAUTHORIZED, "폐기된 토큰입니다."),
     AUTH_REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     AUTH_OAUTH_FAILED(HttpStatus.UNAUTHORIZED, "소셜 로그인에 실패했습니다."),
+    AUTH_PASSWORD_INVALID(HttpStatus.BAD_REQUEST, "비밀번호 형식이 올바르지 않습니다."),
+    AUTH_EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 필요합니다."),
+    AUTH_VERIFICATION_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 토큰입니다."),
+    AUTH_VERIFICATION_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 인증 토큰입니다."),
+    AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER(HttpStatus.CONFLICT, "이미 다른 SNS 로 가입된 이메일입니다."),
+    AUTH_VERIFICATION_RESEND_TOO_SOON(HttpStatus.TOO_MANY_REQUESTS, "인증 메일 재발송은 잠시 후 다시 시도해 주세요."),
 
     // 사용자
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/sseulang/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sseulang/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.http.ResponseEntity;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
@@ -77,6 +78,21 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<ApiResponse<Void>> handleAuthentication(AuthenticationException ex) {
         ErrorCode code = ErrorCode.AUTH_TOKEN_INVALID;
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.fail(code.name(), code.getDefaultMessage(), traceId()));
+    }
+
+    /**
+     * JPA optimistic lock 충돌 — 주로 OAuth takeover 같은 read-modify-write 가 동시에 실행될 때
+     * (User @Version). 5xx 로 떨어지면 운영 노이즈 + 사용자 혼란이라 409 (CONFLICT) 로 변환 —
+     * 사용자가 다시 시도하면 winner 의 변경이 반영된 상태라 정상 흐름 (게이트 1 round 3 보강).
+     */
+    @ExceptionHandler(OptimisticLockingFailureException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOptimisticLock(
+            OptimisticLockingFailureException ex, HttpServletRequest request
+    ) {
+        log.warn("[OptimisticLock] {} {} - {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
+        ErrorCode code = ErrorCode.AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER;
         return ResponseEntity.status(code.getStatus())
                 .body(ApiResponse.fail(code.name(), code.getDefaultMessage(), traceId()));
     }

--- a/src/main/resources/db/migration/V6__add_email_verification.sql
+++ b/src/main/resources/db/migration/V6__add_email_verification.sql
@@ -1,0 +1,33 @@
+-- =====================================================
+-- V6: 이메일 인증 + 계정 연동 인프라 (게이트 1 round 2 보강)
+-- =====================================================
+-- LOCAL 가입 시 이메일 소유 검증을 위한 인증 토큰. OAuth 가입자는 provider 가 검증한 이메일이라
+-- 자동 verified=true. LOCAL 사용자는 인증 클릭 후 verified=true 가 되며, 그전엔 민감 기능
+-- (거래/결제/출금/Item 등록) 이용 차단 (UserApplicationService.requireVerified).
+-- =====================================================
+
+ALTER TABLE users
+    ADD COLUMN email_verified BOOLEAN NOT NULL DEFAULT FALSE AFTER password;
+
+-- 기존 OAuth 사용자 backfill — provider 가 이미 검증한 이메일이므로 verified=true 로 마킹.
+-- 검증된 provider (KAKAO/GOOGLE) 만 명시 — DEV/LOCAL 또는 후속 추가될 검증 미보장 provider 가
+-- 실수로 verified 처리되는 회귀 차단 (게이트 1 round 2). 카카오는 추가로 OAuth provider 응답 단계
+-- 에서 is_email_valid + is_email_verified 를 강제 검증함 (KakaoOAuthProvider).
+UPDATE users
+   SET email_verified = TRUE
+ WHERE social_provider IN ('KAKAO', 'GOOGLE');
+
+CREATE TABLE email_verifications (
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id     BIGINT       NOT NULL,
+    token       VARCHAR(64)  NOT NULL,
+    purpose     VARCHAR(30)  NOT NULL DEFAULT 'SIGNUP',  -- SIGNUP / PASSWORD_RESET (후속)
+    expires_at  DATETIME     NOT NULL,
+    used_at     DATETIME     NULL,
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_email_ver_token (token),
+    KEY idx_email_ver_user (user_id),
+    CONSTRAINT fk_email_ver_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V7__add_user_version.sql
+++ b/src/main/resources/db/migration/V7__add_user_version.sql
@@ -1,0 +1,10 @@
+-- =====================================================
+-- V7: users.version 컬럼 — JPA optimistic lock (게이트 1 round 2 보강)
+-- =====================================================
+-- LOCAL takeover 같은 read-modify-write 흐름에서 두 OAuth provider 가 동시 takeover 시도 시
+-- last-commit-wins 로 한 쪽 social 정보가 사라지는 race 방지. JPA @Version 으로 update 시점에
+-- where version = :loaded 조건 추가 → 동시 변경 충돌은 OptimisticLockException.
+-- =====================================================
+
+ALTER TABLE users
+    ADD COLUMN version BIGINT NOT NULL DEFAULT 0 AFTER point_balance;

--- a/src/test/java/com/sseulang/domain/auth/application/LocalAuthServiceTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/LocalAuthServiceTest.java
@@ -1,0 +1,210 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.application.dto.TokenPair;
+import com.sseulang.domain.auth.domain.RefreshTokenStore;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserRepository;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.security.JwtClaims;
+import com.sseulang.global.security.JwtProperties;
+import com.sseulang.global.security.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LocalAuthServiceTest {
+
+    private static final Email EMAIL = new Email("local@test.com");
+
+    @Mock private UserRepository userRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private RefreshTokenStore refreshTokenStore;
+    @Mock private com.sseulang.domain.auth.application.EmailVerificationService verificationService;
+
+    private LocalAuthService service;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties props = new JwtProperties("0123456789012345678901234567890123", 1800L, 604800L);
+        service = new LocalAuthService(userRepository, passwordEncoder, jwtProvider, refreshTokenStore, verificationService, props);
+    }
+
+    private User savedUser(String hashedPw) {
+        User u = User.createLocalUser(EMAIL, hashedPw, "로컬");
+        ReflectionTestUtils.setField(u, "id", 7L);
+        return u;
+    }
+
+    @Test
+    @DisplayName("signup 정상_BCrypt 해싱 + AT/RT 발급")
+    void signup_정상() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("password123")).thenReturn("$2a$10$hashed");
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> {
+            User u = inv.getArgument(0);
+            ReflectionTestUtils.setField(u, "id", 7L);
+            return u;
+        });
+        when(jwtProvider.issueAccessToken(7L, "USER")).thenReturn("at-token");
+        when(refreshTokenStore.currentTokenVersion("USER", 7L)).thenReturn(0L);
+        when(jwtProvider.issueRefreshToken(7L, "USER", 0L)).thenReturn("rt-token");
+        when(jwtProvider.parse("rt-token")).thenReturn(new JwtClaims(7L, "USER", "rt-jti", 0L, null, null));
+
+        TokenPair pair = service.signup(EMAIL, "password123", "로컬");
+
+        assertThat(pair.accessToken()).isEqualTo("at-token");
+        assertThat(pair.refreshToken()).isEqualTo("rt-token");
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("signup 짧은 password_AUTH_PASSWORD_INVALID")
+    void signup_password_짧음() {
+        assertThatThrownBy(() -> service.signup(EMAIL, "short", "로컬"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_PASSWORD_INVALID);
+    }
+
+    @Test
+    @DisplayName("signup BCrypt 72-byte 초과 password_AUTH_PASSWORD_INVALID")
+    void signup_password_길이초과() {
+        String tooLong = "a".repeat(73);
+        assertThatThrownBy(() -> service.signup(EMAIL, tooLong, "로컬"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_PASSWORD_INVALID);
+    }
+
+    @Test
+    @DisplayName("signup 한글 25자 password (75 bytes UTF-8)_BCrypt truncation 회귀 차단 (게이트 1 round 2)")
+    void signup_password_한글_75bytes_거부() {
+        String multiByte = "가".repeat(25);  // 한글 1자 = 3 bytes UTF-8 → 75 bytes
+        assertThatThrownBy(() -> service.signup(EMAIL, multiByte, "로컬"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_PASSWORD_INVALID);
+    }
+
+    @Test
+    @DisplayName("login 한글 25자 password (75 bytes UTF-8)_AUTH_LOGIN_FAILED (게이트 1 round 2 login byte guard 회귀)")
+    void login_password_한글_75bytes_거부() {
+        String multiByte = "가".repeat(25);
+        // user 시드 없어도 byte 가드가 먼저 트리거 — repo 조회 전 거부.
+        assertThatThrownBy(() -> service.login(EMAIL, multiByte))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_LOGIN_FAILED);
+    }
+
+    @Test
+    @DisplayName("signup 사전 email 중복_USER_EMAIL_DUPLICATED + save 호출 X")
+    void signup_사전_중복() {
+        User existing = savedUser("$2a$10$other");
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.signup(EMAIL, "password123", "로컬"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_EMAIL_DUPLICATED);
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("signup UNIQUE race 패배_USER_EMAIL_DUPLICATED 변환")
+    void signup_race_패배() {
+        when(userRepository.findByEmail(EMAIL))
+                .thenReturn(Optional.empty())  // 사전 체크
+                .thenReturn(Optional.of(savedUser("$2a$10$hashed")));  // race winner 발견
+        when(passwordEncoder.encode("password123")).thenReturn("$2a$10$hashed");
+        when(userRepository.save(any(User.class)))
+                .thenThrow(new DataIntegrityViolationException("uk_users_email"));
+
+        assertThatThrownBy(() -> service.signup(EMAIL, "password123", "로컬"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_EMAIL_DUPLICATED);
+    }
+
+    @Test
+    @DisplayName("login 정상_BCrypt matches + AT/RT 발급")
+    void login_정상() {
+        User user = savedUser("$2a$10$realhash");
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(eq("password123"), eq("$2a$10$realhash"))).thenReturn(true);
+        when(jwtProvider.issueAccessToken(7L, "USER")).thenReturn("at-token");
+        when(refreshTokenStore.currentTokenVersion("USER", 7L)).thenReturn(0L);
+        when(jwtProvider.issueRefreshToken(7L, "USER", 0L)).thenReturn("rt-token");
+        when(jwtProvider.parse("rt-token")).thenReturn(new JwtClaims(7L, "USER", "rt-jti", 0L, null, null));
+
+        TokenPair pair = service.login(EMAIL, "password123");
+        assertThat(pair.accessToken()).isEqualTo("at-token");
+    }
+
+    @Test
+    @DisplayName("login 미존재 email_AUTH_LOGIN_FAILED + dummy hash 로 BCrypt 강제 (timing leak 방어)")
+    void login_미존재_dummy_BCrypt() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.login(EMAIL, "password123"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_LOGIN_FAILED);
+        // 핵심: 미존재 email 분기에서도 passwordEncoder.matches 가 호출됨 (timing 균일)
+        verify(passwordEncoder).matches(eq("password123"), any());
+    }
+
+    @Test
+    @DisplayName("login 소셜 가입자 (password 없음)_AUTH_LOGIN_FAILED + dummy hash matches 호출")
+    void login_소셜가입자_local_거부() {
+        User social = User.createSocialUser(SocialProvider.KAKAO, "k-1", EMAIL, "kakao", null);
+        ReflectionTestUtils.setField(social, "id", 7L);
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(social));
+
+        assertThatThrownBy(() -> service.login(EMAIL, "password123"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_LOGIN_FAILED);
+        verify(passwordEncoder).matches(eq("password123"), any());  // dummy hash 로 timing 균일
+    }
+
+    @Test
+    @DisplayName("login 차단된 user_AUTH_LOGIN_FAILED")
+    void login_차단_거부() {
+        User blocked = savedUser("$2a$10$realhash");
+        ReflectionTestUtils.setField(blocked, "blocked", true);
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(blocked));
+        when(passwordEncoder.matches(any(), any())).thenReturn(true);  // 비밀번호 맞아도 거부
+
+        assertThatThrownBy(() -> service.login(EMAIL, "password123"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_LOGIN_FAILED);
+    }
+
+    @Test
+    @DisplayName("dummyPasswordHash 가 BCrypt 표준 형식 (게이트 2 회귀: 형식 깨짐 차단)")
+    void dummyHash_실제_BCrypt_패턴() {
+        BCryptPasswordEncoder real = new BCryptPasswordEncoder();
+        JwtProperties props = new JwtProperties("0123456789012345678901234567890123", 1800L, 604800L);
+        LocalAuthService realSvc = new LocalAuthService(userRepository, real, jwtProvider, refreshTokenStore, verificationService, props);
+
+        String dummyHash = (String) ReflectionTestUtils.getField(realSvc, "dummyPasswordHash");
+        assertThat(dummyHash)
+                .as("BCrypt 표준 60자 패턴 — 깨지면 미존재 user 분기에서 즉시 false 반환해 timing leak 부활")
+                .matches("^\\$2[ayb]\\$\\d{2}\\$[./A-Za-z0-9]{53}$");
+    }
+}

--- a/src/test/java/com/sseulang/domain/auth/infrastructure/oauth/OAuthProviderJsonTest.java
+++ b/src/test/java/com/sseulang/domain/auth/infrastructure/oauth/OAuthProviderJsonTest.java
@@ -19,13 +19,15 @@ class OAuthProviderJsonTest {
     private ObjectMapper om;
 
     @Test
-    @DisplayName("Kakao /v2/user/me 응답 파싱_id/email/nickname/profile_image_url")
+    @DisplayName("Kakao /v2/user/me 응답 파싱_id/email/verified flags/nickname/profile_image_url")
     void kakao_응답_파싱() throws Exception {
         String json = """
                 {
                   "id": 1234567890,
                   "kakao_account": {
                     "email": "user@kakao.com",
+                    "is_email_valid": true,
+                    "is_email_verified": true,
                     "profile": {
                       "nickname": "쓸랭이",
                       "profile_image_url": "https://img.kakao/u.png"
@@ -39,8 +41,52 @@ class OAuthProviderJsonTest {
 
         assertThat(res.id()).isEqualTo(1234567890L);
         assertThat(res.kakaoAccount().email()).isEqualTo("user@kakao.com");
+        assertThat(res.kakaoAccount().isEmailValid()).isTrue();
+        assertThat(res.kakaoAccount().isEmailVerified()).isTrue();
         assertThat(res.kakaoAccount().profile().nickname()).isEqualTo("쓸랭이");
         assertThat(res.kakaoAccount().profile().profileImageUrl()).isEqualTo("https://img.kakao/u.png");
+    }
+
+    @Test
+    @DisplayName("Kakao 응답_verified flags 부재(null)_매핑 (provider 거부 회귀 보호)")
+    void kakao_응답_verified_flags_null() throws Exception {
+        String json = """
+                {
+                  "id": 1,
+                  "kakao_account": {
+                    "email": "x@y.com",
+                    "profile": { "nickname": "n", "profile_image_url": null }
+                  }
+                }
+                """;
+
+        KakaoOAuthProvider.KakaoUserResponse res =
+                om.readValue(json, KakaoOAuthProvider.KakaoUserResponse.class);
+
+        assertThat(res.kakaoAccount().isEmailValid()).as("flag 부재 → null").isNull();
+        assertThat(res.kakaoAccount().isEmailVerified()).as("flag 부재 → null").isNull();
+    }
+
+    @Test
+    @DisplayName("Kakao 응답_is_email_verified=false_파싱 (provider 단계에서 OAuth 거부 회귀 보호)")
+    void kakao_응답_email_verified_false() throws Exception {
+        String json = """
+                {
+                  "id": 1,
+                  "kakao_account": {
+                    "email": "x@y.com",
+                    "is_email_valid": true,
+                    "is_email_verified": false,
+                    "profile": { "nickname": "n", "profile_image_url": null }
+                  }
+                }
+                """;
+
+        KakaoOAuthProvider.KakaoUserResponse res =
+                om.readValue(json, KakaoOAuthProvider.KakaoUserResponse.class);
+
+        assertThat(res.kakaoAccount().isEmailValid()).isTrue();
+        assertThat(res.kakaoAccount().isEmailVerified()).isFalse();
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/sseulang/domain/auth/presentation/AuthControllerTest.java
@@ -44,7 +44,11 @@ class AuthControllerTest {
         rotationService = mock(RefreshTokenRotationService.class);
         oauthLoginService = mock(OAuthLoginService.class);
         cookieUtil = mock(CookieUtil.class);
-        AuthController controller = new AuthController(rotationService, oauthLoginService, cookieUtil);
+        AuthController controller = new AuthController(
+                rotationService, oauthLoginService,
+                mock(com.sseulang.domain.auth.application.LocalAuthService.class),
+                cookieUtil
+        );
         mvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();

--- a/src/test/java/com/sseulang/domain/auth/presentation/AuthOAuthFlowIT.java
+++ b/src/test/java/com/sseulang/domain/auth/presentation/AuthOAuthFlowIT.java
@@ -44,7 +44,11 @@ class AuthOAuthFlowIT {
         oauthLoginService = mock(OAuthLoginService.class);
         rotationService = mock(RefreshTokenRotationService.class);
         cookieUtil = mock(CookieUtil.class);
-        AuthController controller = new AuthController(rotationService, oauthLoginService, cookieUtil);
+        AuthController controller = new AuthController(
+                rotationService, oauthLoginService,
+                mock(com.sseulang.domain.auth.application.LocalAuthService.class),
+                cookieUtil
+        );
 
         mvc = MockMvcBuilders.standaloneSetup(controller)
                 .addFilter(new TraceIdFilter())

--- a/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
@@ -34,8 +34,8 @@ class ChatRoomApplicationServiceTest {
         roomRepo = new InMemoryFakeChatRoomRepository();
         itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc);
-        service = new ChatRoomApplicationService(roomRepo, itemSvc);
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        service = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
 
         Item item = itemRepo.save(Item.create(
                 SELLER, null, "물건", "설명", 50_000L, null, null, TradeType.판매, null

--- a/src/test/java/com/sseulang/domain/file/application/FileApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/file/application/FileApplicationServiceTest.java
@@ -23,7 +23,7 @@ class FileApplicationServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new FileApplicationService(new FakePresignedUrlGenerator());
+        service = new FileApplicationService(new FakePresignedUrlGenerator(), org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
@@ -35,7 +35,8 @@ class ItemApplicationServiceTest {
         itemRepo = new InMemoryFakeItemRepository();
         categoryRepo = new InMemoryFakeCategoryRepository();
         CategoryApplicationService categoryService = new CategoryApplicationService(categoryRepo);
-        service = new ItemApplicationService(itemRepo, categoryService);
+        // requireVerified 가드는 기본 통과 (mock void no-op) — 단위 테스트는 비즈니스 로직 검증.
+        service = new ItemApplicationService(itemRepo, categoryService, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
         categoryId = categoryRepo.insert(Category.createRoot("디지털/가전", 1)).getId();
     }
 

--- a/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
@@ -36,7 +36,7 @@ class ItemSearchTest {
         InMemoryFakeCategoryRepository categoryRepo = new InMemoryFakeCategoryRepository();
         com.sseulang.domain.category.application.CategoryApplicationService catSvc =
                 new com.sseulang.domain.category.application.CategoryApplicationService(categoryRepo);
-        service = new ItemApplicationService(itemRepo, catSvc);
+        service = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
         catA = categoryRepo.insert(Category.createRoot("A", 1)).getId();
         catB = categoryRepo.insert(Category.createRoot("B", 2)).getId();
     }

--- a/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
@@ -46,8 +46,8 @@ class MessageApplicationServiceTest {
         publisher = new FakeRealtimePublisher();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc);
-        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc);
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
         NotificationApplicationService notifSvc = new NotificationApplicationService(notifRepo);
         service = new MessageApplicationService(msgRepo, roomSvc, notifSvc, publisher);
 

--- a/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
@@ -44,7 +44,7 @@ class PaymentApplicationServiceTest {
         userService = new UserApplicationService(userRepo);
         PointApplicationService pointSvc = new PointApplicationService(userService, pointHistoryRepo);
         service = new PaymentApplicationService(
-                paymentRepo, gateway, pointSvc,
+                paymentRepo, gateway, pointSvc, userService,
                 new TossProperties(CLIENT_KEY, "test_sk_secret", null)
         );
         userId = userRepo.save(User.createSocialUser(

--- a/src/test/java/com/sseulang/domain/report/application/UserReportApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/report/application/UserReportApplicationServiceTest.java
@@ -30,7 +30,7 @@ class UserReportApplicationServiceTest {
     void setUp() {
         repo = new InMemoryFakeUserReportRepository();
         Clock clock = Clock.fixed(NOW.atZone(KST).toInstant(), KST);
-        service = new UserReportApplicationService(repo, clock);
+        service = new UserReportApplicationService(repo, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), clock);
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -46,10 +46,10 @@ class ReviewApplicationServiceTest {
         userRepo = new InMemoryFakeUserRepository();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc);
         UserApplicationService userSvc = new UserApplicationService(userRepo);
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc);
         PointApplicationService pointSvc = new PointApplicationService(userSvc, new InMemoryFakePointHistoryRepository());
-        TransactionApplicationService txSvc = new TransactionApplicationService(txRepo, itemSvc, pointSvc);
+        TransactionApplicationService txSvc = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc);
         service = new ReviewApplicationService(reviewRepo, txSvc, userSvc);
 
         Item item = itemRepo.save(Item.create(

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -46,10 +46,10 @@ class TransactionApplicationServiceTest {
         userRepo = new InMemoryFakeUserRepository();
         pointHistoryRepo = new InMemoryFakePointHistoryRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        itemSvc = new ItemApplicationService(itemRepo, catSvc);
         UserApplicationService userSvc = new UserApplicationService(userRepo);
+        itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc);
         PointApplicationService pointSvc = new PointApplicationService(userSvc, pointHistoryRepo);
-        service = new TransactionApplicationService(txRepo, itemSvc, pointSvc);
+        service = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc);
 
         SELLER = userRepo.save(User.createSocialUser(
                 SocialProvider.KAKAO, "k-seller", new Email("seller@x.com"), "seller", null
@@ -150,7 +150,10 @@ class TransactionApplicationServiceTest {
     @Test
     @DisplayName("두 buyer 동시 거래_첫 reserve 만 성공_두 번째는 TRANSACTION_RESERVED_BY_OTHER")
     void 동시_reserve_차단() {
-        Long buyer2 = 300L;
+        Long buyer2 = userRepo.save(User.createSocialUser(
+                SocialProvider.KAKAO, "k-buyer2-" + System.nanoTime(),
+                new Email("buyer2-" + System.nanoTime() + "@x.com"), "buyer2", null
+        )).getId();
         Long tx1 = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
         Long tx2 = service.create(new TransactionCreateCommand(itemId, buyer2, null, null));
 
@@ -270,7 +273,10 @@ class TransactionApplicationServiceTest {
     @Test
     @DisplayName("cancel 후 다른 buyer 가 같은 Item 으로 거래 시작 가능")
     void cancel_후_새_거래() {
-        Long buyer2 = 300L;
+        Long buyer2 = userRepo.save(User.createSocialUser(
+                SocialProvider.KAKAO, "k-buyer2-" + System.nanoTime(),
+                new Email("buyer2-" + System.nanoTime() + "@x.com"), "buyer2", null
+        )).getId();
         Long tx1 = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
         service.reserve(tx1, SELLER);
         service.cancel(tx1, SELLER, "재예약 가능");

--- a/src/test/java/com/sseulang/domain/user/application/UserApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/user/application/UserApplicationServiceTest.java
@@ -64,8 +64,8 @@ class UserApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("findOrCreateBySocial_신규인데 email 이미 다른 provider 로 가입됨_USER_EMAIL_DUPLICATED")
-    void findOrCreateBySocial_email중복() {
+    @DisplayName("findOrCreateBySocial_email 다른 OAuth provider 점유_AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER (linking 미지원)")
+    void findOrCreateBySocial_email_다른_provider() {
         User other = User.createSocialUser(SocialProvider.KAKAO, "k-other", EMAIL, "n", null);
         when(userRepository.findBySocial(SocialProvider.GOOGLE, "g-1")).thenReturn(Optional.empty());
         when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(other));
@@ -73,9 +73,27 @@ class UserApplicationServiceTest {
         assertThatThrownBy(() ->
                 service.findOrCreateBySocial(SocialProvider.GOOGLE, "g-1", EMAIL, "n", null))
                 .isInstanceOf(BusinessException.class)
-                .extracting("errorCode").isEqualTo(ErrorCode.USER_EMAIL_DUPLICATED);
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER);
 
         verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("findOrCreateBySocial_email 같은 LOCAL user 발견_takeover (linkSocial + verified=true)")
+    void findOrCreateBySocial_LOCAL_takeover() {
+        // 공격자가 victim@email 로 LOCAL 가입 (verified=false). 진짜 owner 가 OAuth 가입 시도
+        User local = User.createLocalUser(EMAIL, "$2a$10$attackerHash", "attacker");
+        when(userRepository.findBySocial(SocialProvider.KAKAO, "k-1")).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(local));
+
+        User result = service.findOrCreateBySocial(SocialProvider.KAKAO, "k-1", EMAIL, "kakaoUser", null);
+
+        // takeover — 같은 user row 에 social 추가, password null, verified true
+        assertThat(result).isSameAs(local);
+        assertThat(result.getSocialProvider()).isEqualTo(SocialProvider.KAKAO);
+        assertThat(result.getSocialId()).isEqualTo("k-1");
+        assertThat(result.getPassword()).as("기존 LOCAL password 무효화 — 공격자 차단").isNull();
+        assertThat(result.isEmailVerified()).isTrue();
     }
 
     @Test
@@ -116,10 +134,10 @@ class UserApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("findOrCreateBySocial_save 시 DB UNIQUE 충돌_재조회 후 email 다른 user 가 점유_USER_EMAIL_DUPLICATED")
+    @DisplayName("findOrCreateBySocial_save 시 DB UNIQUE 충돌_재조회 후 email 다른 OAuth user 가 점유_AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER")
     void findOrCreateBySocial_race_email충돌() {
         User other = User.createSocialUser(SocialProvider.KAKAO, "k-other", EMAIL, "n", null);
-        when(userRepository.findBySocial(SocialProvider.KAKAO, "k-1"))
+        when(userRepository.findBySocial(SocialProvider.GOOGLE, "g-1"))
                 .thenReturn(Optional.empty())   // 첫 호출 — 신규
                 .thenReturn(Optional.empty());  // race 후 재조회 — race winner 도 다른 사용자
         // save 직전엔 비어있었지만 race winner 가 같은 email 로 먼저 가입함
@@ -130,9 +148,9 @@ class UserApplicationServiceTest {
                 .thenThrow(new DataIntegrityViolationException("UNIQUE 위반"));
 
         assertThatThrownBy(() ->
-                service.findOrCreateBySocial(SocialProvider.KAKAO, "k-1", EMAIL, "n", null))
+                service.findOrCreateBySocial(SocialProvider.GOOGLE, "g-1", EMAIL, "n", null))
                 .isInstanceOf(BusinessException.class)
-                .extracting("errorCode").isEqualTo(ErrorCode.USER_EMAIL_DUPLICATED);
+                .extracting("errorCode").isEqualTo(ErrorCode.AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER);
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/user/domain/UserTest.java
+++ b/src/test/java/com/sseulang/domain/user/domain/UserTest.java
@@ -62,4 +62,39 @@ class UserTest {
                 User.createSocialUser(SocialProvider.GOOGLE, "id", EMAIL, null, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    @DisplayName("createLocalUser 정상_provider=LOCAL + hashedPassword 저장 + hasPassword=true")
+    void createLocalUser_정상() {
+        User u = User.createLocalUser(EMAIL, "$2a$10$hashed", "로컬");
+
+        assertThat(u.getEmail()).isEqualTo(EMAIL.value());
+        assertThat(u.getNickname()).isEqualTo("로컬");
+        assertThat(u.getSocialProvider()).isEqualTo(SocialProvider.LOCAL);
+        assertThat(u.getSocialId()).isNull();
+        assertThat(u.getPassword()).isEqualTo("$2a$10$hashed");
+        assertThat(u.hasPassword()).isTrue();
+        assertThat(u.isBlocked()).isFalse();
+        assertThat(u.isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("createLocalUser invalid 인자 거부")
+    void createLocalUser_invalid() {
+        assertThatThrownBy(() -> User.createLocalUser(null, "$2a$10$h", "n"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> User.createLocalUser(EMAIL, "", "n"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> User.createLocalUser(EMAIL, null, "n"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> User.createLocalUser(EMAIL, "$2a$10$h", ""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("hasPassword_소셜 가입자는 false")
+    void hasPassword_소셜() {
+        User social = User.createSocialUser(SocialProvider.KAKAO, "k-1", EMAIL, "kakao", null);
+        assertThat(social.hasPassword()).isFalse();
+    }
 }

--- a/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
@@ -29,7 +29,7 @@ class WishlistApplicationServiceTest {
         wishRepo = new InMemoryFakeWishlistRepository();
         itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc);
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
         service = new WishlistApplicationService(wishRepo, itemSvc);
 
         Item item = itemRepo.save(Item.create(

--- a/src/test/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationServiceTest.java
@@ -44,7 +44,7 @@ class WithdrawalApplicationServiceTest {
         PointApplicationService pointSvc = new PointApplicationService(userSvc, historyRepo);
         // self 는 REQUIRES_NEW proxy 용 — 단위 테스트엔 Spring 컨텍스트 없으니 자기 자신을 주입.
         // 단위 테스트의 InMemoryFake 는 deadlock/duplicate 던지지 않으므로 catch 경로 미진입.
-        service = new WithdrawalApplicationService(withdrawalRepo, pointSvc, null);
+        service = new WithdrawalApplicationService(withdrawalRepo, pointSvc, userSvc, null);
         ReflectionTestUtils.setField(service, "self", service);
 
         userId = userRepo.save(User.createSocialUser(

--- a/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
@@ -40,8 +40,8 @@ class StompAuthChannelInterceptorTest {
         InMemoryFakeChatRoomRepository roomRepo = new InMemoryFakeChatRoomRepository();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc);
-        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc);
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
         interceptor = new StompAuthChannelInterceptor(roomSvc);
 
         Item item = itemRepo.save(Item.create(SELLER, null, "물건", "d", 1L, null, null, TradeType.판매, null));


### PR DESCRIPTION
## 한 줄 요약

이메일/비밀번호 가입 흐름 + 이메일 소유 검증 + 같은 이메일 OAuth 가입 시 자동 연동(takeover). 게이트 1 세 라운드 거쳐 머지 가능.

## 무엇이 들어갔는지 (사람 말로)

### 새 흐름
- **LOCAL 가입/로그인** — email + password (BCrypt). 가입 즉시 자동 로그인 + 인증 메일 발송
- **이메일 인증** — 24시간 유효 토큰. 메일 링크 클릭 시 verified=true
- **OAuth takeover** — 같은 email로 LOCAL 가입자가 있던 자리에 OAuth 사용자가 가입 시도하면, 기존 LOCAL 비밀번호 무효화 + OAuth 정보 추가 + verified=true. 이메일 선점 공격 무력화.
- **다른 OAuth provider 충돌** — 같은 email이 KAKAO로 이미 가입돼있는데 GOOGLE로 시도하면 409 (multi-provider linking은 후속 PR)

### 미인증 사용자 차단 영역
verified=false 상태에선 다음 기능 차단 (FORBIDDEN AUTH_EMAIL_NOT_VERIFIED):
- 거래 시작 / 결제 충전 / 출금 신청
- Item 등록 / Chat 시작 / Report 작성
- File presigned URL 발급

허용:
- 로그인/로그아웃, Item 검색·조회, 본인 프로필, 메일 재발송

### 보안 강화
- BCrypt 72-byte UTF-8 가드 (한글 25자 = 75 bytes 거부) — signup/login 양쪽
- 카카오 응답에 `is_email_valid` + `is_email_verified` 둘 다 true만 허용 (provider 단계 차단)
- LOCAL 가입자 인증 timing leak 방어 — dummy hash로 BCrypt 비용 균일
- `@Version` optimistic lock — 동시 takeover 충돌 시 OptimisticLockException → GlobalExceptionHandler가 409로 변환
- /resend-verification — auth 필수 + CSRF 적용 (auth wildcard permitAll 제거, 명시 endpoint 리스트로)
- 재발송 60초 cooldown + 새 토큰 발급 시 기존 미사용 SIGNUP 토큰 일괄 무효화
- LogEmailSender `@Profile({"local","dev","test"})` allowlist (prod 누수 차단)

## DB 마이그레이션

- **V6**: `users.email_verified` + `email_verifications` 테이블 + KAKAO/GOOGLE 사용자 backfill verified=true
- **V7**: `users.version` 컬럼 (JPA optimistic lock)

## 테스트

- [x] 491 PASS / 0 FAIL
- [x] 한글 25자 password 회귀 (signup/login 둘 다 거부)
- [x] Kakao verified flag false/null 회귀
- [x] LOCAL takeover 시나리오 (LinkSocial 후 password=null + verified=true)
- [x] 다른 OAuth provider 거부

## 코덱스 게이트 1 (3 라운드)

- **Round 1**: critical 2 (이메일 선점 / BCrypt UTF-8) + should-fix 3
- **Round 2**: critical 모두 반영, 새 critical 2 (login byte / Kakao verified) + SF 6 + nit 4
- **Round 3**: 모두 반영, **critical 0 OK 머지 가능** + SF 3 새로 발견 (모두 후속 또는 본 라운드 처리)
- **Round 3 보강**: SF#1 (OptimisticLock 변환) + nit 4건 (주석 / Kakao false 회귀 / 한글 25자 회귀) 처리

## 머지 후 후속 (별도 이슈 트래킹 권장)

- **prod SMTP 어댑터** (현재 LogEmailSender만, prod 부팅 시 별도 SMTP bean 등록 필요)
- **multi-provider linking** (한 user에 KAKAO + GOOGLE 둘 다 연결) — `user_auth_methods` 테이블 도입
- **signup atomicity** — 메일 발송 실패 시 user row만 남는 케이스, prod SMTP 도입 시 outbox 패턴 검토
- **verifyToken 동시 검증 race** — 이메일 인증 멱등이라 피해 작지만 atomic UPDATE 권장
- **resend rate limit Redis-backed** (현재 in-memory, 다중 인스턴스 배포 시 부족)

🤖 Generated with [Claude Code](https://claude.com/claude-code)