### PR TITLE
feat: prod SMTP EmailSender 어댑터 골격

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     // Security + OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSender.java
@@ -1,0 +1,81 @@
+package com.sseulang.domain.auth.infrastructure.email;
+
+import com.sseulang.domain.auth.domain.EmailSender;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * prod SMTP {@link EmailSender} 구현. Spring Mail (JavaMailSender) 사용.
+ *
+ * <p>{@code @Profile("prod")} — prod 환경 전용. local/dev/test 는 {@code LogEmailSender} 가 활성화.
+ * SMTP 설정은 {@code application-prod.yml} 의 {@code spring.mail.*} 환경변수 주입.</p>
+ *
+ * <p>발송 실패 시 {@link RuntimeException} 으로 throw — 호출자(LocalAuthService.signup) 가 회원 가입
+ * 실패로 트랜잭션 롤백. 5/6 이후 outbox 패턴 도입 시 비동기 발송으로 변경 가능.</p>
+ */
+@Component
+@Profile("prod")
+public class SmtpEmailSender implements EmailSender {
+
+    private static final String SUBJECT = "[쓸랭] 이메일 인증을 완료해 주세요";
+
+    private final JavaMailSender mailSender;
+    private final String fromAddress;
+
+    public SmtpEmailSender(
+            JavaMailSender mailSender,
+            @org.springframework.beans.factory.annotation.Value("${app.email.from:noreply@sseulang.test}")
+            String fromAddress
+    ) {
+        this.mailSender = mailSender;
+        this.fromAddress = fromAddress;
+    }
+
+    @Override
+    public void sendVerificationEmail(String toEmail, String verificationUrl) {
+        MimeMessage message = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, StandardCharsets.UTF_8.name());
+            helper.setFrom(fromAddress);
+            helper.setTo(toEmail);
+            helper.setSubject(SUBJECT);
+            helper.setText(buildHtml(verificationUrl), true);
+        } catch (MessagingException e) {
+            throw new RuntimeException("이메일 메시지 빌드 실패: " + e.getMessage(), e);
+        }
+        try {
+            mailSender.send(message);
+        } catch (MailException e) {
+            // 운영 모니터링 대상 — 5/6 이후 outbox 도입 시 비동기 retry 로 강화.
+            throw new RuntimeException("이메일 발송 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private static String buildHtml(String verificationUrl) {
+        return """
+                <!doctype html>
+                <html>
+                  <body style="font-family:sans-serif;line-height:1.6;color:#333">
+                    <h2>쓸랭 이메일 인증</h2>
+                    <p>아래 버튼을 눌러 이메일 인증을 완료해 주세요.</p>
+                    <p>
+                      <a href="%s" style="display:inline-block;padding:12px 24px;background:#5a6cff;color:#fff;text-decoration:none;border-radius:6px">
+                        이메일 인증하기
+                      </a>
+                    </p>
+                    <p style="color:#888;font-size:12px">
+                      버튼이 동작하지 않으면 다음 링크를 복사해 브라우저에 붙여 넣으세요:<br>
+                      <a href="%s">%s</a>
+                    </p>
+                  </body>
+                </html>
+                """.formatted(verificationUrl, verificationUrl, verificationUrl);
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -30,6 +30,20 @@ spring:
       password: ${REDIS_PASSWORD:}
     mongodb:
       uri: ${MONGO_URI}
+  mail:
+    host: ${MAIL_HOST:}
+    port: ${MAIL_PORT:587}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
 
 app:
   jwt:
@@ -60,6 +74,8 @@ app:
     base-url: https://api.tosspayments.com
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
+  email:
+    from: ${MAIL_FROM:noreply@sseulang.test}
 
 logging:
   level:

--- a/src/test/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSenderTest.java
+++ b/src/test/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSenderTest.java
@@ -1,0 +1,70 @@
+package com.sseulang.domain.auth.infrastructure.email;
+
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SmtpEmailSenderTest {
+
+    private JavaMailSender mailSender;
+    private SmtpEmailSender sender;
+
+    @BeforeEach
+    void setUp() {
+        mailSender = mock(JavaMailSender.class);
+
+        // 실제 MimeMessage 생성을 위해 JavaMailSenderImpl 사용 (createMimeMessage() 만 빌려옴)
+        JavaMailSenderImpl real = new JavaMailSenderImpl();
+        real.setJavaMailProperties(new Properties());
+        when(mailSender.createMimeMessage()).thenReturn(real.createMimeMessage());
+
+        sender = new SmtpEmailSender(mailSender, "noreply@sseulang.test");
+    }
+
+    @Test
+    @DisplayName("sendVerificationEmail 정상_subject·to·HTML body 포함")
+    void send_정상() throws Exception {
+        sender.sendVerificationEmail("user@example.com", "https://app.sseulang.kr/verify?token=abc");
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+
+        MimeMessage sent = captor.getValue();
+        sent.saveChanges();
+        assertThat(sent.getAllRecipients()).hasSize(1);
+        assertThat(sent.getAllRecipients()[0].toString()).isEqualTo("user@example.com");
+        assertThat(sent.getSubject()).contains("이메일 인증");
+
+        String content = (String) sent.getContent();
+        assertThat(content).contains("https://app.sseulang.kr/verify?token=abc");
+        assertThat(content).contains("이메일 인증하기");
+        // MimeMessageHelper.setText(html, true) 가 dataHandler 의 ContentType 을 text/html 로 세팅.
+        assertThat(sent.getDataHandler().getContentType()).contains("text/html");
+        assertThat(sent.getDataHandler().getContentType().toLowerCase()).contains("utf-8");
+    }
+
+    @Test
+    @DisplayName("sendVerificationEmail 발송 실패_RuntimeException 으로 wrap")
+    void send_실패_wrap() {
+        doThrow(new MailSendException("smtp down")).when(mailSender).send(any(MimeMessage.class));
+
+        assertThatThrownBy(() -> sender.sendVerificationEmail("user@example.com", "https://x"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("이메일 발송 실패");
+    }
+}


### PR DESCRIPTION
## Summary
- prod 프로파일 전용 SmtpEmailSender 추가 (JavaMailSender + MimeMessageHelper)
- HTML 본문 + UTF-8, 인증 링크 버튼 + plain fallback
- application-prod.yml: spring.mail.* / app.email.from 환경변수 매핑
- LogEmailSender 는 local/dev/test 만 활성화되어 prod 에서는 SMTP 가 자동 선택
- 발송 실패 시 RuntimeException 으로 wrap → signup 트랜잭션 롤백

향후(5/6 이후): outbox 패턴 도입 시 비동기 retry 로 교체 가능.

## Test plan
- [x] SmtpEmailSenderTest — 정상 발송(to/subject/HTML/UTF-8) + 발송 실패 wrap (2 PASS)
- [x] 전체 컴파일 통과
- [ ] prod 환경 변수(MAIL_HOST 등) 실제 SMTP(예: AWS SES) 연결은 5/6 이후 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)