### PR TITLE
feat: Day 9 — 배달대행(delivery) 도메인 + 게이트 1 통과

### DIFF
--- a/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
@@ -88,13 +88,20 @@ public class DeliveryApplicationService {
         if (d.isRequester(riderId)) {
             throw new BusinessException(ErrorCode.DELIVERY_SELF_NOT_ALLOWED);
         }
+        // 사전 조회에서 이미 취소/종료 상태면 ALREADY_ACCEPTED 가 아닌 INVALID_STATE 가 더 정확.
+        // (게이트 1 round 2 — Warning) update 이후 race 패배는 아래 분기에서 통일 처리.
+        if (d.getStatus() != com.sseulang.domain.delivery.domain.DeliveryStatus.모집중) {
+            if (d.getStatus() == com.sseulang.domain.delivery.domain.DeliveryStatus.수락) {
+                throw new BusinessException(ErrorCode.DELIVERY_ALREADY_ACCEPTED);
+            }
+            throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
+        }
         LocalDateTime now = LocalDateTime.now();
         int affected = deliveryRepository.acceptIfStillOpen(deliveryId, riderId, now);
         if (affected == 0) {
-            // 본인 거래는 위에서 사전 검증으로 차단 — affected=0 의 원인은 (a) row 없음 또는
-            // (b) status != 모집중 (race 패배 / 취소). NOT_FOUND 만 분기하고 나머지는
-            // ALREADY_ACCEPTED 로 통일 — REPEATABLE_READ snapshot 으로 인해 같은 트랜잭션의
-            // findById 가 race 우승자의 commit 을 못 보는 케이스 회피 (게이트 1 round 1).
+            // 본인 거래/취소는 위에서 사전 검증으로 차단 — 여기 도달하는 affected=0 은
+            // 실제 동시 accept race 패배 케이스. REPEATABLE_READ snapshot 으로 인해 같은 트랜잭션의
+            // findById 가 race 우승자 commit 을 못 보는 케이스 회피 위해 ALREADY_ACCEPTED 로 통일.
             findOrThrow(deliveryId);
             throw new BusinessException(ErrorCode.DELIVERY_ALREADY_ACCEPTED);
         }

--- a/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
@@ -1,0 +1,186 @@
+package com.sseulang.domain.delivery.application;
+
+import com.sseulang.domain.delivery.application.dto.DeliveryCreateCommand;
+import com.sseulang.domain.delivery.application.dto.DeliveryResult;
+import com.sseulang.domain.delivery.domain.DeliveryRepository;
+import com.sseulang.domain.delivery.domain.DeliveryRequest;
+import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * Delivery (배달대행) ApplicationService — 트랜잭션 경계 + 도메인 흐름 조율.
+ *
+ * <p>핵심 흐름:
+ * <ol>
+ *   <li>{@link #create} — 요청자 등록 (이메일 인증 가드)</li>
+ *   <li>{@link #accept} — 라이더 수락 (conditional UPDATE 로 race 차단, 본인 거래 차단)</li>
+ *   <li>{@link #markPickedUp} / {@link #markDelivered} — 라이더 상태 전이</li>
+ *   <li>{@link #complete} — 요청자가 정산 확인 → 포인트 이동 (요청자 차감 + 라이더 적립)</li>
+ *   <li>{@link #cancel} — 요청자 취소 (모집중 한정)</li>
+ * </ol>
+ *
+ * <p>정산({@link #complete})은 {@link PointApplicationService#transferForDelivery} 한 번에
+ * 차감/적립 + history 두 건 적재가 한 트랜잭션으로 묶여 정합성 보장.</p>
+ *
+ * <p>가이드 §3.3 — Repository 인터페이스만 의존 (구현은 infrastructure). 다른 도메인은
+ * UserApplicationService / PointApplicationService 만 호출.</p>
+ */
+@Service
+@Transactional(readOnly = true)
+public class DeliveryApplicationService {
+
+    private final DeliveryRepository deliveryRepository;
+    private final UserApplicationService userApplicationService;
+    private final PointApplicationService pointApplicationService;
+
+    public DeliveryApplicationService(
+            DeliveryRepository deliveryRepository,
+            UserApplicationService userApplicationService,
+            PointApplicationService pointApplicationService
+    ) {
+        this.deliveryRepository = deliveryRepository;
+        this.userApplicationService = userApplicationService;
+        this.pointApplicationService = pointApplicationService;
+    }
+
+    /**
+     * 요청 등록. 요청자 이메일 인증 필수 (가이드 §4 보안 / §10 happy path).
+     *
+     * <p>현재 정책: <b>등록 시점에 fee escrow 안 함</b> — 정산({@link #complete}) 시점에 차감.
+     * 등록 단계 잔액 체크도 안 함 (라이더가 수락 후 요청자 잔액이 부족해지면 정산 실패 →
+     * 라이더 항의 가능). 5/6 이전 단순화 정책. follow-up: hold 패턴 도입 고려.</p>
+     */
+    @Transactional
+    public DeliveryResult create(DeliveryCreateCommand cmd) {
+        userApplicationService.requireVerified(cmd.requesterId());
+        DeliveryRequest d = DeliveryRequest.create(
+                cmd.requesterId(),
+                cmd.pickupAddress(),
+                cmd.dropoffAddress(),
+                cmd.itemDescription(),
+                cmd.fee(),
+                cmd.requestedDeadline(),
+                cmd.memo(),
+                LocalDateTime.now()
+        );
+        return DeliveryResult.from(deliveryRepository.save(d));
+    }
+
+    /**
+     * 라이더 수락. 본인 거래 차단 + conditional UPDATE 로 동시 수락 race 차단.
+     *
+     * <p>{@link DeliveryRepository#acceptIfStillOpen} 가 {@code WHERE status='모집중'} 조건을
+     * 락 없이 atomic 하게 평가 — 영향 행 0 이면 이미 다른 라이더가 수락했거나 취소된 상태.
+     * 수락한 라이더는 {@link DeliveryRequest#acceptBy} 호출 결과와 일치 (DB 갱신 = aggregate 갱신).</p>
+     */
+    @Transactional
+    public DeliveryResult accept(Long deliveryId, Long riderId) {
+        userApplicationService.requireVerified(riderId);
+        DeliveryRequest d = findOrThrow(deliveryId);
+        if (d.isRequester(riderId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_SELF_NOT_ALLOWED);
+        }
+        LocalDateTime now = LocalDateTime.now();
+        int affected = deliveryRepository.acceptIfStillOpen(deliveryId, riderId, now);
+        if (affected == 0) {
+            // race 패배 또는 취소된 요청 — 현재 상태로 메시지 분기
+            DeliveryRequest current = findOrThrow(deliveryId);
+            if (current.getStatus().canAccept()) {
+                // 정상적으론 도달 불가 — DB 일관성 깨진 상태
+                throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
+            }
+            throw new BusinessException(ErrorCode.DELIVERY_ALREADY_ACCEPTED);
+        }
+        return DeliveryResult.from(findOrThrow(deliveryId));
+    }
+
+    /** 라이더 픽업 — 수락한 라이더만. */
+    @Transactional
+    public DeliveryResult markPickedUp(Long deliveryId, Long riderId) {
+        DeliveryRequest d = findOrThrow(deliveryId);
+        if (!d.isRider(riderId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
+        }
+        d.markPickedUp(LocalDateTime.now());
+        return DeliveryResult.from(d);
+    }
+
+    /** 라이더 배송 완료 — 수락한 라이더만. */
+    @Transactional
+    public DeliveryResult markDelivered(Long deliveryId, Long riderId) {
+        DeliveryRequest d = findOrThrow(deliveryId);
+        if (!d.isRider(riderId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
+        }
+        d.markDelivered(LocalDateTime.now());
+        return DeliveryResult.from(d);
+    }
+
+    /**
+     * 요청자 정산 확인 → 포인트 이동 + 상태 전이.
+     *
+     * <p>요청자 잔액 부족 시 INSUFFICIENT_POINT — 라이더의 선행 적립 (id-asc 순서에 따라 먼저
+     * 처리될 수 있음) 도 같은 트랜잭션 안이라 함께 롤백. 상태 전이도 롤백되므로 재시도 가능.</p>
+     */
+    @Transactional
+    public DeliveryResult complete(Long deliveryId, Long requesterId) {
+        DeliveryRequest d = findOrThrow(deliveryId);
+        if (!d.isRequester(requesterId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
+        }
+        if (!d.getStatus().canSettle()) {
+            throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
+        }
+        // 잔액 변동 먼저, 상태 전이 마지막 — 정산 실패 시 상태 전이도 롤백 (대칭).
+        pointApplicationService.transferForDelivery(
+                d.getRequesterId(),
+                d.getRiderId(),
+                d.getFee(),
+                d.getId(),
+                "배달 정산: delivery#" + d.getId()
+        );
+        d.markSettled(LocalDateTime.now());
+        return DeliveryResult.from(d);
+    }
+
+    /** 요청자 취소 — 모집중 한정. 잔액 이동 없음 (등록 시 escrow 안 했음). */
+    @Transactional
+    public DeliveryResult cancel(Long deliveryId, Long requesterId, String reason) {
+        DeliveryRequest d = findOrThrow(deliveryId);
+        if (!d.isRequester(requesterId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
+        }
+        d.cancelByRequester(LocalDateTime.now(), reason);
+        return DeliveryResult.from(d);
+    }
+
+    public DeliveryResult getById(Long deliveryId, Long requesterId) {
+        DeliveryRequest d = findOrThrow(deliveryId);
+        // 모집중은 누구나 조회 가능 (라이더가 수락 결정 위해). 그 외는 참여자만.
+        if (!d.getStatus().canAccept() && !d.isParticipant(requesterId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
+        }
+        return DeliveryResult.from(d);
+    }
+
+    public Page<DeliveryResult> listOpen(Pageable pageable) {
+        return deliveryRepository.findOpenList(pageable).map(DeliveryResult::from);
+    }
+
+    public Page<DeliveryResult> listMine(Long userId, Pageable pageable) {
+        return deliveryRepository.findByParticipant(userId, pageable).map(DeliveryResult::from);
+    }
+
+    private DeliveryRequest findOrThrow(Long deliveryId) {
+        return deliveryRepository.findById(deliveryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
@@ -91,12 +91,11 @@ public class DeliveryApplicationService {
         LocalDateTime now = LocalDateTime.now();
         int affected = deliveryRepository.acceptIfStillOpen(deliveryId, riderId, now);
         if (affected == 0) {
-            // race 패배 또는 취소된 요청 — 현재 상태로 메시지 분기
-            DeliveryRequest current = findOrThrow(deliveryId);
-            if (current.getStatus().canAccept()) {
-                // 정상적으론 도달 불가 — DB 일관성 깨진 상태
-                throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
-            }
+            // 본인 거래는 위에서 사전 검증으로 차단 — affected=0 의 원인은 (a) row 없음 또는
+            // (b) status != 모집중 (race 패배 / 취소). NOT_FOUND 만 분기하고 나머지는
+            // ALREADY_ACCEPTED 로 통일 — REPEATABLE_READ snapshot 으로 인해 같은 트랜잭션의
+            // findById 가 race 우승자의 commit 을 못 보는 케이스 회피 (게이트 1 round 1).
+            findOrThrow(deliveryId);
             throw new BusinessException(ErrorCode.DELIVERY_ALREADY_ACCEPTED);
         }
         return DeliveryResult.from(findOrThrow(deliveryId));
@@ -127,19 +126,24 @@ public class DeliveryApplicationService {
     /**
      * 요청자 정산 확인 → 포인트 이동 + 상태 전이.
      *
+     * <p>게이트 1 round 1 — Critical 1: {@link DeliveryRepository#findByIdForUpdate} 로 row 락을
+     * 먼저 획득해 동시 complete 2건이 모두 정산 진입하는 race 차단. 락 획득 후 상태 검증 →
+     * {@code transferForDelivery} → {@code markSettled} 순서. 한 트랜잭션 안에서 잔액 변동 실패 시
+     * 상태 전이도 함께 롤백.</p>
+     *
      * <p>요청자 잔액 부족 시 INSUFFICIENT_POINT — 라이더의 선행 적립 (id-asc 순서에 따라 먼저
      * 처리될 수 있음) 도 같은 트랜잭션 안이라 함께 롤백. 상태 전이도 롤백되므로 재시도 가능.</p>
      */
     @Transactional
     public DeliveryResult complete(Long deliveryId, Long requesterId) {
-        DeliveryRequest d = findOrThrow(deliveryId);
+        DeliveryRequest d = deliveryRepository.findByIdForUpdate(deliveryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
         if (!d.isRequester(requesterId)) {
             throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
         }
         if (!d.getStatus().canSettle()) {
             throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
         }
-        // 잔액 변동 먼저, 상태 전이 마지막 — 정산 실패 시 상태 전이도 롤백 (대칭).
         pointApplicationService.transferForDelivery(
                 d.getRequesterId(),
                 d.getRiderId(),
@@ -151,15 +155,30 @@ public class DeliveryApplicationService {
         return DeliveryResult.from(d);
     }
 
-    /** 요청자 취소 — 모집중 한정. 잔액 이동 없음 (등록 시 escrow 안 했음). */
+    /**
+     * 요청자 취소 — 모집중 한정. 잔액 이동 없음 (등록 시 escrow 안 했음).
+     *
+     * <p>게이트 1 round 1 — Critical 2: {@link DeliveryRepository#cancelIfStillOpen} 조건부
+     * UPDATE 로 accept vs cancel race 차단. 영향 행 0 이면 본인 자원 아니거나 이미 수락/취소된 상태.
+     * 사유 분기를 위해 후처리 조회로 메시지 결정.</p>
+     */
     @Transactional
     public DeliveryResult cancel(Long deliveryId, Long requesterId, String reason) {
-        DeliveryRequest d = findOrThrow(deliveryId);
-        if (!d.isRequester(requesterId)) {
-            throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
+        if (reason != null && reason.length() > 255) {
+            throw new IllegalArgumentException("cancelReason 은 255자 이하여야 합니다");
         }
-        d.cancelByRequester(LocalDateTime.now(), reason);
-        return DeliveryResult.from(d);
+        int affected = deliveryRepository.cancelIfStillOpen(
+                deliveryId, requesterId, LocalDateTime.now(), reason
+        );
+        if (affected == 0) {
+            DeliveryRequest current = findOrThrow(deliveryId);
+            if (!current.isRequester(requesterId)) {
+                throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
+            }
+            // 이미 수락된 / 취소된 / 그 이후 단계 — 모집중 아님.
+            throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
+        }
+        return DeliveryResult.from(findOrThrow(deliveryId));
     }
 
     public DeliveryResult getById(Long deliveryId, Long requesterId) {

--- a/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryCreateCommand.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryCreateCommand.java
@@ -1,0 +1,45 @@
+package com.sseulang.domain.delivery.application.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 배달 요청 등록 Command. 문자열 필드는 compact constructor 에서 정규화 (trim/길이 검증).
+ * Aggregate 의 create 와 검증 책임 분리: 여기는 표현 검증, Aggregate 는 비즈니스 룰.
+ */
+public record DeliveryCreateCommand(
+        Long requesterId,
+        String pickupAddress,
+        String dropoffAddress,
+        String itemDescription,
+        long fee,
+        LocalDateTime requestedDeadline,
+        String memo
+) {
+    private static final int MAX_ADDRESS = 255;
+    private static final int MAX_DESCRIPTION = 255;
+    private static final int MAX_MEMO = 500;
+
+    public DeliveryCreateCommand {
+        pickupAddress = normalize(pickupAddress, "pickupAddress", MAX_ADDRESS);
+        dropoffAddress = normalize(dropoffAddress, "dropoffAddress", MAX_ADDRESS);
+        itemDescription = normalize(itemDescription, "itemDescription", MAX_DESCRIPTION);
+        if (memo != null) {
+            memo = memo.trim();
+            if (memo.isEmpty()) memo = null;
+            else if (memo.length() > MAX_MEMO) {
+                throw new IllegalArgumentException("memo 는 " + MAX_MEMO + "자 이하여야 합니다");
+            }
+        }
+    }
+
+    private static String normalize(String value, String name, int maxLength) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " 는 필수입니다");
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() > maxLength) {
+            throw new IllegalArgumentException(name + " 는 " + maxLength + "자 이하여야 합니다");
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryResult.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryResult.java
@@ -1,0 +1,37 @@
+package com.sseulang.domain.delivery.application.dto;
+
+import com.sseulang.domain.delivery.domain.DeliveryRequest;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+
+import java.time.LocalDateTime;
+
+public record DeliveryResult(
+        Long id,
+        Long requesterId,
+        Long riderId,
+        String pickupAddress,
+        String dropoffAddress,
+        String itemDescription,
+        long fee,
+        LocalDateTime requestedDeadline,
+        String memo,
+        DeliveryStatus status,
+        LocalDateTime requestedAt,
+        LocalDateTime acceptedAt,
+        LocalDateTime pickedUpAt,
+        LocalDateTime deliveredAt,
+        LocalDateTime completedAt,
+        LocalDateTime canceledAt,
+        String cancelReason
+) {
+    public static DeliveryResult from(DeliveryRequest d) {
+        return new DeliveryResult(
+                d.getId(), d.getRequesterId(), d.getRiderId(),
+                d.getPickupAddress(), d.getDropoffAddress(), d.getItemDescription(),
+                d.getFee(), d.getRequestedDeadline(), d.getMemo(),
+                d.getStatus(), d.getRequestedAt(), d.getAcceptedAt(),
+                d.getPickedUpAt(), d.getDeliveredAt(), d.getCompletedAt(),
+                d.getCanceledAt(), d.getCancelReason()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
@@ -1,0 +1,36 @@
+package com.sseulang.domain.delivery.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * Delivery Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
+ * 구현은 {@code domain/delivery/infrastructure/persistence}.
+ */
+public interface DeliveryRepository {
+
+    DeliveryRequest save(DeliveryRequest delivery);
+
+    Optional<DeliveryRequest> findById(Long id);
+
+    /**
+     * 라이더 수락 race 차단용 conditional UPDATE.
+     *
+     * <p>{@code UPDATE deliveries SET rider_id=?, status='수락', accepted_at=?
+     * WHERE id=? AND status='모집중'} — 영향 행 수가 1 이면 수락 성공, 0 이면 race 패배
+     * (이미 다른 라이더가 수락했거나 취소됨). 본인이 등록한 요청 차단은 ApplicationService 가
+     * 호출 전 사전 검증.</p>
+     *
+     * @return 영향 행 수 (0 또는 1)
+     */
+    int acceptIfStillOpen(Long deliveryId, Long riderId, LocalDateTime acceptedAt);
+
+    /** 모집중 상태의 페이징 목록 — 라이더가 수락 가능한 후보. */
+    Page<DeliveryRequest> findOpenList(Pageable pageable);
+
+    /** 사용자가 요청자 또는 라이더로 참여한 요청 페이징. */
+    Page<DeliveryRequest> findByParticipant(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
@@ -17,16 +17,35 @@ public interface DeliveryRepository {
     Optional<DeliveryRequest> findById(Long id);
 
     /**
+     * 정산({@code complete}) 진입 시 비관적 락 획득. 동시 complete 호출 race 를 직렬화.
+     * (게이트 1 round 1 — Critical 1: 동시 complete 시 잔액 2회 변동 가능 회귀 차단.)
+     */
+    Optional<DeliveryRequest> findByIdForUpdate(Long id);
+
+    /**
      * 라이더 수락 race 차단용 conditional UPDATE.
      *
      * <p>{@code UPDATE deliveries SET rider_id=?, status='수락', accepted_at=?
-     * WHERE id=? AND status='모집중'} — 영향 행 수가 1 이면 수락 성공, 0 이면 race 패배
-     * (이미 다른 라이더가 수락했거나 취소됨). 본인이 등록한 요청 차단은 ApplicationService 가
-     * 호출 전 사전 검증.</p>
+     * WHERE id=? AND status='모집중' AND requester_id <> ?} — 영향 행 수가 1 이면 수락 성공.
+     * 0 이면 race 패배 / 취소됨 / 본인 거래 (게이트 1 round 1 — W-3: SQL 레벨에서도 본인 거래 차단).</p>
      *
      * @return 영향 행 수 (0 또는 1)
      */
     int acceptIfStillOpen(Long deliveryId, Long riderId, LocalDateTime acceptedAt);
+
+    /**
+     * 요청자 취소 race 차단용 conditional UPDATE.
+     *
+     * <p>{@code UPDATE deliveries SET status='취소', canceled_at=?, cancel_reason=?
+     * WHERE id=? AND requester_id=? AND status='모집중'} — 영향 행 수가 1 이면 취소 성공,
+     * 0 이면 이미 수락됐거나 (cancel vs accept race) 취소된 상태 / 본인 자원 아님.</p>
+     *
+     * <p>(게이트 1 round 1 — Critical 2: cancel 이 일반 로드 후 set 이라 accept conditional UPDATE
+     * 결과를 덮어써 "수락 → 취소" race 발생하던 회귀 차단.)</p>
+     *
+     * @return 영향 행 수 (0 또는 1)
+     */
+    int cancelIfStillOpen(Long deliveryId, Long requesterId, LocalDateTime canceledAt, String reason);
 
     /** 모집중 상태의 페이징 목록 — 라이더가 수락 가능한 후보. */
     Page<DeliveryRequest> findOpenList(Pageable pageable);

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRequest.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRequest.java
@@ -1,0 +1,219 @@
+package com.sseulang.domain.delivery.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Delivery Aggregate Root. V8 스키마 {@code deliveries} 매핑.
+ *
+ * <p>가이드 §1 4축 중 "배달대행" 도메인. 요청자가 등록 → 라이더 수락 → 픽업 → 배송 → 정산.
+ * 정산 시 요청자 포인트 차감 + 라이더 적립을 ApplicationService 가 한 트랜잭션으로 처리.
+ * 본 Aggregate 는 단일 요청의 상태 머신만 책임. 수락 race 는 conditional UPDATE 가 가드.</p>
+ *
+ * <p>Setter 없음. 상태 변경은 명시 비즈니스 메서드만.</p>
+ */
+@Entity
+@Table(name = "deliveries")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryRequest extends BaseEntity {
+
+    private static final int MAX_ADDRESS = 255;
+    private static final int MAX_DESCRIPTION = 255;
+    private static final int MAX_MEMO = 500;
+    private static final int MAX_CANCEL_REASON = 255;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "requester_id", nullable = false)
+    private Long requesterId;
+
+    @Column(name = "rider_id")
+    private Long riderId;
+
+    @Column(name = "pickup_address", nullable = false, length = MAX_ADDRESS)
+    private String pickupAddress;
+
+    @Column(name = "dropoff_address", nullable = false, length = MAX_ADDRESS)
+    private String dropoffAddress;
+
+    @Column(name = "item_description", nullable = false, length = MAX_DESCRIPTION)
+    private String itemDescription;
+
+    @Column(name = "fee", nullable = false)
+    private long fee;
+
+    @Column(name = "requested_deadline")
+    private LocalDateTime requestedDeadline;
+
+    @Column(name = "memo", length = MAX_MEMO)
+    private String memo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private DeliveryStatus status;
+
+    @Column(name = "requested_at", nullable = false, updatable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    @Column(name = "picked_up_at")
+    private LocalDateTime pickedUpAt;
+
+    @Column(name = "delivered_at")
+    private LocalDateTime deliveredAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
+    @Column(name = "cancel_reason", length = MAX_CANCEL_REASON)
+    private String cancelReason;
+
+    public static DeliveryRequest create(
+            Long requesterId,
+            String pickupAddress,
+            String dropoffAddress,
+            String itemDescription,
+            long fee,
+            LocalDateTime requestedDeadline,
+            String memo,
+            LocalDateTime now
+    ) {
+        if (requesterId == null || requesterId <= 0) {
+            throw new IllegalArgumentException("requesterId 는 양수여야 합니다");
+        }
+        if (fee <= 0) {
+            throw new IllegalArgumentException("fee 는 양수여야 합니다");
+        }
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+        if (requestedDeadline != null && !requestedDeadline.isAfter(now)) {
+            throw new IllegalArgumentException("requestedDeadline 은 현재 시각 이후여야 합니다");
+        }
+        validateText(pickupAddress, "pickupAddress", MAX_ADDRESS);
+        validateText(dropoffAddress, "dropoffAddress", MAX_ADDRESS);
+        validateText(itemDescription, "itemDescription", MAX_DESCRIPTION);
+        if (memo != null && memo.length() > MAX_MEMO) {
+            throw new IllegalArgumentException("memo 는 " + MAX_MEMO + "자 이하여야 합니다");
+        }
+
+        DeliveryRequest d = new DeliveryRequest();
+        d.requesterId = requesterId;
+        d.pickupAddress = pickupAddress;
+        d.dropoffAddress = dropoffAddress;
+        d.itemDescription = itemDescription;
+        d.fee = fee;
+        d.requestedDeadline = requestedDeadline;
+        d.memo = memo;
+        d.status = DeliveryStatus.모집중;
+        d.requestedAt = now;
+        return d;
+    }
+
+    /**
+     * 라이더가 수락 — 모집중 → 수락. 본인이 등록한 요청은 수락 거부.
+     *
+     * <p>주의: race 가드는 ApplicationService 의 conditional UPDATE 가 1차 — 본 메서드는 정상 흐름에서만
+     * 호출되며 본인 거래만 추가로 차단한다.</p>
+     */
+    public void acceptBy(Long riderId, LocalDateTime now) {
+        if (riderId == null || riderId <= 0) {
+            throw new IllegalArgumentException("riderId 는 양수여야 합니다");
+        }
+        if (riderId.equals(this.requesterId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_SELF_NOT_ALLOWED);
+        }
+        if (!status.canAccept()) {
+            throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
+        }
+        this.riderId = riderId;
+        this.status = DeliveryStatus.수락;
+        this.acceptedAt = now;
+    }
+
+    /** 라이더 픽업 — 수락 → 배송중. 라이더 본인만 호출 가능 (호출자 검증). */
+    public void markPickedUp(LocalDateTime now) {
+        if (!status.canPickup()) {
+            throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
+        }
+        this.status = DeliveryStatus.배송중;
+        this.pickedUpAt = now;
+    }
+
+    /** 라이더 배송 완료 — 배송중 → 배송완료. */
+    public void markDelivered(LocalDateTime now) {
+        if (!status.canDeliver()) {
+            throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
+        }
+        this.status = DeliveryStatus.배송완료;
+        this.deliveredAt = now;
+    }
+
+    /**
+     * 요청자 정산 확인 — 배송완료 → 정산완료. 포인트 이동(차감/적립)은 ApplicationService 가
+     * 같은 트랜잭션 안에서 별도 호출.
+     */
+    public void markSettled(LocalDateTime now) {
+        if (!status.canSettle()) {
+            throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
+        }
+        this.status = DeliveryStatus.정산완료;
+        this.completedAt = now;
+    }
+
+    /** 요청자 취소 — 모집중만. */
+    public void cancelByRequester(LocalDateTime now, String reason) {
+        if (!status.canRequesterCancel()) {
+            throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
+        }
+        if (reason != null && reason.length() > MAX_CANCEL_REASON) {
+            throw new IllegalArgumentException("cancelReason 은 " + MAX_CANCEL_REASON + "자 이하여야 합니다");
+        }
+        this.status = DeliveryStatus.취소;
+        this.canceledAt = now;
+        this.cancelReason = reason;
+    }
+
+    public boolean isRequester(Long userId) {
+        return userId != null && userId.equals(this.requesterId);
+    }
+
+    public boolean isRider(Long userId) {
+        return userId != null && riderId != null && userId.equals(this.riderId);
+    }
+
+    public boolean isParticipant(Long userId) {
+        return isRequester(userId) || isRider(userId);
+    }
+
+    private static void validateText(String value, String name, int max) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " 는 필수입니다");
+        }
+        if (value.length() > max) {
+            throw new IllegalArgumentException(name + " 는 " + max + "자 이하여야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryStatus.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryStatus.java
@@ -1,0 +1,53 @@
+package com.sseulang.domain.delivery.domain;
+
+/**
+ * 배달대행 요청 상태. DB VARCHAR(20) ENUM 매핑.
+ *
+ * <pre>
+ *   모집중 → 수락 → 배송중 → 배송완료 → 정산완료
+ *      └→ 취소 (요청자, 모집중 한정 — 5/6 이전 단순화)
+ * </pre>
+ *
+ * <p>수락 단계에서 race 가 있으므로 ApplicationService 가 conditional UPDATE
+ * ({@code WHERE id = ? AND status = '모집중'}) 로 동시 수락 차단. 본 enum 은 단일 row
+ * 의 다음 전이가 가능한지 표현만 한다.</p>
+ */
+public enum DeliveryStatus {
+    모집중,
+    수락,
+    배송중,
+    배송완료,
+    정산완료,
+    취소;
+
+    public boolean isTerminal() {
+        return this == 정산완료 || this == 취소;
+    }
+
+    /** 라이더가 수락 가능한 상태 (모집중 → 수락). */
+    public boolean canAccept() {
+        return this == 모집중;
+    }
+
+    /** 라이더가 픽업 처리 가능한 상태 (수락 → 배송중). */
+    public boolean canPickup() {
+        return this == 수락;
+    }
+
+    /** 라이더가 배송 완료 처리 가능한 상태 (배송중 → 배송완료). */
+    public boolean canDeliver() {
+        return this == 배송중;
+    }
+
+    /** 요청자가 정산 확인 가능한 상태 (배송완료 → 정산완료). 포인트 이동은 호출자 책임. */
+    public boolean canSettle() {
+        return this == 배송완료;
+    }
+
+    /**
+     * 요청자가 취소 가능한 상태 (모집중 한정). 수락 이후 취소는 5/6 이후 분쟁 정책 도입 시 확장.
+     */
+    public boolean canRequesterCancel() {
+        return this == 모집중;
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
@@ -1,0 +1,45 @@
+package com.sseulang.domain.delivery.infrastructure.persistence;
+
+import com.sseulang.domain.delivery.domain.DeliveryRequest;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+
+/** Spring Data JPA — {@link DeliveryRepositoryImpl} 가 wrapping. 외부 직접 import 금지. */
+interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
+
+    /**
+     * 라이더 수락 race 차단 — conditional UPDATE.
+     * <p>{@code WHERE status='모집중'} 조건으로 동시에 들어온 두 라이더 중 하나만 1 rows affected.
+     * 이미 수락됐거나 취소된 요청은 0 rows. clearAutomatically 로 영속성 컨텍스트 동기화.</p>
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE DeliveryRequest d
+               SET d.riderId = :riderId,
+                   d.status = com.sseulang.domain.delivery.domain.DeliveryStatus.수락,
+                   d.acceptedAt = :acceptedAt
+             WHERE d.id = :id
+               AND d.status = com.sseulang.domain.delivery.domain.DeliveryStatus.모집중
+            """)
+    int acceptIfStillOpen(@Param("id") Long id,
+                          @Param("riderId") Long riderId,
+                          @Param("acceptedAt") LocalDateTime acceptedAt);
+
+    Page<DeliveryRequest> findByStatusOrderByRequestedAtDesc(DeliveryStatus status, Pageable pageable);
+
+    /** 요청자 또는 라이더로 참여한 요청. */
+    @Query("""
+            SELECT d FROM DeliveryRequest d
+             WHERE d.requesterId = :userId
+                OR d.riderId = :userId
+             ORDER BY d.requestedAt DESC
+            """)
+    Page<DeliveryRequest> findByParticipant(@Param("userId") Long userId, Pageable pageable);
+}

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
@@ -2,22 +2,30 @@ package com.sseulang.domain.delivery.infrastructure.persistence;
 
 import com.sseulang.domain.delivery.domain.DeliveryRequest;
 import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 /** Spring Data JPA — {@link DeliveryRepositoryImpl} 가 wrapping. 외부 직접 import 금지. */
 interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
 
+    /** 정산 진입 직렬화 — SELECT FOR UPDATE 로 동시 complete race 차단 (게이트 1 round 1). */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT d FROM DeliveryRequest d WHERE d.id = :id")
+    Optional<DeliveryRequest> findByIdForUpdate(@Param("id") Long id);
+
     /**
      * 라이더 수락 race 차단 — conditional UPDATE.
-     * <p>{@code WHERE status='모집중'} 조건으로 동시에 들어온 두 라이더 중 하나만 1 rows affected.
-     * 이미 수락됐거나 취소된 요청은 0 rows. clearAutomatically 로 영속성 컨텍스트 동기화.</p>
+     * <p>{@code WHERE status='모집중' AND requester_id <> riderId} 로 동시 두 라이더 중 하나만
+     * 1 rows affected. SQL 자체에 본인 거래 차단 (이중 방어 — 게이트 1 round 1 W-3).</p>
      */
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
@@ -27,10 +35,30 @@ interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
                    d.acceptedAt = :acceptedAt
              WHERE d.id = :id
                AND d.status = com.sseulang.domain.delivery.domain.DeliveryStatus.모집중
+               AND d.requesterId <> :riderId
             """)
     int acceptIfStillOpen(@Param("id") Long id,
                           @Param("riderId") Long riderId,
                           @Param("acceptedAt") LocalDateTime acceptedAt);
+
+    /**
+     * 요청자 취소 race 차단 — conditional UPDATE. accept 와 동시 발생 시 한 쪽만 성공.
+     * (게이트 1 round 1 — Critical 2.)
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE DeliveryRequest d
+               SET d.status = com.sseulang.domain.delivery.domain.DeliveryStatus.취소,
+                   d.canceledAt = :canceledAt,
+                   d.cancelReason = :reason
+             WHERE d.id = :id
+               AND d.requesterId = :requesterId
+               AND d.status = com.sseulang.domain.delivery.domain.DeliveryStatus.모집중
+            """)
+    int cancelIfStillOpen(@Param("id") Long id,
+                          @Param("requesterId") Long requesterId,
+                          @Param("canceledAt") LocalDateTime canceledAt,
+                          @Param("reason") String reason);
 
     Page<DeliveryRequest> findByStatusOrderByRequestedAtDesc(DeliveryStatus status, Pageable pageable);
 

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.sseulang.domain.delivery.infrastructure.persistence;
+
+import com.sseulang.domain.delivery.domain.DeliveryRepository;
+import com.sseulang.domain.delivery.domain.DeliveryRequest;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public class DeliveryRepositoryImpl implements DeliveryRepository {
+
+    private final DeliveryJpaRepository jpa;
+
+    public DeliveryRepositoryImpl(DeliveryJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public DeliveryRequest save(DeliveryRequest delivery) {
+        return jpa.save(delivery);
+    }
+
+    @Override
+    public Optional<DeliveryRequest> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public int acceptIfStillOpen(Long deliveryId, Long riderId, LocalDateTime acceptedAt) {
+        return jpa.acceptIfStillOpen(deliveryId, riderId, acceptedAt);
+    }
+
+    @Override
+    public Page<DeliveryRequest> findOpenList(Pageable pageable) {
+        return jpa.findByStatusOrderByRequestedAtDesc(DeliveryStatus.모집중, pageable);
+    }
+
+    @Override
+    public Page<DeliveryRequest> findByParticipant(Long userId, Pageable pageable) {
+        return jpa.findByParticipant(userId, pageable);
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryRepositoryImpl.java
@@ -30,8 +30,18 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
     }
 
     @Override
+    public Optional<DeliveryRequest> findByIdForUpdate(Long id) {
+        return jpa.findByIdForUpdate(id);
+    }
+
+    @Override
     public int acceptIfStillOpen(Long deliveryId, Long riderId, LocalDateTime acceptedAt) {
         return jpa.acceptIfStillOpen(deliveryId, riderId, acceptedAt);
+    }
+
+    @Override
+    public int cancelIfStillOpen(Long deliveryId, Long requesterId, LocalDateTime canceledAt, String reason) {
+        return jpa.cancelIfStillOpen(deliveryId, requesterId, canceledAt, reason);
     }
 
     @Override

--- a/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryController.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryController.java
@@ -1,0 +1,115 @@
+package com.sseulang.domain.delivery.presentation;
+
+import com.sseulang.domain.delivery.application.DeliveryApplicationService;
+import com.sseulang.domain.delivery.presentation.dto.DeliveryCancelRequest;
+import com.sseulang.domain.delivery.presentation.dto.DeliveryCreateRequest;
+import com.sseulang.domain.delivery.presentation.dto.DeliveryResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/deliveries")
+public class DeliveryController {
+
+    private final DeliveryApplicationService deliveryService;
+
+    public DeliveryController(DeliveryApplicationService deliveryService) {
+        this.deliveryService = deliveryService;
+    }
+
+    /** 요청 등록 — 요청자, requireVerified. */
+    @PostMapping
+    public ResponseEntity<ApiResponse<DeliveryResponse>> create(
+            @AuthenticationPrincipal Long requesterId,
+            @Valid @RequestBody DeliveryCreateRequest request
+    ) {
+        DeliveryResponse body = DeliveryResponse.from(deliveryService.create(request.toCommand(requesterId)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(body));
+    }
+
+    /** 모집중 목록 — 라이더가 수락 가능한 후보. 인증 필수, 본인 등록 여부는 클라이언트에서 필터. */
+    @GetMapping
+    public ApiResponse<PageResponse<DeliveryResponse>> listOpen(Pageable pageable) {
+        return ApiResponse.ok(PageResponse.from(
+                deliveryService.listOpen(pageable).map(DeliveryResponse::from)
+        ));
+    }
+
+    /** 내 요청+수락 목록. */
+    @GetMapping("/me")
+    public ApiResponse<PageResponse<DeliveryResponse>> listMine(
+            @AuthenticationPrincipal Long userId,
+            Pageable pageable
+    ) {
+        return ApiResponse.ok(PageResponse.from(
+                deliveryService.listMine(userId, pageable).map(DeliveryResponse::from)
+        ));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<DeliveryResponse> getOne(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable("id") Long id
+    ) {
+        return ApiResponse.ok(DeliveryResponse.from(deliveryService.getById(id, userId)));
+    }
+
+    /** 라이더 수락. */
+    @PatchMapping("/{id}/accept")
+    public ApiResponse<DeliveryResponse> accept(
+            @AuthenticationPrincipal Long riderId,
+            @PathVariable("id") Long id
+    ) {
+        return ApiResponse.ok(DeliveryResponse.from(deliveryService.accept(id, riderId)));
+    }
+
+    /** 라이더 픽업 완료. */
+    @PatchMapping("/{id}/pickup")
+    public ApiResponse<DeliveryResponse> pickup(
+            @AuthenticationPrincipal Long riderId,
+            @PathVariable("id") Long id
+    ) {
+        return ApiResponse.ok(DeliveryResponse.from(deliveryService.markPickedUp(id, riderId)));
+    }
+
+    /** 라이더 배송 완료. */
+    @PatchMapping("/{id}/deliver")
+    public ApiResponse<DeliveryResponse> deliver(
+            @AuthenticationPrincipal Long riderId,
+            @PathVariable("id") Long id
+    ) {
+        return ApiResponse.ok(DeliveryResponse.from(deliveryService.markDelivered(id, riderId)));
+    }
+
+    /** 요청자 정산 확인 — 포인트 이동 + 정산완료. */
+    @PatchMapping("/{id}/complete")
+    public ApiResponse<DeliveryResponse> complete(
+            @AuthenticationPrincipal Long requesterId,
+            @PathVariable("id") Long id
+    ) {
+        return ApiResponse.ok(DeliveryResponse.from(deliveryService.complete(id, requesterId)));
+    }
+
+    /** 요청자 취소 — 모집중 한정. */
+    @PatchMapping("/{id}/cancel")
+    public ApiResponse<DeliveryResponse> cancel(
+            @AuthenticationPrincipal Long requesterId,
+            @PathVariable("id") Long id,
+            @Valid @RequestBody(required = false) DeliveryCancelRequest request
+    ) {
+        String reason = request == null ? null : request.reason();
+        return ApiResponse.ok(DeliveryResponse.from(deliveryService.cancel(id, requesterId, reason)));
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryCancelRequest.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryCancelRequest.java
@@ -1,0 +1,6 @@
+package com.sseulang.domain.delivery.presentation.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record DeliveryCancelRequest(@Size(max = 255) String reason) {
+}

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryCreateRequest.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.delivery.presentation.dto;
+
+import com.sseulang.domain.delivery.application.dto.DeliveryCreateCommand;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record DeliveryCreateRequest(
+        @NotBlank @Size(max = 255) String pickupAddress,
+        @NotBlank @Size(max = 255) String dropoffAddress,
+        @NotBlank @Size(max = 255) String itemDescription,
+        @Positive long fee,
+        @Future LocalDateTime requestedDeadline,
+        @Size(max = 500) String memo
+) {
+    public DeliveryCreateCommand toCommand(Long requesterId) {
+        return new DeliveryCreateCommand(
+                requesterId, pickupAddress, dropoffAddress, itemDescription,
+                fee, requestedDeadline, memo
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryResponse.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryResponse.java
@@ -1,0 +1,37 @@
+package com.sseulang.domain.delivery.presentation.dto;
+
+import com.sseulang.domain.delivery.application.dto.DeliveryResult;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+
+import java.time.LocalDateTime;
+
+public record DeliveryResponse(
+        Long id,
+        Long requesterId,
+        Long riderId,
+        String pickupAddress,
+        String dropoffAddress,
+        String itemDescription,
+        long fee,
+        LocalDateTime requestedDeadline,
+        String memo,
+        DeliveryStatus status,
+        LocalDateTime requestedAt,
+        LocalDateTime acceptedAt,
+        LocalDateTime pickedUpAt,
+        LocalDateTime deliveredAt,
+        LocalDateTime completedAt,
+        LocalDateTime canceledAt,
+        String cancelReason
+) {
+    public static DeliveryResponse from(DeliveryResult r) {
+        return new DeliveryResponse(
+                r.id(), r.requesterId(), r.riderId(),
+                r.pickupAddress(), r.dropoffAddress(), r.itemDescription(),
+                r.fee(), r.requestedDeadline(), r.memo(),
+                r.status(), r.requestedAt(), r.acceptedAt(),
+                r.pickedUpAt(), r.deliveredAt(), r.completedAt(),
+                r.canceledAt(), r.cancelReason()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/point/application/PointApplicationService.java
+++ b/src/main/java/com/sseulang/domain/point/application/PointApplicationService.java
@@ -133,6 +133,10 @@ public class PointApplicationService {
         if (amount <= 0) {
             throw new IllegalArgumentException("amount 는 양수여야 합니다");
         }
+        // 정산 추적 키. point service 진입점에서 막아 history dangling 회귀 차단 (게이트 1 Suggestion).
+        if (deliveryId == null || deliveryId <= 0) {
+            throw new IllegalArgumentException("deliveryId 는 양수여야 합니다");
+        }
         if (requesterId < riderId) {
             deduct(requesterId, amount, PointHistoryType.배달결제, PointReferenceType.DELIVERY, deliveryId, description);
             credit(riderId, amount, PointHistoryType.배달정산, PointReferenceType.DELIVERY, deliveryId, description);

--- a/src/main/java/com/sseulang/domain/point/application/PointApplicationService.java
+++ b/src/main/java/com/sseulang/domain/point/application/PointApplicationService.java
@@ -110,6 +110,39 @@ public class PointApplicationService {
     }
 
     /**
+     * 배달 정산 — 요청자 차감 → 라이더 적립. 거래 정산({@link #transfer})과 동일하게 id-asc 순서로 락
+     * 획득 (deadlock 방지). type 은 {@link PointHistoryType#배달결제}/{@link PointHistoryType#배달정산},
+     * referenceType 은 {@link PointReferenceType#DELIVERY} 고정.
+     *
+     * <p>요청자 잔액 부족 시 INSUFFICIENT_POINT — 라이더의 선행 적립도 같은 트랜잭션 안이라 함께 롤백.</p>
+     */
+    @Transactional
+    public void transferForDelivery(
+            Long requesterId,
+            Long riderId,
+            long amount,
+            Long deliveryId,
+            String description
+    ) {
+        if (requesterId == null || riderId == null) {
+            throw new IllegalArgumentException("requesterId / riderId 는 필수입니다");
+        }
+        if (requesterId.equals(riderId)) {
+            throw new IllegalArgumentException("requester 와 rider 는 같을 수 없습니다");
+        }
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        if (requesterId < riderId) {
+            deduct(requesterId, amount, PointHistoryType.배달결제, PointReferenceType.DELIVERY, deliveryId, description);
+            credit(riderId, amount, PointHistoryType.배달정산, PointReferenceType.DELIVERY, deliveryId, description);
+        } else {
+            credit(riderId, amount, PointHistoryType.배달정산, PointReferenceType.DELIVERY, deliveryId, description);
+            deduct(requesterId, amount, PointHistoryType.배달결제, PointReferenceType.DELIVERY, deliveryId, description);
+        }
+    }
+
+    /**
      * 거래 환불 — 거래완료 상태였던 거래가 취소되는 케이스. 양쪽 잔액 원복 + 환불 history 두 건 적재.
      * id-asc 락 순서 유지 — buyer 적립 / seller 차감.
      * <p>seller 가 이미 사용/출금 등으로 잔액이 amount 미만이면 INSUFFICIENT_POINT — 운영 이슈로 escalation

--- a/src/main/java/com/sseulang/domain/point/domain/PointHistory.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointHistory.java
@@ -141,16 +141,18 @@ public class PointHistory {
     private static void validateCreditType(PointHistoryType type) {
         if (type != PointHistoryType.충전
                 && type != PointHistoryType.판매정산
-                && type != PointHistoryType.환불) {
-            throw new IllegalArgumentException("recordCredit 은 충전 / 판매정산 / 환불 type 만 허용: " + type);
+                && type != PointHistoryType.환불
+                && type != PointHistoryType.배달정산) {
+            throw new IllegalArgumentException("recordCredit 은 충전 / 판매정산 / 환불 / 배달정산 type 만 허용: " + type);
         }
     }
 
     private static void validateDebitType(PointHistoryType type) {
         if (type != PointHistoryType.결제
                 && type != PointHistoryType.출금
-                && type != PointHistoryType.환불) {
-            throw new IllegalArgumentException("recordDebit 은 결제 / 출금 / 환불 type 만 허용: " + type);
+                && type != PointHistoryType.환불
+                && type != PointHistoryType.배달결제) {
+            throw new IllegalArgumentException("recordDebit 은 결제 / 출금 / 환불 / 배달결제 type 만 허용: " + type);
         }
     }
 }

--- a/src/main/java/com/sseulang/domain/point/domain/PointHistoryType.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointHistoryType.java
@@ -9,6 +9,8 @@ package com.sseulang.domain.point.domain;
  *   <li>{@link #판매정산} — 거래 결제 시 판매자 잔액 적립 (Day 8)</li>
  *   <li>{@link #출금} — 출금 신청 시 잔액 차감 (Day 8)</li>
  *   <li>{@link #환불} — 거래 취소 시 양쪽 잔액 원복 (Day 8)</li>
+ *   <li>{@link #배달결제} — 배달 정산 시 요청자 잔액 차감 (Day 9)</li>
+ *   <li>{@link #배달정산} — 배달 정산 시 라이더 잔액 적립 (Day 9)</li>
  * </ul>
  */
 public enum PointHistoryType {
@@ -16,5 +18,7 @@ public enum PointHistoryType {
     결제,
     판매정산,
     출금,
-    환불
+    환불,
+    배달결제,
+    배달정산
 }

--- a/src/main/java/com/sseulang/domain/point/domain/PointReferenceType.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointReferenceType.java
@@ -7,5 +7,6 @@ package com.sseulang.domain.point.domain;
 public enum PointReferenceType {
     PAYMENT,
     TRANSACTION,
-    WITHDRAWAL
+    WITHDRAWAL,
+    DELIVERY
 }

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -81,7 +81,14 @@ public enum ErrorCode {
 
     // 파일
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
-    FILE_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "파일 검증에 실패했습니다.");
+    FILE_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "파일 검증에 실패했습니다."),
+
+    // 배달대행
+    DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배달 요청을 찾을 수 없습니다."),
+    DELIVERY_FORBIDDEN(HttpStatus.FORBIDDEN, "배달 요청에 대한 권한이 없습니다."),
+    DELIVERY_INVALID_STATE(HttpStatus.BAD_REQUEST, "현재 상태에서 수행할 수 없는 동작입니다."),
+    DELIVERY_ALREADY_ACCEPTED(HttpStatus.CONFLICT, "이미 다른 라이더가 수락한 요청입니다."),
+    DELIVERY_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "본인이 등록한 요청은 수락할 수 없습니다.");
 
     private final HttpStatus status;
     private final String defaultMessage;

--- a/src/main/resources/db/migration/V8__add_deliveries.sql
+++ b/src/main/resources/db/migration/V8__add_deliveries.sql
@@ -1,0 +1,33 @@
+-- =====================================================
+-- V8: deliveries (배달대행 도메인)
+-- =====================================================
+-- 사용자(요청자) 가 배달 요청을 등록하고, 라이더가 수락 → 픽업 → 배송 → 정산 순으로 처리.
+-- 정산 시 요청자 포인트 차감 + 라이더 포인트 적립 (PointHistory: DELIVERY_PAYMENT/INCOME).
+-- 수락 race 차단은 ApplicationService 가 conditional UPDATE 로 처리 (Item 예약 패턴 동일).
+-- =====================================================
+
+CREATE TABLE deliveries (
+    id                  BIGINT       NOT NULL AUTO_INCREMENT,
+    requester_id        BIGINT       NOT NULL,
+    rider_id            BIGINT       NULL,
+    pickup_address      VARCHAR(255) NOT NULL,
+    dropoff_address     VARCHAR(255) NOT NULL,
+    item_description    VARCHAR(255) NOT NULL,
+    fee                 BIGINT       NOT NULL,
+    requested_deadline  DATETIME     NULL,
+    memo                VARCHAR(500) NULL,
+    status              VARCHAR(20)  NOT NULL,
+    requested_at        DATETIME     NOT NULL,
+    accepted_at         DATETIME     NULL,
+    picked_up_at        DATETIME     NULL,
+    delivered_at        DATETIME     NULL,
+    completed_at        DATETIME     NULL,
+    canceled_at         DATETIME     NULL,
+    cancel_reason       VARCHAR(255) NULL,
+    created_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_deliveries_status_requested (status, requested_at DESC),
+    KEY idx_deliveries_requester (requester_id, requested_at DESC),
+    KEY idx_deliveries_rider (rider_id, requested_at DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V8__add_deliveries.sql
+++ b/src/main/resources/db/migration/V8__add_deliveries.sql
@@ -6,6 +6,11 @@
 -- 수락 race 차단은 ApplicationService 가 conditional UPDATE 로 처리 (Item 예약 패턴 동일).
 -- =====================================================
 
+-- point_histories.point_type ENUM 확장 — 배달 정산을 위한 새 type 추가.
+-- 기존 V1 ENUM('충전','결제','판매정산','출금','환불') 에 '배달결제','배달정산' 추가.
+ALTER TABLE point_histories
+    MODIFY COLUMN point_type ENUM('충전','결제','판매정산','출금','환불','배달결제','배달정산') NOT NULL;
+
 CREATE TABLE deliveries (
     id                  BIGINT       NOT NULL AUTO_INCREMENT,
     requester_id        BIGINT       NOT NULL,

--- a/src/main/resources/db/migration/V8__add_deliveries.sql
+++ b/src/main/resources/db/migration/V8__add_deliveries.sql
@@ -34,5 +34,14 @@ CREATE TABLE deliveries (
     PRIMARY KEY (id),
     KEY idx_deliveries_status_requested (status, requested_at DESC),
     KEY idx_deliveries_requester (requester_id, requested_at DESC),
-    KEY idx_deliveries_rider (rider_id, requested_at DESC)
+    KEY idx_deliveries_rider (rider_id, requested_at DESC),
+    -- 정산 도메인 방어선 — 거래/출금 컨벤션 동일 (게이트 1 W-V8).
+    -- FK: 운영상 user 는 soft-delete 패턴이라 실제 row 삭제 X. RESTRICT 로 두면 dangling 차단 +
+    -- MySQL 8 제약(CHECK 에 ON DELETE SET NULL 컬럼 사용 불가, Err 3823) 회피.
+    CONSTRAINT fk_deliveries_requester FOREIGN KEY (requester_id) REFERENCES users(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_deliveries_rider     FOREIGN KEY (rider_id)     REFERENCES users(id) ON DELETE RESTRICT,
+    -- fee 양수 + 본인 거래 차단 + status 화이트리스트.
+    CONSTRAINT chk_deliveries_fee_positive   CHECK (fee > 0),
+    CONSTRAINT chk_deliveries_not_self       CHECK (rider_id IS NULL OR rider_id <> requester_id),
+    CONSTRAINT chk_deliveries_status_allowed CHECK (status IN ('모집중','수락','배송중','배송완료','정산완료','취소'))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/test/java/com/sseulang/domain/delivery/application/DeliveryApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/delivery/application/DeliveryApplicationServiceTest.java
@@ -1,0 +1,282 @@
+package com.sseulang.domain.delivery.application;
+
+import com.sseulang.domain.delivery.application.dto.DeliveryCreateCommand;
+import com.sseulang.domain.delivery.application.dto.DeliveryResult;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.point.domain.PointHistoryType;
+import com.sseulang.domain.point.domain.PointReferenceType;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class DeliveryApplicationServiceTest {
+
+    private static final Long REQUESTER = 100L;
+    private static final Long RIDER = 200L;
+
+    private InMemoryFakeDeliveryRepository repo;
+    private UserApplicationService userService;
+    private PointApplicationService pointService;
+    private DeliveryApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        repo = new InMemoryFakeDeliveryRepository();
+        userService = mock(UserApplicationService.class);
+        pointService = mock(PointApplicationService.class);
+        service = new DeliveryApplicationService(repo, userService, pointService);
+    }
+
+    @Test
+    @DisplayName("create 정상_requireVerified 호출 + 모집중 저장")
+    void create_정상() {
+        DeliveryResult r = service.create(newCommand());
+
+        verify(userService).requireVerified(REQUESTER);
+        assertThat(r.requesterId()).isEqualTo(REQUESTER);
+        assertThat(r.status()).isEqualTo(DeliveryStatus.모집중);
+        assertThat(r.fee()).isEqualTo(5000L);
+    }
+
+    @Test
+    @DisplayName("create 미인증_requireVerified throw")
+    void create_미인증_차단() {
+        doThrow(new BusinessException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED))
+                .when(userService).requireVerified(REQUESTER);
+
+        assertThatThrownBy(() -> service.create(newCommand()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
+    }
+
+    @Test
+    @DisplayName("accept 정상_모집중→수락 + riderId 세팅")
+    void accept_정상() {
+        DeliveryResult created = service.create(newCommand());
+
+        DeliveryResult r = service.accept(created.id(), RIDER);
+
+        verify(userService).requireVerified(RIDER);
+        assertThat(r.status()).isEqualTo(DeliveryStatus.수락);
+        assertThat(r.riderId()).isEqualTo(RIDER);
+        assertThat(r.acceptedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("accept 본인 거래_DELIVERY_SELF_NOT_ALLOWED")
+    void accept_본인_차단() {
+        DeliveryResult created = service.create(newCommand());
+
+        assertThatThrownBy(() -> service.accept(created.id(), REQUESTER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_SELF_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("accept 이미 수락된 요청_DELIVERY_ALREADY_ACCEPTED")
+    void accept_race_loser() {
+        DeliveryResult created = service.create(newCommand());
+        service.accept(created.id(), RIDER);
+
+        assertThatThrownBy(() -> service.accept(created.id(), 300L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_ALREADY_ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("accept 없는 요청_DELIVERY_NOT_FOUND")
+    void accept_not_found() {
+        assertThatThrownBy(() -> service.accept(999L, RIDER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("markPickedUp 정상_수락→배송중 (라이더만)")
+    void pickup_정상() {
+        DeliveryResult created = service.create(newCommand());
+        service.accept(created.id(), RIDER);
+
+        DeliveryResult r = service.markPickedUp(created.id(), RIDER);
+
+        assertThat(r.status()).isEqualTo(DeliveryStatus.배송중);
+        assertThat(r.pickedUpAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("markPickedUp 라이더 아닌 사용자_DELIVERY_FORBIDDEN")
+    void pickup_타인_차단() {
+        DeliveryResult created = service.create(newCommand());
+        service.accept(created.id(), RIDER);
+
+        assertThatThrownBy(() -> service.markPickedUp(created.id(), 999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("complete 정상_정산 호출 + 배송완료→정산완료")
+    void complete_정상() {
+        DeliveryResult created = service.create(newCommand());
+        service.accept(created.id(), RIDER);
+        service.markPickedUp(created.id(), RIDER);
+        service.markDelivered(created.id(), RIDER);
+
+        DeliveryResult r = service.complete(created.id(), REQUESTER);
+
+        verify(pointService).transferForDelivery(
+                eq(REQUESTER), eq(RIDER), eq(5000L), eq(created.id()), anyString()
+        );
+        assertThat(r.status()).isEqualTo(DeliveryStatus.정산완료);
+        assertThat(r.completedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("complete 라이더 시도_DELIVERY_FORBIDDEN (요청자만)")
+    void complete_타인_차단() {
+        DeliveryResult created = service.create(newCommand());
+        service.accept(created.id(), RIDER);
+        service.markPickedUp(created.id(), RIDER);
+        service.markDelivered(created.id(), RIDER);
+
+        assertThatThrownBy(() -> service.complete(created.id(), RIDER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_FORBIDDEN);
+
+        verify(pointService, never()).transferForDelivery(anyLong(), anyLong(), anyLong(), anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("complete 배송완료 아닌 상태_DELIVERY_INVALID_STATE + 잔액 이동 안 함")
+    void complete_invalid_state() {
+        DeliveryResult created = service.create(newCommand());
+        service.accept(created.id(), RIDER);
+
+        // 수락 상태에서 정산 시도
+        assertThatThrownBy(() -> service.complete(created.id(), REQUESTER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_INVALID_STATE);
+
+        verify(pointService, never()).transferForDelivery(anyLong(), anyLong(), anyLong(), anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("complete 잔액 부족_INSUFFICIENT_POINT 전파 + 상태 전이 안 일어남")
+    void complete_잔액부족() {
+        DeliveryResult created = service.create(newCommand());
+        service.accept(created.id(), RIDER);
+        service.markPickedUp(created.id(), RIDER);
+        service.markDelivered(created.id(), RIDER);
+
+        doThrow(new BusinessException(ErrorCode.INSUFFICIENT_POINT))
+                .when(pointService).transferForDelivery(
+                        anyLong(), anyLong(), anyLong(), anyLong(), anyString());
+
+        assertThatThrownBy(() -> service.complete(created.id(), REQUESTER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INSUFFICIENT_POINT);
+
+        // 트랜잭션 롤백 가정 — fake repo 라 검증 한계가 있지만,
+        // 적어도 markSettled 이전에 transfer 가 throw 됐는지 확인 (배송완료 그대로)
+        DeliveryResult after = service.getById(created.id(), REQUESTER);
+        assertThat(after.status()).isEqualTo(DeliveryStatus.배송완료);
+    }
+
+    @Test
+    @DisplayName("cancel 모집중_취소")
+    void cancel_정상() {
+        DeliveryResult created = service.create(newCommand());
+
+        DeliveryResult r = service.cancel(created.id(), REQUESTER, "변심");
+
+        assertThat(r.status()).isEqualTo(DeliveryStatus.취소);
+        assertThat(r.cancelReason()).isEqualTo("변심");
+    }
+
+    @Test
+    @DisplayName("cancel 라이더 시도_DELIVERY_FORBIDDEN")
+    void cancel_타인_차단() {
+        DeliveryResult created = service.create(newCommand());
+
+        assertThatThrownBy(() -> service.cancel(created.id(), 999L, "x"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("cancel 수락 이후_DELIVERY_INVALID_STATE")
+    void cancel_수락이후_차단() {
+        DeliveryResult created = service.create(newCommand());
+        service.accept(created.id(), RIDER);
+
+        assertThatThrownBy(() -> service.cancel(created.id(), REQUESTER, "변심"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("getById 모집중_누구나 조회 가능")
+    void getById_모집중_공개() {
+        DeliveryResult created = service.create(newCommand());
+
+        DeliveryResult r = service.getById(created.id(), 999L);
+
+        assertThat(r.id()).isEqualTo(created.id());
+    }
+
+    @Test
+    @DisplayName("getById 수락 이후_참여자만 조회 가능")
+    void getById_수락이후_제한() {
+        DeliveryResult created = service.create(newCommand());
+        service.accept(created.id(), RIDER);
+
+        // 외부인은 거부
+        assertThatThrownBy(() -> service.getById(created.id(), 999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_FORBIDDEN);
+
+        // 요청자/라이더는 통과
+        assertThat(service.getById(created.id(), REQUESTER).id()).isEqualTo(created.id());
+        assertThat(service.getById(created.id(), RIDER).id()).isEqualTo(created.id());
+    }
+
+    private static DeliveryCreateCommand newCommand() {
+        return new DeliveryCreateCommand(
+                REQUESTER,
+                "서울 강남구 테헤란로 123",
+                "서울 송파구 올림픽로 456",
+                "A4 서류 봉투 1개",
+                5000L,
+                LocalDateTime.now().plusHours(2),
+                "1층 로비 보관함"
+        );
+    }
+}

--- a/src/test/java/com/sseulang/domain/delivery/application/InMemoryFakeDeliveryRepository.java
+++ b/src/test/java/com/sseulang/domain/delivery/application/InMemoryFakeDeliveryRepository.java
@@ -35,11 +35,28 @@ public class InMemoryFakeDeliveryRepository implements DeliveryRepository {
     }
 
     @Override
+    public Optional<DeliveryRequest> findByIdForUpdate(Long id) {
+        // fake — 락 의미 X. prod 동시성 IT 에서 실제 PESSIMISTIC_WRITE 검증.
+        return findById(id);
+    }
+
+    @Override
     public synchronized int acceptIfStillOpen(Long deliveryId, Long riderId, LocalDateTime acceptedAt) {
         DeliveryRequest d = store.get(deliveryId);
         if (d == null) return 0;
         if (d.getStatus() != DeliveryStatus.모집중) return 0;
+        if (riderId == null || riderId.equals(d.getRequesterId())) return 0;
         d.acceptBy(riderId, acceptedAt);
+        return 1;
+    }
+
+    @Override
+    public synchronized int cancelIfStillOpen(Long deliveryId, Long requesterId, LocalDateTime canceledAt, String reason) {
+        DeliveryRequest d = store.get(deliveryId);
+        if (d == null) return 0;
+        if (!requesterId.equals(d.getRequesterId())) return 0;
+        if (d.getStatus() != DeliveryStatus.모집중) return 0;
+        d.cancelByRequester(canceledAt, reason);
         return 1;
     }
 

--- a/src/test/java/com/sseulang/domain/delivery/application/InMemoryFakeDeliveryRepository.java
+++ b/src/test/java/com/sseulang/domain/delivery/application/InMemoryFakeDeliveryRepository.java
@@ -1,0 +1,64 @@
+package com.sseulang.domain.delivery.application;
+
+import com.sseulang.domain.delivery.domain.DeliveryRepository;
+import com.sseulang.domain.delivery.domain.DeliveryRequest;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class InMemoryFakeDeliveryRepository implements DeliveryRepository {
+
+    private final Map<Long, DeliveryRequest> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public DeliveryRequest save(DeliveryRequest delivery) {
+        if (delivery.getId() == null) {
+            ReflectionTestUtils.setField(delivery, "id", ++sequence);
+        }
+        store.put(delivery.getId(), delivery);
+        return delivery;
+    }
+
+    @Override
+    public Optional<DeliveryRequest> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public synchronized int acceptIfStillOpen(Long deliveryId, Long riderId, LocalDateTime acceptedAt) {
+        DeliveryRequest d = store.get(deliveryId);
+        if (d == null) return 0;
+        if (d.getStatus() != DeliveryStatus.모집중) return 0;
+        d.acceptBy(riderId, acceptedAt);
+        return 1;
+    }
+
+    @Override
+    public Page<DeliveryRequest> findOpenList(Pageable pageable) {
+        List<DeliveryRequest> filtered = store.values().stream()
+                .filter(d -> d.getStatus() == DeliveryStatus.모집중)
+                .sorted(Comparator.comparing(DeliveryRequest::getRequestedAt).reversed())
+                .toList();
+        return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+
+    @Override
+    public Page<DeliveryRequest> findByParticipant(Long userId, Pageable pageable) {
+        List<DeliveryRequest> filtered = store.values().stream()
+                .filter(d -> userId.equals(d.getRequesterId())
+                        || (d.getRiderId() != null && userId.equals(d.getRiderId())))
+                .sorted(Comparator.comparing(DeliveryRequest::getRequestedAt).reversed())
+                .toList();
+        return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+}

--- a/src/test/java/com/sseulang/domain/delivery/domain/DeliveryRequestTest.java
+++ b/src/test/java/com/sseulang/domain/delivery/domain/DeliveryRequestTest.java
@@ -1,0 +1,203 @@
+package com.sseulang.domain.delivery.domain;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DeliveryRequestTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 30, 12, 0);
+    private static final Long REQUESTER = 1L;
+    private static final Long RIDER = 2L;
+
+    @Test
+    @DisplayName("create 정상_모집중 + 필드 채워짐")
+    void create_정상() {
+        DeliveryRequest d = newDelivery();
+
+        assertThat(d.getRequesterId()).isEqualTo(REQUESTER);
+        assertThat(d.getRiderId()).isNull();
+        assertThat(d.getPickupAddress()).isEqualTo("서울 강남구");
+        assertThat(d.getDropoffAddress()).isEqualTo("서울 송파구");
+        assertThat(d.getItemDescription()).isEqualTo("서류");
+        assertThat(d.getFee()).isEqualTo(5000L);
+        assertThat(d.getStatus()).isEqualTo(DeliveryStatus.모집중);
+        assertThat(d.getRequestedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("create invalid 인자 거부")
+    void create_invalid() {
+        assertThatThrownBy(() -> DeliveryRequest.create(
+                null, "p", "d", "i", 1000L, null, null, NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> DeliveryRequest.create(
+                REQUESTER, "", "d", "i", 1000L, null, null, NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> DeliveryRequest.create(
+                REQUESTER, "p", "d", "i", 0L, null, null, NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> DeliveryRequest.create(
+                REQUESTER, "p", "d", "i", -1L, null, null, NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> DeliveryRequest.create(
+                REQUESTER, "p", "d", "i", 1000L, NOW.minusHours(1), null, NOW))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("acceptBy 정상_모집중→수락_riderId·acceptedAt 세팅")
+    void acceptBy_정상() {
+        DeliveryRequest d = newDelivery();
+
+        d.acceptBy(RIDER, NOW.plusMinutes(5));
+
+        assertThat(d.getStatus()).isEqualTo(DeliveryStatus.수락);
+        assertThat(d.getRiderId()).isEqualTo(RIDER);
+        assertThat(d.getAcceptedAt()).isEqualTo(NOW.plusMinutes(5));
+    }
+
+    @Test
+    @DisplayName("acceptBy 본인 거래_DELIVERY_SELF_NOT_ALLOWED")
+    void acceptBy_본인_거부() {
+        DeliveryRequest d = newDelivery();
+
+        assertThatThrownBy(() -> d.acceptBy(REQUESTER, NOW))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_SELF_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("acceptBy 모집중_아닌_상태_DELIVERY_INVALID_STATE")
+    void acceptBy_invalid_state() {
+        DeliveryRequest d = newDelivery();
+        d.acceptBy(RIDER, NOW);
+
+        assertThatThrownBy(() -> d.acceptBy(3L, NOW))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("정상 흐름_모집중→수락→배송중→배송완료→정산완료")
+    void 정상_흐름() {
+        DeliveryRequest d = newDelivery();
+
+        d.acceptBy(RIDER, NOW.plusMinutes(5));
+        d.markPickedUp(NOW.plusMinutes(15));
+        d.markDelivered(NOW.plusMinutes(45));
+        d.markSettled(NOW.plusMinutes(50));
+
+        assertThat(d.getStatus()).isEqualTo(DeliveryStatus.정산완료);
+        assertThat(d.getPickedUpAt()).isEqualTo(NOW.plusMinutes(15));
+        assertThat(d.getDeliveredAt()).isEqualTo(NOW.plusMinutes(45));
+        assertThat(d.getCompletedAt()).isEqualTo(NOW.plusMinutes(50));
+    }
+
+    @Test
+    @DisplayName("markPickedUp 수락 아닌 상태_거부")
+    void markPickedUp_invalid() {
+        DeliveryRequest d = newDelivery();
+
+        assertThatThrownBy(() -> d.markPickedUp(NOW))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("markDelivered 배송중 아닌 상태_거부")
+    void markDelivered_invalid() {
+        DeliveryRequest d = newDelivery();
+        d.acceptBy(RIDER, NOW);
+
+        assertThatThrownBy(() -> d.markDelivered(NOW))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("markSettled 배송완료 아닌 상태_거부")
+    void markSettled_invalid() {
+        DeliveryRequest d = newDelivery();
+        d.acceptBy(RIDER, NOW);
+        d.markPickedUp(NOW);
+
+        // 배송중 상태에서 정산 시도
+        assertThatThrownBy(() -> d.markSettled(NOW))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("cancelByRequester 모집중_취소")
+    void cancel_정상() {
+        DeliveryRequest d = newDelivery();
+
+        d.cancelByRequester(NOW.plusMinutes(2), "급해서");
+
+        assertThat(d.getStatus()).isEqualTo(DeliveryStatus.취소);
+        assertThat(d.getCanceledAt()).isEqualTo(NOW.plusMinutes(2));
+        assertThat(d.getCancelReason()).isEqualTo("급해서");
+    }
+
+    @Test
+    @DisplayName("cancelByRequester 수락 이후_거부 (5/6 이전 단순화 정책)")
+    void cancel_수락이후_거부() {
+        DeliveryRequest d = newDelivery();
+        d.acceptBy(RIDER, NOW);
+
+        assertThatThrownBy(() -> d.cancelByRequester(NOW.plusMinutes(1), "변심"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DELIVERY_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("isParticipant — 요청자/라이더 본인만 true")
+    void isParticipant() {
+        DeliveryRequest d = newDelivery();
+        d.acceptBy(RIDER, NOW);
+
+        assertThat(d.isParticipant(REQUESTER)).isTrue();
+        assertThat(d.isParticipant(RIDER)).isTrue();
+        assertThat(d.isParticipant(999L)).isFalse();
+        assertThat(d.isParticipant(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isRider — 라이더 미수락 상태에서는 false")
+    void isRider_미수락() {
+        DeliveryRequest d = newDelivery();
+
+        assertThat(d.isRider(REQUESTER)).isFalse();
+        assertThat(d.isRider(RIDER)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isTerminal — 정산완료/취소 만 종료 상태")
+    void status_terminal() {
+        assertThat(DeliveryStatus.모집중.isTerminal()).isFalse();
+        assertThat(DeliveryStatus.수락.isTerminal()).isFalse();
+        assertThat(DeliveryStatus.배송중.isTerminal()).isFalse();
+        assertThat(DeliveryStatus.배송완료.isTerminal()).isFalse();
+        assertThat(DeliveryStatus.정산완료.isTerminal()).isTrue();
+        assertThat(DeliveryStatus.취소.isTerminal()).isTrue();
+    }
+
+    private static DeliveryRequest newDelivery() {
+        return DeliveryRequest.create(
+                REQUESTER, "서울 강남구", "서울 송파구", "서류",
+                5000L, NOW.plusHours(2), "1층 로비", NOW);
+    }
+}

--- a/src/test/java/com/sseulang/domain/delivery/integration/DeliveryConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/delivery/integration/DeliveryConcurrencyIT.java
@@ -1,0 +1,299 @@
+package com.sseulang.domain.delivery.integration;
+
+import com.sseulang.domain.delivery.application.DeliveryApplicationService;
+import com.sseulang.domain.delivery.application.dto.DeliveryCreateCommand;
+import com.sseulang.domain.delivery.application.dto.DeliveryResult;
+import com.sseulang.domain.delivery.domain.DeliveryRepository;
+import com.sseulang.domain.delivery.domain.DeliveryRequest;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import com.sseulang.domain.delivery.infrastructure.persistence.DeliveryRepositoryImpl;
+import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.point.domain.PointHistoryRepository;
+import com.sseulang.domain.point.infrastructure.persistence.PointHistoryRepositoryImpl;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserRepository;
+import com.sseulang.domain.user.infrastructure.persistence.UserRepositoryImpl;
+import com.sseulang.global.config.JpaAuditingConfig;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Day 9 게이트 1 round 1 보강 — 배달 정산/수락/취소 동시성 DB-backed IT.
+ *
+ * <p>Codex 게이트 1 Critical 1·2 회귀 차단:
+ * <ol>
+ *   <li>{@code 동시 complete} — PESSIMISTIC_WRITE 직렬화 → 정확히 1건만 정산 (잔액 1회 변동, history 2건)</li>
+ *   <li>{@code 동시 accept} — conditional UPDATE → 정확히 1건만 수락</li>
+ *   <li>{@code accept vs cancel race} — 두 conditional UPDATE 가 동일 status='모집중' 가드 →
+ *       정확히 1건만 성공, 다른 1건은 INVALID_STATE 거부</li>
+ * </ol>
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({
+        JpaAuditingConfig.class,
+        UserRepositoryImpl.class,
+        UserApplicationService.class,
+        PointHistoryRepositoryImpl.class,
+        PointApplicationService.class,
+        DeliveryRepositoryImpl.class,
+        DeliveryApplicationService.class
+})
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class DeliveryConcurrencyIT {
+
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("sseulang_test")
+            .withUsername("test")
+            .withPassword("testpw")
+            .withCommand("--character-set-server=utf8mb4",
+                    "--collation-server=utf8mb4_unicode_ci",
+                    "--ngram_token_size=2");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    @Autowired private EntityManager em;
+    @Autowired private DeliveryApplicationService deliveryService;
+    @Autowired private DeliveryRepository deliveryRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private PointHistoryRepository pointHistoryRepository;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate txTemplate;
+    private Long requesterId;
+    private Long riderId;
+    private Long otherRiderId;
+
+    @BeforeEach
+    void setUp() {
+        txTemplate = new TransactionTemplate(transactionManager);
+        txTemplate.execute(s -> {
+            em.createNativeQuery("DELETE FROM point_histories").executeUpdate();
+            em.createNativeQuery("DELETE FROM deliveries").executeUpdate();
+            em.createNativeQuery("DELETE FROM users").executeUpdate();
+            return null;
+        });
+        requesterId = txTemplate.execute(s -> persistVerifiedUser("req"));
+        riderId = txTemplate.execute(s -> persistVerifiedUser("rider1"));
+        otherRiderId = txTemplate.execute(s -> persistVerifiedUser("rider2"));
+        txTemplate.execute(s -> {
+            userRepository.creditPointBalance(requesterId, 50_000L);
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("동시 complete 2건_정확히 1건만 정산 (게이트 1 Critical 1)")
+    void 동시_complete_1건만_정산() throws Exception {
+        Long deliveryId = setupDeliveredDelivery(5_000L);
+
+        ExecutorService exec = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicInteger okCount = new AtomicInteger();
+        AtomicInteger stateErr = new AtomicInteger();
+
+        Runnable complete = () -> {
+            try {
+                start.await();
+                txTemplate.execute(s -> deliveryService.complete(deliveryId, requesterId));
+                okCount.incrementAndGet();
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.DELIVERY_INVALID_STATE) {
+                    stateErr.incrementAndGet();
+                }
+            } catch (Exception ignore) {
+            } finally {
+                done.countDown();
+            }
+        };
+        exec.submit(complete);
+        exec.submit(complete);
+        start.countDown();
+        boolean finished = done.await(15, TimeUnit.SECONDS);
+        exec.shutdown();
+
+        assertThat(finished).as("두 complete 모두 15초 안에 완료").isTrue();
+        assertThat(okCount.get()).as("정확히 1건만 성공").isEqualTo(1);
+        assertThat(stateErr.get()).as("나머지 1건은 상태 가드로 거부").isEqualTo(1);
+
+        // 잔액 — 요청자 50000-5000=45000, 라이더 0+5000=5000 (1회만 변동)
+        assertThat(userRepository.findPointBalance(requesterId)).isEqualTo(45_000L);
+        assertThat(userRepository.findPointBalance(riderId)).isEqualTo(5_000L);
+
+        // history — 정확히 2건 (배달결제 + 배달정산)
+        long deliveryHistoryCount = pointHistoryRepository
+                .findByUserIdOrderByCreatedAtDesc(requesterId).stream()
+                .filter(h -> h.getReferenceId() != null && h.getReferenceId().equals(deliveryId)).count()
+                + pointHistoryRepository
+                .findByUserIdOrderByCreatedAtDesc(riderId).stream()
+                .filter(h -> h.getReferenceId() != null && h.getReferenceId().equals(deliveryId)).count();
+        assertThat(deliveryHistoryCount).as("정확히 2건 (요청자 결제 + 라이더 정산)").isEqualTo(2);
+
+        // 상태
+        DeliveryRequest after = deliveryRepository.findById(deliveryId).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(DeliveryStatus.정산완료);
+    }
+
+    @Test
+    @DisplayName("동시 accept 2건_정확히 1건만 수락 (게이트 1 W-3 + race)")
+    void 동시_accept_1건만() throws Exception {
+        Long deliveryId = txTemplate.execute(s -> deliveryService.create(new DeliveryCreateCommand(
+                requesterId, "출발지", "도착지", "물품", 3_000L, null, null
+        )).id());
+
+        ExecutorService exec = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicInteger okCount = new AtomicInteger();
+        AtomicInteger conflictCount = new AtomicInteger();
+
+        java.util.function.Function<Long, Runnable> acceptFor = (Long rId) -> () -> {
+            try {
+                start.await();
+                txTemplate.execute(s -> deliveryService.accept(deliveryId, rId));
+                okCount.incrementAndGet();
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.DELIVERY_ALREADY_ACCEPTED) {
+                    conflictCount.incrementAndGet();
+                }
+            } catch (Exception ignore) {
+            } finally {
+                done.countDown();
+            }
+        };
+        exec.submit(acceptFor.apply(riderId));
+        exec.submit(acceptFor.apply(otherRiderId));
+        start.countDown();
+        boolean finished = done.await(10, TimeUnit.SECONDS);
+        exec.shutdown();
+
+        assertThat(finished).as("두 accept 모두 10초 안에 완료").isTrue();
+        assertThat(okCount.get()).as("정확히 1건만 성공").isEqualTo(1);
+        assertThat(conflictCount.get()).as("나머지 1건은 ALREADY_ACCEPTED").isEqualTo(1);
+
+        DeliveryRequest after = deliveryRepository.findById(deliveryId).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(DeliveryStatus.수락);
+        assertThat(after.getRiderId()).isIn(riderId, otherRiderId);
+    }
+
+    @Test
+    @DisplayName("accept vs cancel race_정확히 1건만 성공 (게이트 1 Critical 2)")
+    void accept_vs_cancel_race() throws Exception {
+        Long deliveryId = txTemplate.execute(s -> deliveryService.create(new DeliveryCreateCommand(
+                requesterId, "출발지", "도착지", "물품", 3_000L, null, null
+        )).id());
+
+        ExecutorService exec = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicInteger acceptOk = new AtomicInteger();
+        AtomicInteger cancelOk = new AtomicInteger();
+        AtomicInteger stateErr = new AtomicInteger();
+
+        exec.submit(() -> {
+            try {
+                start.await();
+                txTemplate.execute(s -> deliveryService.accept(deliveryId, riderId));
+                acceptOk.incrementAndGet();
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.DELIVERY_ALREADY_ACCEPTED
+                        || e.getErrorCode() == ErrorCode.DELIVERY_INVALID_STATE) {
+                    stateErr.incrementAndGet();
+                }
+            } catch (Exception ignore) {
+            } finally {
+                done.countDown();
+            }
+        });
+        exec.submit(() -> {
+            try {
+                start.await();
+                txTemplate.execute(s -> deliveryService.cancel(deliveryId, requesterId, "변심"));
+                cancelOk.incrementAndGet();
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.DELIVERY_INVALID_STATE) {
+                    stateErr.incrementAndGet();
+                }
+            } catch (Exception ignore) {
+            } finally {
+                done.countDown();
+            }
+        });
+        start.countDown();
+        boolean finished = done.await(10, TimeUnit.SECONDS);
+        exec.shutdown();
+
+        assertThat(finished).as("두 호출 모두 10초 안에 완료").isTrue();
+        assertThat(acceptOk.get() + cancelOk.get()).as("정확히 1건만 성공").isEqualTo(1);
+        assertThat(stateErr.get()).as("나머지 1건은 상태 가드로 거부").isEqualTo(1);
+
+        DeliveryRequest after = deliveryRepository.findById(deliveryId).orElseThrow();
+        assertThat(after.getStatus()).isIn(DeliveryStatus.수락, DeliveryStatus.취소);
+    }
+
+    /** 정산 진입 가능한 상태(배송완료) 까지 만들어 둠. */
+    private Long setupDeliveredDelivery(long fee) {
+        return txTemplate.execute(s -> {
+            DeliveryResult created = deliveryService.create(new DeliveryCreateCommand(
+                    requesterId, "출발지", "도착지", "물품", fee, null, null
+            ));
+            deliveryService.accept(created.id(), riderId);
+            deliveryService.markPickedUp(created.id(), riderId);
+            deliveryService.markDelivered(created.id(), riderId);
+            return created.id();
+        });
+    }
+
+    private Long persistVerifiedUser(String tag) {
+        User user = User.createSocialUser(
+                SocialProvider.KAKAO,
+                "kakao-" + tag + "-" + System.nanoTime(),
+                new Email(tag + "-" + System.nanoTime() + "@d.test"),
+                tag + "-" + System.nanoTime(),
+                null
+        );
+        em.persist(user);
+        em.flush();
+        return user.getId();
+    }
+}

--- a/src/test/java/com/sseulang/domain/delivery/integration/DeliveryConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/delivery/integration/DeliveryConcurrencyIT.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -131,6 +132,7 @@ class DeliveryConcurrencyIT {
         CountDownLatch done = new CountDownLatch(2);
         AtomicInteger okCount = new AtomicInteger();
         AtomicInteger stateErr = new AtomicInteger();
+        AtomicReference<Throwable> otherError = new AtomicReference<>();
 
         Runnable complete = () -> {
             try {
@@ -141,7 +143,8 @@ class DeliveryConcurrencyIT {
                 if (e.getErrorCode() == ErrorCode.DELIVERY_INVALID_STATE) {
                     stateErr.incrementAndGet();
                 }
-            } catch (Exception ignore) {
+            } catch (Exception e) {
+                otherError.compareAndSet(null, e);
             } finally {
                 done.countDown();
             }
@@ -153,6 +156,7 @@ class DeliveryConcurrencyIT {
         exec.shutdown();
 
         assertThat(finished).as("두 complete 모두 15초 안에 완료").isTrue();
+        assertThat(otherError.get()).as("BusinessException 외 예외 없음").isNull();
         assertThat(okCount.get()).as("정확히 1건만 성공").isEqualTo(1);
         assertThat(stateErr.get()).as("나머지 1건은 상태 가드로 거부").isEqualTo(1);
 
@@ -186,6 +190,7 @@ class DeliveryConcurrencyIT {
         CountDownLatch done = new CountDownLatch(2);
         AtomicInteger okCount = new AtomicInteger();
         AtomicInteger conflictCount = new AtomicInteger();
+        AtomicReference<Throwable> otherError = new AtomicReference<>();
 
         java.util.function.Function<Long, Runnable> acceptFor = (Long rId) -> () -> {
             try {
@@ -196,7 +201,8 @@ class DeliveryConcurrencyIT {
                 if (e.getErrorCode() == ErrorCode.DELIVERY_ALREADY_ACCEPTED) {
                     conflictCount.incrementAndGet();
                 }
-            } catch (Exception ignore) {
+            } catch (Exception e) {
+                otherError.compareAndSet(null, e);
             } finally {
                 done.countDown();
             }
@@ -208,6 +214,7 @@ class DeliveryConcurrencyIT {
         exec.shutdown();
 
         assertThat(finished).as("두 accept 모두 10초 안에 완료").isTrue();
+        assertThat(otherError.get()).as("BusinessException 외 예외 없음").isNull();
         assertThat(okCount.get()).as("정확히 1건만 성공").isEqualTo(1);
         assertThat(conflictCount.get()).as("나머지 1건은 ALREADY_ACCEPTED").isEqualTo(1);
 
@@ -229,6 +236,7 @@ class DeliveryConcurrencyIT {
         AtomicInteger acceptOk = new AtomicInteger();
         AtomicInteger cancelOk = new AtomicInteger();
         AtomicInteger stateErr = new AtomicInteger();
+        AtomicReference<Throwable> otherError = new AtomicReference<>();
 
         exec.submit(() -> {
             try {
@@ -240,7 +248,8 @@ class DeliveryConcurrencyIT {
                         || e.getErrorCode() == ErrorCode.DELIVERY_INVALID_STATE) {
                     stateErr.incrementAndGet();
                 }
-            } catch (Exception ignore) {
+            } catch (Exception e) {
+                otherError.compareAndSet(null, e);
             } finally {
                 done.countDown();
             }
@@ -254,7 +263,8 @@ class DeliveryConcurrencyIT {
                 if (e.getErrorCode() == ErrorCode.DELIVERY_INVALID_STATE) {
                     stateErr.incrementAndGet();
                 }
-            } catch (Exception ignore) {
+            } catch (Exception e) {
+                otherError.compareAndSet(null, e);
             } finally {
                 done.countDown();
             }
@@ -264,6 +274,7 @@ class DeliveryConcurrencyIT {
         exec.shutdown();
 
         assertThat(finished).as("두 호출 모두 10초 안에 완료").isTrue();
+        assertThat(otherError.get()).as("BusinessException 외 예외 없음").isNull();
         assertThat(acceptOk.get() + cancelOk.get()).as("정확히 1건만 성공").isEqualTo(1);
         assertThat(stateErr.get()).as("나머지 1건은 상태 가드로 거부").isEqualTo(1);
 

--- a/src/test/java/com/sseulang/integration/DeliveryFlowE2EIT.java
+++ b/src/test/java/com/sseulang/integration/DeliveryFlowE2EIT.java
@@ -1,0 +1,328 @@
+package com.sseulang.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sseulang.domain.auth.domain.OAuthProvider;
+import com.sseulang.domain.auth.domain.OAuthUserInfo;
+import com.sseulang.domain.payment.domain.PaymentConfirmResult;
+import com.sseulang.domain.payment.domain.PaymentGateway;
+import com.sseulang.domain.payment.domain.PaymentMethod;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.global.security.CookieUtil;
+import jakarta.persistence.EntityManager;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 배달대행 e2e — 요청 등록 → 라이더 수락 → 픽업 → 배송 → 정산 한 시퀀스 + race / self-accept.
+ *
+ * <p>외부 의존(OAuth/Toss) 만 mock. DB·Redis·Mongo·Spring Security 모두 real.</p>
+ */
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
+@AutoConfigureMockMvc
+@Import(DeliveryFlowE2EIT.TestOAuthBeans.class)
+@Testcontainers
+class DeliveryFlowE2EIT {
+
+    @TestConfiguration
+    static class TestOAuthBeans {
+        @Bean("kakaoOAuthProvider")
+        OAuthProvider kakaoOAuthProvider() {
+            OAuthProvider m = Mockito.mock(OAuthProvider.class);
+            Mockito.when(m.supports()).thenReturn(SocialProvider.KAKAO);
+            return m;
+        }
+
+        @Bean("googleOAuthProvider")
+        OAuthProvider googleOAuthProvider() {
+            OAuthProvider m = Mockito.mock(OAuthProvider.class);
+            Mockito.when(m.supports()).thenReturn(SocialProvider.GOOGLE);
+            return m;
+        }
+    }
+
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("sseulang_test")
+            .withUsername("test")
+            .withPassword("testpw")
+            .withCommand("--character-set-server=utf8mb4",
+                    "--collation-server=utf8mb4_unicode_ci",
+                    "--ngram_token_size=2");
+
+    @Container
+    static final GenericContainer<?> REDIS = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379);
+
+    @Container
+    static final MongoDBContainer MONGO = new MongoDBContainer(DockerImageName.parse("mongo:7"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        r.add("spring.datasource.username", MYSQL::getUsername);
+        r.add("spring.datasource.password", MYSQL::getPassword);
+        r.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        r.add("spring.flyway.enabled", () -> "true");
+        r.add("spring.data.redis.host", REDIS::getHost);
+        r.add("spring.data.redis.port", REDIS::getFirstMappedPort);
+        r.add("spring.data.mongodb.uri", MONGO::getReplicaSetUrl);
+        r.add("app.dev-auth.enabled", () -> "false");
+    }
+
+    @Autowired private MockMvc mvc;
+    @Autowired private ObjectMapper om;
+    @Autowired private EntityManager em;
+    @Autowired private PlatformTransactionManager txManager;
+
+    @Autowired
+    @org.springframework.beans.factory.annotation.Qualifier("kakaoOAuthProvider")
+    private OAuthProvider kakaoOAuthProvider;
+
+    @MockBean
+    private PaymentGateway paymentGateway;
+
+    @BeforeEach
+    void cleanDb() {
+        new TransactionTemplate(txManager).execute(s -> {
+            em.createNativeQuery("DELETE FROM point_histories").executeUpdate();
+            em.createNativeQuery("DELETE FROM payments").executeUpdate();
+            em.createNativeQuery("DELETE FROM deliveries").executeUpdate();
+            em.createNativeQuery("DELETE FROM users").executeUpdate();
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("delivery happy path — 요청 → 수락 → 픽업 → 배송 → 정산 → 잔액 이동")
+    void delivery_happy_path() throws Exception {
+        // 요청자 가입 + 충전
+        Cookie requesterAt = signup("kakao-req-" + UUID.randomUUID(), "REQ_TOKEN", "요청자");
+        long chargeAmount = 50_000L;
+        chargeBalance(requesterAt, chargeAmount);
+
+        // 라이더 가입
+        Cookie riderAt = signup("kakao-rider-" + UUID.randomUUID(), "RIDER_TOKEN", "라이더");
+
+        // 1) 요청 등록
+        long fee = 5_000L;
+        String createBody = String.format("""
+                {
+                  "pickupAddress": "서울 강남구 테헤란로 123",
+                  "dropoffAddress": "서울 송파구 올림픽로 456",
+                  "itemDescription": "A4 서류 봉투 1개",
+                  "fee": %d,
+                  "requestedDeadline": "%s",
+                  "memo": "1층 로비"
+                }
+                """, fee, LocalDateTime.now().plusHours(2));
+        MvcResult created = mvc.perform(post("/api/v1/deliveries")
+                        .with(csrf()).cookie(requesterAt)
+                        .contentType(MediaType.APPLICATION_JSON).content(createBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.status").value("모집중"))
+                .andReturn();
+        Long deliveryId = readId(created, "/data/id");
+        assertThat(deliveryId).isNotNull();
+
+        // 2) 라이더 수락
+        mvc.perform(patch("/api/v1/deliveries/" + deliveryId + "/accept")
+                        .with(csrf()).cookie(riderAt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("수락"))
+                .andExpect(jsonPath("$.data.riderId").exists());
+
+        // 3) 픽업
+        mvc.perform(patch("/api/v1/deliveries/" + deliveryId + "/pickup")
+                        .with(csrf()).cookie(riderAt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("배송중"));
+
+        // 4) 배송 완료
+        mvc.perform(patch("/api/v1/deliveries/" + deliveryId + "/deliver")
+                        .with(csrf()).cookie(riderAt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("배송완료"));
+
+        // 5) 요청자 정산 확인 → 포인트 이동
+        mvc.perform(patch("/api/v1/deliveries/" + deliveryId + "/complete")
+                        .with(csrf()).cookie(requesterAt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("정산완료"));
+
+        // 잔액 검증 — 요청자: 50000-5000=45000, 라이더: 0+5000=5000.
+        // 일반 user 엔드포인트 미존재 → 본 IT 는 DB 로 직접 조회.
+        long requesterBalance = sumBalanceForRequester();
+        long riderBalance = sumBalanceForRider();
+        assertThat(requesterBalance).isEqualTo(45_000L);
+        assertThat(riderBalance).isEqualTo(5_000L);
+
+        // PointHistory 두 건 적재 검증 (배달결제 / 배달정산)
+        Number historyCount = (Number) em.createNativeQuery(
+                "SELECT COUNT(*) FROM point_histories WHERE reference_type = 'DELIVERY' AND reference_id = " + deliveryId
+        ).getSingleResult();
+        assertThat(historyCount.intValue()).isEqualTo(2);
+    }
+
+    private long sumBalanceForRequester() {
+        return ((Number) em.createNativeQuery(
+                "SELECT point_balance FROM users WHERE id = " +
+                "(SELECT requester_id FROM deliveries ORDER BY id DESC LIMIT 1)"
+        ).getSingleResult()).longValue();
+    }
+
+    private long sumBalanceForRider() {
+        return ((Number) em.createNativeQuery(
+                "SELECT point_balance FROM users WHERE id = " +
+                "(SELECT rider_id FROM deliveries ORDER BY id DESC LIMIT 1)"
+        ).getSingleResult()).longValue();
+    }
+
+    @Test
+    @DisplayName("accept race — 이미 수락된 요청에 다른 라이더 시도 시 409 ALREADY_ACCEPTED")
+    void accept_race() throws Exception {
+        Cookie req = signup("kakao-req2-" + UUID.randomUUID(), "REQ2", "요청자2");
+        Cookie r1 = signup("kakao-r1-" + UUID.randomUUID(), "R1", "라이더1");
+        Cookie r2 = signup("kakao-r2-" + UUID.randomUUID(), "R2", "라이더2");
+
+        Long deliveryId = createDelivery(req, 3000L);
+
+        mvc.perform(patch("/api/v1/deliveries/" + deliveryId + "/accept")
+                        .with(csrf()).cookie(r1))
+                .andExpect(status().isOk());
+
+        mvc.perform(patch("/api/v1/deliveries/" + deliveryId + "/accept")
+                        .with(csrf()).cookie(r2))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("DELIVERY_ALREADY_ACCEPTED"));
+    }
+
+    @Test
+    @DisplayName("self-accept 차단 — 본인 등록 요청 수락 시 400 SELF_NOT_ALLOWED")
+    void accept_self_blocked() throws Exception {
+        Cookie req = signup("kakao-self-" + UUID.randomUUID(), "SELF", "본인");
+
+        Long deliveryId = createDelivery(req, 2000L);
+
+        mvc.perform(patch("/api/v1/deliveries/" + deliveryId + "/accept")
+                        .with(csrf()).cookie(req))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("DELIVERY_SELF_NOT_ALLOWED"));
+    }
+
+    // ───────── helpers ─────────
+
+    private Cookie signup(String providerId, String accessToken, String nickname) throws Exception {
+        OAuthUserInfo info = new OAuthUserInfo(
+                SocialProvider.KAKAO, providerId,
+                new Email("u-" + System.nanoTime() + "@d.test"),
+                nickname, null
+        );
+        when(kakaoOAuthProvider.supports()).thenReturn(SocialProvider.KAKAO);
+        when(kakaoOAuthProvider.verifyAndFetch(accessToken)).thenReturn(info);
+
+        MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/kakao")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accessToken\":\"" + accessToken + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists(CookieUtil.ACCESS_TOKEN_COOKIE))
+                .andReturn();
+        Cookie at = result.getResponse().getCookie(CookieUtil.ACCESS_TOKEN_COOKIE);
+        assertThat(at).isNotNull();
+        return at;
+    }
+
+    private void chargeBalance(Cookie at, long amount) throws Exception {
+        MvcResult chargeStart = mvc.perform(post("/api/v1/payments/charge")
+                        .with(csrf()).cookie(at)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"amount\":" + amount + "}"))
+                .andExpect(status().isCreated())
+                .andReturn();
+        String merchantUid = readString(chargeStart, "/data/merchantUid");
+
+        when(paymentGateway.confirm(any(), any(), any(Long.class)))
+                .thenReturn(new PaymentConfirmResult(
+                        "pk-" + UUID.randomUUID(), merchantUid, amount, PaymentMethod.CARD,
+                        LocalDateTime.now(), "{\"approved\":true}"
+                ));
+
+        String confirmBody = String.format(
+                "{\"paymentKey\":\"pk-%s\",\"orderId\":\"%s\",\"amount\":%d}",
+                UUID.randomUUID(), merchantUid, amount
+        );
+        mvc.perform(post("/api/v1/payments/charge/confirm")
+                        .with(csrf()).cookie(at)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(confirmBody))
+                .andExpect(status().isOk());
+    }
+
+    private Long createDelivery(Cookie requester, long fee) throws Exception {
+        String body = String.format("""
+                {
+                  "pickupAddress": "서울 강남구",
+                  "dropoffAddress": "서울 송파구",
+                  "itemDescription": "서류",
+                  "fee": %d,
+                  "requestedDeadline": "%s"
+                }
+                """, fee, LocalDateTime.now().plusHours(1));
+        MvcResult created = mvc.perform(post("/api/v1/deliveries")
+                        .with(csrf()).cookie(requester)
+                        .contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readId(created, "/data/id");
+    }
+
+    private Long readId(MvcResult result, String pointer) throws Exception {
+        JsonNode root = om.readTree(result.getResponse().getContentAsString());
+        return root.at(pointer).asLong();
+    }
+
+    private String readString(MvcResult result, String pointer) throws Exception {
+        JsonNode root = om.readTree(result.getResponse().getContentAsString());
+        return root.at(pointer).asText();
+    }
+}


### PR DESCRIPTION
## Summary
- 배달대행(delivery) 도메인 풀 구현 — CLAUDE.md §1 4축 (중고/대여/나눔/배달대행) 중 마지막
- 5단계 상태 머신 (모집중→수락→배송중→배송완료→정산완료, +취소)
- 8 API 엔드포인트 (POST/GET 4 + PATCH 4)
- 정산 시 PointApplicationService.transferForDelivery (id-asc 락 순서, 배달결제/배달정산 PointHistory)
- 게이트 1 round 1·2 Critical/Warning 모두 반영 (Codex thread `019ddd70-7e38-7472-9141-809a7841a6c9`)

## 게이트 1 결과
**Round 1**: 🔴 Critical 2건 + 🟡 Warning 3건 + 🟢 1건 → 모두 반영
- Critical 1: 동시 complete race → `findByIdForUpdate` PESSIMISTIC_WRITE 적용
- Critical 2: cancel vs accept race → `cancelIfStillOpen` conditional UPDATE 적용
- W-3: acceptIfStillOpen SQL 본인 거래 차단 (`AND requesterId <> riderId`)
- W-V8: deliveries FK + CHECK (fee>0, !self, status whitelist)
- W-IT: 동시성 IT 추가 (CountDownLatch 패턴)
- Suggestion: transferForDelivery deliveryId null 검증

**Round 2**: 🔴 Critical 0건. 🟡 Warning 1건(accept 에러 코드 정확도) + 🟢 1건 반영.

## 핵심 보안 원칙
- 정산 진입 직렬화: `findByIdForUpdate` (PESSIMISTIC_WRITE) → 동시 complete race 차단
- 수락/취소 race: conditional UPDATE `WHERE status='모집중'` 으로 atomic 차단
- 본인 거래 차단: SQL + service + aggregate 3중 방어
- 잔액 정합성: PointApplicationService.transferForDelivery 한 트랜잭션 (id-asc 락)
- 양측 requireVerified 가드

## Test plan
- [x] DeliveryRequestTest — 도메인 단위 13건 PASS (상태 전이 + 본인 거래 + 취소 정책)
- [x] DeliveryApplicationServiceTest — application 단위 17건 PASS (Mockito)
- [x] DeliveryConcurrencyIT — 동시성 IT 3건 PASS (`@DataJpaTest` + Testcontainers MySQL)
  - 동시 complete 2건 → 1건만 정산 (잔액 1회 / history 2건)
  - 동시 accept 2건 → 1건만 수락
  - accept vs cancel race → 1건만 성공
- [x] DeliveryFlowE2EIT — e2e 3건 PASS (`@SpringBootTest` + Testcontainers)
  - happy path (요청→수락→픽업→배송→정산 + 잔액/history 검증)
  - accept race (순차)
  - self-accept 차단
- [x] 전체 빌드 BUILD SUCCESSFUL

## Follow-up (5/6 이후)
- escrow 도입 (요청 등록 시 fee hold) — 잔액 부족 정산 실패 회피
- 수락 이후 분쟁 처리 / 라이더 포기 흐름
- 배달 통계 admin dashboard 통합
- 실시간 위치 추적 (WebSocket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)