### PR TITLE
docs(swagger): Request DTO 예시 JSON + 핵심 6 도메인 Tag

### DIFF
--- a/src/main/java/com/sseulang/domain/admin/presentation/dto/AdminLoginRequest.java
+++ b/src/main/java/com/sseulang/domain/admin/presentation/dto/AdminLoginRequest.java
@@ -1,8 +1,13 @@
 package com.sseulang.domain.admin.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "관리자 로그인. 성공 시 ROLE_ADMIN AT/RT 쿠키 발급.")
 public record AdminLoginRequest(
+        @Schema(description = "관리자 username", example = "admin")
         @NotBlank String username,
+
+        @Schema(description = "관리자 비밀번호", example = "AdminP@ssw0rd!")
         @NotBlank String password
 ) {}

--- a/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
@@ -12,6 +12,7 @@ import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import com.sseulang.global.security.CookieUtil;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Auth", description = "회원가입 / 로그인 (LOCAL·OAuth) / 토큰 / 로그아웃")
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController {

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/LocalLoginRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/LocalLoginRequest.java
@@ -1,11 +1,16 @@
 package com.sseulang.domain.auth.presentation.dto;
 
 import com.sseulang.domain.user.domain.Email;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "LOCAL 가입자 로그인. 성공 시 AT/RT 쿠키 발급.")
 public record LocalLoginRequest(
+        @Schema(description = "가입 이메일", example = "alice@sseulang.test", maxLength = 100)
         @NotBlank @jakarta.validation.constraints.Email @Size(max = 100) String email,
+
+        @Schema(description = "비밀번호", example = "P@ssw0rd!", maxLength = 72)
         @NotBlank @Size(max = 72) String password
 ) {
     public Email toEmailVO() {

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/LocalSignupRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/LocalSignupRequest.java
@@ -1,6 +1,7 @@
 package com.sseulang.domain.auth.presentation.dto;
 
 import com.sseulang.domain.user.domain.Email;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -8,9 +9,15 @@ import jakarta.validation.constraints.Size;
  * LOCAL 가입 요청. 비밀번호는 BCrypt 72-byte limit + 보안 정책으로 8~72자.
  * 길이/형식 추가 검증은 LocalAuthService 가 도메인 룰로 한 번 더 가드.
  */
+@Schema(description = "이메일 + 비밀번호 + 닉네임으로 LOCAL 가입")
 public record LocalSignupRequest(
+        @Schema(description = "이메일 (최대 100자, RFC 5322 형식)", example = "alice@sseulang.test", maxLength = 100)
         @NotBlank @jakarta.validation.constraints.Email @Size(max = 100) String email,
+
+        @Schema(description = "비밀번호 (8~72자, BCrypt 72-byte limit)", example = "P@ssw0rd!", minLength = 8, maxLength = 72)
         @NotBlank @Size(min = 8, max = 72) String password,
+
+        @Schema(description = "닉네임 (최대 50자)", example = "쓸랭이", maxLength = 50)
         @NotBlank @Size(max = 50) String nickname
 ) {
     public Email toEmailVO() {

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/OAuthLoginRequest.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.auth.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 /**
@@ -7,7 +8,12 @@ import jakarta.validation.constraints.NotBlank;
  *
  * <p>가이드 §4.4 "프론트가 카카오/구글 SDK로 access_token 획득 → 백엔드로 전달".</p>
  */
+@Schema(description = "프론트가 SDK로 받은 OAuth access_token 을 전달. 백엔드가 사용자 정보 조회 + 가입/로그인 처리.")
 public record OAuthLoginRequest(
+        @Schema(
+                description = "카카오/구글 SDK 에서 받은 OAuth access_token",
+                example = "ya29.a0AfH6SMBxYVhc0BkExampleAccessToken..."
+        )
         @NotBlank(message = "accessToken 은 필수입니다")
         String accessToken
 ) {

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/VerifyEmailRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/VerifyEmailRequest.java
@@ -1,8 +1,15 @@
 package com.sseulang.domain.auth.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "이메일 인증 토큰 검증. 가입 메일에 포함된 32~64자 토큰.")
 public record VerifyEmailRequest(
+        @Schema(
+                description = "가입 메일에 포함된 인증 토큰 (UUID hex 32자)",
+                example = "a1b2c3d4e5f60718293a4b5c6d7e8f90",
+                minLength = 32, maxLength = 64
+        )
         @NotBlank @Size(min = 32, max = 64) String token
 ) {}

--- a/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerActiveRequest.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerActiveRequest.java
@@ -1,5 +1,10 @@
 package com.sseulang.domain.banner.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record BannerActiveRequest(@NotNull Boolean active) {}
+@Schema(description = "배너 활성/비활성 토글.")
+public record BannerActiveRequest(
+        @Schema(description = "활성 여부", example = "true")
+        @NotNull Boolean active
+) {}

--- a/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerUpsertRequest.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerUpsertRequest.java
@@ -1,17 +1,30 @@
 package com.sseulang.domain.banner.presentation.dto;
 
 import com.sseulang.domain.banner.application.dto.BannerUpsertCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "배너 등록/수정 (관리자). startsAt~endsAt 사이만 active. sortOrder 작을수록 상단.")
 public record BannerUpsertRequest(
+        @Schema(description = "배너 제목", example = "여름 세일", maxLength = 200)
         @NotBlank @Size(max = 200) String title,
+
+        @Schema(description = "배너 이미지 URL", example = "https://cdn.sseulang.test/banners/summer.jpg", maxLength = 500)
         @NotBlank @Size(max = 500) String imageUrl,
+
+        @Schema(description = "클릭 시 이동 URL (선택)", example = "https://sseulang.test/events/summer", maxLength = 500, nullable = true)
         @Size(max = 500) String linkUrl,
+
+        @Schema(description = "노출 정렬 순서 (작을수록 상단)", example = "10")
         int sortOrder,
+
+        @Schema(description = "노출 시작 시각 (선택, null이면 즉시)", example = "2026-05-01T00:00:00", nullable = true)
         LocalDateTime startsAt,
+
+        @Schema(description = "노출 종료 시각 (선택, null이면 무기한)", example = "2026-05-31T23:59:59", nullable = true)
         LocalDateTime endsAt
 ) {
     public BannerUpsertCommand toCommand() {

--- a/src/main/java/com/sseulang/domain/block/presentation/dto/UserBlockRequest.java
+++ b/src/main/java/com/sseulang/domain/block/presentation/dto/UserBlockRequest.java
@@ -1,6 +1,11 @@
 package com.sseulang.domain.block.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
-public record UserBlockRequest(@NotNull @Positive Long userId) { }
+@Schema(description = "사용자 차단 — 차단 대상의 userId. 차단된 사용자와는 채팅/거래 불가.")
+public record UserBlockRequest(
+        @Schema(description = "차단할 사용자 id", example = "42")
+        @NotNull @Positive Long userId
+) { }

--- a/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomCreateRequest.java
@@ -1,6 +1,11 @@
 package com.sseulang.domain.chat.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
-public record ChatRoomCreateRequest(@NotNull @Positive Long itemId) { }
+@Schema(description = "Item 기준 1:1 채팅방 개설/조회. 동일 (buyer, item) 재요청 시 기존 채팅방 반환 (멱등).")
+public record ChatRoomCreateRequest(
+        @Schema(description = "채팅 대상 itemId", example = "42")
+        @NotNull @Positive Long itemId
+) { }

--- a/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryController.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.delivery.presentation.dto.DeliveryCreateRequest;
 import com.sseulang.domain.delivery.presentation.dto.DeliveryResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Delivery", description = "배달대행 — 모집중→수락→배송중→배송완료→정산완료 (또는 취소).")
 @RestController
 @RequestMapping("/api/v1/deliveries")
 public class DeliveryController {

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryCancelRequest.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryCancelRequest.java
@@ -1,6 +1,11 @@
 package com.sseulang.domain.delivery.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
-public record DeliveryCancelRequest(@Size(max = 255) String reason) {
+@Schema(description = "배달 요청 취소. 모집중 상태만 취소 가능 (수락 이후는 분쟁 처리 영역).")
+public record DeliveryCancelRequest(
+        @Schema(description = "취소 사유 (선택)", example = "직접 가기로 변경", maxLength = 255, nullable = true)
+        @Size(max = 255) String reason
+) {
 }

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryCreateRequest.java
@@ -1,6 +1,7 @@
 package com.sseulang.domain.delivery.presentation.dto;
 
 import com.sseulang.domain.delivery.application.dto.DeliveryCreateCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
@@ -8,12 +9,24 @@ import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "배달대행 요청 등록. 모집중 상태로 시작 → 라이더 수락 → 픽업 → 배송 → 정산.")
 public record DeliveryCreateRequest(
+        @Schema(description = "출발지 주소", example = "서울 강남구 테헤란로 123", maxLength = 255)
         @NotBlank @Size(max = 255) String pickupAddress,
+
+        @Schema(description = "도착지 주소", example = "서울 송파구 올림픽로 456", maxLength = 255)
         @NotBlank @Size(max = 255) String dropoffAddress,
+
+        @Schema(description = "물품 설명", example = "A4 서류 봉투 1개", maxLength = 255)
         @NotBlank @Size(max = 255) String itemDescription,
+
+        @Schema(description = "라이더에게 지급할 수수료 (포인트)", example = "5000")
         @Positive long fee,
+
+        @Schema(description = "희망 도착 시각 (현재 이후, 선택)", example = "2026-05-01T15:00:00", nullable = true)
         @Future LocalDateTime requestedDeadline,
+
+        @Schema(description = "메모 (선택)", example = "1층 로비 보관함", maxLength = 500, nullable = true)
         @Size(max = 500) String memo
 ) {
     public DeliveryCreateCommand toCommand(Long requesterId) {

--- a/src/main/java/com/sseulang/domain/file/presentation/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/dto/PresignedUrlRequest.java
@@ -1,18 +1,28 @@
 package com.sseulang.domain.file.presentation.dto;
 
 import com.sseulang.domain.file.domain.FilePurpose;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
+@Schema(description = "S3 presigned URL 발급 요청. 클라이언트가 직접 S3 업로드 후, 반환된 URL 을 Item/Message 에 사용.")
 public record PresignedUrlRequest(
+        @Schema(description = "업로드 용도", example = "ITEM_IMAGE",
+                allowableValues = {"ITEM_IMAGE", "PROFILE_IMAGE", "MESSAGE_IMAGE"})
         @NotNull FilePurpose purpose,
+
+        @Schema(description = "업로드 파일 메타 목록")
         @NotEmpty @Valid List<PresignedFileItem> files
 ) {
+    @Schema(description = "단일 파일 메타")
     public record PresignedFileItem(
+            @Schema(description = "MIME 타입", example = "image/jpeg")
             @NotNull String contentType,
+
+            @Schema(description = "바이트 길이", example = "524288")
             @NotNull Long contentLength
     ) { }
 }

--- a/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
@@ -10,6 +10,7 @@ import com.sseulang.domain.item.presentation.dto.ItemSummaryResponse;
 import com.sseulang.domain.item.presentation.dto.ItemUpdateRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Item", description = "물품 등록·검색·수정·삭제·예약 상태 조회")
 @RestController
 @RequestMapping("/api/v1/items")
 public class ItemController {

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemRegisterRequest.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemRegisterRequest.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.item.presentation.dto;
 import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
 import com.sseulang.domain.item.domain.RentalUnit;
 import com.sseulang.domain.item.domain.TradeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -10,16 +11,39 @@ import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
+@Schema(description = "물품 등록 요청. tradeType=대여 인 경우 deposit/rentalUnit 권장.")
 public record ItemRegisterRequest(
+        @Schema(description = "카테고리 id (선택)", example = "3")
         Long categoryId,
+
+        @Schema(description = "제목", example = "아이폰 15 프로 256GB", maxLength = 200)
         @NotBlank @Size(max = 200) String title,
+
+        @Schema(description = "상세 설명", example = "구매 1년차, 박스/충전기 풀구성. 직거래 선호.")
         @NotBlank String description,
+
+        @Schema(description = "가격 (원). 나눔이면 0", example = "850000")
         @NotNull @PositiveOrZero Long price,
+
+        @Schema(description = "보증금 (대여 거래 전용, 그 외 null)", example = "100000", nullable = true)
         @PositiveOrZero Long deposit,
+
+        @Schema(description = "대여 단위 (대여 거래 전용)", example = "DAY",
+                allowableValues = {"HOUR", "DAY", "WEEK", "MONTH"}, nullable = true)
         RentalUnit rentalUnit,
+
+        @Schema(description = "거래 유형", example = "판매",
+                allowableValues = {"판매", "대여", "나눔"})
         @NotNull TradeType tradeType,
+
+        @Schema(description = "지역", example = "서울 강남구", maxLength = 100, nullable = true)
         @Size(max = 100) String region,
+
+        @Schema(description = "이미지 URL 목록 (최대 5장, S3 presigned URL 업로드 후 키)",
+                example = "[\"https://cdn.sseulang.test/items/abc.jpg\"]", nullable = true)
         List<String> imageUrls,
+
+        @Schema(description = "해시태그 (선택)", example = "[\"애플\",\"중고폰\"]", nullable = true)
         List<String> hashtags
 ) {
     public ItemRegisterCommand toCommand(Long sellerId) {

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemUpdateRequest.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemUpdateRequest.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.item.presentation.dto;
 
 import com.sseulang.domain.item.application.dto.ItemUpdateCommand;
 import com.sseulang.domain.item.domain.RentalUnit;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -9,15 +10,33 @@ import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
+@Schema(description = "물품 수정 요청. tradeType 은 변경 불가 — 거래 흐름 일관성 위해 등록 시점에 고정.")
 public record ItemUpdateRequest(
+        @Schema(description = "카테고리 id", example = "3", nullable = true)
         Long categoryId,
+
+        @Schema(description = "제목", example = "아이폰 15 프로 256GB (가격 인하)", maxLength = 200)
         @NotBlank @Size(max = 200) String title,
+
+        @Schema(description = "상세 설명", example = "가격 5만원 인하했습니다.")
         @NotBlank String description,
+
+        @Schema(description = "가격", example = "800000")
         @NotNull @PositiveOrZero Long price,
+
+        @Schema(description = "보증금 (대여 거래)", example = "100000", nullable = true)
         @PositiveOrZero Long deposit,
+
+        @Schema(description = "대여 단위", example = "DAY", nullable = true)
         RentalUnit rentalUnit,
+
+        @Schema(description = "지역", example = "서울 강남구", maxLength = 100, nullable = true)
         @Size(max = 100) String region,
+
+        @Schema(description = "이미지 URL 목록", nullable = true)
         List<String> imageUrls,
+
+        @Schema(description = "해시태그", nullable = true)
         List<String> hashtags
 ) {
     public ItemUpdateCommand toCommand() {

--- a/src/main/java/com/sseulang/domain/message/presentation/dto/MessageSendRequest.java
+++ b/src/main/java/com/sseulang/domain/message/presentation/dto/MessageSendRequest.java
@@ -1,13 +1,19 @@
 package com.sseulang.domain.message.presentation.dto;
 
 import com.sseulang.domain.message.application.dto.MessageSendCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 /** content 또는 imageUrls 둘 중 하나는 필수. ApplicationService 가 도메인 invariant 로 검증. */
+@Schema(description = "채팅 메시지 전송 — content 또는 imageUrls 중 최소 1개 필수.")
 public record MessageSendRequest(
+        @Schema(description = "텍스트 메시지", example = "안녕하세요, 거래 가능한가요?", maxLength = 2000, nullable = true)
         @Size(max = 2000) String content,
+
+        @Schema(description = "첨부 이미지 URL 목록 (S3 업로드 후 키)",
+                example = "[\"https://cdn.sseulang.test/messages/abc.jpg\"]", nullable = true)
         List<String> imageUrls
 ) {
     public MessageSendCommand toCommand(Long chatRoomId, Long senderId) {

--- a/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeToggleRequest.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeToggleRequest.java
@@ -1,6 +1,11 @@
 package com.sseulang.domain.notice.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 /** pin / publish 토글 공용 — 단순 boolean payload. */
-public record NoticeToggleRequest(@NotNull Boolean value) {}
+@Schema(description = "공지 pin/publish 토글. 엔드포인트에 따라 의미가 달라짐.")
+public record NoticeToggleRequest(
+        @Schema(description = "켜기/끄기", example = "true")
+        @NotNull Boolean value
+) {}

--- a/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeUpsertRequest.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeUpsertRequest.java
@@ -2,18 +2,31 @@ package com.sseulang.domain.notice.presentation.dto;
 
 import com.sseulang.domain.notice.application.dto.NoticeUpsertCommand;
 import com.sseulang.domain.notice.domain.NoticeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "공지/이벤트 등록·수정 (관리자).")
 public record NoticeUpsertRequest(
+        @Schema(description = "공지 유형", example = "공지", allowableValues = {"공지", "이벤트"})
         @NotNull NoticeType type,
+
+        @Schema(description = "제목", example = "5월 거래 수수료 무료 이벤트", maxLength = 200)
         @NotBlank @Size(max = 200) String title,
+
+        @Schema(description = "본문 (HTML/Markdown 자유)", example = "5월 한 달간 모든 거래 수수료가 무료입니다.")
         @NotBlank String content,
+
+        @Schema(description = "썸네일 이미지 URL (선택)", example = "https://cdn.sseulang.test/notices/202605.jpg", maxLength = 500, nullable = true)
         @Size(max = 500) String imageUrl,
+
+        @Schema(description = "노출 시작 시각", example = "2026-05-01T00:00:00", nullable = true)
         LocalDateTime startsAt,
+
+        @Schema(description = "노출 종료 시각", example = "2026-05-31T23:59:59", nullable = true)
         LocalDateTime endsAt
 ) {
     public NoticeUpsertCommand toCommand() {

--- a/src/main/java/com/sseulang/domain/payment/presentation/PaymentController.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/PaymentController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.payment.presentation.dto.ChargeStartRequest;
 import com.sseulang.domain.payment.presentation.dto.ChargeStartResponse;
 import com.sseulang.domain.payment.presentation.dto.PaymentResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Payment", description = "토스 페이먼츠 충전 — startCharge → 토스 SDK 결제 → confirmCharge.")
 @RestController
 @RequestMapping("/api/v1/payments")
 public class PaymentController {

--- a/src/main/java/com/sseulang/domain/payment/presentation/dto/ChargeConfirmRequest.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/dto/ChargeConfirmRequest.java
@@ -1,13 +1,20 @@
 package com.sseulang.domain.payment.presentation.dto;
 
 import com.sseulang.domain.payment.application.dto.ChargeConfirmCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+@Schema(description = "토스 결제 승인 — 프론트가 토스 SDK 로 결제 완료 후 paymentKey/orderId/amount 전달. 백엔드가 토스 confirm API 로 검증.")
 public record ChargeConfirmRequest(
+        @Schema(description = "토스 paymentKey (결제 식별)", example = "tgen_20240101101010A1B2C3")
         @NotBlank String paymentKey,
+
+        @Schema(description = "백엔드 startCharge 응답의 merchantUid (= orderId)", example = "ORD-20260501-abc123")
         @NotBlank String orderId,
+
+        @Schema(description = "결제 금액 (위변조 검증용)", example = "50000")
         @NotNull @Positive Long amount
 ) {
     public ChargeConfirmCommand toCommand(Long requesterId) {

--- a/src/main/java/com/sseulang/domain/payment/presentation/dto/ChargeStartRequest.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/dto/ChargeStartRequest.java
@@ -1,10 +1,15 @@
 package com.sseulang.domain.payment.presentation.dto;
 
 import com.sseulang.domain.payment.application.dto.ChargeStartCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
-public record ChargeStartRequest(@NotNull @Positive Long amount) {
+@Schema(description = "포인트 충전 시작. 토스 결제 준비 단계 — merchantUid + clientKey 발급.")
+public record ChargeStartRequest(
+        @Schema(description = "충전 금액 (원)", example = "50000")
+        @NotNull @Positive Long amount
+) {
     public ChargeStartCommand toCommand(Long userId) {
         return new ChargeStartCommand(userId, amount);
     }

--- a/src/main/java/com/sseulang/domain/report/presentation/dto/AdminReportDecisionRequest.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/dto/AdminReportDecisionRequest.java
@@ -1,10 +1,16 @@
 package com.sseulang.domain.report.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "관리자 신고 처리. MARK_IN_PROGRESS(검토 시작) / COMPLETE(처리 완료) / REJECT(반려).")
 public record AdminReportDecisionRequest(
+        @Schema(description = "처리 액션", example = "MARK_IN_PROGRESS",
+                allowableValues = {"MARK_IN_PROGRESS", "COMPLETE", "REJECT"})
         @NotNull Action action,
+
+        @Schema(description = "처리 메모 (선택)", example = "사용자 차단 처리 완료", maxLength = 500, nullable = true)
         @Size(max = 500) String memo
 ) {
     public enum Action { MARK_IN_PROGRESS, COMPLETE, REJECT }

--- a/src/main/java/com/sseulang/domain/report/presentation/dto/ReportRequest.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/dto/ReportRequest.java
@@ -1,9 +1,14 @@
 package com.sseulang.domain.report.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "사용자/물품 신고. reason 은 짧은 분류, detail 은 자세한 설명.")
 public record ReportRequest(
+        @Schema(description = "신고 사유 분류", example = "사기 의심", maxLength = 50)
         @NotBlank @Size(max = 50) String reason,
+
+        @Schema(description = "상세 설명 (선택)", example = "결제 후 연락 끊김. 채팅 내역 첨부.", maxLength = 5000, nullable = true)
         @Size(max = 5000) String detail
 ) { }

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewWriteRequest.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewWriteRequest.java
@@ -1,15 +1,22 @@
 package com.sseulang.domain.review.presentation.dto;
 
 import com.sseulang.domain.review.application.dto.ReviewWriteCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "거래 후기 작성. 거래완료 후 7일 내 양 당사자만 작성 가능. 별점 1~5 + 한줄평.")
 public record ReviewWriteRequest(
+        @Schema(description = "리뷰 대상 거래 id", example = "100")
         @NotNull @Positive Long transactionId,
+
+        @Schema(description = "별점 (1~5)", example = "5", minimum = "1", maximum = "5")
         @Min(1) @Max(5) int rating,
+
+        @Schema(description = "한줄평 (선택)", example = "거래 정확하시고 친절했습니다", maxLength = 500, nullable = true)
         @Size(max = 500) String comment
 ) {
     public ReviewWriteCommand toCommand(Long reviewerId) {

--- a/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
@@ -8,6 +8,7 @@ import com.sseulang.domain.transaction.presentation.dto.TransactionResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Transaction", description = "거래 — 채팅중→예약→거래완료 (또는 취소). 정산은 거래완료 시점에 buyer→seller 포인트 이동.")
 @RestController
 @RequestMapping("/api/v1/transactions")
 public class TransactionController {

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionCreateRequest.java
@@ -1,14 +1,21 @@
 package com.sseulang.domain.transaction.presentation.dto;
 
 import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "거래 생성 (구매자가 호출). 채팅중 상태로 시작. 대여 거래만 rentalStart/End 필요.")
 public record TransactionCreateRequest(
+        @Schema(description = "거래 대상 itemId", example = "42")
         @NotNull @Positive Long itemId,
+
+        @Schema(description = "대여 시작 시각 (대여 거래 전용)", example = "2026-05-01T10:00:00", nullable = true)
         LocalDateTime rentalStart,
+
+        @Schema(description = "대여 종료 시각 (대여 거래 전용, start 이후)", example = "2026-05-03T10:00:00", nullable = true)
         LocalDateTime rentalEnd
 ) {
     public TransactionCreateCommand toCommand(Long buyerId) {

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchRequest.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchRequest.java
@@ -1,6 +1,7 @@
 package com.sseulang.domain.transaction.presentation.dto;
 
 import com.sseulang.domain.transaction.domain.TransactionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -8,8 +9,13 @@ import jakarta.validation.constraints.Size;
  * 거래 상태 전이 요청. {@code action} 으로 의도된 상태(예약/거래완료/취소) 명시.
  * cancelReason 은 action=취소 일 때만 의미. 다른 action 일 때 null/무시.
  */
+@Schema(description = "거래 상태 전이. action 별 권한: 예약/거래완료=seller, 취소=양쪽 참여자.")
 public record TransactionPatchRequest(
+        @Schema(description = "전이할 상태", example = "예약",
+                allowableValues = {"예약", "거래완료", "취소"})
         @NotNull TransactionStatus action,
+
+        @Schema(description = "취소 사유 (action=취소 전용)", example = "구매자 변심", nullable = true, maxLength = 255)
         @Size(max = 255) String cancelReason
 ) {
     public boolean isReserve() {

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/UserBlockRequest.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/UserBlockRequest.java
@@ -1,5 +1,10 @@
 package com.sseulang.domain.user.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record UserBlockRequest(@NotNull Boolean blocked) {}
+@Schema(description = "관리자 사용자 차단/해제. blocked=true 면 로그인·거래 모두 차단.")
+public record UserBlockRequest(
+        @Schema(description = "차단 여부", example = "true")
+        @NotNull Boolean blocked
+) {}

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/WithdrawalController.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/WithdrawalController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalRequest;
 import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Withdrawal", description = "포인트 출금 신청 — 신청 시 즉시 잔액 차감 + 관리자 승인 후 외부 이체.")
 @RestController
 @RequestMapping("/api/v1/withdrawals")
 public class WithdrawalController {

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/AdminWithdrawalDecisionRequest.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/AdminWithdrawalDecisionRequest.java
@@ -1,15 +1,19 @@
 package com.sseulang.domain.withdrawal.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 /**
  * 관리자 출금 처리 요청 — action: APPROVE / REJECT / COMPLETE.
  */
+@Schema(description = "관리자 출금 처리. APPROVE(신청→승인) / REJECT(신청→거부, 잔액 환불) / COMPLETE(승인→완료, 외부 이체).")
 public record AdminWithdrawalDecisionRequest(
+        @Schema(description = "처리 액션", example = "APPROVE", allowableValues = {"APPROVE", "REJECT", "COMPLETE"})
         @NotNull(message = "action 은 필수입니다")
         Action action,
 
+        @Schema(description = "처리 메모 (선택)", example = "본인 확인 완료", maxLength = 500, nullable = true)
         @Size(max = 500)
         String memo
 ) {

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalRequest.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalRequest.java
@@ -1,30 +1,37 @@
 package com.sseulang.domain.withdrawal.presentation.dto;
 
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalRequestCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "포인트 출금 신청. 신청 시점에 즉시 잔액 차감 + 관리자 승인 후 외부 이체.")
 public record WithdrawalRequest(
         /**
          * 클라이언트 발급 멱등성 키 (UUID 권장). 같은 (사용자, 키) 재요청 시 새 출금 행 생성하지 않고
          * 기존 행을 그대로 반환 — 더블클릭/네트워크 재시도로 잔액 중복 차감 방지 (게이트 1).
          */
+        @Schema(description = "클라이언트 발급 멱등성 키 (UUID 권장)", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479", maxLength = 64)
         @NotBlank(message = "idempotencyKey 는 필수입니다")
         @Size(max = 64)
         String idempotencyKey,
 
+        @Schema(description = "출금 금액", example = "30000")
         @Min(value = 1, message = "amount 는 1 이상이어야 합니다")
         long amount,
 
+        @Schema(description = "은행명", example = "신한", maxLength = 50)
         @NotBlank(message = "bankName 은 필수입니다")
         @Size(max = 50)
         String bankName,
 
+        @Schema(description = "계좌번호", example = "110-123-456789", maxLength = 50)
         @NotBlank(message = "accountNumber 는 필수입니다")
         @Size(max = 50)
         String accountNumber,
 
+        @Schema(description = "예금주", example = "홍길동", maxLength = 50)
         @NotBlank(message = "accountHolder 는 필수입니다")
         @Size(max = 50)
         String accountHolder


### PR DESCRIPTION
## Summary
API 수동 테스트 / 프론트 통합 편의를 위해 Swagger UI 에 요청 본문 예시 JSON 노출.

## 변경
- **Request DTO 25개에 \`@Schema(description, example)\` 추가** — 필드별 의미 + 실제 동작하는 예시값
- **핵심 6 Controller에 \`@Tag\`** (Auth / Item / Transaction / Payment / Delivery / Withdrawal)
- 나머지 Controller 는 springdoc 자동 그룹화

## 효과
- `/swagger-ui.html` 에서 "Try it out" 시 예시 JSON 이 미리 채워져 즉시 테스트 가능
- 필드별 description 으로 의미·제약(min/max/포맷) 한눈에 확인
- 핵심 도메인 6개는 별도 Tag 로 그룹화되어 탐색 용이

## Test plan
- [x] 전체 컴파일 통과 (functional 변경 없음)
- [ ] 로컬에서 `/swagger-ui.html` 진입 → 6 도메인 Tag 그룹 확인
- [ ] Auth/Item/Transaction/Payment/Delivery/Withdrawal 각 endpoint "Try it out" → 예시 JSON 자동 채움 확인
- [ ] description 한국어 깨짐 없음 (UTF-8 노출)

🤖 Generated with [Claude Code](https://claude.com/claude-code)