### PR TITLE
feat: follow-up wave 1 — signup atomicity (#41) + verifyToken atomic (#42) + Toss dangling 복구 (#21)

### DIFF
--- a/src/main/java/com/sseulang/SseulangApplication.java
+++ b/src/main/java/com/sseulang/SseulangApplication.java
@@ -5,10 +5,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.time.Clock;
 
 @SpringBootApplication
+@EnableScheduling
 @ConfigurationPropertiesScan("com.sseulang")
 public class SseulangApplication {
 

--- a/src/main/java/com/sseulang/domain/auth/application/EmailDispatchEventListener.java
+++ b/src/main/java/com/sseulang/domain/auth/application/EmailDispatchEventListener.java
@@ -1,0 +1,42 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.application.event.EmailDispatchRequestedEvent;
+import com.sseulang.domain.auth.domain.EmailSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 이메일 인증 메일 비동기 발송 listener. 트랜잭션 commit 후 발송 (follow-up #41 atomicity 보장):
+ * <ul>
+ *   <li>user / token 은 commit 된 후라 메일 발송 실패해도 dangling 없음</li>
+ *   <li>발송 실패는 로깅만 — 사용자가 {@code /resend-verification} 으로 재시도</li>
+ *   <li>{@code AFTER_COMMIT} phase — 트랜잭션 롤백 시 listener 호출 X (가입 실패 → 메일 발송 X)</li>
+ * </ul>
+ *
+ * <p>현재는 동기 처리 (호출 스레드). 응답 지연 issue 발생 시 {@code @Async} 추가 또는 outbox
+ * 패턴으로 교체.</p>
+ */
+@Component
+public class EmailDispatchEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(EmailDispatchEventListener.class);
+
+    private final EmailSender emailSender;
+
+    public EmailDispatchEventListener(EmailSender emailSender) {
+        this.emailSender = emailSender;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onEmailDispatch(EmailDispatchRequestedEvent event) {
+        try {
+            emailSender.sendVerificationEmail(event.email(), event.verificationUrl());
+        } catch (RuntimeException e) {
+            // 가입은 이미 commit 됨 — 메일 발송 실패만 로깅. 사용자가 /resend-verification 으로 재시도.
+            log.error("[email-dispatch] 발송 실패 email={} reason={}", event.email(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/application/EmailVerificationService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/EmailVerificationService.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.auth.application;
 
+import com.sseulang.domain.auth.application.event.EmailDispatchRequestedEvent;
 import com.sseulang.domain.auth.domain.EmailSender;
 import com.sseulang.domain.auth.domain.EmailVerification;
 import com.sseulang.domain.auth.domain.EmailVerificationRepository;
@@ -9,6 +10,7 @@ import com.sseulang.domain.user.domain.User;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,7 +50,8 @@ public class EmailVerificationService {
 
     private final EmailVerificationRepository verificationRepository;
     private final UserApplicationService userService;
-    private final EmailSender emailSender;
+    private final EmailSender emailSender;  // 직접 호출은 deprecated — 이벤트 listener 가 발송 (follow-up #41)
+    private final ApplicationEventPublisher eventPublisher;
     private final Clock clock;
     private final String verificationUrlBase;
 
@@ -56,6 +59,7 @@ public class EmailVerificationService {
             EmailVerificationRepository verificationRepository,
             UserApplicationService userService,
             EmailSender emailSender,
+            ApplicationEventPublisher eventPublisher,
             Clock clock,
             @Value("${app.email.verification-url-base:http://localhost:8080/api/v1/auth/verify-email}")
             String verificationUrlBase
@@ -63,6 +67,7 @@ public class EmailVerificationService {
         this.verificationRepository = verificationRepository;
         this.userService = userService;
         this.emailSender = emailSender;
+        this.eventPublisher = eventPublisher;
         this.clock = clock;
         this.verificationUrlBase = verificationUrlBase;
     }
@@ -76,6 +81,11 @@ public class EmailVerificationService {
      * </ol>
      * 가입 직후 흐름 (LocalAuthService.signup) 에서도 호출되며, 가입 시점엔 기존 토큰이 없어 invalidate 는 no-op.
      */
+    /**
+     * SIGNUP 토큰 발급 + 메일 발송 이벤트 발행 (follow-up #41 atomicity).
+     * 메일 발송은 트랜잭션 commit 후 별도 listener 가 처리 — 메일 시스템 다운 시에도
+     * user/token 은 보존, 사용자가 {@code /resend-verification} 으로 재시도 가능.
+     */
     @Transactional
     public void issueSignupToken(Long userId, String email) {
         LocalDateTime now = LocalDateTime.now(clock);
@@ -83,19 +93,40 @@ public class EmailVerificationService {
         String token = generateToken();
         LocalDateTime expiresAt = now.plus(TOKEN_TTL);
         verificationRepository.save(EmailVerification.issue(userId, token, VerificationPurpose.SIGNUP, expiresAt));
-        emailSender.sendVerificationEmail(email, verificationUrlBase + "?token=" + token);
+        // AFTER_COMMIT 으로 발송 — 본 트랜잭션 롤백 시 메일 발송 X.
+        eventPublisher.publishEvent(new EmailDispatchRequestedEvent(email, verificationUrlBase + "?token=" + token));
         lastIssuedAt.put(userId, now);
     }
 
-    /** 토큰 검증 + user.markEmailVerified. 만료/재사용/없음 모두 명시 ErrorCode. */
+    /**
+     * 토큰 검증 + user.markEmailVerified. 만료/재사용/없음 모두 명시 ErrorCode.
+     *
+     * <p>{@link EmailVerificationRepository#markUsedIfValid} atomic UPDATE 로 동시 검증 race 차단
+     * (follow-up #42). 정확히 1건만 1 rows affected — 다른 요청은 0 rows → 사유 분기.</p>
+     */
     @Transactional
     public void verifyToken(String token) {
         if (token == null || token.isBlank()) {
             throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID);
         }
+        LocalDateTime now = LocalDateTime.now(clock);
+        int affected = verificationRepository.markUsedIfValid(token, now);
+        if (affected == 0) {
+            // 사유 분기 — 미존재 / 이미 사용 / 만료 중 정확한 ErrorCode 결정.
+            EmailVerification ver = verificationRepository.findByToken(token)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID));
+            if (ver.isUsed()) {
+                throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID);
+            }
+            if (ver.isExpired(now)) {
+                throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_EXPIRED);
+            }
+            // 정상적으론 도달 불가 — race 우승자 트랜잭션이 아직 commit 전 인 보기 드문 경우.
+            throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID);
+        }
+        // atomic UPDATE 성공. user 조회 + verified 플래그 마킹.
         EmailVerification ver = verificationRepository.findByToken(token)
                 .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID));
-        ver.markUsed(LocalDateTime.now(clock));  // 만료/재사용 시 throw
         User user = userService.getById(ver.getUserId());
         user.markEmailVerified();
     }

--- a/src/main/java/com/sseulang/domain/auth/application/LocalAuthService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/LocalAuthService.java
@@ -12,6 +12,7 @@ import com.sseulang.global.security.JwtProvider;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -74,7 +75,12 @@ public class LocalAuthService {
     /**
      * LOCAL 가입 + 자동 로그인. email 중복 시 {@link ErrorCode#USER_EMAIL_DUPLICATED} (다른 provider
      * 로 이미 가입돼있어도 동일 — 가이드 §12 정책).
+     *
+     * <p>{@code @Transactional} — user 저장 + 인증 토큰 발급을 한 트랜잭션으로 묶어 atomicity 보장
+     * (follow-up #41). 메일 발송은 트랜잭션 commit 후 별도 listener 가 처리 — 메일 다운 시에도
+     * user/token 보존, 재발송으로 회복 가능.</p>
      */
+    @Transactional
     public TokenPair signup(Email email, String rawPassword, String nickname) {
         validatePassword(rawPassword);
 

--- a/src/main/java/com/sseulang/domain/auth/application/event/EmailDispatchRequestedEvent.java
+++ b/src/main/java/com/sseulang/domain/auth/application/event/EmailDispatchRequestedEvent.java
@@ -1,0 +1,23 @@
+package com.sseulang.domain.auth.application.event;
+
+/**
+ * 이메일 인증 메일 발송 요청 이벤트. {@link com.sseulang.domain.auth.application.EmailVerificationService}
+ * 가 토큰 INSERT 후 발행. 별도 listener 가 {@code @TransactionalEventListener(AFTER_COMMIT)} 로
+ * 받아 메일 발송 — 트랜잭션 commit 후 발송이라 메일 시스템 다운 시에도 user/token 은 보존,
+ * 가입 자체는 차단되지 않음 (follow-up #41).
+ *
+ * <p>발송 실패는 로그만 — 사용자가 {@code /api/v1/auth/resend-verification} 으로 재시도 가능.</p>
+ */
+public record EmailDispatchRequestedEvent(
+        String email,
+        String verificationUrl
+) {
+    public EmailDispatchRequestedEvent {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("email 은 필수입니다");
+        }
+        if (verificationUrl == null || verificationUrl.isBlank()) {
+            throw new IllegalArgumentException("verificationUrl 은 필수입니다");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/auth/domain/EmailVerificationRepository.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/EmailVerificationRepository.java
@@ -13,4 +13,15 @@ public interface EmailVerificationRepository {
      * 영향받은 행 수 반환.
      */
     int invalidateUnusedSignupTokens(Long userId, java.time.LocalDateTime now);
+
+    /**
+     * 토큰 단일 atomic 소진 (follow-up #42 race 차단).
+     *
+     * <p>{@code UPDATE email_verifications SET used_at=? WHERE token=? AND used_at IS NULL
+     * AND expires_at > ?} — 동시 두 요청이 같은 token 으로 도달해도 정확히 1건만 1 rows affected.
+     * 0 rows = 미존재 / 이미 사용 / 만료 — 호출자가 사유 분기 (선택).</p>
+     *
+     * @return 영향 행 수 (0 또는 1)
+     */
+    int markUsedIfValid(String token, java.time.LocalDateTime now);
 }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/EmailVerificationJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/EmailVerificationJpaRepository.java
@@ -25,4 +25,18 @@ interface EmailVerificationJpaRepository extends JpaRepository<EmailVerification
                AND v.usedAt IS NULL
             """)
     int invalidateUnusedSignupTokens(@Param("userId") Long userId, @Param("now") LocalDateTime now);
+
+    /**
+     * 토큰 atomic 소진 — 동시 두 요청이 같은 token 으로 도달해도 1건만 성공 (follow-up #42).
+     * clearAutomatically + flushAutomatically 로 영속성 컨텍스트 동기화.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE EmailVerification v
+               SET v.usedAt = :now
+             WHERE v.token = :token
+               AND v.usedAt IS NULL
+               AND v.expiresAt > :now
+            """)
+    int markUsedIfValid(@Param("token") String token, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/EmailVerificationRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/EmailVerificationRepositoryImpl.java
@@ -29,4 +29,9 @@ public class EmailVerificationRepositoryImpl implements EmailVerificationReposit
     public int invalidateUnusedSignupTokens(Long userId, java.time.LocalDateTime now) {
         return jpa.invalidateUnusedSignupTokens(userId, now);
     }
+
+    @Override
+    public int markUsedIfValid(String token, java.time.LocalDateTime now) {
+        return jpa.markUsedIfValid(token, now);
+    }
 }

--- a/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
@@ -348,6 +348,59 @@ public class PaymentApplicationService {
         return new PaymentStatsResult(paymentRepository.countPaid(), paymentRepository.sumPaidAmount());
     }
 
+    // ───────── Reconciliation (follow-up #21) ─────────
+
+    /**
+     * dangling 복구 — orderId 로 토스 lookup 시도 후 일치하면 markAsPaid + 적립.
+     * Reconciliation 스케줄러가 호출. 단일 Payment 단위 트랜잭션.
+     *
+     * @return true = 복구 성공 (markAsPaid), false = 토스 측 미완료 / 위변조 / 매칭 실패 등
+     */
+    @Transactional
+    public boolean reconcileStalePayment(Long paymentId) {
+        Payment payment = paymentRepository.findById(paymentId).orElse(null);
+        if (payment == null || payment.getStatus() != PaymentStatus.대기) {
+            return false;
+        }
+        PaymentConfirmResult lookup;
+        try {
+            lookup = paymentGateway.lookupByOrderId(payment.getMerchantUid());
+        } catch (BusinessException e) {
+            log.debug("[reconcile] payment#{} lookup 실패 code={}", paymentId, e.getErrorCode());
+            return false;
+        } catch (Exception e) {
+            log.warn("[reconcile] payment#{} lookup 통신 실패 — 다음 cycle 재시도", paymentId, e);
+            return false;
+        }
+        Payment locked = paymentRepository.findByMerchantUidForUpdate(payment.getMerchantUid()).orElse(null);
+        if (locked == null || locked.getStatus() != PaymentStatus.대기) {
+            return false;
+        }
+        locked.verifyAmount(lookup.amount());
+        boolean newlyPaid = locked.markAsPaid(
+                lookup.paymentKey(), lookup.method(), lookup.approvedAt(), lookup.rawResponse()
+        );
+        if (newlyPaid) {
+            pointApplicationService.credit(
+                    locked.getUserId(),
+                    locked.getAmount(),
+                    PointHistoryType.충전,
+                    PointReferenceType.PAYMENT,
+                    locked.getId(),
+                    "토스 reconcile 복구"
+            );
+            log.info("[reconcile] payment#{} 복구 완료", paymentId);
+        }
+        return true;
+    }
+
+    /** Reconciliation 스케줄러 진입점 — stale Payment id 목록 조회. */
+    public java.util.List<Long> findStalePendingIds(java.time.LocalDateTime cutoff, int limit) {
+        return paymentRepository.findStalePending(cutoff, limit).stream()
+                .map(Payment::getId)
+                .toList();
+    }
+
     private static String generateMerchantUid() {
         return "charge-" + UUID.randomUUID();
     }

--- a/src/main/java/com/sseulang/domain/payment/application/PaymentReconciliationScheduler.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentReconciliationScheduler.java
@@ -1,0 +1,75 @@
+package com.sseulang.domain.payment.application;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 토스 결제 dangling 복구 스케줄러 (follow-up #21).
+ *
+ * <p>주기적으로 status=대기 + 일정 시간 경과 Payment 를 토스 lookup 으로 동기화. 시나리오:
+ * <ul>
+ *   <li>confirm 도중 응답 유실 / 5xx → DB 는 대기, 토스는 DONE</li>
+ *   <li>markAsPaid + creditPoint 직전 commit 장애 → 동일</li>
+ *   <li>webhook 도 못 받은 케이스 (토스 측 webhook 발송 실패 또는 네트워크)</li>
+ * </ul>
+ *
+ * <p>각 Payment 는 별도 트랜잭션으로 처리 — 한 건 실패해도 다른 건 진행.
+ * 스케줄 주기는 {@code app.payment.reconcile.interval-millis} (기본 5분).</p>
+ */
+@Component
+public class PaymentReconciliationScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentReconciliationScheduler.class);
+
+    /** 한 cycle 에 처리할 최대 건수 — Toss API 부하 / 트랜잭션 시간 제어. */
+    private static final int BATCH_LIMIT = 50;
+
+    private final PaymentApplicationService paymentService;
+    private final Clock clock;
+    private final long staleAfterMillis;
+
+    public PaymentReconciliationScheduler(
+            PaymentApplicationService paymentService,
+            Clock clock,
+            @Value("${app.payment.reconcile.stale-after-millis:600000}")  // 기본 10분
+            long staleAfterMillis
+    ) {
+        this.paymentService = paymentService;
+        this.clock = clock;
+        this.staleAfterMillis = staleAfterMillis;
+    }
+
+    /**
+     * 5분마다 실행. fixedDelay — 이전 cycle 끝난 후 5분 (overlap 차단).
+     * 운영 환경에서 주기 변경은 {@code app.payment.reconcile.fixed-delay-millis} (Spring Boot 자동 바인딩 X 라
+     * 본 메서드 변경 필요 — 5/6 이전 단순화).
+     */
+    @Scheduled(fixedDelayString = "${app.payment.reconcile.fixed-delay-millis:300000}", initialDelayString = "60000")
+    public void reconcile() {
+        LocalDateTime cutoff = LocalDateTime.now(clock).minus(Duration.ofMillis(staleAfterMillis));
+        List<Long> stale = paymentService.findStalePendingIds(cutoff, BATCH_LIMIT);
+        if (stale.isEmpty()) {
+            return;
+        }
+        log.info("[reconcile] stale Payment {} 건 처리 시작 (cutoff={})", stale.size(), cutoff);
+        int recovered = 0;
+        for (Long id : stale) {
+            try {
+                if (paymentService.reconcileStalePayment(id)) {
+                    recovered++;
+                }
+            } catch (Exception e) {
+                log.error("[reconcile] payment#{} 처리 중 예외 (다음 cycle 재시도)", id, e);
+            }
+        }
+        log.info("[reconcile] stale Payment {} 건 중 {} 건 복구", stale.size(), recovered);
+    }
+}

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentGateway.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentGateway.java
@@ -19,4 +19,11 @@ public interface PaymentGateway {
      * <p>4xx (없는 paymentKey 등) → BusinessException, 5xx → ExternalApiException.</p>
      */
     PaymentConfirmResult lookup(String paymentKey);
+
+    /**
+     * orderId(merchantUid) 로 PG 측 결제 상태 조회. dangling 복구 스케줄러용 (follow-up #21):
+     * confirm 도중 응답 유실로 paymentKey 를 못 받은 status=대기 Payment 를 orderId 만으로 토스 측 상태 동기화.
+     * <p>4xx (없는 orderId 등) → BusinessException, 5xx → ExternalApiException.</p>
+     */
+    PaymentConfirmResult lookupByOrderId(String orderId);
 }

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentRepository.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentRepository.java
@@ -13,6 +13,13 @@ public interface PaymentRepository {
 
     Payment save(Payment payment);
 
+    /**
+     * dangling 복구 스케줄러용 (follow-up #21) — status=대기 + created_at < cutoff 인 Payment 목록.
+     * confirm 도중 응답 유실 / 5xx 등으로 토스는 처리됐지만 우리 DB 는 대기 상태로 남은 결제를
+     * 주기적으로 토스 lookup 으로 동기화.
+     */
+    java.util.List<Payment> findStalePending(java.time.LocalDateTime cutoff, int limit);
+
     // ───────── 관리자 통계 ─────────
 
     /** status=완료 결제의 paid_amount 합계. 미완료 결제는 제외. */

--- a/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/PaymentJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/PaymentJpaRepository.java
@@ -2,11 +2,14 @@ package com.sseulang.domain.payment.infrastructure.persistence;
 
 import com.sseulang.domain.payment.domain.Payment;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
@@ -26,4 +29,15 @@ interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
 
     @Query("SELECT COUNT(p) FROM Payment p WHERE p.status = com.sseulang.domain.payment.domain.PaymentStatus.완료")
     long countPaid();
+
+    /**
+     * dangling 복구 스케줄러용 (follow-up #21) — status=대기 + createdAt < cutoff. 오래된 것부터.
+     */
+    @Query("""
+            SELECT p FROM Payment p
+             WHERE p.status = com.sseulang.domain.payment.domain.PaymentStatus.대기
+               AND p.createdAt < :cutoff
+             ORDER BY p.createdAt ASC
+            """)
+    List<Payment> findStalePending(@Param("cutoff") LocalDateTime cutoff, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -36,6 +36,11 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     }
 
     @Override
+    public java.util.List<Payment> findStalePending(java.time.LocalDateTime cutoff, int limit) {
+        return jpa.findStalePending(cutoff, org.springframework.data.domain.PageRequest.of(0, limit));
+    }
+
+    @Override
     public long sumPaidAmount() {
         return jpa.sumPaidAmount();
     }

--- a/src/main/java/com/sseulang/domain/payment/infrastructure/toss/TossPaymentGateway.java
+++ b/src/main/java/com/sseulang/domain/payment/infrastructure/toss/TossPaymentGateway.java
@@ -70,6 +70,9 @@ public class TossPaymentGateway implements PaymentGateway {
             response = restClient.post()
                     .uri("/v1/payments/confirm")
                     .header("Authorization", authorizationHeader)
+                    // Idempotency-Key: 같은 paymentKey 로 confirm 재시도 시 토스가 동일 응답 반환 (follow-up #21).
+                    // 응답 유실/네트워크 타임아웃 후 재시도 안전 — paymentKey 자체가 결제 단위 멱등 키.
+                    .header("Idempotency-Key", paymentKey)
                     .body(body)
                     .retrieve()
                     .body(String.class);
@@ -104,6 +107,26 @@ public class TossPaymentGateway implements PaymentGateway {
             throw new ExternalApiException("토스 결제 조회 실패", e);
         } catch (Exception e) {
             throw new ExternalApiException("토스 결제 조회 통신 실패", e);
+        }
+        return parse(response);
+    }
+
+    @Override
+    public PaymentConfirmResult lookupByOrderId(String orderId) {
+        String response;
+        try {
+            response = restClient.get()
+                    .uri("/v1/payments/orders/{orderId}", orderId)
+                    .header("Authorization", authorizationHeader)
+                    .retrieve()
+                    .body(String.class);
+        } catch (RestClientResponseException e) {
+            if (e.getStatusCode().is4xxClientError()) {
+                throw new BusinessException(ErrorCode.PAYMENT_VERIFY_FAILED);
+            }
+            throw new ExternalApiException("토스 결제 조회(orderId) 실패", e);
+        } catch (Exception e) {
+            throw new ExternalApiException("토스 결제 조회(orderId) 통신 실패", e);
         }
         return parse(response);
     }

--- a/src/test/java/com/sseulang/domain/auth/application/EmailDispatchEventListenerTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/EmailDispatchEventListenerTest.java
@@ -1,0 +1,60 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.application.event.EmailDispatchRequestedEvent;
+import com.sseulang.domain.auth.domain.EmailSender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class EmailDispatchEventListenerTest {
+
+    private EmailSender emailSender;
+    private EmailDispatchEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        emailSender = mock(EmailSender.class);
+        listener = new EmailDispatchEventListener(emailSender);
+    }
+
+    @Test
+    @DisplayName("onEmailDispatch 정상_emailSender.sendVerificationEmail 호출")
+    void onEmailDispatch_정상() {
+        EmailDispatchRequestedEvent event = new EmailDispatchRequestedEvent(
+                "user@example.com", "https://app.sseulang.test/verify?token=abc"
+        );
+
+        listener.onEmailDispatch(event);
+
+        verify(emailSender).sendVerificationEmail("user@example.com", "https://app.sseulang.test/verify?token=abc");
+    }
+
+    @Test
+    @DisplayName("onEmailDispatch 발송 실패_RuntimeException 잡고 정상 종료 (가입 흐름 영향 X)")
+    void onEmailDispatch_실패() {
+        doThrow(new RuntimeException("smtp down")).when(emailSender)
+                .sendVerificationEmail(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+        EmailDispatchRequestedEvent event = new EmailDispatchRequestedEvent(
+                "user@example.com", "https://x"
+        );
+
+        // 예외 던지지 않고 정상 종료해야 함 — listener 가 catch 후 로깅만
+        assertThatCode(() -> listener.onEmailDispatch(event)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("EmailDispatchRequestedEvent email 누락_거부")
+    void event_validation() {
+        org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+                new EmailDispatchRequestedEvent(null, "https://x"))
+                .isInstanceOf(IllegalArgumentException.class);
+        org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+                new EmailDispatchRequestedEvent("u@x.com", ""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/sseulang/domain/payment/application/FakePaymentGateway.java
+++ b/src/test/java/com/sseulang/domain/payment/application/FakePaymentGateway.java
@@ -28,6 +28,10 @@ public class FakePaymentGateway implements PaymentGateway {
 
     public int confirmCalls;
     public int lookupCalls;
+    public int lookupByOrderIdCalls;
+    /** lookupByOrderId 응답 amount/orderId override (null 이면 호출 시 받은 orderId 그대로 echo, amount=lastConfirmAmount). */
+    public Long lookupByOrderIdAmount;
+    public RuntimeException lookupByOrderIdException;
     private long lastConfirmAmount;
     private String lastConfirmOrderId;
 
@@ -69,6 +73,23 @@ public class FakePaymentGateway implements PaymentGateway {
                 PaymentMethod.CARD,
                 LocalDateTime.now(),
                 "{\"raw\":\"fake-lookup\"}"
+        );
+    }
+
+    @Override
+    public PaymentConfirmResult lookupByOrderId(String orderId) {
+        lookupByOrderIdCalls++;
+        if (lookupByOrderIdException != null) {
+            throw lookupByOrderIdException;
+        }
+        long resultAmount = lookupByOrderIdAmount != null ? lookupByOrderIdAmount : lastConfirmAmount;
+        return new PaymentConfirmResult(
+                "fake-pk-" + orderId,
+                orderId,
+                resultAmount,
+                PaymentMethod.CARD,
+                LocalDateTime.now(),
+                "{\"raw\":\"fake-lookup-by-orderId\"}"
         );
     }
 }

--- a/src/test/java/com/sseulang/domain/payment/application/InMemoryFakePaymentRepository.java
+++ b/src/test/java/com/sseulang/domain/payment/application/InMemoryFakePaymentRepository.java
@@ -42,6 +42,20 @@ public class InMemoryFakePaymentRepository implements PaymentRepository {
     }
 
     @Override
+    public java.util.List<Payment> findStalePending(java.time.LocalDateTime cutoff, int limit) {
+        return store.values().stream()
+                .filter(p -> p.getStatus() == PaymentStatus.대기)
+                .filter(p -> p.getCreatedAt() == null || p.getCreatedAt().isBefore(cutoff))
+                .sorted((a, b) -> {
+                    if (a.getCreatedAt() == null) return -1;
+                    if (b.getCreatedAt() == null) return 1;
+                    return a.getCreatedAt().compareTo(b.getCreatedAt());
+                })
+                .limit(limit)
+                .toList();
+    }
+
+    @Override
     public long sumPaidAmount() {
         return store.values().stream()
                 .filter(p -> p.getStatus() == PaymentStatus.완료)

--- a/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
@@ -462,6 +462,87 @@ class PaymentApplicationServiceTest {
                 .isEqualTo(PaymentStatus.대기);
     }
 
+    // ───────── follow-up #21 — Reconciliation ─────────
+
+    @Test
+    @DisplayName("reconcile 정상_dangling Payment 가 lookupByOrderId 로 복구 + 적립")
+    void reconcile_정상() {
+        long amount = 25_000L;
+        ChargeStartResult started = service.startCharge(new ChargeStartCommand(userId, amount));
+        gateway.lookupByOrderIdAmount = amount;
+
+        boolean recovered = service.reconcileStalePayment(started.paymentId());
+
+        assertThat(recovered).isTrue();
+        assertThat(gateway.lookupByOrderIdCalls).isEqualTo(1);
+        assertThat(userRepo.findPointBalance(userId)).isEqualTo(amount);
+        assertThat(paymentRepo.findById(started.paymentId()).orElseThrow().getStatus())
+                .isEqualTo(PaymentStatus.완료);
+    }
+
+    @Test
+    @DisplayName("reconcile 이미 완료된 Payment_skip (lookup 호출 X)")
+    void reconcile_이미완료() {
+        long amount = 10_000L;
+        ChargeStartResult started = service.startCharge(new ChargeStartCommand(userId, amount));
+        service.confirmCharge(new ChargeConfirmCommand(userId, "pk", started.merchantUid(), amount));
+        int lookupBefore = gateway.lookupByOrderIdCalls;
+
+        boolean recovered = service.reconcileStalePayment(started.paymentId());
+
+        assertThat(recovered).isFalse();
+        assertThat(gateway.lookupByOrderIdCalls).isEqualTo(lookupBefore);
+    }
+
+    @Test
+    @DisplayName("reconcile lookupByOrderId 4xx_skip (다음 cycle 대기)")
+    void reconcile_lookup_4xx() {
+        ChargeStartResult started = service.startCharge(new ChargeStartCommand(userId, 5_000L));
+        gateway.lookupByOrderIdException = new BusinessException(ErrorCode.PAYMENT_VERIFY_FAILED);
+
+        boolean recovered = service.reconcileStalePayment(started.paymentId());
+
+        assertThat(recovered).isFalse();
+        assertThat(userRepo.findPointBalance(userId)).isZero();
+        assertThat(paymentRepo.findById(started.paymentId()).orElseThrow().getStatus())
+                .isEqualTo(PaymentStatus.대기);
+    }
+
+    @Test
+    @DisplayName("reconcile lookupByOrderId 5xx_skip (재시도 가능)")
+    void reconcile_lookup_5xx() {
+        ChargeStartResult started = service.startCharge(new ChargeStartCommand(userId, 5_000L));
+        gateway.lookupByOrderIdException = new com.sseulang.global.exception.ExternalApiException("toss", "5xx");
+
+        boolean recovered = service.reconcileStalePayment(started.paymentId());
+
+        assertThat(recovered).isFalse();
+        assertThat(paymentRepo.findById(started.paymentId()).orElseThrow().getStatus())
+                .isEqualTo(PaymentStatus.대기);
+    }
+
+    @Test
+    @DisplayName("reconcile amount 위변조_PAYMENT_AMOUNT_MISMATCH (적립 X)")
+    void reconcile_amount_위변조() {
+        long realAmount = 7_000L;
+        ChargeStartResult started = service.startCharge(new ChargeStartCommand(userId, realAmount));
+        gateway.lookupByOrderIdAmount = realAmount + 50_000L;
+
+        assertThatThrownBy(() -> service.reconcileStalePayment(started.paymentId()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        assertThat(userRepo.findPointBalance(userId)).isZero();
+    }
+
+    @Test
+    @DisplayName("findStalePendingIds_status=대기 Payment id 반환")
+    void findStalePending_정상() {
+        ChargeStartResult fresh = service.startCharge(new ChargeStartCommand(userId, 1_000L));
+        java.util.List<Long> stale = service.findStalePendingIds(java.time.LocalDateTime.now(), 10);
+        assertThat(stale).contains(fresh.paymentId());
+    }
+
     @Test
     @DisplayName("handleWebhook 저장된 paymentKey 는 lookup 응답의 것 (payload 위변조 차단)")
     void handleWebhook_paymentKey_from_lookup() {


### PR DESCRIPTION
## Summary
보안/정합성 follow-up 3건 일괄 처리.

### #41 LOCAL signup atomicity
메일 발송 실패 시 user row dangling 차단:
- `LocalAuthService.signup` @Transactional — user 저장 + 토큰 발급 한 트랜잭션
- `EmailVerificationService` 가 메일 발송 대신 `EmailDispatchRequestedEvent` 발행
- 신규 `EmailDispatchEventListener` — `@TransactionalEventListener(AFTER_COMMIT)` 로 메일 발송
- 메일 다운 시에도 user/token 보존 → `/resend-verification` 으로 회복

### #42 EmailVerification atomic UPDATE
동시 토큰 검증 race 차단:
- `EmailVerificationRepository.markUsedIfValid` (atomic UPDATE)
- `WHERE token=? AND used_at IS NULL AND expires_at > ?` — 1건만 affected=1
- affected=0 시 사유 분기 (만료/사용/미존재)

### #21 Toss 결제 dangling 자동 복구
- **Idempotency-Key 헤더**: `TossPaymentGateway.confirm` 에 `Idempotency-Key: {paymentKey}` 추가 → 응답 유실 재시도 안전
- **lookupByOrderId**: `/v1/payments/orders/{orderId}` — paymentKey 못 받은 dangling 도 복구 가능
- **PaymentReconciliationScheduler**: `@Scheduled fixedDelay 5분` — status=대기 + 10분 경과 Payment 를 lookupByOrderId 로 동기화
- 한 cycle 최대 50건, 단일 Payment 단위 트랜잭션 (한 건 실패해도 진행)
- `@EnableScheduling`

## Test plan
- [x] 전체 빌드 BUILD SUCCESSFUL
- [x] EmailDispatchEventListenerTest 3 PASS (정상/실패/event validation)
- [x] PaymentApplicationServiceTest 37 PASS (reconcile 정상/멱등/4xx/5xx/위변조 + handleWebhook 시나리오)
- [ ] prod 환경 reconcile 주기/staleAfter 운영 데이터 보고 튜닝

## Follow-up
- ExternalApi 롤백 IT, saveAndFlush UNIQUE 충돌 IT, confirm/webhook race IT (이미 #53 등록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)