### PR TITLE
feat: follow-up wave 2 — RT TTL + 인덱스 + Clock + 6 이슈 close

### DIFF
--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStore.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStore.java
@@ -36,6 +36,11 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
     private static final String KEY_PREFIX = "auth:rt:";
     private static final String VERSION_KEY_PREFIX = "auth:rtv:";
     private static final String MARKER = "1";
+    /**
+     * revokeAll 직후 versionKey TTL — RT TTL(보통 7일) 보다 길게 잡아 사용자 재로그인 grace window 확보.
+     * 30일 비활성 시 rtv 도 자연 회수 (follow-up #34).
+     */
+    private static final Duration VERSION_KEY_TTL_AFTER_REVOKE = Duration.ofDays(30);
 
     /**
      * Lua: (1) currentTv 조회 (없으면 "0"), (2) claimTv 와 비교, (3) 일치하면 DEL jti 시도.
@@ -78,6 +83,14 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
     @Override
     public void save(String role, Long userId, String jti, Duration ttl) {
         redis.opsForValue().set(jtiKey(role, userId, jti), MARKER, ttl);
+        // versionKey TTL = RT TTL — 비활성 사용자 rtv 잔존 차단 (follow-up #34).
+        // 기존 값 보존 + TTL 갱신 (없으면 "0" 으로 신규).
+        String vKey = versionKey(role, userId);
+        if (Boolean.TRUE.equals(redis.hasKey(vKey))) {
+            redis.expire(vKey, ttl);
+        } else {
+            redis.opsForValue().setIfAbsent(vKey, "0", ttl);
+        }
     }
 
     @Override
@@ -100,7 +113,10 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
     public void revokeAll(String role, Long userId) {
         // INCR 한 방. 진행 중 동시 save 가 있어도 이후 consume 의 tv 검증에서 mismatch 로 거부.
         // 폐기된 jti 키들은 TTL 만료까지 잔존하지만 의미상 무효 (consume 단계에서 막힘).
-        redis.opsForValue().increment(versionKey(role, userId));
+        String vKey = versionKey(role, userId);
+        redis.opsForValue().increment(vKey);
+        // INCR 가 새 키 만들면 TTL=-1 — 비활성 사용자 누적 차단 위해 명시 expire (follow-up #34).
+        redis.expire(vKey, VERSION_KEY_TTL_AFTER_REVOKE);
     }
 
     private static String jtiKey(String role, Long userId, String jti) {

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -45,17 +45,20 @@ public class TransactionApplicationService {
     private final ItemApplicationService itemApplicationService;
     private final PointApplicationService pointApplicationService;
     private final UserApplicationService userApplicationService;
+    private final java.time.Clock clock;
 
     public TransactionApplicationService(
             TransactionRepository transactionRepository,
             ItemApplicationService itemApplicationService,
             PointApplicationService pointApplicationService,
-            UserApplicationService userApplicationService
+            UserApplicationService userApplicationService,
+            java.time.Clock clock
     ) {
         this.transactionRepository = transactionRepository;
         this.itemApplicationService = itemApplicationService;
         this.pointApplicationService = pointApplicationService;
         this.userApplicationService = userApplicationService;
+        this.clock = clock;
     }
 
     @Transactional
@@ -87,7 +90,7 @@ public class TransactionApplicationService {
         }
         // Item 락 + 상태 전이 — 락 순서 Transaction → Item 고정 (deadlock 회피)
         itemApplicationService.markItemAsReserved(tx.getItemId());
-        tx.markAsReserved(LocalDateTime.now());
+        tx.markAsReserved(LocalDateTime.now(clock));
     }
 
     /**
@@ -121,7 +124,7 @@ public class TransactionApplicationService {
                     "거래 결제: tx#" + tx.getId()
             );
         }
-        tx.markAsCompleted(LocalDateTime.now());
+        tx.markAsCompleted(LocalDateTime.now(clock));
     }
 
     @Transactional
@@ -131,7 +134,7 @@ public class TransactionApplicationService {
             throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
         }
         boolean wasReserved = tx.getStatus() == TransactionStatus.예약;
-        tx.cancel(LocalDateTime.now(), reason);
+        tx.cancel(LocalDateTime.now(clock), reason);
         if (wasReserved) {
             // 예약 상태였던 거래만 Item 을 판매중으로 복원 (가이드 §5.2 채팅 재활성화)
             itemApplicationService.restoreItemFromReserved(tx.getItemId());
@@ -165,7 +168,7 @@ public class TransactionApplicationService {
             throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
         }
         // 7일 경계 정확 비교 — Duration.toDays() 는 내림이라 7일 23시간도 허용되는 회귀 (Codex 게이트 2).
-        if (LocalDateTime.now().isAfter(tx.getCompletedAt().plusDays(7))) {
+        if (LocalDateTime.now(clock).isAfter(tx.getCompletedAt().plusDays(7))) {
             throw new BusinessException(ErrorCode.REVIEW_PERIOD_EXPIRED);
         }
         Long revieweeId = tx.isSeller(requesterId) ? tx.getBuyerId() : tx.getSellerId();

--- a/src/main/resources/db/migration/V10__add_users_deleted_index.sql
+++ b/src/main/resources/db/migration/V10__add_users_deleted_index.sql
@@ -1,0 +1,12 @@
+-- =====================================================
+-- V10: users.is_deleted 단독 인덱스 (follow-up #37)
+-- =====================================================
+-- 배경: V5 의 (is_blocked, is_deleted) 복합 인덱스는 leftmost is_blocked 매칭이 가능한
+-- countActive / countBlocked 에선 seek OK 지만, countDeleted (WHERE is_deleted=true) 는
+-- 복합 인덱스에서 leftmost 가드 못 받아 covering scan 또는 skip scan 사용.
+-- 단독 인덱스로 admin dashboard 의 countDeleted 응답 시간 안정화.
+--
+-- 카디널리티: is_deleted=true 가 매우 적은 비율 (정상 운영에서) 이라 인덱스 효율 우수.
+-- =====================================================
+
+CREATE INDEX idx_users_deleted ON users (is_deleted);

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -49,7 +49,7 @@ class ReviewApplicationServiceTest {
         UserApplicationService userSvc = new UserApplicationService(userRepo);
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc);
         PointApplicationService pointSvc = new PointApplicationService(userSvc, new InMemoryFakePointHistoryRepository());
-        TransactionApplicationService txSvc = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc);
+        TransactionApplicationService txSvc = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());
         service = new ReviewApplicationService(reviewRepo, txSvc, userSvc);
 
         Item item = itemRepo.save(Item.create(

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -49,7 +49,7 @@ class TransactionApplicationServiceTest {
         UserApplicationService userSvc = new UserApplicationService(userRepo);
         itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc);
         PointApplicationService pointSvc = new PointApplicationService(userSvc, pointHistoryRepo);
-        service = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc);
+        service = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());
 
         SELLER = userRepo.save(User.createSocialUser(
                 SocialProvider.KAKAO, "k-seller", new Email("seller@x.com"), "seller", null


### PR DESCRIPTION
## Summary
보안/정합성 follow-up 추가 처리 + 작은 nit 6개 정리.

### #34 RT TTL
- \`auth:rtv:{ROLE}:{userId}\` Redis 카운터 TTL 추가
- save 시 RT TTL = 7일 갱신, revokeAll 시 30일 (재로그인 grace window)
- 비활성 사용자 카운터 자연 회수

### #37 users.is_deleted 단독 인덱스 (V10)
- countDeleted seek 안정화
- V5 복합 인덱스 leftmost 가드 미적용 케이스 보강

### #16 Clock 주입 (분리)
- TransactionApplicationService 가 Clock 빈 주입
- 모든 LocalDateTime.now() → LocalDateTime.now(clock)
- pending reviews API + 응답 공개 범위 → #56 으로 분리 (PM 합의 후)

### Issue 정리 (코드 변경 X, close)
- #4 token version: Day 8 PR-b 의 Redis 카운터로 부분 구현됨
- #5 RT SCAN→SET: Lua INCR 으로 SCAN 자체 제거됨
- #14 Transaction race latch: 기존 IT + DeliveryConcurrencyIT 패턴 충분
- #13 Wishlist race: UNIQUE + atomic SQL + 좁은 catch 다층 방어 충분
- #35 Withdrawal 3-latch: 2-latch 충분 (flaky 시 재오픈)
- #36 Transaction GROUP BY slice IT: 회귀 위험 작음

## Test plan
- [x] 전체 빌드 BUILD SUCCESSFUL
- [ ] prod RT TTL 30일이 운영 정책에 맞는지 PM 확인
- [ ] V10 prod 배포 시 metadata lock 확인 (작은 테이블이라 instant 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)