### PR TITLE
feat: follow-up wave 3 — STOMP AFTER_COMMIT (#19) + presigned ownership (#12) + FULLTEXT 골격 (#10)

### DIFF
--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -43,6 +43,9 @@ public class ItemApplicationService {
         // Item 등록 — 사기 방지 위해 이메일 인증 필수 (게이트 1).
         userApplicationService.requireVerified(cmd.sellerId());
         categoryApplicationService.requireExists(cmd.categoryId());
+        // presigned URL 발급 시 받은 이미지 키가 본인 ownership prefix(items/{sellerId}/) 인지 검증.
+        // 다른 사용자의 임시 키를 본인 Item 으로 등록하는 위변조 차단 (follow-up #12 옵션 B).
+        validateImageOwnership(cmd.sellerId(), cmd.imageUrls());
         Item item = Item.create(
                 cmd.sellerId(), cmd.categoryId(),
                 cmd.title(), cmd.description(),
@@ -79,6 +82,8 @@ public class ItemApplicationService {
             item.assignCategory(cmd.categoryId());
         }
         if (cmd.imageUrls() != null) {
+            // 업데이트 시에도 동일 ownership 검증 (follow-up #12 옵션 B).
+            validateImageOwnership(item.getSellerId(), cmd.imageUrls());
             item.clearImages();
             applyImages(item, cmd.imageUrls());
         }
@@ -208,6 +213,23 @@ public class ItemApplicationService {
         for (String url : imageUrls) {
             order++;
             item.addImage(url, order, order == 1);
+        }
+    }
+
+    /**
+     * presigned URL 발급 시 받은 이미지 키가 본인 sellerId 의 prefix 를 가지는지 검증.
+     * key 형식: {@code items/{sellerId}/{uuid}.{ext}} (FileApplicationService.buildKey 참조).
+     * 다른 사용자의 임시 키를 본인 Item 으로 등록하는 위변조 차단 (follow-up #12).
+     */
+    private static void validateImageOwnership(Long sellerId, List<String> imageUrls) {
+        if (imageUrls == null || imageUrls.isEmpty()) {
+            return;
+        }
+        String expectedPrefix = "items/" + sellerId + "/";
+        for (String url : imageUrls) {
+            if (url == null || !url.contains(expectedPrefix)) {
+                throw new BusinessException(ErrorCode.ITEM_FORBIDDEN);
+            }
         }
     }
 

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
@@ -19,7 +19,9 @@ import java.util.List;
  * Item 동적 검색 — QueryDSL BooleanBuilder.
  *
  * <p>q 검색은 현재 단순 {@code LIKE '%q%'} 로, V1 스키마의 FULLTEXT(ngram) 인덱스를 활용하지 못한다.
- * 데이터 규모가 커지면 풀스캔 위험 — MATCH AGAINST 마이그는 별도 트래킹: <a href="https://github.com/sseullaeng/sl-server/issues/10">issue #10</a>.</p>
+ * 데이터 규모가 커지면 풀스캔 위험 — MATCH AGAINST 마이그는 ngram boolean mode 한글 매칭 검증
+ * 필요해 follow-up #10 으로 미룸. {@link com.sseulang.global.config.FullTextFunctionContributor} 는
+ * Hibernate function 등록 골격으로 유지 (활성화 시 즉시 사용).</p>
  */
 @Repository
 public class ItemQuerydslRepository {

--- a/src/main/java/com/sseulang/domain/message/application/ChatRealtimeEventListener.java
+++ b/src/main/java/com/sseulang/domain/message/application/ChatRealtimeEventListener.java
@@ -1,0 +1,43 @@
+package com.sseulang.domain.message.application;
+
+import com.sseulang.domain.message.application.event.ChatRealtimePublishRequestedEvent;
+import com.sseulang.global.websocket.RealtimePublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 채팅 실시간 publish listener — AFTER_COMMIT (follow-up #19).
+ *
+ * <p>이전: send 트랜잭션 안에서 publish — 트랜잭션 롤백돼도 STOMP 메시지는 이미 발송돼 회수 불가.
+ * 이후: 트랜잭션 commit 후 publish — 롤백 시 listener 호출 X 라 정합성 보장.</p>
+ *
+ * <p>publish 자체 실패는 로깅만 — 채팅방 토픽 broadcast / 알림 push 는 best-effort.</p>
+ */
+@Component
+public class ChatRealtimeEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(ChatRealtimeEventListener.class);
+
+    private final RealtimePublisher realtimePublisher;
+
+    public ChatRealtimeEventListener(RealtimePublisher realtimePublisher) {
+        this.realtimePublisher = realtimePublisher;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPublish(ChatRealtimePublishRequestedEvent event) {
+        try {
+            realtimePublisher.publishNotification(event.opponentId(), event.notification());
+        } catch (RuntimeException e) {
+            log.warn("[chat-realtime] notification publish 실패 opponentId={}", event.opponentId(), e);
+        }
+        try {
+            realtimePublisher.publishToChatRoom(event.chatRoomId(), event.message());
+        } catch (RuntimeException e) {
+            log.warn("[chat-realtime] chat-room broadcast 실패 chatRoomId={}", event.chatRoomId(), e);
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/message/application/MessageApplicationService.java
+++ b/src/main/java/com/sseulang/domain/message/application/MessageApplicationService.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.message.application;
 import com.sseulang.domain.chat.application.ChatRoomApplicationService;
 import com.sseulang.domain.message.application.dto.MessageResult;
 import com.sseulang.domain.message.application.dto.MessageSendCommand;
+import com.sseulang.domain.message.application.event.ChatRealtimePublishRequestedEvent;
 import com.sseulang.domain.message.domain.Message;
 import com.sseulang.domain.message.domain.MessageRepository;
 import com.sseulang.domain.notification.application.NotificationApplicationService;
@@ -10,6 +11,7 @@ import com.sseulang.domain.notification.application.dto.NotificationResult;
 import com.sseulang.domain.notification.domain.Notification;
 import com.sseulang.domain.notification.domain.NotificationType;
 import com.sseulang.global.websocket.RealtimePublisher;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,18 +38,21 @@ public class MessageApplicationService {
     private final MessageRepository messageRepository;
     private final ChatRoomApplicationService chatRoomApplicationService;
     private final NotificationApplicationService notificationApplicationService;
-    private final RealtimePublisher realtimePublisher;
+    private final RealtimePublisher realtimePublisher;  // 단위 테스트 호환용 (deprecated 직접 호출)
+    private final ApplicationEventPublisher eventPublisher;
 
     public MessageApplicationService(
             MessageRepository messageRepository,
             ChatRoomApplicationService chatRoomApplicationService,
             NotificationApplicationService notificationApplicationService,
-            RealtimePublisher realtimePublisher
+            RealtimePublisher realtimePublisher,
+            ApplicationEventPublisher eventPublisher
     ) {
         this.messageRepository = messageRepository;
         this.chatRoomApplicationService = chatRoomApplicationService;
         this.notificationApplicationService = notificationApplicationService;
         this.realtimePublisher = realtimePublisher;
+        this.eventPublisher = eventPublisher;
     }
 
     /**
@@ -76,7 +81,7 @@ public class MessageApplicationService {
 
         MessageResult result = MessageResult.from(saved);
 
-        // 상대방 알림 생성 + 실시간 push
+        // 상대방 알림 생성 (트랜잭션 안에서 저장)
         Notification notification = notificationApplicationService.notify(
                 opponentId,
                 NotificationType.메시지,
@@ -85,10 +90,14 @@ public class MessageApplicationService {
                 "chat-room",
                 cmd.chatRoomId()
         );
-        realtimePublisher.publishNotification(opponentId, NotificationResult.from(notification));
 
-        // 채팅방 토픽 broadcast — 양쪽 클라이언트가 구독 중
-        realtimePublisher.publishToChatRoom(cmd.chatRoomId(), result);
+        // 실시간 publish 는 AFTER_COMMIT 으로 분리 (follow-up #19) — 트랜잭션 롤백 시 발송 X.
+        eventPublisher.publishEvent(new ChatRealtimePublishRequestedEvent(
+                cmd.chatRoomId(),
+                opponentId,
+                result,
+                NotificationResult.from(notification)
+        ));
 
         return result;
     }

--- a/src/main/java/com/sseulang/domain/message/application/event/ChatRealtimePublishRequestedEvent.java
+++ b/src/main/java/com/sseulang/domain/message/application/event/ChatRealtimePublishRequestedEvent.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.message.application.event;
+
+import com.sseulang.domain.message.application.dto.MessageResult;
+import com.sseulang.domain.notification.application.dto.NotificationResult;
+
+/**
+ * 채팅 메시지 / 알림 실시간 publish 요청 이벤트 (follow-up #19 — AFTER_COMMIT 분리).
+ *
+ * <p>MessageApplicationService.send 가 트랜잭션 안에서 발행, listener 가 commit 후 publish.
+ * 트랜잭션 롤백 시 listener 호출 X — 메시지 저장 실패 시 STOMP 메시지 발송 안 됨 (정합성).</p>
+ */
+public record ChatRealtimePublishRequestedEvent(
+        Long chatRoomId,
+        Long opponentId,
+        MessageResult message,
+        NotificationResult notification
+) {
+}

--- a/src/main/java/com/sseulang/global/config/FullTextFunctionContributor.java
+++ b/src/main/java/com/sseulang/global/config/FullTextFunctionContributor.java
@@ -1,0 +1,27 @@
+package com.sseulang.global.config;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.type.StandardBasicTypes;
+
+/**
+ * MySQL FULLTEXT MATCH AGAINST 를 Hibernate function 으로 등록 (follow-up #10).
+ *
+ * <p>QueryDSL 에서 {@code Expressions.numberTemplate("function('match_against', ...)")} 로 호출.
+ * Boolean mode — 부분 매칭 + 가중치 정렬. ngram 토큰 사이즈 2 (docker-compose / my.cnf 설정 필수).</p>
+ *
+ * <p>등록은 {@code META-INF/services/org.hibernate.boot.model.FunctionContributor} 파일이 본 클래스를
+ * 가리켜야 활성. Spring Boot 가 자동 스캔.</p>
+ */
+public class FullTextFunctionContributor implements FunctionContributor {
+
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        functionContributions.getFunctionRegistry().registerPattern(
+                "match_against",
+                "match(?1, ?2) against (?3 in boolean mode)",
+                functionContributions.getTypeConfiguration().getBasicTypeRegistry()
+                        .resolve(StandardBasicTypes.DOUBLE)
+        );
+    }
+}

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+com.sseulang.global.config.FullTextFunctionContributor

--- a/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
@@ -46,7 +46,7 @@ class ItemApplicationServiceTest {
         Long id = service.register(new ItemRegisterCommand(
                 SELLER, categoryId, "title", "desc", 10_000L, null, null, TradeType.판매,
                 "서울",
-                List.of("https://img/1", "https://img/2"),
+                List.of("https://cdn.test/items/" + SELLER + "/img1.jpg", "https://cdn.test/items/" + SELLER + "/img2.jpg"),
                 List.of("아이폰", "미개봉")
         ));
 
@@ -131,16 +131,16 @@ class ItemApplicationServiceTest {
     void update_이미지_전체교체() {
         Long id = service.register(new ItemRegisterCommand(
                 SELLER, categoryId, "t", "d", 1L, null, null, TradeType.판매, null,
-                List.of("https://old/1", "https://old/2"), null
+                List.of("https://cdn.test/items/" + SELLER + "/old1.jpg", "https://cdn.test/items/" + SELLER + "/old2.jpg"), null
         ));
 
         service.update(id, SELLER, new ItemUpdateCommand(
-                null, "t", "d", 1L, null, null, null, List.of("https://new/1"), null
+                null, "t", "d", 1L, null, null, null, List.of("https://cdn.test/items/" + SELLER + "/new1.jpg"), null
         ));
 
         ItemDetailResult r = service.getById(id);
         assertThat(r.images()).hasSize(1);
-        assertThat(r.images().get(0).imageUrl()).isEqualTo("https://new/1");
+        assertThat(r.images().get(0).imageUrl()).isEqualTo("https://cdn.test/items/" + SELLER + "/new1.jpg");
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
@@ -11,6 +11,7 @@ import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.item.domain.TradeType;
 import com.sseulang.domain.message.application.dto.MessageResult;
 import com.sseulang.domain.message.application.dto.MessageSendCommand;
+import com.sseulang.domain.message.application.event.ChatRealtimePublishRequestedEvent;
 import com.sseulang.domain.notification.application.InMemoryFakeNotificationRepository;
 import com.sseulang.domain.notification.application.NotificationApplicationService;
 import com.sseulang.global.exception.BusinessException;
@@ -49,7 +50,14 @@ class MessageApplicationServiceTest {
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
         ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
         NotificationApplicationService notifSvc = new NotificationApplicationService(notifRepo);
-        service = new MessageApplicationService(msgRepo, roomSvc, notifSvc, publisher);
+        // 단위 테스트에선 트랜잭션 컨텍스트 X — AFTER_COMMIT listener 직접 호출하는 fake event publisher.
+        ChatRealtimeEventListener listener = new ChatRealtimeEventListener(publisher);
+        org.springframework.context.ApplicationEventPublisher eventPublisher = event -> {
+            if (event instanceof ChatRealtimePublishRequestedEvent e) {
+                listener.onPublish(e);
+            }
+        };
+        service = new MessageApplicationService(msgRepo, roomSvc, notifSvc, publisher, eventPublisher);
 
         Item item = itemRepo.save(Item.create(SELLER, null, "물건", "d", 1L, null, null, TradeType.판매, null));
         roomId = roomSvc.openFor(BUYER, item.getId()).id();


### PR DESCRIPTION
## Summary
보안/정합성 follow-up 추가 처리.

### #19 STOMP broadcast/notify AFTER_COMMIT 분리
- ApplicationEventPublisher 로 ChatRealtimePublishRequestedEvent 발행
- ChatRealtimeEventListener @TransactionalEventListener(AFTER_COMMIT) 처리
- 트랜잭션 롤백 시 STOMP 발송 안 됨 (정합성 보장)
- publish 자체 실패는 로그만 (best-effort)

### #12 Item presigned key ownership 검증
- register / update 시 imageUrls 각 키가 'items/{sellerId}/' prefix 포함 검증
- 다른 사용자의 임시 키 위변조 차단

### #10 FULLTEXT 골격
- FullTextFunctionContributor 추가 (Hibernate match_against)
- META-INF/services 등록
- 실제 적용은 ngram boolean mode 한글 매칭 검증 후 — #10 그대로 유지

## Test plan
- [x] MessageApplicationServiceTest 통과 (AFTER_COMMIT listener 직접 호출 fake)
- [x] ItemApplicationServiceTest 통과 (imageUrls items/{seller}/ prefix 사용)
- [x] 전체 BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)