### PR TITLE
feat: follow-up wave 4 (#10/#12/#19/#32/#52/#56)

### DIFF
--- a/docs/migration/V4_DEPLOYMENT.md
+++ b/docs/migration/V4_DEPLOYMENT.md
@@ -1,0 +1,96 @@
+# V4 prod 배포 절차 — withdrawals UNIQUE index
+
+> follow-up #32. V4 (`V4__add_withdrawal_idempotency_key.sql`) 는 `withdrawals` 에 컬럼 1개 추가 + UNIQUE 인덱스 1개 생성. prod 배포 시 metadata lock 으로 짧은 쓰기 차단이 발생할 수 있어 절차를 명시.
+
+## 변경 내용
+
+```sql
+ALTER TABLE withdrawals
+    ADD COLUMN idempotency_key VARCHAR(64) NULL AFTER user_id,
+    ADD UNIQUE KEY uk_withdrawals_user_idem (user_id, idempotency_key);
+```
+
+- 컬럼 추가: NULL 허용 → 기존 row 재기록 X (instant DDL).
+- UNIQUE 인덱스: 모든 row 의 `(user_id, idempotency_key)` 조합 검증 필요 → **table copy + metadata lock**.
+
+## 배포 시 영향
+
+| 데이터 규모 | 예상 시간 (MySQL 8 기준) | 락 영향 |
+|---|---|---|
+| ~1만 row | 1초 미만 | 무시 가능 |
+| ~10만 row | 수 초 | 그 시간 동안 INSERT/UPDATE 대기 |
+| ~100만 row 이상 | 수십 초 ~ 수 분 | 결제/출금 흐름 영향 큼 |
+
+> 쓸랭 배포 시점(5/6) 기준 withdrawals 는 0~수십 row → **즉시 적용 안전**. 이 문서는 향후 재차 UNIQUE 인덱스 추가 시 참조용.
+
+## 절차 — 데이터 적은 경우 (기본)
+
+```bash
+# 1. 백업
+mysqldump --single-transaction sseulang withdrawals > /tmp/withdrawals_backup_$(date +%s).sql
+
+# 2. Flyway 자동 실행 — 백엔드 서버 시작 시
+docker compose up -d backend
+
+# 3. 검증
+mysql -u sseulang -p sseulang -e "SHOW INDEX FROM withdrawals WHERE Key_name='uk_withdrawals_user_idem';"
+mysql -u sseulang -p sseulang -e "SELECT * FROM flyway_schema_history WHERE version='4';"
+```
+
+## 절차 — 데이터 많은 경우 (수십만 row 이상)
+
+Flyway 가 metadata lock 잡고 길게 멈추면 결제/출금 트래픽이 막힌다. **수동으로 pt-online-schema-change 사용 후 Flyway 는 baseline-on-migrate 로 스킵.**
+
+```bash
+# 1. 백업
+mysqldump --single-transaction sseulang withdrawals > /tmp/withdrawals_backup_$(date +%s).sql
+
+# 2. pt-online-schema-change — 락 없이 새 테이블 만들고 trigger 로 동기화
+pt-online-schema-change \
+  --alter "ADD COLUMN idempotency_key VARCHAR(64) NULL AFTER user_id, \
+           ADD UNIQUE KEY uk_withdrawals_user_idem (user_id, idempotency_key)" \
+  --execute D=sseulang,t=withdrawals
+
+# 3. Flyway 에 V4 적용됐다고 알림 (실행은 스킵)
+mysql -u sseulang -p sseulang -e "
+  INSERT INTO flyway_schema_history (installed_rank, version, description, type,
+    script, checksum, installed_by, installed_on, execution_time, success)
+  VALUES (4, '4', 'add withdrawal idempotency key', 'SQL',
+    'V4__add_withdrawal_idempotency_key.sql', NULL, 'sseulang', NOW(), 0, 1);
+"
+
+# 4. 백엔드 재시작 — Flyway 가 V4 이미 적용된 것으로 간주하고 V5 부터 적용
+docker compose up -d backend
+```
+
+> ⚠️ pt-online-schema-change 의 checksum 은 NULL — 향후 V4 파일 내용이 바뀌면 Flyway 가 checksum mismatch 에러. 현재 파일은 freeze 상태로 유지.
+
+## 롤백
+
+UNIQUE 인덱스가 만들어진 후 중복 데이터가 들어올 일이 없으므로 롤백 거의 불필요. 만약 컬럼 자체를 제거해야 하면:
+
+```sql
+ALTER TABLE withdrawals
+    DROP INDEX uk_withdrawals_user_idem,
+    DROP COLUMN idempotency_key;
+```
+
+후 `flyway_schema_history` 에서 V4 row 삭제. 백엔드 코드는 V4 컬럼을 사용하므로 함께 이전 버전으로 배포 필요.
+
+## 검증 체크리스트
+
+- [ ] `SHOW INDEX FROM withdrawals` 에 `uk_withdrawals_user_idem` 존재
+- [ ] `SHOW CREATE TABLE withdrawals` 에 `idempotency_key VARCHAR(64) NULL` 컬럼 존재
+- [ ] `flyway_schema_history` 의 V4 `success=1`
+- [ ] 동일 `(user_id, idempotency_key)` 로 출금 두 번 시도 → 두 번째 거부 (E2E 검증)
+- [ ] 백엔드 로그에 Flyway migration 에러 없음
+
+## 향후 UNIQUE 인덱스 추가 시 동일 절차 적용 영역
+
+| 후보 | 영향 |
+|---|---|
+| `chat_rooms (user1_id, user2_id, item_id)` | 중복 채팅방 방지 (현재는 코드 레벨 체크) |
+| `reviews (transaction_id, reviewer_id)` | 한 거래당 본인 리뷰 1건 (현재 V1 에 이미 적용됨) |
+| `payments (merchant_uid)` | 결제 멱등성 (V1 에 이미 적용됨) |
+
+새 UNIQUE 인덱스 마이그레이션 작성 시 본 문서를 참조해 데이터 규모를 먼저 확인할 것.

--- a/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
@@ -2,8 +2,11 @@ package com.sseulang.domain.delivery.application;
 
 import com.sseulang.domain.delivery.application.dto.DeliveryCreateCommand;
 import com.sseulang.domain.delivery.application.dto.DeliveryResult;
+import com.sseulang.domain.delivery.application.dto.DeliveryStatsResult;
 import com.sseulang.domain.delivery.domain.DeliveryRepository;
 import com.sseulang.domain.delivery.domain.DeliveryRequest;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import com.sseulang.domain.delivery.domain.DeliveryStatusCount;
 import com.sseulang.domain.point.application.PointApplicationService;
 import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.global.exception.BusinessException;
@@ -14,6 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.EnumMap;
+import java.util.Map;
 
 /**
  * Delivery (배달대행) ApplicationService — 트랜잭션 경계 + 도메인 흐름 조율.
@@ -208,5 +213,23 @@ public class DeliveryApplicationService {
     private DeliveryRequest findOrThrow(Long deliveryId) {
         return deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
+    }
+
+    /**
+     * 관리자 dashboard 용 배달대행 통계 (follow-up #52). status 별 카운트 + 정산완료 fee 합계.
+     * 모든 status 가 byStatus 에 포함됨 — 0 건이면 0L. 단일 GROUP BY + 단일 SUM 쿼리.
+     */
+    public DeliveryStatsResult adminGetStats() {
+        Map<DeliveryStatus, Long> byStatus = new EnumMap<>(DeliveryStatus.class);
+        for (DeliveryStatus s : DeliveryStatus.values()) {
+            byStatus.put(s, 0L);
+        }
+        long total = 0;
+        for (DeliveryStatusCount row : deliveryRepository.countGroupByStatus()) {
+            byStatus.put(row.status(), row.count());
+            total += row.count();
+        }
+        long settledFeeTotal = deliveryRepository.sumSettledFee();
+        return new DeliveryStatsResult(total, byStatus, settledFeeTotal);
     }
 }

--- a/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryStatsResult.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryStatsResult.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.delivery.application.dto;
+
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+
+import java.util.Map;
+
+/**
+ * 관리자 dashboard 용 배달대행 통계.
+ *
+ * @param total 전체 요청 건수
+ * @param byStatus status 별 건수 (모든 enum 포함, 0 이면 0L)
+ * @param settledFeeTotal 정산완료 상태 fee 합계 (KRW). 라이더 수익 총액 추정.
+ */
+public record DeliveryStatsResult(
+        long total,
+        Map<DeliveryStatus, Long> byStatus,
+        long settledFeeTotal
+) {}

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -52,4 +53,10 @@ public interface DeliveryRepository {
 
     /** 사용자가 요청자 또는 라이더로 참여한 요청 페이징. */
     Page<DeliveryRequest> findByParticipant(Long userId, Pageable pageable);
+
+    /** status 별 카운트 집계 (admin stats). 단일 GROUP BY — N+1 없음. */
+    List<DeliveryStatusCount> countGroupByStatus();
+
+    /** 정산완료 상태의 fee 총합 (admin stats). 누적 라이더 수익 추정. */
+    long sumSettledFee();
 }

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryStatusCount.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryStatusCount.java
@@ -1,0 +1,4 @@
+package com.sseulang.domain.delivery.domain;
+
+/** Delivery status 별 카운트 집계 row (admin stats 용). */
+public record DeliveryStatusCount(DeliveryStatus status, long count) {}

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.delivery.infrastructure.persistence;
 
 import com.sseulang.domain.delivery.domain.DeliveryRequest;
 import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import com.sseulang.domain.delivery.domain.DeliveryStatusCount;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /** Spring Data JPA — {@link DeliveryRepositoryImpl} 가 wrapping. 외부 직접 import 금지. */
@@ -70,4 +72,20 @@ interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
              ORDER BY d.requestedAt DESC
             """)
     Page<DeliveryRequest> findByParticipant(@Param("userId") Long userId, Pageable pageable);
+
+    /** status 별 건수 — 단일 GROUP BY (admin stats follow-up #52). */
+    @Query("""
+            SELECT new com.sseulang.domain.delivery.domain.DeliveryStatusCount(d.status, COUNT(d))
+              FROM DeliveryRequest d
+             GROUP BY d.status
+            """)
+    List<DeliveryStatusCount> countGroupByStatusJpql();
+
+    /** 정산완료 fee 합계. NULL → 0 변환은 호출자(Impl)가 처리. */
+    @Query("""
+            SELECT COALESCE(SUM(d.fee), 0)
+              FROM DeliveryRequest d
+             WHERE d.status = com.sseulang.domain.delivery.domain.DeliveryStatus.정산완료
+            """)
+    Long sumSettledFeeJpql();
 }

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryRepositoryImpl.java
@@ -3,11 +3,13 @@ package com.sseulang.domain.delivery.infrastructure.persistence;
 import com.sseulang.domain.delivery.domain.DeliveryRepository;
 import com.sseulang.domain.delivery.domain.DeliveryRequest;
 import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import com.sseulang.domain.delivery.domain.DeliveryStatusCount;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -52,5 +54,16 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
     @Override
     public Page<DeliveryRequest> findByParticipant(Long userId, Pageable pageable) {
         return jpa.findByParticipant(userId, pageable);
+    }
+
+    @Override
+    public List<DeliveryStatusCount> countGroupByStatus() {
+        return jpa.countGroupByStatusJpql();
+    }
+
+    @Override
+    public long sumSettledFee() {
+        Long sum = jpa.sumSettledFeeJpql();
+        return sum != null ? sum : 0L;
     }
 }

--- a/src/main/java/com/sseulang/domain/file/domain/PresignedUrlGenerator.java
+++ b/src/main/java/com/sseulang/domain/file/domain/PresignedUrlGenerator.java
@@ -3,10 +3,23 @@ package com.sseulang.domain.file.domain;
 import java.time.Duration;
 
 /**
- * S3 등 외부 스토리지의 PUT 용 presigned URL 발급 인터페이스. 도메인 layer 인터페이스 — 외부 SDK 의존 X.
- * 구현은 {@code domain/file/infrastructure/s3/S3PresignedUrlGenerator}.
+ * S3 등 외부 스토리지의 PUT 용 presigned URL 발급 + 키 승격(copy+delete) 인터페이스.
+ * 도메인 layer 인터페이스 — 외부 SDK 의존 X. 구현은 {@code domain/file/infrastructure/s3/S3PresignedUrlGenerator}.
  */
 public interface PresignedUrlGenerator {
 
     PresignedUrlResult generate(String key, String contentType, Duration expiresIn);
+
+    /**
+     * 임시 폴더의 객체를 정식 폴더로 복사 + 원본 삭제 (follow-up #12 옵션 A).
+     *
+     * <p>예: {@code items/123/uuid.jpg} → {@code items/4567/uuid.jpg}. URL 변환 책임도 본 메서드가
+     * 가짐 — 호출자는 받은 새 URL 을 그대로 DB 에 저장하면 된다. dst 가 이미 존재하면 덮어쓴다 (idempotent).</p>
+     *
+     * @param sourceUrl  PresignedUrlResult.key 가 path 에 포함된 GET URL (또는 key 자체)
+     * @param fromPrefix 원본 prefix — {@code "items/{userId}/"}
+     * @param toPrefix   목적지 prefix — {@code "items/{itemId}/"}
+     * @return 승격된 정식 GET URL (sourceUrl 의 prefix 만 toPrefix 로 치환). 비매칭 시 sourceUrl 반환.
+     */
+    String promote(String sourceUrl, String fromPrefix, String toPrefix);
 }

--- a/src/main/java/com/sseulang/domain/file/infrastructure/s3/S3PresignedUrlGenerator.java
+++ b/src/main/java/com/sseulang/domain/file/infrastructure/s3/S3PresignedUrlGenerator.java
@@ -3,8 +3,14 @@ package com.sseulang.domain.file.infrastructure.s3;
 import com.sseulang.domain.file.domain.PresignedUrlGenerator;
 import com.sseulang.domain.file.domain.PresignedUrlResult;
 import com.sseulang.global.infra.s3.S3Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -14,11 +20,15 @@ import java.time.Duration;
 @Component
 public class S3PresignedUrlGenerator implements PresignedUrlGenerator {
 
+    private static final Logger log = LoggerFactory.getLogger(S3PresignedUrlGenerator.class);
+
     private final S3Presigner presigner;
+    private final S3Client s3Client;
     private final String bucket;
 
-    public S3PresignedUrlGenerator(S3Presigner presigner, S3Properties props) {
+    public S3PresignedUrlGenerator(S3Presigner presigner, S3Client s3Client, S3Properties props) {
         this.presigner = presigner;
+        this.s3Client = s3Client;
         this.bucket = props.s3().bucket();
     }
 
@@ -35,5 +45,44 @@ public class S3PresignedUrlGenerator implements PresignedUrlGenerator {
                 .build();
         PresignedPutObjectRequest presigned = presigner.presignPutObject(req);
         return new PresignedUrlResult(presigned.url().toString(), key);
+    }
+
+    /**
+     * sourceUrl 안에서 fromPrefix 가 toPrefix 로 치환되는 키를 찾아 S3 copy + 원본 delete.
+     *
+     * <p>실패는 RuntimeException 으로 전파 — 호출 트랜잭션이 롤백되어 DB 상태가 임시 url 에 머문다
+     * (사용자는 재시도하면 된다). copy 만 성공하고 delete 가 실패한 경우는 src 가 garbage 로 남고
+     * dst 는 정상 작동 — lifecycle 정책으로 정리.</p>
+     */
+    @Override
+    public String promote(String sourceUrl, String fromPrefix, String toPrefix) {
+        if (sourceUrl == null || fromPrefix == null || toPrefix == null) {
+            return sourceUrl;
+        }
+        int idx = sourceUrl.indexOf(fromPrefix);
+        if (idx < 0) {
+            return sourceUrl;  // 이미 승격됐거나 다른 prefix — no-op
+        }
+        String fromKey = sourceUrl.substring(idx);
+        String toKey = toPrefix + fromKey.substring(fromPrefix.length());
+
+        try {
+            s3Client.copyObject(CopyObjectRequest.builder()
+                    .sourceBucket(bucket).sourceKey(fromKey)
+                    .destinationBucket(bucket).destinationKey(toKey)
+                    .build());
+        } catch (S3Exception e) {
+            throw new RuntimeException("S3 copy 실패 src=" + fromKey + " dst=" + toKey, e);
+        }
+
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucket).key(fromKey).build());
+        } catch (S3Exception e) {
+            // delete 실패는 best-effort — copy 는 이미 성공했으므로 dst 사용 가능. 로깅만.
+            log.warn("[s3] promote delete 실패 — src={} 잔여, lifecycle 정리 의존", fromKey, e);
+        }
+
+        return sourceUrl.substring(0, idx) + toPrefix + fromKey.substring(fromPrefix.length());
     }
 }

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -1,6 +1,7 @@
 package com.sseulang.domain.item.application;
 
 import com.sseulang.domain.category.application.CategoryApplicationService;
+import com.sseulang.domain.file.domain.PresignedUrlGenerator;
 import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.domain.item.application.dto.ItemDetailResult;
 import com.sseulang.domain.item.application.dto.ItemForTransactionResult;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -27,15 +29,18 @@ public class ItemApplicationService {
     private final ItemRepository itemRepository;
     private final CategoryApplicationService categoryApplicationService;
     private final UserApplicationService userApplicationService;
+    private final PresignedUrlGenerator presignedUrlGenerator;
 
     public ItemApplicationService(
             ItemRepository itemRepository,
             CategoryApplicationService categoryApplicationService,
-            UserApplicationService userApplicationService
+            UserApplicationService userApplicationService,
+            PresignedUrlGenerator presignedUrlGenerator
     ) {
         this.itemRepository = itemRepository;
         this.categoryApplicationService = categoryApplicationService;
         this.userApplicationService = userApplicationService;
+        this.presignedUrlGenerator = presignedUrlGenerator;
     }
 
     @Transactional
@@ -52,9 +57,14 @@ public class ItemApplicationService {
                 cmd.price(), cmd.deposit(), cmd.rentalUnit(), cmd.tradeType(),
                 cmd.region()
         );
-        applyImages(item, cmd.imageUrls());
         applyHashtags(item, cmd.hashtags());
-        return itemRepository.save(item).getId();
+        Item saved = itemRepository.save(item);
+        // 등록된 itemId 가 생긴 후, 임시 폴더(items/{userId}/) 의 키를 정식 폴더(items/{itemId}/) 로
+        // S3 copy + delete (follow-up #12 옵션 A). 트랜잭션 안에서 실패 시 DB 롤백 + S3 garbage 는
+        // lifecycle 정책으로 정리.
+        List<String> promoted = promoteImageUrls(cmd.sellerId(), saved.getId(), cmd.imageUrls());
+        applyImages(saved, promoted);
+        return saved.getId();
     }
 
     @Transactional
@@ -82,10 +92,13 @@ public class ItemApplicationService {
             item.assignCategory(cmd.categoryId());
         }
         if (cmd.imageUrls() != null) {
-            // 업데이트 시에도 동일 ownership 검증 (follow-up #12 옵션 B).
-            validateImageOwnership(item.getSellerId(), cmd.imageUrls());
+            // 업데이트 시에도 동일 ownership 검증 — sellerId 임시 폴더 또는 이미 promote 된 itemId
+            // 정식 폴더 prefix 둘 다 허용 (follow-up #12 옵션 A/B 통합).
+            validateImageOwnershipForUpdate(item.getSellerId(), item.getId(), cmd.imageUrls());
             item.clearImages();
-            applyImages(item, cmd.imageUrls());
+            // 새로 업로드된 임시 키는 정식 폴더로 promote, 이미 정식인 키는 promoter 가 no-op.
+            List<String> promoted = promoteImageUrls(item.getSellerId(), item.getId(), cmd.imageUrls());
+            applyImages(item, promoted);
         }
         if (cmd.hashtags() != null) {
             item.clearHashtags();
@@ -217,6 +230,23 @@ public class ItemApplicationService {
     }
 
     /**
+     * 임시 폴더({@code items/{sellerId}/}) 의 객체를 정식 폴더({@code items/{itemId}/}) 로 S3 promote.
+     * 이미 정식 폴더에 있는 url 은 promoter 가 no-op (follow-up #12 옵션 A).
+     */
+    private List<String> promoteImageUrls(Long sellerId, Long itemId, List<String> sourceUrls) {
+        if (sourceUrls == null || sourceUrls.isEmpty()) {
+            return sourceUrls;
+        }
+        String fromPrefix = "items/" + sellerId + "/";
+        String toPrefix = "items/" + itemId + "/";
+        List<String> promoted = new ArrayList<>(sourceUrls.size());
+        for (String src : sourceUrls) {
+            promoted.add(presignedUrlGenerator.promote(src, fromPrefix, toPrefix));
+        }
+        return promoted;
+    }
+
+    /**
      * presigned URL 발급 시 받은 이미지 키가 본인 sellerId 의 prefix 를 가지는지 검증.
      * key 형식: {@code items/{sellerId}/{uuid}.{ext}} (FileApplicationService.buildKey 참조).
      * 다른 사용자의 임시 키를 본인 Item 으로 등록하는 위변조 차단 (follow-up #12).
@@ -228,6 +258,23 @@ public class ItemApplicationService {
         String expectedPrefix = "items/" + sellerId + "/";
         for (String url : imageUrls) {
             if (url == null || !url.contains(expectedPrefix)) {
+                throw new BusinessException(ErrorCode.ITEM_FORBIDDEN);
+            }
+        }
+    }
+
+    /**
+     * update 전용 — 임시 폴더({@code items/{sellerId}/}) 또는 정식 폴더({@code items/{itemId}/})
+     * 둘 다 허용. 정식 폴더는 이전 register 단계에서 promote 된 결과 url (사용자가 그대로 다시 보낸 경우).
+     */
+    private static void validateImageOwnershipForUpdate(Long sellerId, Long itemId, List<String> imageUrls) {
+        if (imageUrls == null || imageUrls.isEmpty()) {
+            return;
+        }
+        String tempPrefix = "items/" + sellerId + "/";
+        String finalPrefix = "items/" + itemId + "/";
+        for (String url : imageUrls) {
+            if (url == null || (!url.contains(tempPrefix) && !url.contains(finalPrefix))) {
                 throw new BusinessException(ErrorCode.ITEM_FORBIDDEN);
             }
         }

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
@@ -1,6 +1,8 @@
 package com.sseulang.domain.item.infrastructure.persistence;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
@@ -13,18 +15,24 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Item 동적 검색 — QueryDSL BooleanBuilder.
  *
- * <p>q 검색은 현재 단순 {@code LIKE '%q%'} 로, V1 스키마의 FULLTEXT(ngram) 인덱스를 활용하지 못한다.
- * 데이터 규모가 커지면 풀스캔 위험 — MATCH AGAINST 마이그는 ngram boolean mode 한글 매칭 검증
- * 필요해 follow-up #10 으로 미룸. {@link com.sseulang.global.config.FullTextFunctionContributor} 는
- * Hibernate function 등록 골격으로 유지 (활성화 시 즉시 사용).</p>
+ * <p>q 검색은 V1 스키마의 {@code FULLTEXT KEY ft_items_title_desc (title, description) WITH PARSER ngram}
+ * 인덱스를 사용 (follow-up #10). MySQL ngram_token_size=2 + boolean mode + AND 조합:
+ * 입력 토큰 중 길이 ≥ 2 만 사용해 {@code +token1 +token2} 형태로 변환 후
+ * {@link com.sseulang.global.config.FullTextFunctionContributor#contributeFunctions Hibernate match_against
+ * function} 호출. 토큰 길이 1 이거나 sanitization 후 빈 입력은 LIKE 폴백.</p>
  */
 @Repository
 public class ItemQuerydslRepository {
+
+    /** ngram_token_size=2 — 1글자 토큰은 매칭 불가. LIKE 로 폴백. */
+    private static final int MIN_NGRAM_TOKEN_LENGTH = 2;
 
     private final JPAQueryFactory queryFactory;
 
@@ -38,8 +46,20 @@ public class ItemQuerydslRepository {
         where.and(item.status.ne(ItemStatus.삭제));
 
         if (criteria.q() != null && !criteria.q().isBlank()) {
-            String pattern = "%" + criteria.q().strip() + "%";
-            where.and(item.title.like(pattern).or(item.description.like(pattern)));
+            String input = criteria.q().strip();
+            String booleanQuery = toBooleanModeQuery(input);
+            if (!booleanQuery.isEmpty()) {
+                NumberExpression<Double> matchScore = Expressions.numberTemplate(
+                        Double.class,
+                        "function('match_against', {0}, {1}, {2})",
+                        item.title, item.description, booleanQuery
+                );
+                where.and(matchScore.gt(0));
+            } else {
+                // 모든 토큰 길이 < 2 → FULLTEXT 매칭 불가. LIKE 폴백.
+                String pattern = "%" + input + "%";
+                where.and(item.title.like(pattern).or(item.description.like(pattern)));
+            }
         }
         if (criteria.categoryId() != null) {
             where.and(item.categoryId.eq(criteria.categoryId()));
@@ -77,5 +97,24 @@ public class ItemQuerydslRepository {
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total == null ? 0L : total);
+    }
+
+    /**
+     * 사용자 입력을 MySQL FULLTEXT boolean mode 쿼리로 변환.
+     * <ul>
+     *   <li>boolean mode 메타문자 제거 (injection / 의도치 않은 OR 회피)</li>
+     *   <li>공백으로 split, 길이 ≥ {@value #MIN_NGRAM_TOKEN_LENGTH} 토큰만 채택</li>
+     *   <li>각 토큰에 {@code +} prefix → 모든 토큰 AND 매칭</li>
+     * </ul>
+     * 결과가 빈 문자열이면 호출자가 LIKE 폴백을 사용해야 함.
+     */
+    static String toBooleanModeQuery(String input) {
+        if (input == null) return "";
+        String sanitized = input.replaceAll("[+\\-*\"<>()~@]", " ").trim();
+        if (sanitized.isEmpty()) return "";
+        return Arrays.stream(sanitized.split("\\s+"))
+                .filter(s -> s.length() >= MIN_NGRAM_TOKEN_LENGTH)
+                .map(s -> "+" + s)
+                .collect(Collectors.joining(" "));
     }
 }

--- a/src/main/java/com/sseulang/domain/review/application/ReviewApplicationService.java
+++ b/src/main/java/com/sseulang/domain/review/application/ReviewApplicationService.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.review.application.dto.ReviewWriteCommand;
 import com.sseulang.domain.review.domain.Review;
 import com.sseulang.domain.review.domain.ReviewRepository;
 import com.sseulang.domain.transaction.application.TransactionApplicationService;
+import com.sseulang.domain.transaction.application.dto.PendingReviewableResult;
 import com.sseulang.domain.transaction.application.dto.ReviewableTransactionResult;
 import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.global.exception.BusinessException;
@@ -78,6 +79,14 @@ public class ReviewApplicationService {
         return reviewRepository.findByRevieweeId(revieweeId, pageable)
                 .map(ReviewResult::from)
                 .map(r -> r.masked(requesterId));
+    }
+
+    /**
+     * Review 작성 대기 거래 목록 (follow-up #56). 본인이 reviewer 로 아직 작성 안 한 7일 이내 완료 거래.
+     * Cross-aggregate read 는 TransactionApplicationService 가 책임 — 본 서비스는 단순 위임.
+     */
+    public Page<PendingReviewableResult> listPending(Long requesterId, Pageable pageable) {
+        return transactionApplicationService.findPendingReviewable(requesterId, pageable);
     }
 
     private static boolean isUniqueConflict(DataIntegrityViolationException violation) {

--- a/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
@@ -1,6 +1,7 @@
 package com.sseulang.domain.review.presentation;
 
 import com.sseulang.domain.review.application.ReviewApplicationService;
+import com.sseulang.domain.review.presentation.dto.PendingReviewResponse;
 import com.sseulang.domain.review.presentation.dto.ReviewIdResponse;
 import com.sseulang.domain.review.presentation.dto.ReviewResponse;
 import com.sseulang.domain.review.presentation.dto.ReviewWriteRequest;
@@ -54,6 +55,25 @@ public class ReviewController {
 
         Page<ReviewResponse> result = reviewService.listReceived(userId, requesterId, pageable)
                 .map(ReviewResponse::from);
+        return ApiResponse.ok(PageResponse.from(result));
+    }
+
+    /**
+     * Review 작성 대기 거래 (follow-up #56). 본인이 reviewer 로 아직 작성 안 한 7일 이내 완료 거래.
+     * 인증 필수 — SecurityFilter 가 보호.
+     */
+    @GetMapping("/api/v1/reviews/pending")
+    public ApiResponse<PageResponse<PendingReviewResponse>> listPending(
+            @AuthenticationPrincipal Long requesterId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+
+        Page<PendingReviewResponse> result = reviewService.listPending(requesterId, pageable)
+                .map(PendingReviewResponse::from);
         return ApiResponse.ok(PageResponse.from(result));
     }
 }

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/PendingReviewResponse.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/PendingReviewResponse.java
@@ -1,0 +1,33 @@
+package com.sseulang.domain.review.presentation.dto;
+
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.domain.transaction.application.dto.PendingReviewableResult;
+
+import java.time.LocalDateTime;
+
+/**
+ * Review 작성 대기 거래 응답 (follow-up #56).
+ *
+ * <p>{@code deadline = completedAt + 7d} — 클라이언트가 남은 시간 카운트다운 UI 에 직접 사용.</p>
+ */
+public record PendingReviewResponse(
+        Long transactionId,
+        Long itemId,
+        Long revieweeId,
+        TradeType tradeType,
+        long price,
+        LocalDateTime completedAt,
+        LocalDateTime deadline
+) {
+    public static PendingReviewResponse from(PendingReviewableResult r) {
+        return new PendingReviewResponse(
+                r.transactionId(),
+                r.itemId(),
+                r.revieweeId(),
+                r.tradeType(),
+                r.price(),
+                r.completedAt(),
+                r.deadline()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/stats/application/AdminDashboardResult.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminDashboardResult.java
@@ -1,14 +1,16 @@
 package com.sseulang.domain.stats.application;
 
+import com.sseulang.domain.delivery.application.dto.DeliveryStatsResult;
 import com.sseulang.domain.payment.application.dto.PaymentStatsResult;
 import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
 import com.sseulang.domain.user.application.dto.UserStatsResult;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
 
-/** 4개 도메인 통계 묶음. 단순 wrapper — 각 도메인 stats result 는 그 도메인 dto 그대로 노출. */
+/** 5개 도메인 통계 묶음. 단순 wrapper — 각 도메인 stats result 는 그 도메인 dto 그대로 노출. */
 public record AdminDashboardResult(
         UserStatsResult users,
         TransactionStatsResult transactions,
         PaymentStatsResult payments,
-        WithdrawalStatsResult withdrawals
+        WithdrawalStatsResult withdrawals,
+        DeliveryStatsResult deliveries
 ) {}

--- a/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
@@ -1,5 +1,7 @@
 package com.sseulang.domain.stats.application;
 
+import com.sseulang.domain.delivery.application.DeliveryApplicationService;
+import com.sseulang.domain.delivery.application.dto.DeliveryStatsResult;
 import com.sseulang.domain.payment.application.PaymentApplicationService;
 import com.sseulang.domain.payment.application.dto.PaymentStatsResult;
 import com.sseulang.domain.transaction.application.TransactionApplicationService;
@@ -18,8 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
  * 다른 도메인 Repository 직접 호출 금지, 각 도메인 ApplicationService 만 의존.</p>
  *
  * <p>각 도메인 stats 호출은 단일 집계 쿼리 (GROUP BY / SUM / COUNT) 라 N+1 없음. 전체 dashboard
- * 한 번 호출 시 SQL 9개 (User 4 [all/blocked/deleted/active] + Transaction 1 + Payment 2 +
- * Withdrawal 2). prod 트래픽 스케일 커지면 schedule 캐싱 검토.</p>
+ * 한 번 호출 시 SQL 11개 (User 4 [all/blocked/deleted/active] + Transaction 1 + Payment 2 +
+ * Withdrawal 2 + Delivery 2). prod 트래픽 스케일 커지면 schedule 캐싱 검토.</p>
  */
 @Service
 @Transactional(readOnly = true)
@@ -29,17 +31,20 @@ public class AdminStatsService {
     private final TransactionApplicationService transactionService;
     private final PaymentApplicationService paymentService;
     private final WithdrawalApplicationService withdrawalService;
+    private final DeliveryApplicationService deliveryService;
 
     public AdminStatsService(
             UserApplicationService userService,
             TransactionApplicationService transactionService,
             PaymentApplicationService paymentService,
-            WithdrawalApplicationService withdrawalService
+            WithdrawalApplicationService withdrawalService,
+            DeliveryApplicationService deliveryService
     ) {
         this.userService = userService;
         this.transactionService = transactionService;
         this.paymentService = paymentService;
         this.withdrawalService = withdrawalService;
+        this.deliveryService = deliveryService;
     }
 
     public AdminDashboardResult dashboard() {
@@ -47,6 +52,7 @@ public class AdminStatsService {
         TransactionStatsResult transactions = transactionService.adminGetStats();
         PaymentStatsResult payments = paymentService.adminGetStats();
         WithdrawalStatsResult withdrawals = withdrawalService.adminGetStats();
-        return new AdminDashboardResult(users, transactions, payments, withdrawals);
+        DeliveryStatsResult deliveries = deliveryService.adminGetStats();
+        return new AdminDashboardResult(users, transactions, payments, withdrawals, deliveries);
     }
 }

--- a/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardResponse.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardResponse.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.stats.presentation.dto;
 
+import com.sseulang.domain.delivery.application.dto.DeliveryStatsResult;
 import com.sseulang.domain.payment.application.dto.PaymentStatsResult;
 import com.sseulang.domain.stats.application.AdminDashboardResult;
 import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
@@ -14,9 +15,12 @@ public record AdminDashboardResponse(
         UserStatsResult users,
         TransactionStatsResult transactions,
         PaymentStatsResult payments,
-        WithdrawalStatsResult withdrawals
+        WithdrawalStatsResult withdrawals,
+        DeliveryStatsResult deliveries
 ) {
     public static AdminDashboardResponse from(AdminDashboardResult r) {
-        return new AdminDashboardResponse(r.users(), r.transactions(), r.payments(), r.withdrawals());
+        return new AdminDashboardResponse(
+                r.users(), r.transactions(), r.payments(), r.withdrawals(), r.deliveries()
+        );
     }
 }

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.item.application.dto.ItemForTransactionResult;
 import com.sseulang.domain.point.application.PointApplicationService;
 import com.sseulang.domain.point.domain.PointReferenceType;
 import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.transaction.application.dto.PendingReviewableResult;
 import com.sseulang.domain.transaction.application.dto.ReviewableTransactionResult;
 import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
 import com.sseulang.domain.transaction.application.dto.TransactionResult;
@@ -15,6 +16,8 @@ import com.sseulang.domain.transaction.domain.TransactionStatus;
 import com.sseulang.domain.transaction.domain.TransactionStatusCount;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -190,6 +193,29 @@ public class TransactionApplicationService {
             total += row.count();
         }
         return new TransactionStatsResult(total, byStatus);
+    }
+
+    /**
+     * 본인이 reviewer 로 아직 작성하지 않은 거래완료 거래 페이징 (follow-up #56).
+     *
+     * <p>completedAt 이 7일 이내인 것만 — 작성 가능 기간이 지난 거래는 제외 (가이드 §5.5).
+     * 응답 DTO 의 deadline = completedAt + 7d → 클라이언트가 남은 시간 UI 작성에 사용.</p>
+     */
+    public Page<PendingReviewableResult> findPendingReviewable(Long userId, Pageable pageable) {
+        LocalDateTime since = LocalDateTime.now(clock).minusDays(7);
+        return transactionRepository.findPendingReviewable(userId, since, pageable)
+                .map(tx -> {
+                    Long revieweeId = tx.isSeller(userId) ? tx.getBuyerId() : tx.getSellerId();
+                    return new PendingReviewableResult(
+                            tx.getId(),
+                            tx.getItemId(),
+                            revieweeId,
+                            tx.getTradeType(),
+                            tx.getPrice(),
+                            tx.getCompletedAt(),
+                            tx.getCompletedAt().plusDays(7)
+                    );
+                });
     }
 
     private Transaction findOrThrow(Long id) {

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/PendingReviewableResult.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/PendingReviewableResult.java
@@ -1,0 +1,21 @@
+package com.sseulang.domain.transaction.application.dto;
+
+import com.sseulang.domain.item.domain.TradeType;
+
+import java.time.LocalDateTime;
+
+/**
+ * Review 작성 대기 중 거래 — 거래완료된 본인 참여 거래 중 본인이 아직 review 작성 안 한 것.
+ *
+ * <p>follow-up #56. 7일 작성 가능 기간 안에 들어오는 거래만. 상대방 id(revieweeId) 와
+ * 작성 deadline(completedAt + 7d) 을 함께 노출 — 클라이언트가 "남은 시간" UI 만들기 쉽게.</p>
+ */
+public record PendingReviewableResult(
+        Long transactionId,
+        Long itemId,
+        Long revieweeId,
+        TradeType tradeType,
+        long price,
+        LocalDateTime completedAt,
+        LocalDateTime deadline
+) {}

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -1,5 +1,9 @@
 package com.sseulang.domain.transaction.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,4 +29,17 @@ public interface TransactionRepository {
 
     /** 단일 GROUP BY 집계 — (status, count) 행 리스트 (가능한 모든 status 행 포함, 0 인 status 는 없음). */
     List<TransactionStatusCount> countGroupByStatus();
+
+    // ───────── Review pending (follow-up #56) ─────────
+
+    /**
+     * 사용자가 reviewer 로 아직 작성하지 않은 거래완료 transaction 목록 (페이징, completedAt DESC).
+     *
+     * <p>cross-aggregate read query — Review 와 NOT EXISTS 로 join. write flow 는 여전히
+     * 각 aggregate root 가 책임. 본 메서드는 read-only 라 도메인 invariant 를 깨지 않음.</p>
+     *
+     * @param userId    조회 주체 (seller 또는 buyer 중 하나로 참여)
+     * @param since     completedAt 하한 (보통 now - 7일) — 작성 가능 기간 밖은 제외
+     */
+    Page<Transaction> findPendingReviewable(Long userId, LocalDateTime since, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -3,11 +3,14 @@ package com.sseulang.domain.transaction.infrastructure.persistence;
 import com.sseulang.domain.transaction.domain.Transaction;
 import com.sseulang.domain.transaction.domain.TransactionStatusCount;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,4 +31,35 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
              GROUP BY t.status
             """)
     List<TransactionStatusCount> countGroupByStatusJpql();
+
+    /**
+     * Review 작성 대기 거래 — completedAt 하한 + 본인 참여 + 본인이 reviewer 인 review 가 아직 없는 것.
+     * Review 와 NOT EXISTS 로 cross-aggregate read (write 가 아니라 도메인 invariant 영향 X).
+     */
+    @Query(value = """
+            SELECT t FROM Transaction t
+             WHERE t.status = com.sseulang.domain.transaction.domain.TransactionStatus.거래완료
+               AND t.completedAt >= :since
+               AND (t.sellerId = :userId OR t.buyerId = :userId)
+               AND NOT EXISTS (
+                   SELECT 1 FROM com.sseulang.domain.review.domain.Review r
+                    WHERE r.transactionId = t.id
+                      AND r.reviewerId = :userId
+               )
+             ORDER BY t.completedAt DESC
+            """,
+            countQuery = """
+            SELECT COUNT(t) FROM Transaction t
+             WHERE t.status = com.sseulang.domain.transaction.domain.TransactionStatus.거래완료
+               AND t.completedAt >= :since
+               AND (t.sellerId = :userId OR t.buyerId = :userId)
+               AND NOT EXISTS (
+                   SELECT 1 FROM com.sseulang.domain.review.domain.Review r
+                    WHERE r.transactionId = t.id
+                      AND r.reviewerId = :userId
+               )
+            """)
+    Page<Transaction> findPendingReviewableJpql(@Param("userId") Long userId,
+                                                 @Param("since") LocalDateTime since,
+                                                 Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -3,8 +3,11 @@ package com.sseulang.domain.transaction.infrastructure.persistence;
 import com.sseulang.domain.transaction.domain.Transaction;
 import com.sseulang.domain.transaction.domain.TransactionRepository;
 import com.sseulang.domain.transaction.domain.TransactionStatusCount;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,5 +38,10 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     @Override
     public List<TransactionStatusCount> countGroupByStatus() {
         return jpa.countGroupByStatusJpql();
+    }
+
+    @Override
+    public Page<Transaction> findPendingReviewable(Long userId, LocalDateTime since, Pageable pageable) {
+        return jpa.findPendingReviewableJpql(userId, since, pageable);
     }
 }

--- a/src/main/java/com/sseulang/global/config/SecurityConfig.java
+++ b/src/main/java/com/sseulang/global/config/SecurityConfig.java
@@ -68,8 +68,9 @@ public class SecurityConfig {
             "/api/v1/auth/logout",
             "/api/v1/auth/verify-email",
             // WebSocket handshake 는 SockJS 폴백 path 까지 포함해 CSRF 면제 — STOMP CONNECT 단계의
-            // 인증·인가는 ChannelInterceptor 가 별도 검증.
+            // 인증·인가는 ChannelInterceptor 가 별도 검증. native ws (follow-up #19) 도 동일.
             "/ws-stomp/**",
+            "/ws-stomp-native/**",
             // 토스 webhook — 외부 PG 가 호출하는 콜백. 시그니처 검증은 webhook 핸들러 책임 (후속).
             "/api/v1/payments/webhook/**"
     };
@@ -129,7 +130,7 @@ public class SecurityConfig {
     @Order(2)
     public SecurityFilterChain userFilterChain(HttpSecurity http) throws Exception {
         applyCommon(http)
-                .securityMatcher("/api/v1/**", "/ws-stomp/**")
+                .securityMatcher("/api/v1/**", "/ws-stomp/**", "/ws-stomp-native/**")
                 .csrf(csrf -> csrf
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                         .csrfTokenRequestHandler(eagerCsrfHandler())
@@ -142,6 +143,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/items/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/categories/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/payments/webhook/**").permitAll()
+                        // WebSocket handshake 는 인증 없이 통과 — STOMP CONNECT 단계의 ChannelInterceptor 가
+                        // Authorization 헤더 검증으로 인증 책임 (follow-up #19 native 토큰 인증).
+                        .requestMatchers("/ws-stomp/**", "/ws-stomp-native/**").permitAll()
                         // ROLE_USER 강제 — ADMIN AT 가 user 영역(특히 출금/결제) 진입하지 못하도록 차단.
                         // adminId 와 userId 가 동일 숫자면 본인 검사도 통과해버리는 격리 누수 방지 (게이트 1).
                         .anyRequest().hasRole("USER"))

--- a/src/main/java/com/sseulang/global/config/WebSocketConfig.java
+++ b/src/main/java/com/sseulang/global/config/WebSocketConfig.java
@@ -31,9 +31,15 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // SockJS 폴백 — 브라우저 환경(쿠키 핸드셰이크)
         registry.addEndpoint("/ws-stomp")
                 .setAllowedOrigins(corsProperties.originsArray())
                 .withSockJS();
+        // native WebSocket — 모바일 / non-browser 클라이언트 (follow-up #19).
+        // 인증은 STOMP CONNECT frame 의 nativeHeader Authorization: Bearer <jwt> 로
+        // {@link com.sseulang.global.websocket.StompAuthChannelInterceptor} 가 처리.
+        registry.addEndpoint("/ws-stomp-native")
+                .setAllowedOrigins(corsProperties.originsArray());
     }
 
     @Override

--- a/src/main/java/com/sseulang/global/infra/s3/S3Config.java
+++ b/src/main/java/com/sseulang/global/infra/s3/S3Config.java
@@ -3,8 +3,11 @@ package com.sseulang.global.infra.s3;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -13,15 +16,28 @@ public class S3Config {
     @Bean
     public S3Presigner s3Presigner(S3Properties props) {
         S3Presigner.Builder builder = S3Presigner.builder()
-                .region(Region.of(props.region()));
+                .region(Region.of(props.region()))
+                .credentialsProvider(credentialsProvider(props));
+        return builder.build();
+    }
 
+    /** 키 promotion(copy+delete) 용 동기 S3 클라이언트 — follow-up #12. */
+    @Bean
+    public S3Client s3Client(S3Properties props) {
+        return S3Client.builder()
+                .region(Region.of(props.region()))
+                .credentialsProvider(credentialsProvider(props))
+                .build();
+    }
+
+    private static AwsCredentialsProvider credentialsProvider(S3Properties props) {
         if (props.accessKey() != null && !props.accessKey().isBlank()
                 && props.secretKey() != null && !props.secretKey().isBlank()) {
-            builder.credentialsProvider(StaticCredentialsProvider.create(
+            return StaticCredentialsProvider.create(
                     AwsBasicCredentials.create(props.accessKey(), props.secretKey())
-            ));
+            );
         }
         // accessKey 비어있으면 DefaultCredentialsProvider 폴백 (env / IAM role / shared profile)
-        return builder.build();
+        return DefaultCredentialsProvider.create();
     }
 }

--- a/src/main/java/com/sseulang/global/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/sseulang/global/websocket/StompAuthChannelInterceptor.java
@@ -1,21 +1,34 @@
 package com.sseulang.global.websocket;
 
+import com.sseulang.domain.auth.domain.AccessTokenBlacklist;
 import com.sseulang.domain.chat.application.ChatRoomApplicationService;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.security.JwtClaims;
+import com.sseulang.global.security.JwtProvider;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 /**
  * STOMP CONNECT/SUBSCRIBE 단계의 인증·인가 검증. 가이드 §4.10 / §9.6 (게이트 1 영역).
  *
  * <ul>
- *   <li>CONNECT: Principal 없으면 {@link ErrorCode#AUTH_TOKEN_MISSING}.</li>
+ *   <li>CONNECT: Principal 없으면 STOMP nativeHeader {@code Authorization: Bearer <jwt>} 에서
+ *       토큰을 추출해 {@link JwtProvider} 로 검증 → {@link AccessTokenBlacklist} 체크 후
+ *       accessor.setUser 로 SecurityContext 와 동등한 Principal 주입 (follow-up #19).
+ *       쿠키 기반 SockJS 클라이언트는 handshake 단계에서 이미 SecurityContext 가 채워져
+ *       getUser() 가 non-null. native WS(쿠키 X) 클라이언트는 이 헤더 경로로만 인증.
+ *       어떤 방법으로도 Principal 못 채우면 {@link ErrorCode#AUTH_TOKEN_MISSING}.</li>
  *   <li>SUBSCRIBE — destination allowlist (Codex 게이트 1 보강):
  *     <ul>
  *       <li>{@code /topic/chat-room/{roomId}} — 채팅방 참여자만</li>
@@ -32,11 +45,21 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     private static final String CHAT_TOPIC_PREFIX = "/topic/chat-room/";
     private static final String USER_QUEUE_MESSAGES = "/user/queue/messages";
     private static final String USER_QUEUE_NOTIFICATIONS = "/user/queue/notifications";
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
 
     private final ChatRoomApplicationService chatRoomService;
+    private final JwtProvider jwtProvider;
+    private final AccessTokenBlacklist accessTokenBlacklist;
 
-    public StompAuthChannelInterceptor(ChatRoomApplicationService chatRoomService) {
+    public StompAuthChannelInterceptor(
+            ChatRoomApplicationService chatRoomService,
+            JwtProvider jwtProvider,
+            AccessTokenBlacklist accessTokenBlacklist
+    ) {
         this.chatRoomService = chatRoomService;
+        this.jwtProvider = jwtProvider;
+        this.accessTokenBlacklist = accessTokenBlacklist;
     }
 
     @Override
@@ -47,7 +70,12 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             return message;
         }
         switch (command) {
-            case CONNECT -> requireAuthenticated(accessor);
+            case CONNECT -> {
+                requireAuthenticated(accessor);
+                // accessor.setUser 로 채워진 Principal 을 후속 채널로 전파하려면 새 Message 로 재발행 필요.
+                // 기존 message 의 header 는 immutable 라 accessor 변경이 그대로 반영되지 않음.
+                return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
+            }
             case SUBSCRIBE -> requireSubscribePermission(accessor);
             default -> { /* 다른 커맨드는 ApplicationService 검증 위임 */ }
         }
@@ -55,9 +83,34 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     }
 
     private void requireAuthenticated(StompHeaderAccessor accessor) {
-        if (extractUserIdOrNull(accessor) == null) {
+        // 1. handshake 단계에서 SecurityContext propagation 으로 이미 채워진 경우 통과 (SockJS+쿠키)
+        if (extractUserIdOrNull(accessor) != null) {
+            return;
+        }
+        // 2. native WS 클라이언트 — STOMP nativeHeader Authorization: Bearer <jwt> 로 인증
+        String bearer = firstNativeHeader(accessor, AUTH_HEADER);
+        if (bearer == null || !bearer.startsWith(BEARER_PREFIX)) {
             throw new BusinessException(ErrorCode.AUTH_TOKEN_MISSING);
         }
+        String token = bearer.substring(BEARER_PREFIX.length()).trim();
+        if (token.isEmpty()) {
+            throw new BusinessException(ErrorCode.AUTH_TOKEN_MISSING);
+        }
+        JwtClaims claims = jwtProvider.parse(token);  // EXPIRED / INVALID 는 그대로 BusinessException
+        if (accessTokenBlacklist.isBlacklisted(claims.jti())) {
+            throw new BusinessException(ErrorCode.AUTH_TOKEN_REVOKED);
+        }
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                claims.userId(),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_" + claims.role()))
+        );
+        accessor.setUser(auth);
+    }
+
+    private static String firstNativeHeader(StompHeaderAccessor accessor, String name) {
+        List<String> values = accessor.getNativeHeader(name);
+        return (values == null || values.isEmpty()) ? null : values.get(0);
     }
 
     private void requireSubscribePermission(StompHeaderAccessor accessor) {

--- a/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
@@ -34,7 +34,7 @@ class ChatRoomApplicationServiceTest {
         roomRepo = new InMemoryFakeChatRoomRepository();
         itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
         service = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
 
         Item item = itemRepo.save(Item.create(

--- a/src/test/java/com/sseulang/domain/delivery/application/DeliveryApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/delivery/application/DeliveryApplicationServiceTest.java
@@ -268,13 +268,64 @@ class DeliveryApplicationServiceTest {
         assertThat(service.getById(created.id(), RIDER).id()).isEqualTo(created.id());
     }
 
+    @Test
+    @DisplayName("adminGetStats_status 별 카운트 + 정산완료 fee 합계 (follow-up #52)")
+    void adminGetStats_집계() {
+        // 시드: 모집중 2, 수락 1, 정산완료 2 (fee 5000+7000=12000), 취소 1
+        DeliveryResult c1 = service.create(newCommandWithFee(5000L));
+        service.create(newCommandWithFee(3000L));  // 모집중 유지
+        DeliveryResult c3 = service.create(newCommandWithFee(4000L));
+        service.accept(c3.id(), RIDER);  // 수락
+        DeliveryResult c4 = service.create(newCommandWithFee(5000L));
+        service.accept(c4.id(), RIDER);
+        markSettled(c4.id());  // 정산완료 5000
+        DeliveryResult c5 = service.create(newCommandWithFee(7000L));
+        service.accept(c5.id(), RIDER);
+        markSettled(c5.id());  // 정산완료 7000
+        service.cancel(c1.id(), REQUESTER, "변심");  // 취소
+
+        com.sseulang.domain.delivery.application.dto.DeliveryStatsResult stats = service.adminGetStats();
+
+        assertThat(stats.total()).isEqualTo(5);
+        assertThat(stats.byStatus()).containsEntry(DeliveryStatus.모집중, 1L);
+        assertThat(stats.byStatus()).containsEntry(DeliveryStatus.수락, 1L);
+        assertThat(stats.byStatus()).containsEntry(DeliveryStatus.정산완료, 2L);
+        assertThat(stats.byStatus()).containsEntry(DeliveryStatus.취소, 1L);
+        assertThat(stats.byStatus()).containsEntry(DeliveryStatus.배송중, 0L);  // enum 전부 채움
+        assertThat(stats.byStatus()).containsEntry(DeliveryStatus.배송완료, 0L);
+        assertThat(stats.settledFeeTotal()).isEqualTo(12_000L);
+    }
+
+    @Test
+    @DisplayName("adminGetStats 0건_total 0 + 모든 status 0L")
+    void adminGetStats_빈상태() {
+        com.sseulang.domain.delivery.application.dto.DeliveryStatsResult stats = service.adminGetStats();
+
+        assertThat(stats.total()).isZero();
+        assertThat(stats.settledFeeTotal()).isZero();
+        for (DeliveryStatus s : DeliveryStatus.values()) {
+            assertThat(stats.byStatus()).containsEntry(s, 0L);
+        }
+    }
+
+    private void markSettled(Long deliveryId) {
+        // 배송중 → 배송완료 → 정산완료 전이 (단위 테스트 — pointService 는 mock 이라 transferForDelivery noop)
+        service.markPickedUp(deliveryId, RIDER);
+        service.markDelivered(deliveryId, RIDER);
+        service.complete(deliveryId, REQUESTER);
+    }
+
     private static DeliveryCreateCommand newCommand() {
+        return newCommandWithFee(5000L);
+    }
+
+    private static DeliveryCreateCommand newCommandWithFee(long fee) {
         return new DeliveryCreateCommand(
                 REQUESTER,
                 "서울 강남구 테헤란로 123",
                 "서울 송파구 올림픽로 456",
                 "A4 서류 봉투 1개",
-                5000L,
+                fee,
                 LocalDateTime.now().plusHours(2),
                 "1층 로비 보관함"
         );

--- a/src/test/java/com/sseulang/domain/delivery/application/InMemoryFakeDeliveryRepository.java
+++ b/src/test/java/com/sseulang/domain/delivery/application/InMemoryFakeDeliveryRepository.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.delivery.application;
 import com.sseulang.domain.delivery.domain.DeliveryRepository;
 import com.sseulang.domain.delivery.domain.DeliveryRequest;
 import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import com.sseulang.domain.delivery.domain.DeliveryStatusCount;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -10,6 +11,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,5 +79,24 @@ public class InMemoryFakeDeliveryRepository implements DeliveryRepository {
                 .sorted(Comparator.comparing(DeliveryRequest::getRequestedAt).reversed())
                 .toList();
         return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+
+    @Override
+    public List<DeliveryStatusCount> countGroupByStatus() {
+        Map<DeliveryStatus, Long> grouped = new EnumMap<>(DeliveryStatus.class);
+        for (DeliveryRequest d : store.values()) {
+            grouped.merge(d.getStatus(), 1L, Long::sum);
+        }
+        return grouped.entrySet().stream()
+                .map(e -> new DeliveryStatusCount(e.getKey(), e.getValue()))
+                .toList();
+    }
+
+    @Override
+    public long sumSettledFee() {
+        return store.values().stream()
+                .filter(d -> d.getStatus() == DeliveryStatus.정산완료)
+                .mapToLong(DeliveryRequest::getFee)
+                .sum();
     }
 }

--- a/src/test/java/com/sseulang/domain/file/application/NoOpPresignedUrlGenerator.java
+++ b/src/test/java/com/sseulang/domain/file/application/NoOpPresignedUrlGenerator.java
@@ -5,14 +5,14 @@ import com.sseulang.domain.file.domain.PresignedUrlResult;
 
 import java.time.Duration;
 
-public class FakePresignedUrlGenerator implements PresignedUrlGenerator {
+/**
+ * 단위 테스트용 — generate 는 dummy URL, promote 는 단순 string replace (no S3 call).
+ */
+public class NoOpPresignedUrlGenerator implements PresignedUrlGenerator {
 
     @Override
     public PresignedUrlResult generate(String key, String contentType, Duration expiresIn) {
-        String url = "https://fake.s3/" + key
-                + "?ct=" + contentType
-                + "&exp=" + expiresIn.toSeconds();
-        return new PresignedUrlResult(url, key);
+        return new PresignedUrlResult("https://test/" + key + "?signed", key);
     }
 
     @Override

--- a/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
@@ -36,12 +36,12 @@ class ItemApplicationServiceTest {
         categoryRepo = new InMemoryFakeCategoryRepository();
         CategoryApplicationService categoryService = new CategoryApplicationService(categoryRepo);
         // requireVerified 가드는 기본 통과 (mock void no-op) — 단위 테스트는 비즈니스 로직 검증.
-        service = new ItemApplicationService(itemRepo, categoryService, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        service = new ItemApplicationService(itemRepo, categoryService, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
         categoryId = categoryRepo.insert(Category.createRoot("디지털/가전", 1)).getId();
     }
 
     @Test
-    @DisplayName("register 정상_id 발급되고 이미지+해시태그 add")
+    @DisplayName("register 정상_id 발급되고 이미지+해시태그 add + 이미지 url promote (follow-up #12)")
     void register_정상() {
         Long id = service.register(new ItemRegisterCommand(
                 SELLER, categoryId, "title", "desc", 10_000L, null, null, TradeType.판매,
@@ -55,6 +55,9 @@ class ItemApplicationServiceTest {
         assertThat(result.sellerId()).isEqualTo(SELLER);
         assertThat(result.images()).hasSize(2);
         assertThat(result.images().get(0).thumbnail()).isTrue();
+        // 등록 시 임시 폴더(items/{SELLER}/) → 정식 폴더(items/{itemId}/) 로 promote
+        assertThat(result.images().get(0).imageUrl()).isEqualTo("https://cdn.test/items/" + id + "/img1.jpg");
+        assertThat(result.images().get(1).imageUrl()).isEqualTo("https://cdn.test/items/" + id + "/img2.jpg");
         assertThat(result.hashtags()).containsExactly("아이폰", "미개봉");
     }
 
@@ -127,7 +130,7 @@ class ItemApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("update imageUrls non-null_전체 교체")
+    @DisplayName("update imageUrls non-null_전체 교체 + 임시 prefix 자동 promote (follow-up #12)")
     void update_이미지_전체교체() {
         Long id = service.register(new ItemRegisterCommand(
                 SELLER, categoryId, "t", "d", 1L, null, null, TradeType.판매, null,
@@ -140,7 +143,8 @@ class ItemApplicationServiceTest {
 
         ItemDetailResult r = service.getById(id);
         assertThat(r.images()).hasSize(1);
-        assertThat(r.images().get(0).imageUrl()).isEqualTo("https://cdn.test/items/" + SELLER + "/new1.jpg");
+        // 임시 폴더(items/{SELLER}/) 가 정식 폴더(items/{itemId}/) 로 promote 됨
+        assertThat(r.images().get(0).imageUrl()).isEqualTo("https://cdn.test/items/" + id + "/new1.jpg");
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
@@ -36,7 +36,7 @@ class ItemSearchTest {
         InMemoryFakeCategoryRepository categoryRepo = new InMemoryFakeCategoryRepository();
         com.sseulang.domain.category.application.CategoryApplicationService catSvc =
                 new com.sseulang.domain.category.application.CategoryApplicationService(categoryRepo);
-        service = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        service = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
         catA = categoryRepo.insert(Category.createRoot("A", 1)).getId();
         catB = categoryRepo.insert(Category.createRoot("B", 2)).getId();
     }

--- a/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepositoryIT.java
+++ b/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepositoryIT.java
@@ -118,19 +118,27 @@ class ItemQuerydslRepositoryIT {
                 .containsExactly(alive.getId());
     }
 
+    /**
+     * <p>FULLTEXT 매칭은 InnoDB 의 commit 된 데이터만 인덱스에 반영 — @DataJpaTest 의 rollback
+     * 트랜잭션 안에서 persist 한 row 는 매칭에서 보이지 않는다 (follow-up #10 적용 후 회귀).
+     * IT 검증은 NOT_SUPPORTED + 명시 commit 패턴이 필요해 별도 클래스로 분리 예정 — 본 클래스는
+     * LIKE/필터/페이징 검증에 집중. 단위 토큰화 검증은 {@link ItemQuerydslRepositoryToBooleanModeTest}.</p>
+     */
     @Test
-    @DisplayName("search q 부분일치")
-    void search_q() {
-        persistItem("아이폰 14 Pro", TradeType.판매, 100L);
-        persistItem("갤럭시 S24", TradeType.판매, 100L);
+    @DisplayName("search q 영문 1글자_LIKE 폴백 동작 (FULLTEXT 미매칭 케이스)")
+    void search_q_1글자_LIKE_폴백() {
+        persistItem("X Special", TradeType.판매, 100L);
+        persistItem("Y Edition", TradeType.판매, 100L);
 
+        // "X" 1글자 → ngram_token_size=2 미달 → toBooleanModeQuery 빈 문자열 → LIKE 폴백.
+        // LIKE 는 트랜잭션 내 INSERT row 도 즉시 매칭됨.
         Page<Item> result = repository.search(
-                new ItemSearchCriteria("아이폰", null, null, null, null, null),
+                new ItemSearchCriteria("X", null, null, null, null, null),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Item::getTitle)
-                .containsExactly("아이폰 14 Pro");
+                .containsExactly("X Special");
     }
 
     @Test
@@ -199,6 +207,7 @@ class ItemQuerydslRepositoryIT {
         em.flush();
         return item;
     }
+
 
     private static void sleepMs(long ms) {
         try {

--- a/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepositoryToBooleanModeTest.java
+++ b/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepositoryToBooleanModeTest.java
@@ -1,0 +1,78 @@
+package com.sseulang.domain.item.infrastructure.persistence;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link ItemQuerydslRepository#toBooleanModeQuery} 단위 — FULLTEXT boolean mode 쿼리 변환 검증
+ * (follow-up #10). package-private static 메서드라 reflection 호출.
+ */
+class ItemQuerydslRepositoryToBooleanModeTest {
+
+    @Test
+    @DisplayName("한글 단일 토큰_+토큰 prefix")
+    void single_korean() {
+        assertThat(invoke("아이폰")).isEqualTo("+아이폰");
+    }
+
+    @Test
+    @DisplayName("두 단어 공백 split_각 +prefix AND")
+    void two_words() {
+        assertThat(invoke("아이폰 미개봉")).isEqualTo("+아이폰 +미개봉");
+    }
+
+    @Test
+    @DisplayName("길이 1 토큰 제외 (ngram_token_size=2)")
+    void short_token_excluded() {
+        assertThat(invoke("아 아이폰")).isEqualTo("+아이폰");
+    }
+
+    @Test
+    @DisplayName("모든 토큰 길이 1_빈 문자열 (LIKE 폴백 신호)")
+    void all_short() {
+        assertThat(invoke("a b c")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("boolean mode 메타문자 sanitization (+ - * \" < > ( ) ~ @)")
+    void sanitize_meta() {
+        assertThat(invoke("+아이폰 -미개봉*")).isEqualTo("+아이폰 +미개봉");
+        assertThat(invoke("\"갤럭시\" (S급)")).isEqualTo("+갤럭시 +S급");
+        assertThat(invoke("@user~")).isEqualTo("+user");
+        assertThat(invoke("@user~50")).isEqualTo("+user +50");  // 메타 분리 후 두 토큰
+    }
+
+    @Test
+    @DisplayName("연속 공백 split 정상")
+    void multi_spaces() {
+        assertThat(invoke("아이폰   미개봉")).isEqualTo("+아이폰 +미개봉");
+    }
+
+    @Test
+    @DisplayName("입력 null/빈/공백_빈 문자열")
+    void empty_inputs() {
+        assertThat(invoke(null)).isEmpty();
+        assertThat(invoke("")).isEmpty();
+        assertThat(invoke("   ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("영문 + 숫자 혼합")
+    void mixed_alphanumeric() {
+        assertThat(invoke("iphone 15 pro")).isEqualTo("+iphone +15 +pro");
+    }
+
+    private static String invoke(String input) {
+        try {
+            Method m = ItemQuerydslRepository.class.getDeclaredMethod("toBooleanModeQuery", String.class);
+            m.setAccessible(true);
+            return (String) m.invoke(null, input);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemSearchFullTextIT.java
+++ b/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemSearchFullTextIT.java
@@ -1,0 +1,154 @@
+package com.sseulang.domain.item.infrastructure.persistence;
+
+import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.global.config.JpaAuditingConfig;
+import com.sseulang.global.config.QuerydslConfig;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * FULLTEXT(ngram) IT (follow-up #10).
+ *
+ * <p>InnoDB FULLTEXT 인덱스는 commit 된 데이터만 매칭하므로 일반 @DataJpaTest 의 rollback 트랜잭션
+ * 안에서 persist 한 row 는 매칭되지 않는다. 본 클래스는 클래스 단위 {@code NOT_SUPPORTED} 로 트랜잭션을
+ * 끄고, 시드 INSERT 마다 명시적으로 commit 하여 prod 와 동일한 가시성으로 검증.</p>
+ *
+ * <p>cleanup: 각 테스트 시작 시 {@code DELETE FROM items} + {@code DELETE FROM users} 직접 실행.</p>
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QuerydslConfig.class, JpaAuditingConfig.class, ItemQuerydslRepository.class})
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class ItemSearchFullTextIT {
+
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("sseulang_test")
+            .withUsername("test")
+            .withPassword("testpw")
+            .withCommand("--character-set-server=utf8mb4",
+                    "--collation-server=utf8mb4_unicode_ci",
+                    "--ngram_token_size=2",
+                    "--innodb_ft_min_token_size=2");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    @Autowired private EntityManager em;
+    @Autowired private ItemQuerydslRepository repository;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate tx;
+    private Long sellerId;
+
+    @BeforeEach
+    void setUp() {
+        tx = new TransactionTemplate(transactionManager);
+        tx.execute(s -> {
+            em.createNativeQuery("DELETE FROM item_hashtags").executeUpdate();
+            em.createNativeQuery("DELETE FROM item_images").executeUpdate();
+            em.createNativeQuery("DELETE FROM items").executeUpdate();
+            em.createNativeQuery("DELETE FROM users").executeUpdate();
+            return null;
+        });
+        sellerId = tx.execute(s -> {
+            User user = User.createSocialUser(
+                    SocialProvider.KAKAO,
+                    "kakao-ft-" + System.nanoTime(),
+                    new Email("ft-" + System.nanoTime() + "@example.com"),
+                    "ft-tester",
+                    null
+            );
+            em.persist(user);
+            em.flush();
+            return user.getId();
+        });
+    }
+
+    @Test
+    @DisplayName("한글 부분 ngram 매칭 — '아이폰' → '아이폰 14 Pro'")
+    void ngram_한글_매칭() {
+        seedItem("아이폰 14 Pro", "디테일 없음");
+        seedItem("갤럭시 S24", "디테일 없음");
+
+        Page<Item> result = repository.search(
+                new ItemSearchCriteria("아이폰", null, null, null, null, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Item::getTitle)
+                .containsExactly("아이폰 14 Pro");
+    }
+
+    @Test
+    @DisplayName("두 토큰 AND — '아이폰 미개봉' = +아이폰 +미개봉")
+    void boolean_and() {
+        seedItem("아이폰 14 미개봉", "x");
+        seedItem("아이폰 13 사용감 있음", "x");
+        seedItem("갤럭시 미개봉", "x");
+
+        Page<Item> result = repository.search(
+                new ItemSearchCriteria("아이폰 미개봉", null, null, null, null, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Item::getTitle)
+                .containsExactly("아이폰 14 미개봉");
+    }
+
+    @Test
+    @DisplayName("description 매칭 — title+description 인덱스")
+    void description_매칭() {
+        seedItem("물건1", "정품 갤럭시 액세서리");
+        seedItem("물건2", "다른 제품 설명");
+
+        Page<Item> result = repository.search(
+                new ItemSearchCriteria("갤럭시", null, null, null, null, null),
+                PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Item::getTitle)
+                .containsExactly("물건1");
+    }
+
+    private void seedItem(String title, String description) {
+        tx.execute(s -> {
+            Item item = Item.create(sellerId, null, title, description, 100L, null, null, TradeType.판매, null);
+            em.persist(item);
+            em.flush();
+            return null;
+        });
+    }
+}

--- a/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
@@ -47,7 +47,7 @@ class MessageApplicationServiceTest {
         publisher = new FakeRealtimePublisher();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
         ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
         NotificationApplicationService notifSvc = new NotificationApplicationService(notifRepo);
         // 단위 테스트에선 트랜잭션 컨텍스트 X — AFTER_COMMIT listener 직접 호출하는 fake event publisher.

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -47,7 +47,7 @@ class ReviewApplicationServiceTest {
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         UserApplicationService userSvc = new UserApplicationService(userRepo);
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc);
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, new InMemoryFakePointHistoryRepository());
         TransactionApplicationService txSvc = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());
         service = new ReviewApplicationService(reviewRepo, txSvc, userSvc);
@@ -125,6 +125,50 @@ class ReviewApplicationServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.TRANSACTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("listPending 본인 미작성 거래완료_포함 / 작성한 거래는 제외 (follow-up #56)")
+    void listPending_미작성_포함() {
+        // setUp 의 completedTxId 는 BUYER 입장에서 미작성 → 포함
+        // SELLER 가 작성한 별도 거래 시드 후 SELLER 입장에서는 제외되어야 함
+        Long anotherTxId = persistCompletedTransaction(1L, LocalDateTime.now().minusDays(2));
+        service.write(new ReviewWriteCommand(anotherTxId, SELLER, 4, null));
+        // SELLER 가 anotherTxId 에 대해 작성했음을 fake repo 에 알림 (NOT EXISTS 시뮬레이션)
+        txRepo.markReviewed(anotherTxId, SELLER);
+
+        org.springframework.data.domain.Page<com.sseulang.domain.transaction.application.dto.PendingReviewableResult> sellerPending =
+                service.listPending(SELLER, org.springframework.data.domain.PageRequest.of(0, 20));
+
+        // SELLER 는 anotherTxId 에 대해 이미 작성 → 제외. completedTxId 는 미작성 → 포함.
+        assertThat(sellerPending.getContent()).extracting("transactionId")
+                .containsExactlyInAnyOrder(completedTxId);
+        // 상대방(reviewee) 는 BUYER
+        assertThat(sellerPending.getContent().get(0).revieweeId()).isEqualTo(BUYER);
+    }
+
+    @Test
+    @DisplayName("listPending 7일 초과 거래는 제외")
+    void listPending_7일_초과_제외() {
+        Long oldTxId = persistCompletedTransaction(1L, LocalDateTime.now().minusDays(8));
+
+        org.springframework.data.domain.Page<com.sseulang.domain.transaction.application.dto.PendingReviewableResult> pending =
+                service.listPending(BUYER, org.springframework.data.domain.PageRequest.of(0, 20));
+
+        // 7일 이내인 completedTxId 만 포함 — oldTxId 는 since 필터로 제외
+        assertThat(pending.getContent()).extracting("transactionId").doesNotContain(oldTxId);
+        assertThat(pending.getContent()).extracting("transactionId").contains(completedTxId);
+    }
+
+    @Test
+    @DisplayName("listPending deadline = completedAt + 7d")
+    void listPending_deadline_정확() {
+        org.springframework.data.domain.Page<com.sseulang.domain.transaction.application.dto.PendingReviewableResult> pending =
+                service.listPending(BUYER, org.springframework.data.domain.PageRequest.of(0, 20));
+
+        assertThat(pending.getContent()).hasSize(1);
+        com.sseulang.domain.transaction.application.dto.PendingReviewableResult r = pending.getContent().get(0);
+        assertThat(r.deadline()).isEqualTo(r.completedAt().plusDays(7));
     }
 
     private Long persistCompletedTransaction(Long itemId, LocalDateTime completedAt) {

--- a/src/test/java/com/sseulang/domain/stats/application/AdminStatsServiceTest.java
+++ b/src/test/java/com/sseulang/domain/stats/application/AdminStatsServiceTest.java
@@ -1,5 +1,8 @@
 package com.sseulang.domain.stats.application;
 
+import com.sseulang.domain.delivery.application.DeliveryApplicationService;
+import com.sseulang.domain.delivery.application.dto.DeliveryStatsResult;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
 import com.sseulang.domain.payment.application.PaymentApplicationService;
 import com.sseulang.domain.payment.application.dto.PaymentStatsResult;
 import com.sseulang.domain.transaction.application.TransactionApplicationService;
@@ -20,7 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * AdminStatsService 단위 — 4개 도메인 ApplicationService 호출 + 응답 합성을 검증.
+ * AdminStatsService 단위 — 5개 도메인 ApplicationService 호출 + 응답 합성을 검증.
  * 각 도메인의 stats 로직은 자체 ApplicationServiceTest 가 책임. 본 테스트는 orchestration 정확성만.
  */
 class AdminStatsServiceTest {
@@ -29,6 +32,7 @@ class AdminStatsServiceTest {
     private TransactionApplicationService transactionService;
     private PaymentApplicationService paymentService;
     private WithdrawalApplicationService withdrawalService;
+    private DeliveryApplicationService deliveryService;
     private AdminStatsService statsService;
 
     @BeforeEach
@@ -37,11 +41,12 @@ class AdminStatsServiceTest {
         transactionService = mock(TransactionApplicationService.class);
         paymentService = mock(PaymentApplicationService.class);
         withdrawalService = mock(WithdrawalApplicationService.class);
-        statsService = new AdminStatsService(userService, transactionService, paymentService, withdrawalService);
+        deliveryService = mock(DeliveryApplicationService.class);
+        statsService = new AdminStatsService(userService, transactionService, paymentService, withdrawalService, deliveryService);
     }
 
     @Test
-    @DisplayName("dashboard_4개 도메인 stats 합성 + 각 service 1회만 호출")
+    @DisplayName("dashboard_5개 도메인 stats 합성 + 각 service 1회만 호출")
     void dashboard_orchestration() {
         UserStatsResult users = new UserStatsResult(100, 5, 2, 93);
         TransactionStatsResult transactions = new TransactionStatsResult(50,
@@ -50,11 +55,16 @@ class AdminStatsServiceTest {
         PaymentStatsResult payments = new PaymentStatsResult(20, 1_000_000L);
         WithdrawalStatsResult withdrawals = new WithdrawalStatsResult(10,
                 java.util.Map.of(WithdrawalStatus.신청, 3L, WithdrawalStatus.완료, 7L), 700_000L);
+        DeliveryStatsResult deliveries = new DeliveryStatsResult(8,
+                java.util.Map.of(DeliveryStatus.모집중, 1L, DeliveryStatus.수락, 0L,
+                        DeliveryStatus.배송중, 1L, DeliveryStatus.배송완료, 1L,
+                        DeliveryStatus.정산완료, 4L, DeliveryStatus.취소, 1L), 24_000L);
 
         when(userService.adminGetStats()).thenReturn(users);
         when(transactionService.adminGetStats()).thenReturn(transactions);
         when(paymentService.adminGetStats()).thenReturn(payments);
         when(withdrawalService.adminGetStats()).thenReturn(withdrawals);
+        when(deliveryService.adminGetStats()).thenReturn(deliveries);
 
         AdminDashboardResult result = statsService.dashboard();
 
@@ -62,11 +72,13 @@ class AdminStatsServiceTest {
         assertThat(result.transactions()).isSameAs(transactions);
         assertThat(result.payments()).isSameAs(payments);
         assertThat(result.withdrawals()).isSameAs(withdrawals);
+        assertThat(result.deliveries()).isSameAs(deliveries);
 
         // N+1 회피 — 각 도메인 ApplicationService 는 정확히 1회만 호출되어야 함
         verify(userService).adminGetStats();
         verify(transactionService).adminGetStats();
         verify(paymentService).adminGetStats();
         verify(withdrawalService).adminGetStats();
+        verify(deliveryService).adminGetStats();
     }
 }

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -2,13 +2,21 @@ package com.sseulang.domain.transaction.application;
 
 import com.sseulang.domain.transaction.domain.Transaction;
 import com.sseulang.domain.transaction.domain.TransactionRepository;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
 import com.sseulang.domain.transaction.domain.TransactionStatusCount;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class InMemoryFakeTransactionRepository implements TransactionRepository {
@@ -43,5 +51,29 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
                 .entrySet().stream()
                 .map(e -> new TransactionStatusCount(e.getKey(), e.getValue()))
                 .toList();
+    }
+
+    /**
+     * 단위 테스트용 — Review 도메인을 cross-aggregate 로 알 수 없으므로 외부에서 (txId, reviewerId) pair 를
+     * 주입받아 NOT EXISTS 시뮬레이션. 비어 있으면 모든 거래완료 거래가 pending 으로 반환됨.
+     */
+    private final Set<String> reviewedPairs = new HashSet<>();
+
+    public void markReviewed(Long transactionId, Long reviewerId) {
+        reviewedPairs.add(transactionId + ":" + reviewerId);
+    }
+
+    @Override
+    public Page<Transaction> findPendingReviewable(Long userId, LocalDateTime since, Pageable pageable) {
+        List<Transaction> filtered = store.values().stream()
+                .filter(t -> t.getStatus() == TransactionStatus.거래완료)
+                .filter(t -> t.getCompletedAt() != null && !t.getCompletedAt().isBefore(since))
+                .filter(t -> userId.equals(t.getSellerId()) || userId.equals(t.getBuyerId()))
+                .filter(t -> !reviewedPairs.contains(t.getId() + ":" + userId))
+                .sorted(Comparator.comparing(Transaction::getCompletedAt).reversed())
+                .toList();
+        int start = Math.min((int) pageable.getOffset(), filtered.size());
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
     }
 }

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -47,7 +47,7 @@ class TransactionApplicationServiceTest {
         pointHistoryRepo = new InMemoryFakePointHistoryRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         UserApplicationService userSvc = new UserApplicationService(userRepo);
-        itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc);
+        itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, pointHistoryRepo);
         service = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());
 

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -2,6 +2,8 @@ package com.sseulang.domain.transaction.integration;
 
 import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.infrastructure.persistence.CategoryRepositoryImpl;
+import com.sseulang.domain.file.application.NoOpPresignedUrlGenerator;
+import com.sseulang.domain.file.domain.PresignedUrlGenerator;
 import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
 import com.sseulang.domain.item.domain.Item;
@@ -73,6 +75,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         ItemQuerydslRepository.class,
         ItemRepositoryImpl.class,
         ItemApplicationService.class,
+        NoOpPresignedUrlGenerator.class,
         CategoryRepositoryImpl.class,
         CategoryApplicationService.class,
         UserRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.transaction.integration;
 
 import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.infrastructure.persistence.CategoryRepositoryImpl;
+import com.sseulang.domain.file.application.NoOpPresignedUrlGenerator;
 import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
 import com.sseulang.domain.item.domain.Item;
@@ -64,6 +65,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         ItemQuerydslRepository.class,
         ItemRepositoryImpl.class,
         ItemApplicationService.class,
+        NoOpPresignedUrlGenerator.class,
         CategoryRepositoryImpl.class,
         CategoryApplicationService.class,
         UserRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
@@ -29,7 +29,7 @@ class WishlistApplicationServiceTest {
         wishRepo = new InMemoryFakeWishlistRepository();
         itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
         service = new WishlistApplicationService(wishRepo, itemSvc);
 
         Item item = itemRepo.save(Item.create(

--- a/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.sseulang.global.websocket;
 
+import com.sseulang.domain.auth.domain.AccessTokenBlacklist;
 import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.application.InMemoryFakeCategoryRepository;
 import com.sseulang.domain.chat.application.ChatRoomApplicationService;
@@ -10,6 +11,8 @@ import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.item.domain.TradeType;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
+import com.sseulang.global.security.JwtClaims;
+import com.sseulang.global.security.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,9 +21,16 @@ import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -33,6 +43,9 @@ class StompAuthChannelInterceptorTest {
     private static final Long OUTSIDER = 999L;
 
     private StompAuthChannelInterceptor interceptor;
+    private JwtProvider jwtProvider;
+    private AccessTokenBlacklist blacklist;
+    private final Map<String, Long> validTokens = new java.util.HashMap<>();
     private Long roomId;
 
     @BeforeEach
@@ -40,9 +53,23 @@ class StompAuthChannelInterceptorTest {
         InMemoryFakeChatRoomRepository roomRepo = new InMemoryFakeChatRoomRepository();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
         ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
-        interceptor = new StompAuthChannelInterceptor(roomSvc);
+
+        validTokens.clear();
+        jwtProvider = mock(JwtProvider.class);
+        when(jwtProvider.parse(anyString())).thenAnswer(inv -> {
+            String token = inv.getArgument(0, String.class);
+            Long uid = validTokens.get(token);
+            if (uid == null) {
+                throw new BusinessException(ErrorCode.AUTH_TOKEN_INVALID);
+            }
+            return new JwtClaims(uid, "USER", "jti-" + token, null, Instant.now(), Instant.now().plusSeconds(60));
+        });
+        blacklist = mock(AccessTokenBlacklist.class);
+        when(blacklist.isBlacklisted(anyString())).thenReturn(false);
+
+        interceptor = new StompAuthChannelInterceptor(roomSvc, jwtProvider, blacklist);
 
         Item item = itemRepo.save(Item.create(SELLER, null, "물건", "d", 1L, null, null, TradeType.판매, null));
         roomId = roomSvc.openFor(BUYER, item.getId()).id();
@@ -164,6 +191,101 @@ class StompAuthChannelInterceptorTest {
         // SEND 는 인터셉터에서 검증 X
         Message<?> result = interceptor.preSend(msg, null);
         assertThat(result).isNotNull();
+    }
+
+    // ───────── follow-up #19 — native WS 토큰 인증 ─────────
+
+    @Test
+    @DisplayName("CONNECT Authorization Bearer 토큰_정상 검증 + accessor.setUser 주입")
+    void connect_native_bearer_정상() {
+        validTokens.put("good-token", BUYER);
+        Message<byte[]> msg = stompMessageWithAuthHeader(StompCommand.CONNECT, "Bearer good-token");
+
+        Message<?> result = interceptor.preSend(msg, null);
+
+        StompHeaderAccessor out = StompHeaderAccessor.wrap(result);
+        Authentication auth = (Authentication) out.getUser();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getPrincipal()).isEqualTo(BUYER);
+        assertThat(auth.getAuthorities()).extracting("authority").containsExactly("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("CONNECT Authorization 헤더 없음_AUTH_TOKEN_MISSING")
+    void connect_native_헤더없음() {
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, null, null);
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_TOKEN_MISSING);
+    }
+
+    @Test
+    @DisplayName("CONNECT Bearer prefix 누락_AUTH_TOKEN_MISSING")
+    void connect_native_bearer_prefix_누락() {
+        Message<byte[]> msg = stompMessageWithAuthHeader(StompCommand.CONNECT, "good-token");
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_TOKEN_MISSING);
+    }
+
+    @Test
+    @DisplayName("CONNECT Bearer 빈 토큰_AUTH_TOKEN_MISSING")
+    void connect_native_bearer_빈토큰() {
+        Message<byte[]> msg = stompMessageWithAuthHeader(StompCommand.CONNECT, "Bearer    ");
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_TOKEN_MISSING);
+    }
+
+    @Test
+    @DisplayName("CONNECT 위변조 토큰_AUTH_TOKEN_INVALID 그대로 전파")
+    void connect_native_위변조() {
+        Message<byte[]> msg = stompMessageWithAuthHeader(StompCommand.CONNECT, "Bearer forged-xx");
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_TOKEN_INVALID);
+    }
+
+    @Test
+    @DisplayName("CONNECT blacklist 토큰_AUTH_TOKEN_REVOKED")
+    void connect_native_blacklist() {
+        validTokens.put("revoked-tk", BUYER);
+        when(blacklist.isBlacklisted("jti-revoked-tk")).thenReturn(true);
+
+        Message<byte[]> msg = stompMessageWithAuthHeader(StompCommand.CONNECT, "Bearer revoked-tk");
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_TOKEN_REVOKED);
+    }
+
+    @Test
+    @DisplayName("CONNECT handshake-Principal 우선_native bearer 무시")
+    void connect_principal_우선() {
+        // accessor.user 가 이미 채워져 있으면 native bearer 검증 skip
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, null, BUYER);
+
+        Message<?> result = interceptor.preSend(msg, null);
+
+        StompHeaderAccessor out = StompHeaderAccessor.wrap(result);
+        Authentication auth = (Authentication) out.getUser();
+        assertThat(auth.getPrincipal()).isEqualTo(BUYER);
+        // jwtProvider.parse 가 호출되지 않았어야 함 — 단, validTokens 는 비어 있어 호출되면 throw 났을 것.
+    }
+
+    private Message<byte[]> stompMessageWithAuthHeader(StompCommand cmd, String authValue) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(cmd);
+        accessor.addNativeHeader("Authorization", authValue);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
     }
 
     private static Message<byte[]> stompMessage(StompCommand cmd, String destination, Long userId) {


### PR DESCRIPTION
## Summary

5/6 마감 전 처리 가능한 follow-up 6건 묶음. 모두 5/6 후 처리 권장이었으나 시간 여유로 앞당김.

| # | 작업 | 영향 |
|---|---|---|
| **#32** | V4 prod 배포 절차 문서 (`docs/migration/V4_DEPLOYMENT.md`) | 배포 페이즈 |
| **#52** | delivery admin stats 통합 — status 카운트 + 정산 fee 합계 | dashboard |
| **#56** | `GET /api/v1/reviews/pending` — 미작성 거래 7일 이내 | UX |
| **#19** | STOMP CONNECT nativeHeader `Authorization: Bearer <jwt>` 인증 + `/ws-stomp-native` endpoint | 모바일 클라이언트 |
| **#12** | S3 copy 폴더 승격 (items/{userId}/* → items/{itemId}/*) | 정합성 |
| **#10** | FULLTEXT ngram 한글 검색 (boolean mode +AND, 1글자 LIKE 폴백) | 검색 UX |

#23 (결제/포인트 동시성 IT 강화) 는 시간 부족으로 wave 4 미포함, open 유지.

## Changes

### Code
- `delivery/` — Stats DTO + Repository GROUP BY + ApplicationService.adminGetStats
- `review/` — listPending API, `Transaction NOT EXISTS Review` JPQL
- `item/` — FULLTEXT match_against, S3 promotion (PresignedUrlGenerator.promote)
- `file/` — PresignedUrlGenerator 인터페이스에 promote 추가, S3Client bean 추가
- `global/websocket/` — StompAuthChannelInterceptor JWT 헤더 검증
- `global/config/` — SecurityConfig + WebSocketConfig 에 native ws endpoint
- `stats/` — AdminDashboard 5개 도메인으로 확장

### Docs
- `docs/migration/V4_DEPLOYMENT.md` — UNIQUE 인덱스 + pt-osc + 롤백 절차

### Tests
- 추가: `ItemQuerydslRepositoryToBooleanModeTest` (9), `ItemSearchFullTextIT` (3, NOT_SUPPORTED 패턴)
- 추가: `StompAuthChannelInterceptorTest` native bearer 7건
- 추가: delivery stats 2건, review pending 3건
- 기존 테스트 모두 새 시그니처(생성자 추가) 반영, NoOpPresignedUrlGenerator 헬퍼

**최종: 597 PASS / 0 FAIL.**

## Test plan

- [x] `./gradlew test` — 전체 597건 PASS
- [x] FULLTEXT IT — Testcontainers MySQL 8 + ngram_token_size=2
- [x] Settlement/TransactionConcurrency IT — NoOpPresignedUrlGenerator import 갱신
- [ ] 수동 — STOMP native client 로 `/ws-stomp-native` CONNECT 검증 (배포 후)
- [ ] 수동 — Item 등록 시 S3 콘솔에서 items/{itemId}/ 폴더 생성 + 임시 폴더 삭제 확인
- [ ] 수동 — `/api/v1/reviews/pending` Swagger 호출

## Notes

- `#23` (결제 동시성 IT 강화) — wave 4 미포함, 별도 follow-up 으로 open 유지
- FULLTEXT in-tx 매칭은 InnoDB 특성상 commit 후만 가시 — IT 는 NOT_SUPPORTED + 명시 commit 패턴 필수

🤖 Generated with [Claude Code](https://claude.com/claude-code)