### PR TITLE
docs(swagger): Controller @Tag 일괄 + OpenApiConfig 보강 + Response @Schema

### DIFF
--- a/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
+++ b/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.auth.application.dto.TokenPair;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.security.CookieUtil;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 관리자 로그인 진입점. SecurityConfig 의 {@code /api/v1/auth/**} permitAll 영역.
  * 일반 사용자 OAuth 흐름 ({@link com.sseulang.domain.auth.presentation.AuthController}) 와 분리.
  */
+@Tag(name = "AdminAuth", description = "관리자 로그인")
 @RestController
 @RequestMapping("/api/v1/auth/admin")
 public class AdminAuthController {

--- a/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.auth.application.EmailVerificationService;
 import com.sseulang.domain.auth.presentation.dto.VerifyEmailRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
  *   <li>{@code /resend-verification} — auth 필수 (hasRole("USER")) + CSRF 적용 (게이트 1 round 2 보강)</li>
  * </ul>
  */
+@Tag(name = "EmailVerification", description = "이메일 인증 메일 발송/확인")
 @RestController
 @RequestMapping("/api/v1/auth")
 public class EmailVerificationController {

--- a/src/main/java/com/sseulang/domain/banner/presentation/AdminBannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/AdminBannerController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.banner.presentation.dto.BannerUpsertRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "AdminBanner", description = "관리자 — 배너 관리")
 @RestController
 @RequestMapping("/api/v1/admin/banners")
 public class AdminBannerController {

--- a/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.banner.presentation;
 import com.sseulang.domain.banner.application.BannerApplicationService;
 import com.sseulang.domain.banner.presentation.dto.BannerResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 /** 사용자 활성 배너 목록 — sort_order 정렬. */
+@Tag(name = "Banner", description = "배너 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/banners")
 public class BannerController {

--- a/src/main/java/com/sseulang/domain/block/presentation/UserBlockController.java
+++ b/src/main/java/com/sseulang/domain/block/presentation/UserBlockController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.block.presentation.dto.UserBlockResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "UserBlock", description = "사용자 차단/해제")
 @RestController
 @RequestMapping("/api/v1/blocks")
 public class UserBlockController {

--- a/src/main/java/com/sseulang/domain/category/presentation/CategoryController.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/CategoryController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.presentation.dto.CategoryNodeResponse;
 import com.sseulang.domain.category.presentation.dto.CategoryResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Category", description = "카테고리 트리 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/categories")
 public class CategoryController {

--- a/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.chat.presentation.dto.ChatRoomResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "ChatRoom", description = "1:1 채팅방 개설/조회")
 @RestController
 @RequestMapping("/api/v1/chat-rooms")
 public class ChatRoomController {

--- a/src/main/java/com/sseulang/domain/file/presentation/FileController.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/FileController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.file.presentation.dto.PresignedUrlRequest;
 import com.sseulang.domain.file.presentation.dto.PresignedUrlResponse;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "File", description = "S3 presigned URL 발급")
 @RestController
 @RequestMapping("/api/v1/files")
 public class FileController {

--- a/src/main/java/com/sseulang/domain/message/presentation/MessageController.java
+++ b/src/main/java/com/sseulang/domain/message/presentation/MessageController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.message.presentation.dto.MessageResponse;
 import com.sseulang.domain.message.presentation.dto.MessageSendRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Message", description = "채팅 메시지 송수신 + 페이징")
 @RestController
 @RequestMapping("/api/v1/chat-rooms/{roomId}/messages")
 public class MessageController {

--- a/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
@@ -8,6 +8,7 @@ import com.sseulang.domain.notice.presentation.dto.NoticeUpsertRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 관리자 공지 CRUD + 상태 토글. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
  */
+@Tag(name = "AdminNotice", description = "관리자 — 공지 작성/관리")
 @RestController
 @RequestMapping("/api/v1/admin/notices")
 public class AdminNoticeController {

--- a/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.notice.domain.NoticeType;
 import com.sseulang.domain.notice.presentation.dto.NoticeResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 사용자 공지 조회 — 노출 윈도우 통과한 공지만. SecurityConfig user chain 으로 ROLE_USER 강제.
  */
+@Tag(name = "Notice", description = "공지 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/notices")
 public class NoticeController {

--- a/src/main/java/com/sseulang/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/sseulang/domain/notification/presentation/NotificationController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.notification.application.NotificationApplicationServi
 import com.sseulang.domain.notification.presentation.dto.NotificationResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Notification", description = "알림 조회/읽음 처리")
 @RestController
 @RequestMapping("/api/v1/notifications")
 public class NotificationController {

--- a/src/main/java/com/sseulang/domain/report/presentation/AdminReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/AdminReportController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.report.presentation.dto.AdminReportResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "AdminReport", description = "관리자 — 신고 처리")
 @RestController
 @RequestMapping("/api/v1/admin/reports")
 public class AdminReportController {

--- a/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.report.presentation.dto.ReportIdResponse;
 import com.sseulang.domain.report.presentation.dto.ReportRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 사용자/물품 신고 진입점. Item 신고는 가이드 §6.1 의 {@code POST /api/v1/items/{id}/report},
  * User 신고는 별도 {@code POST /api/v1/users/{id}/report}.
  */
+@Tag(name = "Report", description = "사용자 신고 등록")
 @RestController
 public class UserReportController {
 

--- a/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
@@ -8,6 +8,7 @@ import com.sseulang.domain.review.presentation.dto.ReviewWriteRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Review", description = "거래 리뷰 작성/조회/대기 목록")
 @RestController
 public class ReviewController {
 

--- a/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
@@ -3,11 +3,13 @@ package com.sseulang.domain.stats.presentation;
 import com.sseulang.domain.stats.application.AdminStatsService;
 import com.sseulang.domain.stats.presentation.dto.AdminDashboardResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /** 관리자 통계 dashboard. SecurityConfig admin chain 으로 ROLE_ADMIN 강제. */
+@Tag(name = "AdminStats", description = "관리자 — dashboard 통계")
 @RestController
 @RequestMapping("/api/v1/admin/stats")
 public class AdminStatsController {

--- a/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.user.presentation.dto.UserBlockRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 관리자 회원 관리. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
  */
+@Tag(name = "AdminUser", description = "관리자 — 사용자 목록/차단")
 @RestController
 @RequestMapping("/api/v1/admin/users")
 public class AdminUserController {

--- a/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
+++ b/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.wishlist.presentation;
 
 import com.sseulang.domain.wishlist.application.WishlistApplicationService;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Wishlist 진입점은 Item 자원 하위로 둔다 (가이드 §6.1):
  * {@code POST /api/v1/items/{id}/wishlist}, {@code DELETE /api/v1/items/{id}/wishlist}.
  */
+@Tag(name = "Wishlist", description = "물품 찜 추가/해제")
 @RestController
 @RequestMapping("/api/v1/items/{itemId}/wishlist")
 public class WishlistController {

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 관리자 출금 처리 — SecurityConfig 의 admin chain 이 ROLE_ADMIN 강제. AuthenticationPrincipal 은
  * adminId (현재 SecurityFilter 정책 그대로 사용).
  */
+@Tag(name = "AdminWithdrawal", description = "관리자 — 출금 신청 승인/거부")
 @RestController
 @RequestMapping("/api/v1/admin/withdrawals")
 public class AdminWithdrawalController {

--- a/src/main/java/com/sseulang/global/common/ApiResponse.java
+++ b/src/main/java/com/sseulang/global/common/ApiResponse.java
@@ -1,9 +1,15 @@
 package com.sseulang.global.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ApiResponse<T>(boolean success, T data, ErrorBody error) {
+@Schema(description = "API 표준 응답 — 성공이면 data, 실패면 error 만 채워진다.")
+public record ApiResponse<T>(
+        @Schema(description = "성공 여부", example = "true") boolean success,
+        @Schema(description = "성공 시 데이터 (실패 시 null)") T data,
+        @Schema(description = "실패 시 에러 본문 (성공 시 null)") ErrorBody error
+) {
 
     public static <T> ApiResponse<T> ok(T data) {
         return new ApiResponse<>(true, data, null);
@@ -17,5 +23,10 @@ public record ApiResponse<T>(boolean success, T data, ErrorBody error) {
         return new ApiResponse<>(false, null, new ErrorBody(code, message, traceId));
     }
 
-    public record ErrorBody(String code, String message, String traceId) {}
+    @Schema(description = "에러 본문 — 코드는 ErrorCode enum 값, message 는 한국어, traceId 는 서버 로그 추적용.")
+    public record ErrorBody(
+            @Schema(description = "ErrorCode enum 값", example = "AUTH_TOKEN_EXPIRED") String code,
+            @Schema(description = "한국어 사용자 노출 메시지", example = "만료된 토큰입니다.") String message,
+            @Schema(description = "서버 로그 traceId (지원 요청 시 첨부)", example = "9f2c8c5b") String traceId
+    ) {}
 }

--- a/src/main/java/com/sseulang/global/common/PageResponse.java
+++ b/src/main/java/com/sseulang/global/common/PageResponse.java
@@ -1,16 +1,19 @@
 package com.sseulang.global.common;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 import org.springframework.data.domain.Page;
 
+@Schema(description = "페이징 응답 — page 는 0-based, size 는 1~100. 채팅 메시지 등 일부 영역은 커서 페이징 사용.")
 public record PageResponse<T>(
-        List<T> content,
-        int page,
-        int size,
-        long totalElements,
-        int totalPages,
-        boolean hasNext,
-        boolean hasPrevious
+        @Schema(description = "현재 페이지 항목 리스트") List<T> content,
+        @Schema(description = "현재 페이지 번호 (0-based)", example = "0") int page,
+        @Schema(description = "페이지 크기", example = "20") int size,
+        @Schema(description = "전체 항목 수", example = "123") long totalElements,
+        @Schema(description = "전체 페이지 수", example = "7") int totalPages,
+        @Schema(description = "다음 페이지 존재 여부", example = "true") boolean hasNext,
+        @Schema(description = "이전 페이지 존재 여부", example = "false") boolean hasPrevious
 ) {
 
     public static <T> PageResponse<T> from(Page<T> page) {

--- a/src/main/java/com/sseulang/global/config/OpenApiConfig.java
+++ b/src/main/java/com/sseulang/global/config/OpenApiConfig.java
@@ -2,30 +2,58 @@ package com.sseulang.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
 
     private static final String COOKIE_AUTH = "cookieAuth";
+    private static final String CSRF_HEADER = "csrfToken";
 
     @Bean
     public OpenAPI sseulangOpenApi() {
         return new OpenAPI()
                 .info(new Info()
                         .title("쓸랭(Sseulang) API")
-                        .description("중고 거래 + 대여 + 나눔 + 배달대행 통합 C2C 플랫폼 API")
-                        .version("v1"))
-                .addSecurityItem(new SecurityRequirement().addList(COOKIE_AUTH))
+                        .description("""
+                                중고 거래 + 대여 + 나눔 + 배달대행 통합 C2C 플랫폼.
+
+                                **인증**: HttpOnly 쿠키 `at` (Access) / `rt` (Refresh) — 브라우저가 자동 동봉.
+                                Swagger UI 에서 테스트하려면 먼저 `POST /api/v1/auth/login` 으로 로그인하세요.
+
+                                **CSRF**: 모든 mutating(POST/PATCH/PUT/DELETE) 요청은 `X-XSRF-TOKEN` 헤더 필수.
+                                값은 `XSRF-TOKEN` 쿠키에서 읽어 echo. (`/api/v1/auth/**`, `/api/v1/payments/webhook/**`,
+                                `/ws-stomp*` 는 면제)
+
+                                **응답 포맷**: 성공 `{success:true, data}`, 실패 `{success:false, error:{code,message,traceId}}`,
+                                페이징 `{content, page, size, totalElements, totalPages, hasNext, hasPrevious}`.
+
+                                **상세 ErrorCode + 연동 가이드**: `docs/FRONTEND_INTEGRATION.md`.
+                                """)
+                        .version("v1")
+                        .contact(new Contact().name("쓸랭 백엔드").email("noreply@sseulang.test")))
+                .servers(List.of(
+                        new Server().url("/").description("현재 서버"),
+                        new Server().url("http://localhost:8080").description("로컬")))
+                .addSecurityItem(new SecurityRequirement().addList(COOKIE_AUTH).addList(CSRF_HEADER))
                 .components(new Components()
                         .addSecuritySchemes(COOKIE_AUTH, new SecurityScheme()
                                 .type(SecurityScheme.Type.APIKEY)
                                 .in(SecurityScheme.In.COOKIE)
-                                .name("ACCESS_TOKEN")
-                                .description("HttpOnly 쿠키로 자동 전송됩니다. 브라우저에서 테스트하려면 로그인 후 사용하세요.")));
+                                .name("at")
+                                .description("HttpOnly Access Token. 로그인 후 자동 발급. Swagger 에서는 직접 설정 X — 로그인 응답 후 자동 동봉됨."))
+                        .addSecuritySchemes(CSRF_HEADER, new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .name("X-XSRF-TOKEN")
+                                .description("XSRF-TOKEN 쿠키 값을 echo. mutating 요청 필수.")));
     }
 }

--- a/src/main/java/com/sseulang/global/dev/DevAuthController.java
+++ b/src/main/java/com/sseulang/global/dev/DevAuthController.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>OAuth 콘솔 키 없이도 임의 user 시드 + JWT 쿠키 받아서 Swagger / curl 시나리오 가능.
  * 정식 OAuth 흐름 (가이드 §4.4) 과는 무관 — local 작업 편의 용이며 실서비스 배포 시 등록 X.</p>
  */
+@Tag(name = "DevAuth", description = "로컬 개발 인증 우회 (prod 비활성)")
 @RestController
 @RequestMapping("/api/v1/auth/dev")
 @Profile("local")


### PR DESCRIPTION
## Summary

프론트 연동 직전 Swagger UI 명세 보강. 모든 Controller 가 분류 가능하게 + 인증/CSRF 스키마 명시 + 응답 포맷 schema 노출.

## Changes

### Controller @Tag (20건 추가 → 총 26건)
| 그룹 | Controller |
|---|---|
| USER | Category, ChatRoom, File, EmailVerification, Notification, Report, Banner, Wishlist, UserBlock, Message, Notice, Review |
| ADMIN | AdminAuth, AdminWithdrawal, AdminReport, AdminStats, AdminBanner, AdminUser, AdminNotice |
| DEV | DevAuth |

### OpenApiConfig
- `info.description` — 인증/CSRF/응답 포맷 + `FRONTEND_INTEGRATION.md` 참조
- `servers` — 현재 / localhost
- `securitySchemes` — `cookieAuth` (cookie `at`) + `csrfToken` (header `X-XSRF-TOKEN`)
- 🔧 **수정**: 쿠키 이름 `ACCESS_TOKEN` → `at` (CookieUtil.ACCESS_TOKEN_COOKIE 와 정합)

### Response Wrapper @Schema
- `ApiResponse<T>` + `ErrorBody` 필드별 description/example
- `PageResponse<T>` 필드별 description/example

## Test plan

- [x] `./gradlew test` — 597 PASS / 0 FAIL
- [ ] 수동 — `/swagger-ui.html` 에서 26개 Tag 그룹화 확인
- [ ] 수동 — 인증/CSRF 스키마 노출 확인
- [ ] 수동 — Try It Out 으로 로그인 후 mutating 요청 동작 확인

## Notes

- 개별 endpoint `@Operation summary` + `@ApiResponses(401/403/404)` 보강은 별도 PR 또는 follow-up.
- 본 PR 의 `@Tag` 만으로도 프론트 합류 시 endpoint 탐색이 크게 좋아짐.

🤖 Generated with [Claude Code](https://claude.com/claude-code)