### PR TITLE
docs(swagger): Response DTO 26개 @Schema (PR #61 후속)

### DIFF
--- a/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
+++ b/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.auth.application.dto.TokenPair;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.security.CookieUtil;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 관리자 로그인 진입점. SecurityConfig 의 {@code /api/v1/auth/**} permitAll 영역.
  * 일반 사용자 OAuth 흐름 ({@link com.sseulang.domain.auth.presentation.AuthController}) 와 분리.
  */
+@Tag(name = "AdminAuth", description = "관리자 로그인")
 @RestController
 @RequestMapping("/api/v1/auth/admin")
 public class AdminAuthController {

--- a/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.auth.application.EmailVerificationService;
 import com.sseulang.domain.auth.presentation.dto.VerifyEmailRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
  *   <li>{@code /resend-verification} — auth 필수 (hasRole("USER")) + CSRF 적용 (게이트 1 round 2 보강)</li>
  * </ul>
  */
+@Tag(name = "EmailVerification", description = "이메일 인증 메일 발송/확인")
 @RestController
 @RequestMapping("/api/v1/auth")
 public class EmailVerificationController {

--- a/src/main/java/com/sseulang/domain/banner/presentation/AdminBannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/AdminBannerController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.banner.presentation.dto.BannerUpsertRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "AdminBanner", description = "관리자 — 배너 관리")
 @RestController
 @RequestMapping("/api/v1/admin/banners")
 public class AdminBannerController {

--- a/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.banner.presentation;
 import com.sseulang.domain.banner.application.BannerApplicationService;
 import com.sseulang.domain.banner.presentation.dto.BannerResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 /** 사용자 활성 배너 목록 — sort_order 정렬. */
+@Tag(name = "Banner", description = "배너 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/banners")
 public class BannerController {

--- a/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerResponse.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerResponse.java
@@ -1,17 +1,19 @@
 package com.sseulang.domain.banner.presentation.dto;
 
 import com.sseulang.domain.banner.application.dto.BannerResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "메인 배너 — 클릭 시 linkUrl 로 이동. active+startsAt~endsAt 로 노출 제어.")
 public record BannerResponse(
-        Long id,
-        Long adminId,
-        String title,
-        String imageUrl,
-        String linkUrl,
-        int sortOrder,
-        boolean active,
+        @Schema(example = "2") Long id,
+        @Schema(example = "1") Long adminId,
+        @Schema(example = "5월 봄맞이 이벤트") String title,
+        @Schema(example = "https://cdn.sseulang.com/banners/1/spring.jpg") String imageUrl,
+        @Schema(example = "/events/spring") String linkUrl,
+        @Schema(example = "1", description = "정렬 순서 (작을수록 앞)") int sortOrder,
+        @Schema(example = "true") boolean active,
         LocalDateTime startsAt,
         LocalDateTime endsAt,
         LocalDateTime createdAt

--- a/src/main/java/com/sseulang/domain/block/presentation/UserBlockController.java
+++ b/src/main/java/com/sseulang/domain/block/presentation/UserBlockController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.block.presentation.dto.UserBlockResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "UserBlock", description = "사용자 차단/해제")
 @RestController
 @RequestMapping("/api/v1/blocks")
 public class UserBlockController {

--- a/src/main/java/com/sseulang/domain/block/presentation/dto/UserBlockResponse.java
+++ b/src/main/java/com/sseulang/domain/block/presentation/dto/UserBlockResponse.java
@@ -1,10 +1,17 @@
 package com.sseulang.domain.block.presentation.dto;
 
 import com.sseulang.domain.block.application.dto.UserBlockResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-public record UserBlockResponse(Long id, Long blockerId, Long blockedId, LocalDateTime createdAt) {
+@Schema(description = "사용자 차단 관계 — blocker → blocked. 차단 후 채팅/거래 불가.")
+public record UserBlockResponse(
+        @Schema(example = "23") Long id,
+        @Schema(example = "100", description = "차단한 사용자") Long blockerId,
+        @Schema(example = "200", description = "차단당한 사용자") Long blockedId,
+        LocalDateTime createdAt
+) {
     public static UserBlockResponse from(UserBlockResult r) {
         return new UserBlockResponse(r.id(), r.blockerId(), r.blockedId(), r.createdAt());
     }

--- a/src/main/java/com/sseulang/domain/category/presentation/CategoryController.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/CategoryController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.presentation.dto.CategoryNodeResponse;
 import com.sseulang.domain.category.presentation.dto.CategoryResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Category", description = "카테고리 트리 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/categories")
 public class CategoryController {

--- a/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryNodeResponse.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryNodeResponse.java
@@ -1,13 +1,15 @@
 package com.sseulang.domain.category.presentation.dto;
 
 import com.sseulang.domain.category.application.dto.CategoryNodeResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "카테고리 트리 노드 — children 재귀 구조. GET /categories 의 응답.")
 public record CategoryNodeResponse(
-        Long id,
-        String name,
-        int sortOrder,
+        @Schema(example = "5") Long id,
+        @Schema(example = "디지털/가전") String name,
+        @Schema(example = "1") int sortOrder,
         List<CategoryNodeResponse> children
 ) {
     public static CategoryNodeResponse from(CategoryNodeResult node) {

--- a/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryResponse.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryResponse.java
@@ -1,12 +1,14 @@
 package com.sseulang.domain.category.presentation.dto;
 
 import com.sseulang.domain.category.application.dto.CategoryResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "카테고리 단건 — parentId null 이면 루트.")
 public record CategoryResponse(
-        Long id,
-        Long parentId,
-        String name,
-        int sortOrder
+        @Schema(example = "5") Long id,
+        @Schema(description = "루트면 null") Long parentId,
+        @Schema(example = "디지털/가전") String name,
+        @Schema(example = "1") int sortOrder
 ) {
     public static CategoryResponse from(CategoryResult result) {
         return new CategoryResponse(result.id(), result.parentId(), result.name(), result.sortOrder());

--- a/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.chat.presentation.dto.ChatRoomResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "ChatRoom", description = "1:1 채팅방 개설/조회")
 @RestController
 @RequestMapping("/api/v1/chat-rooms")
 public class ChatRoomController {

--- a/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
@@ -1,19 +1,21 @@
 package com.sseulang.domain.chat.presentation.dto;
 
 import com.sseulang.domain.chat.application.dto.ChatRoomResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "1:1 채팅방 — (user1, user2, item) UNIQUE. user1Id < user2Id 정규화.")
 public record ChatRoomResponse(
-        Long id,
-        Long itemId,
-        Long user1Id,
-        Long user2Id,
-        String lastMessage,
+        @Schema(example = "8") Long id,
+        @Schema(example = "42") Long itemId,
+        @Schema(description = "정규화된 첫 사용자 (id 작은 쪽)", example = "100") Long user1Id,
+        @Schema(description = "정규화된 두번째 사용자", example = "200") Long user2Id,
+        @Schema(example = "안녕하세요, 거래 가능할까요?", description = "최근 메시지 미리보기") String lastMessage,
         LocalDateTime lastMessageAt,
-        int user1Unread,
-        int user2Unread,
-        boolean active,
+        @Schema(example = "0", description = "user1 의 미읽음 카운트") int user1Unread,
+        @Schema(example = "3", description = "user2 의 미읽음 카운트") int user2Unread,
+        @Schema(description = "false 면 차단/예약 등으로 비활성") boolean active,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryResponse.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryResponse.java
@@ -2,19 +2,21 @@ package com.sseulang.domain.delivery.presentation.dto;
 
 import com.sseulang.domain.delivery.application.dto.DeliveryResult;
 import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "배달 요청 — 모집중→수락→배송중→배송완료→정산완료. 정산 시 요청자 차감/라이더 적립.")
 public record DeliveryResponse(
-        Long id,
-        Long requesterId,
-        Long riderId,
-        String pickupAddress,
-        String dropoffAddress,
-        String itemDescription,
-        long fee,
+        @Schema(example = "55") Long id,
+        @Schema(example = "100") Long requesterId,
+        @Schema(description = "수락 후 채워짐", example = "200") Long riderId,
+        @Schema(example = "서울 강남구 테헤란로 123") String pickupAddress,
+        @Schema(example = "서울 송파구 올림픽로 456") String dropoffAddress,
+        @Schema(example = "A4 서류 봉투 1개") String itemDescription,
+        @Schema(example = "5000", description = "라이더 수수료 — 정산 시 요청자 잔액에서 차감") long fee,
         LocalDateTime requestedDeadline,
-        String memo,
+        @Schema(example = "1층 로비 보관함") String memo,
         DeliveryStatus status,
         LocalDateTime requestedAt,
         LocalDateTime acceptedAt,

--- a/src/main/java/com/sseulang/domain/file/presentation/FileController.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/FileController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.file.presentation.dto.PresignedUrlRequest;
 import com.sseulang.domain.file.presentation.dto.PresignedUrlResponse;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "File", description = "S3 presigned URL 발급")
 @RestController
 @RequestMapping("/api/v1/files")
 public class FileController {

--- a/src/main/java/com/sseulang/domain/file/presentation/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/dto/PresignedUrlResponse.java
@@ -1,12 +1,19 @@
 package com.sseulang.domain.file.presentation.dto;
 
 import com.sseulang.domain.file.application.dto.PresignResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "S3 presigned URL 발급 응답 — 각 파일에 대해 PUT 가능한 URL + key 반환. 5분 만료.")
 public record PresignedUrlResponse(List<Upload> uploads) {
 
-    public record Upload(String presignedUrl, String key) {
+    @Schema(description = "단일 파일 업로드 URL 쌍.")
+    public record Upload(
+            @Schema(example = "https://bucket.s3.ap-northeast-2.amazonaws.com/items/100/abc.jpg?X-Amz-...",
+                    description = "이 URL 로 PUT (Content-Type 헤더 포함)") String presignedUrl,
+            @Schema(example = "items/100/abc.jpg", description = "S3 객체 키 — Item 등록 시 imageUrls 에 그대로 사용") String key
+    ) {
         public static Upload from(PresignResult r) {
             return new Upload(r.presignedUrl(), r.key());
         }

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemDetailResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemDetailResponse.java
@@ -4,26 +4,28 @@ import com.sseulang.domain.item.application.dto.ItemDetailResult;
 import com.sseulang.domain.item.domain.ItemStatus;
 import com.sseulang.domain.item.domain.RentalUnit;
 import com.sseulang.domain.item.domain.TradeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "물품 상세 — 이미지/해시태그 포함. GET /items/{id} 호출 시 viewCount 1 증가.")
 public record ItemDetailResponse(
-        Long id,
-        Long sellerId,
-        Long categoryId,
-        String title,
-        String description,
-        long price,
-        Long deposit,
-        RentalUnit rentalUnit,
+        @Schema(example = "42") Long id,
+        @Schema(example = "100") Long sellerId,
+        @Schema(example = "5", description = "카테고리 id (없으면 null)") Long categoryId,
+        @Schema(example = "아이폰 14 Pro 미개봉") String title,
+        @Schema(example = "박스 미개봉, 색상 딥퍼플") String description,
+        @Schema(example = "1200000") long price,
+        @Schema(example = "100000", description = "대여 시 보증금 (판매/나눔은 null)") Long deposit,
+        @Schema(description = "대여 단위 (판매/나눔은 null)") RentalUnit rentalUnit,
         TradeType tradeType,
         ItemStatus status,
-        String region,
-        int viewCount,
-        int wishlistCount,
+        @Schema(example = "서울 강남구") String region,
+        @Schema(example = "127") int viewCount,
+        @Schema(example = "8") int wishlistCount,
         List<ItemImageResponse> images,
-        List<String> hashtags,
+        @Schema(example = "[\"아이폰\",\"미개봉\"]") List<String> hashtags,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemIdResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemIdResponse.java
@@ -1,3 +1,6 @@
 package com.sseulang.domain.item.presentation.dto;
 
-public record ItemIdResponse(Long id) { }
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "물품 등록 후 발급된 id 응답.")
+public record ItemIdResponse(@Schema(example = "42") Long id) { }

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemImageResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemImageResponse.java
@@ -1,8 +1,14 @@
 package com.sseulang.domain.item.presentation.dto;
 
 import com.sseulang.domain.item.application.dto.ItemImageResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record ItemImageResponse(String imageUrl, int sortOrder, boolean thumbnail) {
+@Schema(description = "물품 이미지 — 등록 시 임시 폴더에서 정식 폴더(items/{itemId}/) 로 promote 된 url.")
+public record ItemImageResponse(
+        @Schema(example = "https://cdn.sseulang.com/items/42/abc.jpg") String imageUrl,
+        @Schema(example = "1", description = "표시 순서 (1-based)") int sortOrder,
+        @Schema(example = "true", description = "썸네일 여부 (sortOrder=1 만 true)") boolean thumbnail
+) {
     public static ItemImageResponse from(ItemImageResult r) {
         return new ItemImageResponse(r.imageUrl(), r.sortOrder(), r.thumbnail());
     }

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemSummaryResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemSummaryResponse.java
@@ -3,18 +3,20 @@ package com.sseulang.domain.item.presentation.dto;
 import com.sseulang.domain.item.application.dto.ItemSummaryResult;
 import com.sseulang.domain.item.domain.ItemStatus;
 import com.sseulang.domain.item.domain.TradeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "물품 목록 row — 검색/페이징 응답에 포함.")
 public record ItemSummaryResponse(
-        Long id,
-        Long sellerId,
-        Long categoryId,
-        String title,
-        long price,
+        @Schema(example = "42") Long id,
+        @Schema(example = "100") Long sellerId,
+        @Schema(example = "5") Long categoryId,
+        @Schema(example = "아이폰 14 Pro 미개봉") String title,
+        @Schema(example = "1200000") long price,
         TradeType tradeType,
         ItemStatus status,
-        String region,
+        @Schema(example = "서울 강남구") String region,
         LocalDateTime createdAt
 ) {
     public static ItemSummaryResponse from(ItemSummaryResult r) {

--- a/src/main/java/com/sseulang/domain/message/presentation/MessageController.java
+++ b/src/main/java/com/sseulang/domain/message/presentation/MessageController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.message.presentation.dto.MessageResponse;
 import com.sseulang.domain.message.presentation.dto.MessageSendRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Message", description = "채팅 메시지 송수신 + 페이징")
 @RestController
 @RequestMapping("/api/v1/chat-rooms/{roomId}/messages")
 public class MessageController {

--- a/src/main/java/com/sseulang/domain/message/presentation/dto/MessageResponse.java
+++ b/src/main/java/com/sseulang/domain/message/presentation/dto/MessageResponse.java
@@ -1,16 +1,18 @@
 package com.sseulang.domain.message.presentation.dto;
 
 import com.sseulang.domain.message.application.dto.MessageResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 import java.util.List;
 
+@Schema(description = "채팅 메시지 — MongoDB 저장. content/imageUrls 둘 중 하나 이상 채워짐.")
 public record MessageResponse(
-        String id,
-        Long chatRoomId,
-        Long senderId,
-        String content,
-        List<String> imageUrls,
+        @Schema(example = "65a1b2c3d4e5f60001234567", description = "MongoDB ObjectId hex") String id,
+        @Schema(example = "8") Long chatRoomId,
+        @Schema(example = "200") Long senderId,
+        @Schema(example = "안녕하세요, 거래 가능할까요?") String content,
+        @Schema(description = "이미지 메시지 URL 목록 (텍스트 메시지면 빈 배열)") List<String> imageUrls,
         Instant createdAt
 ) {
     public static MessageResponse from(MessageResult r) {

--- a/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
@@ -8,6 +8,7 @@ import com.sseulang.domain.notice.presentation.dto.NoticeUpsertRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 관리자 공지 CRUD + 상태 토글. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
  */
+@Tag(name = "AdminNotice", description = "관리자 — 공지 작성/관리")
 @RestController
 @RequestMapping("/api/v1/admin/notices")
 public class AdminNoticeController {

--- a/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.notice.domain.NoticeType;
 import com.sseulang.domain.notice.presentation.dto.NoticeResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 사용자 공지 조회 — 노출 윈도우 통과한 공지만. SecurityConfig user chain 으로 ROLE_USER 강제.
  */
+@Tag(name = "Notice", description = "공지 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/notices")
 public class NoticeController {

--- a/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeResponse.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeResponse.java
@@ -2,19 +2,21 @@ package com.sseulang.domain.notice.presentation.dto;
 
 import com.sseulang.domain.notice.application.dto.NoticeResult;
 import com.sseulang.domain.notice.domain.NoticeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "공지사항 — 관리자 작성. pinned 는 상단 고정, published+startsAt~endsAt 로 노출 제어.")
 public record NoticeResponse(
-        Long id,
-        Long adminId,
+        @Schema(example = "3") Long id,
+        @Schema(example = "1", description = "작성한 관리자 id") Long adminId,
         NoticeType type,
-        String title,
-        String content,
-        String imageUrl,
-        boolean pinned,
-        boolean published,
-        int viewCount,
+        @Schema(example = "결제 시스템 점검 안내") String title,
+        @Schema(example = "5/3 03:00~05:00 결제 일시 중단됩니다.") String content,
+        @Schema(description = "본문 상단 이미지 (선택)") String imageUrl,
+        @Schema(example = "true", description = "상단 고정 여부") boolean pinned,
+        @Schema(example = "true", description = "게시 여부") boolean published,
+        @Schema(example = "152") int viewCount,
         LocalDateTime startsAt,
         LocalDateTime endsAt,
         LocalDateTime createdAt

--- a/src/main/java/com/sseulang/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/sseulang/domain/notification/presentation/NotificationController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.notification.application.NotificationApplicationServi
 import com.sseulang.domain.notification.presentation.dto.NotificationResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Notification", description = "알림 조회/읽음 처리")
 @RestController
 @RequestMapping("/api/v1/notifications")
 public class NotificationController {

--- a/src/main/java/com/sseulang/domain/notification/presentation/dto/NotificationResponse.java
+++ b/src/main/java/com/sseulang/domain/notification/presentation/dto/NotificationResponse.java
@@ -2,17 +2,19 @@ package com.sseulang.domain.notification.presentation.dto;
 
 import com.sseulang.domain.notification.application.dto.NotificationResult;
 import com.sseulang.domain.notification.domain.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 
+@Schema(description = "알림 — MongoDB 저장. linkType+linkId 로 클라이언트가 화면 라우팅.")
 public record NotificationResponse(
-        String id,
+        @Schema(example = "65a1b2c3d4e5f60001234567") String id,
         NotificationType type,
-        String title,
-        String content,
-        String linkType,
-        Long linkId,
-        boolean read,
+        @Schema(example = "새 메시지") String title,
+        @Schema(example = "안녕하세요, 거래 가능할까요?") String content,
+        @Schema(example = "CHAT_ROOM", description = "라우팅 종류 (CHAT_ROOM / TRANSACTION / DELIVERY 등)") String linkType,
+        @Schema(example = "8") Long linkId,
+        @Schema(description = "읽음 여부", example = "false") boolean read,
         Instant createdAt
 ) {
     public static NotificationResponse from(NotificationResult r) {

--- a/src/main/java/com/sseulang/domain/payment/presentation/dto/ChargeStartResponse.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/dto/ChargeStartResponse.java
@@ -1,12 +1,14 @@
 package com.sseulang.domain.payment.presentation.dto;
 
 import com.sseulang.domain.payment.application.dto.ChargeStartResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "충전 시작 응답 — 받은 merchantUid + amount + tossClientKey 로 토스 SDK 결제창 호출.")
 public record ChargeStartResponse(
-        Long paymentId,
-        String merchantUid,
-        long amount,
-        String tossClientKey
+        @Schema(example = "78") Long paymentId,
+        @Schema(example = "merchant-9f2c8c5b", description = "토스 결제창에 전달할 주문번호 (UNIQUE, 백엔드 발급)") String merchantUid,
+        @Schema(example = "50000") long amount,
+        @Schema(example = "test_ck_...", description = "프론트가 토스 SDK 초기화에 사용") String tossClientKey
 ) {
     public static ChargeStartResponse from(ChargeStartResult r) {
         return new ChargeStartResponse(r.paymentId(), r.merchantUid(), r.amount(), r.tossClientKey());

--- a/src/main/java/com/sseulang/domain/payment/presentation/dto/PaymentResponse.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/dto/PaymentResponse.java
@@ -4,18 +4,20 @@ import com.sseulang.domain.payment.application.dto.PaymentResult;
 import com.sseulang.domain.payment.domain.PaymentMethod;
 import com.sseulang.domain.payment.domain.PaymentStatus;
 import com.sseulang.domain.payment.domain.PaymentType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "결제 — 토스페이먼츠 충전. paidAt 채워지면 잔액 충전 완료. status 가 PENDING 이면 webhook 또는 reconciliation 대기.")
 public record PaymentResponse(
-        Long id,
-        Long userId,
-        Long transactionId,
+        @Schema(example = "78") Long id,
+        @Schema(example = "100") Long userId,
+        @Schema(description = "거래 결제용일 때만 채워짐 (충전형은 null)", example = "12") Long transactionId,
         PaymentType paymentType,
         PaymentMethod method,
-        long amount,
+        @Schema(example = "50000") long amount,
         PaymentStatus status,
-        String merchantUid,
+        @Schema(example = "merchant-9f2c8c5b") String merchantUid,
         LocalDateTime paidAt,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/sseulang/domain/report/presentation/AdminReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/AdminReportController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.report.presentation.dto.AdminReportResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "AdminReport", description = "관리자 — 신고 처리")
 @RestController
 @RequestMapping("/api/v1/admin/reports")
 public class AdminReportController {

--- a/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.report.presentation.dto.ReportIdResponse;
 import com.sseulang.domain.report.presentation.dto.ReportRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 사용자/물품 신고 진입점. Item 신고는 가이드 §6.1 의 {@code POST /api/v1/items/{id}/report},
  * User 신고는 별도 {@code POST /api/v1/users/{id}/report}.
  */
+@Tag(name = "Report", description = "사용자 신고 등록")
 @RestController
 public class UserReportController {
 

--- a/src/main/java/com/sseulang/domain/report/presentation/dto/AdminReportResponse.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/dto/AdminReportResponse.java
@@ -2,19 +2,21 @@ package com.sseulang.domain.report.presentation.dto;
 
 import com.sseulang.domain.report.domain.ReportStatus;
 import com.sseulang.domain.report.domain.UserReport;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "관리자 — 사용자 신고 단건.")
 public record AdminReportResponse(
-        Long id,
-        Long reporterId,
-        Long reportedId,
-        Long itemId,
-        String reason,
-        String detail,
+        @Schema(example = "17") Long id,
+        @Schema(example = "100", description = "신고한 사용자") Long reporterId,
+        @Schema(example = "200", description = "신고당한 사용자") Long reportedId,
+        @Schema(description = "관련 물품 (없으면 null)", example = "42") Long itemId,
+        @Schema(example = "FRAUD", description = "FRAUD / SPAM / HARASSMENT 등") String reason,
+        @Schema(example = "결제 후 물품을 보내지 않습니다") String detail,
         ReportStatus status,
-        Long adminId,
-        String adminMemo,
+        @Schema(description = "처리한 관리자 (PENDING 단계는 null)") Long adminId,
+        @Schema(example = "확인 후 경고 처리") String adminMemo,
         LocalDateTime processedAt,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/sseulang/domain/report/presentation/dto/ReportIdResponse.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/dto/ReportIdResponse.java
@@ -1,3 +1,6 @@
 package com.sseulang.domain.report.presentation.dto;
 
-public record ReportIdResponse(Long id) { }
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "신고 등록 후 발급된 id 응답.")
+public record ReportIdResponse(@Schema(example = "17") Long id) { }

--- a/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
@@ -8,6 +8,7 @@ import com.sseulang.domain.review.presentation.dto.ReviewWriteRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Review", description = "거래 리뷰 작성/조회/대기 목록")
 @RestController
 public class ReviewController {
 

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/PendingReviewResponse.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/PendingReviewResponse.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.review.presentation.dto;
 
 import com.sseulang.domain.item.domain.TradeType;
 import com.sseulang.domain.transaction.application.dto.PendingReviewableResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
@@ -10,14 +11,15 @@ import java.time.LocalDateTime;
  *
  * <p>{@code deadline = completedAt + 7d} — 클라이언트가 남은 시간 카운트다운 UI 에 직접 사용.</p>
  */
+@Schema(description = "리뷰 작성 대기 거래 — 본인이 reviewer 로 아직 작성 안 한 7일 이내 완료 거래.")
 public record PendingReviewResponse(
-        Long transactionId,
-        Long itemId,
-        Long revieweeId,
+        @Schema(example = "12") Long transactionId,
+        @Schema(example = "42") Long itemId,
+        @Schema(description = "상대방 (reviewee) id", example = "200") Long revieweeId,
         TradeType tradeType,
-        long price,
+        @Schema(example = "1200000") long price,
         LocalDateTime completedAt,
-        LocalDateTime deadline
+        @Schema(description = "완료일 + 7일. 이 시간 지나면 작성 불가") LocalDateTime deadline
 ) {
     public static PendingReviewResponse from(PendingReviewableResult r) {
         return new PendingReviewResponse(

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewIdResponse.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewIdResponse.java
@@ -1,3 +1,6 @@
 package com.sseulang.domain.review.presentation.dto;
 
-public record ReviewIdResponse(Long id) { }
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "리뷰 작성 후 발급된 id 응답.")
+public record ReviewIdResponse(@Schema(example = "9") Long id) { }

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewResponse.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewResponse.java
@@ -1,16 +1,18 @@
 package com.sseulang.domain.review.presentation.dto;
 
 import com.sseulang.domain.review.application.dto.ReviewResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "리뷰 — 거래 완료 후 7일 이내 작성. 한줄평(comment)은 작성자 본인에게만 노출 (그 외엔 마스킹).")
 public record ReviewResponse(
-        Long id,
-        Long transactionId,
-        Long reviewerId,
-        Long revieweeId,
-        int rating,
-        String comment,
+        @Schema(example = "9") Long id,
+        @Schema(example = "12") Long transactionId,
+        @Schema(example = "200") Long reviewerId,
+        @Schema(example = "100") Long revieweeId,
+        @Schema(example = "5", description = "1~5") int rating,
+        @Schema(example = "친절하고 빠른 거래", description = "한줄평. 작성자 본인 외엔 null 마스킹") String comment,
         LocalDateTime createdAt
 ) {
     public static ReviewResponse from(ReviewResult r) {

--- a/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
@@ -3,11 +3,13 @@ package com.sseulang.domain.stats.presentation;
 import com.sseulang.domain.stats.application.AdminStatsService;
 import com.sseulang.domain.stats.presentation.dto.AdminDashboardResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /** 관리자 통계 dashboard. SecurityConfig admin chain 으로 ROLE_ADMIN 강제. */
+@Tag(name = "AdminStats", description = "관리자 — dashboard 통계")
 @RestController
 @RequestMapping("/api/v1/admin/stats")
 public class AdminStatsController {

--- a/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardResponse.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardResponse.java
@@ -6,11 +6,13 @@ import com.sseulang.domain.stats.application.AdminDashboardResult;
 import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
 import com.sseulang.domain.user.application.dto.UserStatsResult;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * 관리자 dashboard JSON 응답. presentation layer 응답 — application Result 를 그대로 노출하지만
  * 향후 응답 shape 분리(예: 일부 필드 마스킹)에 대비해 wrapper 유지.
  */
+@Schema(description = "관리자 dashboard — 5개 도메인 (User/Transaction/Payment/Withdrawal/Delivery) 통계 묶음.")
 public record AdminDashboardResponse(
         UserStatsResult users,
         TransactionStatsResult transactions,

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionIdResponse.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionIdResponse.java
@@ -1,3 +1,6 @@
 package com.sseulang.domain.transaction.presentation.dto;
 
-public record TransactionIdResponse(Long id) { }
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "거래 생성 후 발급된 id 응답.")
+public record TransactionIdResponse(@Schema(example = "12") Long id) { }

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionResponse.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionResponse.java
@@ -3,24 +3,26 @@ package com.sseulang.domain.transaction.presentation.dto;
 import com.sseulang.domain.item.domain.TradeType;
 import com.sseulang.domain.transaction.application.dto.TransactionResult;
 import com.sseulang.domain.transaction.domain.TransactionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "거래 — 채팅중→예약→거래완료 상태 머신. 정산은 거래완료 시 buyer 차감/seller 적립.")
 public record TransactionResponse(
-        Long id,
-        Long itemId,
-        Long sellerId,
-        Long buyerId,
+        @Schema(example = "12") Long id,
+        @Schema(example = "42") Long itemId,
+        @Schema(example = "100") Long sellerId,
+        @Schema(example = "200") Long buyerId,
         TradeType tradeType,
-        long price,
-        Long deposit,
+        @Schema(example = "1200000") long price,
+        @Schema(example = "100000", description = "대여 보증금 (판매/나눔은 null)") Long deposit,
         LocalDateTime rentalStart,
         LocalDateTime rentalEnd,
         TransactionStatus status,
         LocalDateTime reservedAt,
         LocalDateTime completedAt,
         LocalDateTime canceledAt,
-        String cancelReason,
+        @Schema(example = "구매자 변심") String cancelReason,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.user.presentation.dto.UserBlockRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 관리자 회원 관리. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
  */
+@Tag(name = "AdminUser", description = "관리자 — 사용자 목록/차단")
 @RestController
 @RequestMapping("/api/v1/admin/users")
 public class AdminUserController {

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
@@ -2,22 +2,24 @@ package com.sseulang.domain.user.presentation.dto;
 
 import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /** 관리자용 회원 단건 응답 — 비밀번호/소셜 토큰 등 민감 정보는 제외. */
+@Schema(description = "관리자 — 회원 단건 (민감 정보 제외).")
 public record AdminUserResponse(
-        Long id,
-        String email,
-        String nickname,
-        String profileImage,
-        SocialProvider socialProvider,
-        boolean blocked,
-        boolean deleted,
-        BigDecimal trustScore,
-        int reviewCount,
-        long pointBalance,
+        @Schema(example = "100") Long id,
+        @Schema(example = "user@example.com") String email,
+        @Schema(example = "쓸랭이") String nickname,
+        @Schema(example = "https://cdn.sseulang.com/profile/100/avatar.jpg") String profileImage,
+        @Schema(description = "LOCAL / KAKAO / GOOGLE") SocialProvider socialProvider,
+        @Schema(example = "false") boolean blocked,
+        @Schema(example = "false") boolean deleted,
+        @Schema(example = "4.7", description = "받은 리뷰 평균 (1.0~5.0). 리뷰 0건이면 null") BigDecimal trustScore,
+        @Schema(example = "12") int reviewCount,
+        @Schema(example = "50000", description = "현재 포인트 잔액 (KRW)") long pointBalance,
         LocalDateTime createdAt
 ) {
     public static AdminUserResponse from(User u) {

--- a/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
+++ b/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.wishlist.presentation;
 
 import com.sseulang.domain.wishlist.application.WishlistApplicationService;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Wishlist 진입점은 Item 자원 하위로 둔다 (가이드 §6.1):
  * {@code POST /api/v1/items/{id}/wishlist}, {@code DELETE /api/v1/items/{id}/wishlist}.
  */
+@Tag(name = "Wishlist", description = "물품 찜 추가/해제")
 @RestController
 @RequestMapping("/api/v1/items/{itemId}/wishlist")
 public class WishlistController {

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 관리자 출금 처리 — SecurityConfig 의 admin chain 이 ROLE_ADMIN 강제. AuthenticationPrincipal 은
  * adminId (현재 SecurityFilter 정책 그대로 사용).
  */
+@Tag(name = "AdminWithdrawal", description = "관리자 — 출금 신청 승인/거부")
 @RestController
 @RequestMapping("/api/v1/admin/withdrawals")
 public class AdminWithdrawalController {

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalResponse.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalResponse.java
@@ -2,19 +2,21 @@ package com.sseulang.domain.withdrawal.presentation.dto;
 
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalResult;
 import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "출금 신청 — 신청→승인→완료 / 거부. 신청 즉시 잔액 차감, 거부 시 자동 환불.")
 public record WithdrawalResponse(
-        Long id,
-        Long userId,
-        long amount,
-        String bankName,
-        String accountNumber,
-        String accountHolder,
+        @Schema(example = "31") Long id,
+        @Schema(example = "100") Long userId,
+        @Schema(example = "100000") long amount,
+        @Schema(example = "신한") String bankName,
+        @Schema(example = "110-123-456789") String accountNumber,
+        @Schema(example = "홍길동") String accountHolder,
         WithdrawalStatus status,
-        Long adminId,
-        String adminMemo,
+        @Schema(description = "처리한 관리자 id (신청 단계는 null)") Long adminId,
+        @Schema(description = "거부 사유 등 관리자 메모", example = "본인 계좌 미일치") String adminMemo,
         LocalDateTime requestedAt,
         LocalDateTime processedAt
 ) {

--- a/src/main/java/com/sseulang/global/common/ApiResponse.java
+++ b/src/main/java/com/sseulang/global/common/ApiResponse.java
@@ -1,9 +1,15 @@
 package com.sseulang.global.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ApiResponse<T>(boolean success, T data, ErrorBody error) {
+@Schema(description = "API 표준 응답 — 성공이면 data, 실패면 error 만 채워진다.")
+public record ApiResponse<T>(
+        @Schema(description = "성공 여부", example = "true") boolean success,
+        @Schema(description = "성공 시 데이터 (실패 시 null)") T data,
+        @Schema(description = "실패 시 에러 본문 (성공 시 null)") ErrorBody error
+) {
 
     public static <T> ApiResponse<T> ok(T data) {
         return new ApiResponse<>(true, data, null);
@@ -17,5 +23,10 @@ public record ApiResponse<T>(boolean success, T data, ErrorBody error) {
         return new ApiResponse<>(false, null, new ErrorBody(code, message, traceId));
     }
 
-    public record ErrorBody(String code, String message, String traceId) {}
+    @Schema(description = "에러 본문 — 코드는 ErrorCode enum 값, message 는 한국어, traceId 는 서버 로그 추적용.")
+    public record ErrorBody(
+            @Schema(description = "ErrorCode enum 값", example = "AUTH_TOKEN_EXPIRED") String code,
+            @Schema(description = "한국어 사용자 노출 메시지", example = "만료된 토큰입니다.") String message,
+            @Schema(description = "서버 로그 traceId (지원 요청 시 첨부)", example = "9f2c8c5b") String traceId
+    ) {}
 }

--- a/src/main/java/com/sseulang/global/common/PageResponse.java
+++ b/src/main/java/com/sseulang/global/common/PageResponse.java
@@ -1,16 +1,19 @@
 package com.sseulang.global.common;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 import org.springframework.data.domain.Page;
 
+@Schema(description = "페이징 응답 — page 는 0-based, size 는 1~100. 채팅 메시지 등 일부 영역은 커서 페이징 사용.")
 public record PageResponse<T>(
-        List<T> content,
-        int page,
-        int size,
-        long totalElements,
-        int totalPages,
-        boolean hasNext,
-        boolean hasPrevious
+        @Schema(description = "현재 페이지 항목 리스트") List<T> content,
+        @Schema(description = "현재 페이지 번호 (0-based)", example = "0") int page,
+        @Schema(description = "페이지 크기", example = "20") int size,
+        @Schema(description = "전체 항목 수", example = "123") long totalElements,
+        @Schema(description = "전체 페이지 수", example = "7") int totalPages,
+        @Schema(description = "다음 페이지 존재 여부", example = "true") boolean hasNext,
+        @Schema(description = "이전 페이지 존재 여부", example = "false") boolean hasPrevious
 ) {
 
     public static <T> PageResponse<T> from(Page<T> page) {

--- a/src/main/java/com/sseulang/global/config/OpenApiConfig.java
+++ b/src/main/java/com/sseulang/global/config/OpenApiConfig.java
@@ -2,30 +2,58 @@ package com.sseulang.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
 
     private static final String COOKIE_AUTH = "cookieAuth";
+    private static final String CSRF_HEADER = "csrfToken";
 
     @Bean
     public OpenAPI sseulangOpenApi() {
         return new OpenAPI()
                 .info(new Info()
                         .title("쓸랭(Sseulang) API")
-                        .description("중고 거래 + 대여 + 나눔 + 배달대행 통합 C2C 플랫폼 API")
-                        .version("v1"))
-                .addSecurityItem(new SecurityRequirement().addList(COOKIE_AUTH))
+                        .description("""
+                                중고 거래 + 대여 + 나눔 + 배달대행 통합 C2C 플랫폼.
+
+                                **인증**: HttpOnly 쿠키 `at` (Access) / `rt` (Refresh) — 브라우저가 자동 동봉.
+                                Swagger UI 에서 테스트하려면 먼저 `POST /api/v1/auth/login` 으로 로그인하세요.
+
+                                **CSRF**: 모든 mutating(POST/PATCH/PUT/DELETE) 요청은 `X-XSRF-TOKEN` 헤더 필수.
+                                값은 `XSRF-TOKEN` 쿠키에서 읽어 echo. (`/api/v1/auth/**`, `/api/v1/payments/webhook/**`,
+                                `/ws-stomp*` 는 면제)
+
+                                **응답 포맷**: 성공 `{success:true, data}`, 실패 `{success:false, error:{code,message,traceId}}`,
+                                페이징 `{content, page, size, totalElements, totalPages, hasNext, hasPrevious}`.
+
+                                **상세 ErrorCode + 연동 가이드**: `docs/FRONTEND_INTEGRATION.md`.
+                                """)
+                        .version("v1")
+                        .contact(new Contact().name("쓸랭 백엔드").email("noreply@sseulang.test")))
+                .servers(List.of(
+                        new Server().url("/").description("현재 서버"),
+                        new Server().url("http://localhost:8080").description("로컬")))
+                .addSecurityItem(new SecurityRequirement().addList(COOKIE_AUTH).addList(CSRF_HEADER))
                 .components(new Components()
                         .addSecuritySchemes(COOKIE_AUTH, new SecurityScheme()
                                 .type(SecurityScheme.Type.APIKEY)
                                 .in(SecurityScheme.In.COOKIE)
-                                .name("ACCESS_TOKEN")
-                                .description("HttpOnly 쿠키로 자동 전송됩니다. 브라우저에서 테스트하려면 로그인 후 사용하세요.")));
+                                .name("at")
+                                .description("HttpOnly Access Token. 로그인 후 자동 발급. Swagger 에서는 직접 설정 X — 로그인 응답 후 자동 동봉됨."))
+                        .addSecuritySchemes(CSRF_HEADER, new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .name("X-XSRF-TOKEN")
+                                .description("XSRF-TOKEN 쿠키 값을 echo. mutating 요청 필수.")));
     }
 }

--- a/src/main/java/com/sseulang/global/dev/DevAuthController.java
+++ b/src/main/java/com/sseulang/global/dev/DevAuthController.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>OAuth 콘솔 키 없이도 임의 user 시드 + JWT 쿠키 받아서 Swagger / curl 시나리오 가능.
  * 정식 OAuth 흐름 (가이드 §4.4) 과는 무관 — local 작업 편의 용이며 실서비스 배포 시 등록 X.</p>
  */
+@Tag(name = "DevAuth", description = "로컬 개발 인증 우회 (prod 비활성)")
 @RestController
 @RequestMapping("/api/v1/auth/dev")
 @Profile("local")


### PR DESCRIPTION
## Summary

PR #61 (Controller @Tag + OpenApiConfig) 위에 stack — 모든 Response DTO 26개에 `@Schema` 필드별 description + example 추가.

PR #61 머지 후 본 PR rebase → 머지.

## Changes

26 Response DTO 처리:
| 도메인 | DTO |
|---|---|
| Item | ItemDetail, ItemSummary, ItemId, ItemImage |
| Transaction | Transaction, TransactionId |
| Payment | Payment, ChargeStart |
| Withdrawal | Withdrawal |
| Delivery | Delivery |
| Review | Review, ReviewId, PendingReview |
| Chat/Message/Notification | ChatRoom, Message, Notification |
| Notice/Banner/Category | Notice, Banner, Category, CategoryNode |
| File | PresignedUrl + Upload nested |
| Admin | AdminUser, AdminReport, AdminDashboard |
| 기타 | ReportId, UserBlock |

각 record class 에 `@Schema(description="...")` 추가 + 필드별 `@Schema(example, description)`.

## Test plan

- [x] `./gradlew test` — 597 PASS / 0 FAIL
- [ ] 수동 — Swagger UI 에서 각 endpoint 의 응답 schema 가 description+example 포함되어 노출되는지 확인
- [ ] 수동 — Try It Out 에서 응답 모델 펼쳐 보기

## Notes

- 본 PR 후 추가 보강 가능 영역 (별도 follow-up):
  - 개별 endpoint `@Operation summary`
  - GlobalExceptionHandler → OpenApi global ApiResponses (401/403/404)
- PR #61 베이스. 머지 순서: #61 → 본 PR rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)