### PR TITLE
docs(swagger): API 명세 종합 보강 — Tag/Schema/Operation/Customizer/Enum

### DIFF
--- a/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
+++ b/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.auth.application.dto.TokenPair;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.security.CookieUtil;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -32,6 +33,8 @@ public class AdminAuthController {
         this.cookieUtil = cookieUtil;
     }
 
+    @Operation(summary = "관리자 로그인",
+            description = "username/password (BCrypt). 성공 시 ROLE_ADMIN AT/RT 쿠키 발급. 실패 401 AUTH_LOGIN_FAILED.")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody AdminLoginRequest request) {
         TokenPair pair = adminLoginService.login(request.username(), request.password());

--- a/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
+++ b/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.auth.application.dto.TokenPair;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.security.CookieUtil;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 관리자 로그인 진입점. SecurityConfig 의 {@code /api/v1/auth/**} permitAll 영역.
  * 일반 사용자 OAuth 흐름 ({@link com.sseulang.domain.auth.presentation.AuthController}) 와 분리.
  */
+@Tag(name = "AdminAuth", description = "관리자 로그인")
 @RestController
 @RequestMapping("/api/v1/auth/admin")
 public class AdminAuthController {

--- a/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
@@ -12,6 +12,7 @@ import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import com.sseulang.global.security.CookieUtil;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
@@ -46,14 +47,18 @@ public class AuthController {
         this.cookieUtil = cookieUtil;
     }
 
-    /** LOCAL email/password 가입 — 가입 즉시 자동 로그인 (AT/RT 쿠키 발급). */
+    @Operation(summary = "LOCAL 회원가입",
+            description = "이메일/비밀번호 가입. 성공 시 AT(at)/RT(rt) HttpOnly 쿠키 자동 발급 + 인증 메일 발송. "
+                    + "이메일 인증 전엔 자금 영향 API 가 403(AUTH_EMAIL_NOT_VERIFIED) 떨굼.")
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody LocalSignupRequest request) {
         TokenPair pair = localAuthService.signup(request.toEmailVO(), request.password(), request.nickname());
         return setAuthCookies(pair);
     }
 
-    /** LOCAL email/password 로그인. 미존재/차단/비밀번호 불일치 모두 동일 응답 (leak 방어). */
+    @Operation(summary = "LOCAL 로그인",
+            description = "이메일/비밀번호 로그인. 미존재/차단/비밀번호 불일치 모두 동일 응답(401 AUTH_LOGIN_FAILED) — 이메일 존재 여부 leak 방지. "
+                    + "성공 시 AT/RT 쿠키 자동 발급.")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody LocalLoginRequest request) {
         TokenPair pair = localAuthService.login(request.toEmailVO(), request.password());
@@ -69,6 +74,9 @@ public class AuthController {
                 .body(ApiResponse.ok());
     }
 
+    @Operation(summary = "OAuth 로그인 (kakao/google)",
+            description = "프론트가 SDK 로 받은 access_token 을 본 endpoint 에 POST. 백엔드가 provider 검증 + 신규/기존/takeover 분기 처리. "
+                    + "신규 가입은 email_verified=true 로 즉시 발급 (provider 검증된 이메일).")
     @PostMapping("/oauth2/{provider}")
     public ResponseEntity<ApiResponse<Void>> oauth2(
             @PathVariable("provider") String provider,
@@ -97,6 +105,9 @@ public class AuthController {
         };
     }
 
+    @Operation(summary = "AT 재발급 (RT rotation)",
+            description = "RT 쿠키로 새 AT/RT 쌍 발급. RT rotation 적용 — 사용된 RT 즉시 폐기. "
+                    + "AT 만료(401 AUTH_TOKEN_EXPIRED) 시 axios interceptor 등으로 자동 호출 권장.")
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<Void>> refresh(
             @CookieValue(name = CookieUtil.REFRESH_TOKEN_COOKIE, required = false) String refreshToken
@@ -115,6 +126,9 @@ public class AuthController {
                 .body(ApiResponse.ok());
     }
 
+    @Operation(summary = "로그아웃",
+            description = "AT 즉시 blacklist + RT 폐기 + AT/RT 쿠키 만료. "
+                    + "응답 후 모든 인증 요청 401(AUTH_TOKEN_REVOKED) 떨어짐.")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @CookieValue(name = CookieUtil.ACCESS_TOKEN_COOKIE, required = false) String accessToken,

--- a/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.auth.application.EmailVerificationService;
 import com.sseulang.domain.auth.presentation.dto.VerifyEmailRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
  *   <li>{@code /resend-verification} — auth 필수 (hasRole("USER")) + CSRF 적용 (게이트 1 round 2 보강)</li>
  * </ul>
  */
+@Tag(name = "EmailVerification", description = "이메일 인증 메일 발송/확인")
 @RestController
 @RequestMapping("/api/v1/auth")
 public class EmailVerificationController {

--- a/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.auth.application.EmailVerificationService;
 import com.sseulang.domain.auth.presentation.dto.VerifyEmailRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,13 +32,16 @@ public class EmailVerificationController {
         this.verificationService = verificationService;
     }
 
+    @Operation(summary = "이메일 인증 토큰 확인 (익명)",
+            description = "사용자가 인증 메일 링크 클릭 시 호출. 만료 400 AUTH_VERIFICATION_TOKEN_EXPIRED, 잘못된 토큰 400 AUTH_VERIFICATION_TOKEN_INVALID.")
     @PostMapping("/verify-email")
     public ApiResponse<Void> verify(@Valid @RequestBody VerifyEmailRequest request) {
         verificationService.verifyToken(request.token());
         return ApiResponse.ok();
     }
 
-    /** 본인 인증 메일 재발송 — 로그인 필수. 이미 verified 면 no-op. */
+    @Operation(summary = "인증 메일 재발송",
+            description = "로그인 필수. 이미 verified 면 no-op. rate limit 적용 (429 AUTH_VERIFICATION_RESEND_TOO_SOON).")
     @PostMapping("/resend-verification")
     public ApiResponse<Void> resend(@AuthenticationPrincipal Long userId) {
         verificationService.resendForUser(userId);

--- a/src/main/java/com/sseulang/domain/banner/presentation/AdminBannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/AdminBannerController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.banner.presentation.dto.BannerUpsertRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "AdminBanner", description = "관리자 — 배너 관리")
 @RestController
 @RequestMapping("/api/v1/admin/banners")
 public class AdminBannerController {

--- a/src/main/java/com/sseulang/domain/banner/presentation/AdminBannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/AdminBannerController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.banner.presentation.dto.BannerUpsertRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,7 @@ public class AdminBannerController {
         this.bannerService = bannerService;
     }
 
+    @Operation(summary = "[관리자] 배너 전체 목록", description = "active=false / 윈도우 외 배너도 모두 포함.")
     @GetMapping
     public ApiResponse<PageResponse<BannerResponse>> list(Pageable pageable) {
         return ApiResponse.ok(PageResponse.from(
@@ -39,11 +41,13 @@ public class AdminBannerController {
         ));
     }
 
+    @Operation(summary = "[관리자] 배너 단건 조회")
     @GetMapping("/{id}")
     public ApiResponse<BannerResponse> getOne(@PathVariable("id") Long id) {
         return ApiResponse.ok(BannerResponse.from(bannerService.adminFindById(id)));
     }
 
+    @Operation(summary = "[관리자] 배너 생성")
     @PostMapping
     public ResponseEntity<ApiResponse<Long>> create(
             @AuthenticationPrincipal Long adminId,
@@ -53,6 +57,7 @@ public class AdminBannerController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(id));
     }
 
+    @Operation(summary = "[관리자] 배너 전체 수정")
     @PatchMapping("/{id}")
     public ApiResponse<Void> update(
             @PathVariable("id") Long id,
@@ -62,6 +67,7 @@ public class AdminBannerController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "[관리자] 배너 활성/비활성 토글")
     @PatchMapping("/{id}/active")
     public ApiResponse<Void> setActive(
             @PathVariable("id") Long id,
@@ -71,6 +77,7 @@ public class AdminBannerController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "[관리자] 배너 삭제")
     @DeleteMapping("/{id}")
     public ApiResponse<Void> delete(@PathVariable("id") Long id) {
         bannerService.delete(id);

--- a/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.banner.presentation;
 import com.sseulang.domain.banner.application.BannerApplicationService;
 import com.sseulang.domain.banner.presentation.dto.BannerResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 /** 사용자 활성 배너 목록 — sort_order 정렬. */
+@Tag(name = "Banner", description = "배너 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/banners")
 public class BannerController {

--- a/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.banner.presentation;
 import com.sseulang.domain.banner.application.BannerApplicationService;
 import com.sseulang.domain.banner.presentation.dto.BannerResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +23,8 @@ public class BannerController {
         this.bannerService = bannerService;
     }
 
+    @Operation(summary = "활성 배너 목록 (공개)",
+            description = "active=true + 노출 윈도우 통과한 배너. sortOrder 오름차순.")
     @GetMapping
     public ApiResponse<List<BannerResponse>> list() {
         return ApiResponse.ok(bannerService.findVisible().stream()

--- a/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerResponse.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerResponse.java
@@ -1,17 +1,19 @@
 package com.sseulang.domain.banner.presentation.dto;
 
 import com.sseulang.domain.banner.application.dto.BannerResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "메인 배너 — 클릭 시 linkUrl 로 이동. active+startsAt~endsAt 로 노출 제어.")
 public record BannerResponse(
-        Long id,
-        Long adminId,
-        String title,
-        String imageUrl,
-        String linkUrl,
-        int sortOrder,
-        boolean active,
+        @Schema(example = "2") Long id,
+        @Schema(example = "1") Long adminId,
+        @Schema(example = "5월 봄맞이 이벤트") String title,
+        @Schema(example = "https://cdn.sseulang.com/banners/1/spring.jpg") String imageUrl,
+        @Schema(example = "/events/spring") String linkUrl,
+        @Schema(example = "1", description = "정렬 순서 (작을수록 앞)") int sortOrder,
+        @Schema(example = "true") boolean active,
         LocalDateTime startsAt,
         LocalDateTime endsAt,
         LocalDateTime createdAt

--- a/src/main/java/com/sseulang/domain/block/presentation/UserBlockController.java
+++ b/src/main/java/com/sseulang/domain/block/presentation/UserBlockController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.block.presentation.dto.UserBlockResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "UserBlock", description = "사용자 차단/해제")
 @RestController
 @RequestMapping("/api/v1/blocks")
 public class UserBlockController {

--- a/src/main/java/com/sseulang/domain/block/presentation/UserBlockController.java
+++ b/src/main/java/com/sseulang/domain/block/presentation/UserBlockController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.block.presentation.dto.UserBlockResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -33,6 +34,7 @@ public class UserBlockController {
         this.blockService = blockService;
     }
 
+    @Operation(summary = "사용자 차단", description = "차단 후 채팅/거래 불가. 멱등 — 이미 차단 상태 재호출 OK.")
     @PostMapping
     public ApiResponse<Void> block(
             @AuthenticationPrincipal Long blockerId,
@@ -42,6 +44,7 @@ public class UserBlockController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "사용자 차단 해제", description = "멱등 — 차단 안 한 상태 재호출 OK.")
     @DeleteMapping("/{userId}")
     public ApiResponse<Void> unblock(
             @AuthenticationPrincipal Long blockerId,
@@ -51,6 +54,7 @@ public class UserBlockController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "내가 차단한 사용자 목록")
     @GetMapping
     public ApiResponse<PageResponse<UserBlockResponse>> listMine(
             @AuthenticationPrincipal Long blockerId,

--- a/src/main/java/com/sseulang/domain/block/presentation/dto/UserBlockResponse.java
+++ b/src/main/java/com/sseulang/domain/block/presentation/dto/UserBlockResponse.java
@@ -1,10 +1,17 @@
 package com.sseulang.domain.block.presentation.dto;
 
 import com.sseulang.domain.block.application.dto.UserBlockResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-public record UserBlockResponse(Long id, Long blockerId, Long blockedId, LocalDateTime createdAt) {
+@Schema(description = "사용자 차단 관계 — blocker → blocked. 차단 후 채팅/거래 불가.")
+public record UserBlockResponse(
+        @Schema(example = "23") Long id,
+        @Schema(example = "100", description = "차단한 사용자") Long blockerId,
+        @Schema(example = "200", description = "차단당한 사용자") Long blockedId,
+        LocalDateTime createdAt
+) {
     public static UserBlockResponse from(UserBlockResult r) {
         return new UserBlockResponse(r.id(), r.blockerId(), r.blockedId(), r.createdAt());
     }

--- a/src/main/java/com/sseulang/domain/category/presentation/CategoryController.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/CategoryController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.presentation.dto.CategoryNodeResponse;
 import com.sseulang.domain.category.presentation.dto.CategoryResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Category", description = "카테고리 트리 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/categories")
 public class CategoryController {

--- a/src/main/java/com/sseulang/domain/category/presentation/CategoryController.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/CategoryController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.presentation.dto.CategoryNodeResponse;
 import com.sseulang.domain.category.presentation.dto.CategoryResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,6 +24,8 @@ public class CategoryController {
         this.categoryService = categoryService;
     }
 
+    @Operation(summary = "카테고리 트리 조회 (공개)",
+            description = "활성 카테고리 전체 트리. 루트부터 children 재귀.")
     @GetMapping
     public ApiResponse<List<CategoryNodeResponse>> getTree() {
         List<CategoryNodeResponse> tree = categoryService.getActiveTree().stream()
@@ -31,6 +34,7 @@ public class CategoryController {
         return ApiResponse.ok(tree);
     }
 
+    @Operation(summary = "카테고리 단건 조회 (공개)")
     @GetMapping("/{id}")
     public ApiResponse<CategoryResponse> getOne(@PathVariable("id") Long id) {
         return ApiResponse.ok(CategoryResponse.from(categoryService.getById(id)));

--- a/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryNodeResponse.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryNodeResponse.java
@@ -1,13 +1,15 @@
 package com.sseulang.domain.category.presentation.dto;
 
 import com.sseulang.domain.category.application.dto.CategoryNodeResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "카테고리 트리 노드 — children 재귀 구조. GET /categories 의 응답.")
 public record CategoryNodeResponse(
-        Long id,
-        String name,
-        int sortOrder,
+        @Schema(example = "5") Long id,
+        @Schema(example = "디지털/가전") String name,
+        @Schema(example = "1") int sortOrder,
         List<CategoryNodeResponse> children
 ) {
     public static CategoryNodeResponse from(CategoryNodeResult node) {

--- a/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryResponse.java
+++ b/src/main/java/com/sseulang/domain/category/presentation/dto/CategoryResponse.java
@@ -1,12 +1,14 @@
 package com.sseulang.domain.category.presentation.dto;
 
 import com.sseulang.domain.category.application.dto.CategoryResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "카테고리 단건 — parentId null 이면 루트.")
 public record CategoryResponse(
-        Long id,
-        Long parentId,
-        String name,
-        int sortOrder
+        @Schema(example = "5") Long id,
+        @Schema(description = "루트면 null") Long parentId,
+        @Schema(example = "디지털/가전") String name,
+        @Schema(example = "1") int sortOrder
 ) {
     public static CategoryResponse from(CategoryResult result) {
         return new CategoryResponse(result.id(), result.parentId(), result.name(), result.sortOrder());

--- a/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.chat.presentation.dto.ChatRoomResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -32,7 +33,9 @@ public class ChatRoomController {
         this.chatRoomService = chatRoomService;
     }
 
-    /** 멱등 — 같은 (요청자, 상대, 물품) 채팅방이 있으면 기존 반환, 없으면 생성. */
+    @Operation(summary = "채팅방 개설 (멱등)",
+            description = "이메일 인증 필수. 같은 (요청자, 상대, 물품) 채팅방이 있으면 기존 반환, 없으면 생성. "
+                    + "본인 물품 거부(403 CHAT_FORBIDDEN). 삭제/비공개 물품 거부.")
     @PostMapping
     public ApiResponse<ChatRoomResponse> openFor(
             @AuthenticationPrincipal Long requesterId,
@@ -42,6 +45,8 @@ public class ChatRoomController {
                 chatRoomService.openFor(requesterId, request.itemId())));
     }
 
+    @Operation(summary = "내 채팅방 목록",
+            description = "본인이 참여한 채팅방 페이징. lastMessageAt 최신순.")
     @GetMapping
     public ApiResponse<PageResponse<ChatRoomResponse>> listMine(
             @AuthenticationPrincipal Long requesterId,
@@ -57,6 +62,8 @@ public class ChatRoomController {
         return ApiResponse.ok(PageResponse.from(result));
     }
 
+    @Operation(summary = "채팅방 단건 조회",
+            description = "참여자만. 그 외 403 CHAT_FORBIDDEN.")
     @GetMapping("/{id}")
     public ApiResponse<ChatRoomResponse> getOne(
             @AuthenticationPrincipal Long requesterId,

--- a/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.chat.presentation.dto.ChatRoomResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "ChatRoom", description = "1:1 채팅방 개설/조회")
 @RestController
 @RequestMapping("/api/v1/chat-rooms")
 public class ChatRoomController {

--- a/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
@@ -1,19 +1,21 @@
 package com.sseulang.domain.chat.presentation.dto;
 
 import com.sseulang.domain.chat.application.dto.ChatRoomResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "1:1 채팅방 — (user1, user2, item) UNIQUE. user1Id < user2Id 정규화.")
 public record ChatRoomResponse(
-        Long id,
-        Long itemId,
-        Long user1Id,
-        Long user2Id,
-        String lastMessage,
+        @Schema(example = "8") Long id,
+        @Schema(example = "42") Long itemId,
+        @Schema(description = "정규화된 첫 사용자 (id 작은 쪽)", example = "100") Long user1Id,
+        @Schema(description = "정규화된 두번째 사용자", example = "200") Long user2Id,
+        @Schema(example = "안녕하세요, 거래 가능할까요?", description = "최근 메시지 미리보기") String lastMessage,
         LocalDateTime lastMessageAt,
-        int user1Unread,
-        int user2Unread,
-        boolean active,
+        @Schema(example = "0", description = "user1 의 미읽음 카운트") int user1Unread,
+        @Schema(example = "3", description = "user2 의 미읽음 카운트") int user2Unread,
+        @Schema(description = "false 면 차단/예약 등으로 비활성") boolean active,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryStatsResult.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryStatsResult.java
@@ -1,18 +1,18 @@
 package com.sseulang.domain.delivery.application.dto;
 
 import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 
 /**
  * 관리자 dashboard 용 배달대행 통계.
- *
- * @param total 전체 요청 건수
- * @param byStatus status 별 건수 (모든 enum 포함, 0 이면 0L)
- * @param settledFeeTotal 정산완료 상태 fee 합계 (KRW). 라이더 수익 총액 추정.
  */
+@Schema(description = "관리자 dashboard — 배달대행 통계.")
 public record DeliveryStatsResult(
-        long total,
+        @Schema(example = "42", description = "전체 배달 요청 수") long total,
+        @Schema(description = "status 별 카운트 — 모집중/수락/배송중/배송완료/정산완료/취소",
+                example = "{\"모집중\":3,\"수락\":2,\"배송중\":1,\"배송완료\":1,\"정산완료\":33,\"취소\":2}")
         Map<DeliveryStatus, Long> byStatus,
-        long settledFeeTotal
+        @Schema(example = "165000", description = "정산완료 상태 fee 합계 — 라이더 수익 총액 추정 (KRW)") long settledFeeTotal
 ) {}

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryStatus.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryStatus.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.delivery.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 배달대행 요청 상태. DB VARCHAR(20) ENUM 매핑.
  *
@@ -12,6 +13,7 @@ package com.sseulang.domain.delivery.domain;
  * ({@code WHERE id = ? AND status = '모집중'}) 로 동시 수락 차단. 본 enum 은 단일 row
  * 의 다음 전이가 가능한지 표현만 한다.</p>
  */
+@Schema(description = "배달 상태. 모집중→수락→배송중→배송완료→정산완료 (또는 취소).")
 public enum DeliveryStatus {
     모집중,
     수락,

--- a/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryController.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.delivery.presentation.dto.DeliveryCreateRequest;
 import com.sseulang.domain.delivery.presentation.dto.DeliveryResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +32,8 @@ public class DeliveryController {
         this.deliveryService = deliveryService;
     }
 
-    /** 요청 등록 — 요청자, requireVerified. */
+    @Operation(summary = "배달 요청 등록 (요청자)",
+            description = "이메일 인증 필수. 등록 시점에 fee escrow 안 함 — 정산(complete)에서 차감.")
     @PostMapping
     public ResponseEntity<ApiResponse<DeliveryResponse>> create(
             @AuthenticationPrincipal Long requesterId,
@@ -41,7 +43,8 @@ public class DeliveryController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(body));
     }
 
-    /** 모집중 목록 — 라이더가 수락 가능한 후보. 인증 필수, 본인 등록 여부는 클라이언트에서 필터. */
+    @Operation(summary = "모집중 배달 목록",
+            description = "라이더가 수락 가능한 후보. 본인 등록 여부 필터는 클라이언트 책임.")
     @GetMapping
     public ApiResponse<PageResponse<DeliveryResponse>> listOpen(Pageable pageable) {
         return ApiResponse.ok(PageResponse.from(
@@ -49,7 +52,8 @@ public class DeliveryController {
         ));
     }
 
-    /** 내 요청+수락 목록. */
+    @Operation(summary = "내 배달 목록 (요청+수락 포함)",
+            description = "본인이 requester 또는 rider 로 참여한 배달 페이징.")
     @GetMapping("/me")
     public ApiResponse<PageResponse<DeliveryResponse>> listMine(
             @AuthenticationPrincipal Long userId,
@@ -60,6 +64,8 @@ public class DeliveryController {
         ));
     }
 
+    @Operation(summary = "배달 단건 조회",
+            description = "모집중은 누구나 조회 가능. 그 외 상태는 참여자(requester/rider)만.")
     @GetMapping("/{id}")
     public ApiResponse<DeliveryResponse> getOne(
             @AuthenticationPrincipal Long userId,
@@ -68,7 +74,9 @@ public class DeliveryController {
         return ApiResponse.ok(DeliveryResponse.from(deliveryService.getById(id, userId)));
     }
 
-    /** 라이더 수락. */
+    @Operation(summary = "라이더 수락",
+            description = "이메일 인증 필수. 본인 거래 차단(400 DELIVERY_SELF_NOT_ALLOWED). "
+                    + "동시 수락 race 시 한 명만 성공(409 DELIVERY_ALREADY_ACCEPTED).")
     @PatchMapping("/{id}/accept")
     public ApiResponse<DeliveryResponse> accept(
             @AuthenticationPrincipal Long riderId,
@@ -77,7 +85,8 @@ public class DeliveryController {
         return ApiResponse.ok(DeliveryResponse.from(deliveryService.accept(id, riderId)));
     }
 
-    /** 라이더 픽업 완료. */
+    @Operation(summary = "라이더 픽업 완료",
+            description = "수락한 라이더만. 수락 → 배송중 전이.")
     @PatchMapping("/{id}/pickup")
     public ApiResponse<DeliveryResponse> pickup(
             @AuthenticationPrincipal Long riderId,
@@ -86,7 +95,8 @@ public class DeliveryController {
         return ApiResponse.ok(DeliveryResponse.from(deliveryService.markPickedUp(id, riderId)));
     }
 
-    /** 라이더 배송 완료. */
+    @Operation(summary = "라이더 배송 완료",
+            description = "수락한 라이더만. 배송중 → 배송완료 전이.")
     @PatchMapping("/{id}/deliver")
     public ApiResponse<DeliveryResponse> deliver(
             @AuthenticationPrincipal Long riderId,
@@ -95,7 +105,8 @@ public class DeliveryController {
         return ApiResponse.ok(DeliveryResponse.from(deliveryService.markDelivered(id, riderId)));
     }
 
-    /** 요청자 정산 확인 — 포인트 이동 + 정산완료. */
+    @Operation(summary = "요청자 정산 확인 — 포인트 이동",
+            description = "요청자만. 잔액에서 fee 차감 → 라이더 적립. 잔액 부족 400 INSUFFICIENT_POINT (전체 트랜잭션 롤백).")
     @PatchMapping("/{id}/complete")
     public ApiResponse<DeliveryResponse> complete(
             @AuthenticationPrincipal Long requesterId,
@@ -104,7 +115,8 @@ public class DeliveryController {
         return ApiResponse.ok(DeliveryResponse.from(deliveryService.complete(id, requesterId)));
     }
 
-    /** 요청자 취소 — 모집중 한정. */
+    @Operation(summary = "요청자 취소",
+            description = "모집중 한정. 수락 이후 취소는 400 DELIVERY_INVALID_STATE — 분쟁 흐름 별도 (follow-up).")
     @PatchMapping("/{id}/cancel")
     public ApiResponse<DeliveryResponse> cancel(
             @AuthenticationPrincipal Long requesterId,

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryResponse.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryResponse.java
@@ -2,19 +2,21 @@ package com.sseulang.domain.delivery.presentation.dto;
 
 import com.sseulang.domain.delivery.application.dto.DeliveryResult;
 import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "배달 요청 — 모집중→수락→배송중→배송완료→정산완료. 정산 시 요청자 차감/라이더 적립.")
 public record DeliveryResponse(
-        Long id,
-        Long requesterId,
-        Long riderId,
-        String pickupAddress,
-        String dropoffAddress,
-        String itemDescription,
-        long fee,
+        @Schema(example = "55") Long id,
+        @Schema(example = "100") Long requesterId,
+        @Schema(description = "수락 후 채워짐", example = "200") Long riderId,
+        @Schema(example = "서울 강남구 테헤란로 123") String pickupAddress,
+        @Schema(example = "서울 송파구 올림픽로 456") String dropoffAddress,
+        @Schema(example = "A4 서류 봉투 1개") String itemDescription,
+        @Schema(example = "5000", description = "라이더 수수료 — 정산 시 요청자 잔액에서 차감") long fee,
         LocalDateTime requestedDeadline,
-        String memo,
+        @Schema(example = "1층 로비 보관함") String memo,
         DeliveryStatus status,
         LocalDateTime requestedAt,
         LocalDateTime acceptedAt,

--- a/src/main/java/com/sseulang/domain/file/domain/FilePurpose.java
+++ b/src/main/java/com/sseulang/domain/file/domain/FilePurpose.java
@@ -1,11 +1,13 @@
 package com.sseulang.domain.file.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 업로드 용도. S3 폴더 구조 1단계 — {@code {purpose}/{ownerId}/{uuid}.{ext}}.
  *
  * <p>가이드 §4.5 폴더 구조와 정합. {@code messages/{roomId}/...} 처럼 owner 의미가 다른 케이스도
  * controller 에서 owner 를 적절히 결정해 전달한다.</p>
  */
+@Schema(description = "S3 업로드 용도 — PROFILE(프로필) / ITEM(물품) 만 일반 사용자 가능. NOTICE/BANNER/MESSAGE 는 도메인 전용.")
 public enum FilePurpose {
     PROFILE("profiles"),
     ITEM("items"),

--- a/src/main/java/com/sseulang/domain/file/presentation/FileController.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/FileController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.file.presentation.dto.PresignedUrlRequest;
 import com.sseulang.domain.file.presentation.dto.PresignedUrlResponse;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "File", description = "S3 presigned URL 발급")
 @RestController
 @RequestMapping("/api/v1/files")
 public class FileController {

--- a/src/main/java/com/sseulang/domain/file/presentation/FileController.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/FileController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.file.presentation.dto.PresignedUrlRequest;
 import com.sseulang.domain.file.presentation.dto.PresignedUrlResponse;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,6 +28,9 @@ public class FileController {
         this.fileService = fileService;
     }
 
+    @Operation(summary = "S3 presigned URL 발급",
+            description = "이메일 인증 필수. purpose=PROFILE/ITEM 만 (그 외 403 FORBIDDEN). "
+                    + "Content-Type=image/*, ≤5MB, 한 번에 ≤10건. URL 5분 만료. 발급 후 클라이언트가 S3 에 PUT 직접 업로드.")
     @PostMapping("/presigned-url")
     public ApiResponse<PresignedUrlResponse> issue(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/sseulang/domain/file/presentation/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/dto/PresignedUrlResponse.java
@@ -1,12 +1,19 @@
 package com.sseulang.domain.file.presentation.dto;
 
 import com.sseulang.domain.file.application.dto.PresignResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "S3 presigned URL 발급 응답 — 각 파일에 대해 PUT 가능한 URL + key 반환. 5분 만료.")
 public record PresignedUrlResponse(List<Upload> uploads) {
 
-    public record Upload(String presignedUrl, String key) {
+    @Schema(description = "단일 파일 업로드 URL 쌍.")
+    public record Upload(
+            @Schema(example = "https://bucket.s3.ap-northeast-2.amazonaws.com/items/100/abc.jpg?X-Amz-...",
+                    description = "이 URL 로 PUT (Content-Type 헤더 포함)") String presignedUrl,
+            @Schema(example = "items/100/abc.jpg", description = "S3 객체 키 — Item 등록 시 imageUrls 에 그대로 사용") String key
+    ) {
         public static Upload from(PresignResult r) {
             return new Upload(r.presignedUrl(), r.key());
         }

--- a/src/main/java/com/sseulang/domain/item/domain/ItemStatus.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemStatus.java
@@ -1,11 +1,13 @@
 package com.sseulang.domain.item.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 물품 상태. DB ENUM('판매중','예약','거래완료','비공개','삭제') 1:1 매핑.
  *
  * <p>거래 관련 상태(예약, 거래완료) 전이는 {@code transaction} 도메인이 트리거 — Item 자체로는
  * markAsHidden / markAsDeleted / restore 만 직접 노출.</p>
  */
+@Schema(description = "물품 상태. 판매중→예약→거래완료. 비공개/삭제 는 별도.")
 public enum ItemStatus {
     판매중,
     예약,

--- a/src/main/java/com/sseulang/domain/item/domain/RentalUnit.java
+++ b/src/main/java/com/sseulang/domain/item/domain/RentalUnit.java
@@ -1,8 +1,10 @@
 package com.sseulang.domain.item.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 대여 단위. DB는 VARCHAR(20) — '시간 | 일 | 주 | 월'. {@code @Enumerated(EnumType.STRING)} 으로 그대로 저장.
  */
+@Schema(description = "대여 단위 — 시간 / 일 / 주 / 월. 대여 거래에만 사용 (판매/나눔은 null).")
 public enum RentalUnit {
     시간,
     일,

--- a/src/main/java/com/sseulang/domain/item/domain/TradeType.java
+++ b/src/main/java/com/sseulang/domain/item/domain/TradeType.java
@@ -1,8 +1,10 @@
 package com.sseulang.domain.item.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 거래 타입. DB ENUM('대여','판매','나눔') 과 1:1 매핑 — {@code @Enumerated(EnumType.STRING)} 으로 name 그대로 저장.
  */
+@Schema(description = "거래 종류 — 판매 / 대여 / 나눔.")
 public enum TradeType {
     대여,
     판매,

--- a/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
@@ -10,6 +10,7 @@ import com.sseulang.domain.item.presentation.dto.ItemSummaryResponse;
 import com.sseulang.domain.item.presentation.dto.ItemUpdateRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -41,6 +42,8 @@ public class ItemController {
         this.itemService = itemService;
     }
 
+    @Operation(summary = "물품 등록",
+            description = "이메일 인증 필수. imageUrls 의 임시 폴더(items/{userId}/) 가 등록 후 정식 폴더(items/{itemId}/) 로 자동 promote.")
     @PostMapping
     public ResponseEntity<ApiResponse<ItemIdResponse>> register(
             @AuthenticationPrincipal Long sellerId,
@@ -51,6 +54,8 @@ public class ItemController {
                 .body(ApiResponse.ok(new ItemIdResponse(id)));
     }
 
+    @Operation(summary = "물품 검색·페이징 (공개)",
+            description = "FULLTEXT(ngram) 검색. q 1글자는 LIKE 폴백. categoryId/tradeType/minPrice/maxPrice/tag 조합 필터. 인증 불필요.")
     @GetMapping
     public ApiResponse<PageResponse<ItemSummaryResponse>> list(
             @RequestParam(name = "q", required = false) String q,
@@ -72,11 +77,15 @@ public class ItemController {
         return ApiResponse.ok(PageResponse.from(result));
     }
 
+    @Operation(summary = "물품 상세 조회 (공개)",
+            description = "조회 시 viewCount 1 증가. 삭제된 물품은 404. 인증 불필요.")
     @GetMapping("/{id}")
     public ApiResponse<ItemDetailResponse> getOne(@PathVariable("id") Long id) {
         return ApiResponse.ok(ItemDetailResponse.from(itemService.getById(id)));
     }
 
+    @Operation(summary = "물품 수정",
+            description = "본인 물품만. imageUrls non-null 이면 전체 교체 + 임시→정식 promote. hashtags non-null 이면 전체 교체.")
     @PatchMapping("/{id}")
     public ApiResponse<Void> update(
             @AuthenticationPrincipal Long requesterId,
@@ -87,6 +96,8 @@ public class ItemController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "물품 삭제 (soft delete)",
+            description = "본인 물품만. status=삭제 로 전환. 관련 거래/채팅방은 유지.")
     @DeleteMapping("/{id}")
     public ApiResponse<Void> delete(
             @AuthenticationPrincipal Long requesterId,

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemDetailResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemDetailResponse.java
@@ -4,26 +4,28 @@ import com.sseulang.domain.item.application.dto.ItemDetailResult;
 import com.sseulang.domain.item.domain.ItemStatus;
 import com.sseulang.domain.item.domain.RentalUnit;
 import com.sseulang.domain.item.domain.TradeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "물품 상세 — 이미지/해시태그 포함. GET /items/{id} 호출 시 viewCount 1 증가.")
 public record ItemDetailResponse(
-        Long id,
-        Long sellerId,
-        Long categoryId,
-        String title,
-        String description,
-        long price,
-        Long deposit,
-        RentalUnit rentalUnit,
+        @Schema(example = "42") Long id,
+        @Schema(example = "100") Long sellerId,
+        @Schema(example = "5", description = "카테고리 id (없으면 null)") Long categoryId,
+        @Schema(example = "아이폰 14 Pro 미개봉") String title,
+        @Schema(example = "박스 미개봉, 색상 딥퍼플") String description,
+        @Schema(example = "1200000") long price,
+        @Schema(example = "100000", description = "대여 시 보증금 (판매/나눔은 null)") Long deposit,
+        @Schema(description = "대여 단위 (판매/나눔은 null)") RentalUnit rentalUnit,
         TradeType tradeType,
         ItemStatus status,
-        String region,
-        int viewCount,
-        int wishlistCount,
+        @Schema(example = "서울 강남구") String region,
+        @Schema(example = "127") int viewCount,
+        @Schema(example = "8") int wishlistCount,
         List<ItemImageResponse> images,
-        List<String> hashtags,
+        @Schema(example = "[\"아이폰\",\"미개봉\"]") List<String> hashtags,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemIdResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemIdResponse.java
@@ -1,3 +1,6 @@
 package com.sseulang.domain.item.presentation.dto;
 
-public record ItemIdResponse(Long id) { }
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "물품 등록 후 발급된 id 응답.")
+public record ItemIdResponse(@Schema(example = "42") Long id) { }

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemImageResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemImageResponse.java
@@ -1,8 +1,14 @@
 package com.sseulang.domain.item.presentation.dto;
 
 import com.sseulang.domain.item.application.dto.ItemImageResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record ItemImageResponse(String imageUrl, int sortOrder, boolean thumbnail) {
+@Schema(description = "물품 이미지 — 등록 시 임시 폴더에서 정식 폴더(items/{itemId}/) 로 promote 된 url.")
+public record ItemImageResponse(
+        @Schema(example = "https://cdn.sseulang.com/items/42/abc.jpg") String imageUrl,
+        @Schema(example = "1", description = "표시 순서 (1-based)") int sortOrder,
+        @Schema(example = "true", description = "썸네일 여부 (sortOrder=1 만 true)") boolean thumbnail
+) {
     public static ItemImageResponse from(ItemImageResult r) {
         return new ItemImageResponse(r.imageUrl(), r.sortOrder(), r.thumbnail());
     }

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemSummaryResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemSummaryResponse.java
@@ -3,18 +3,20 @@ package com.sseulang.domain.item.presentation.dto;
 import com.sseulang.domain.item.application.dto.ItemSummaryResult;
 import com.sseulang.domain.item.domain.ItemStatus;
 import com.sseulang.domain.item.domain.TradeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "물품 목록 row — 검색/페이징 응답에 포함.")
 public record ItemSummaryResponse(
-        Long id,
-        Long sellerId,
-        Long categoryId,
-        String title,
-        long price,
+        @Schema(example = "42") Long id,
+        @Schema(example = "100") Long sellerId,
+        @Schema(example = "5") Long categoryId,
+        @Schema(example = "아이폰 14 Pro 미개봉") String title,
+        @Schema(example = "1200000") long price,
         TradeType tradeType,
         ItemStatus status,
-        String region,
+        @Schema(example = "서울 강남구") String region,
         LocalDateTime createdAt
 ) {
     public static ItemSummaryResponse from(ItemSummaryResult r) {

--- a/src/main/java/com/sseulang/domain/message/presentation/MessageController.java
+++ b/src/main/java/com/sseulang/domain/message/presentation/MessageController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.message.presentation.dto.MessageResponse;
 import com.sseulang.domain.message.presentation.dto.MessageSendRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,9 @@ public class MessageController {
         this.messageService = messageService;
     }
 
+    @Operation(summary = "메시지 전송 (REST)",
+            description = "채팅방 참여자만. content 또는 imageUrls 둘 중 하나 이상. 전송 후 STOMP topic 으로 broadcast + 상대방 알림 푸시. "
+                    + "WebSocket SEND 와 동일 결과 — 어느 경로든 OK.")
     @PostMapping
     public ResponseEntity<ApiResponse<MessageResponse>> send(
             @AuthenticationPrincipal Long senderId,
@@ -42,7 +46,8 @@ public class MessageController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
     }
 
-    /** 커서 페이징 — {@code ?before={messageId}&size=30}. 결과는 최신순. */
+    @Operation(summary = "메시지 커서 페이징",
+            description = "최신순. before(messageId) 가 있으면 그 이전 size 개 — 무한 스크롤 패턴. 채팅방 참여자만.")
     @GetMapping
     public ApiResponse<List<MessageResponse>> listPage(
             @AuthenticationPrincipal Long requesterId,

--- a/src/main/java/com/sseulang/domain/message/presentation/MessageController.java
+++ b/src/main/java/com/sseulang/domain/message/presentation/MessageController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.message.presentation.dto.MessageResponse;
 import com.sseulang.domain.message.presentation.dto.MessageSendRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Message", description = "채팅 메시지 송수신 + 페이징")
 @RestController
 @RequestMapping("/api/v1/chat-rooms/{roomId}/messages")
 public class MessageController {

--- a/src/main/java/com/sseulang/domain/message/presentation/dto/MessageResponse.java
+++ b/src/main/java/com/sseulang/domain/message/presentation/dto/MessageResponse.java
@@ -1,16 +1,18 @@
 package com.sseulang.domain.message.presentation.dto;
 
 import com.sseulang.domain.message.application.dto.MessageResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 import java.util.List;
 
+@Schema(description = "채팅 메시지 — MongoDB 저장. content/imageUrls 둘 중 하나 이상 채워짐.")
 public record MessageResponse(
-        String id,
-        Long chatRoomId,
-        Long senderId,
-        String content,
-        List<String> imageUrls,
+        @Schema(example = "65a1b2c3d4e5f60001234567", description = "MongoDB ObjectId hex") String id,
+        @Schema(example = "8") Long chatRoomId,
+        @Schema(example = "200") Long senderId,
+        @Schema(example = "안녕하세요, 거래 가능할까요?") String content,
+        @Schema(description = "이미지 메시지 URL 목록 (텍스트 메시지면 빈 배열)") List<String> imageUrls,
         Instant createdAt
 ) {
     public static MessageResponse from(MessageResult r) {

--- a/src/main/java/com/sseulang/domain/notice/domain/NoticeType.java
+++ b/src/main/java/com/sseulang/domain/notice/domain/NoticeType.java
@@ -1,9 +1,11 @@
 package com.sseulang.domain.notice.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * V1 schema notices.type ENUM 매핑. 한글 enum 이름은 DB ENUM 값과 동일해야 한다 (Hibernate
  * EnumType.STRING 으로 그대로 매핑).
  */
+@Schema(description = "공지 유형 — 공지(일반) / 이벤트.")
 public enum NoticeType {
     공지,
     이벤트

--- a/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
@@ -8,6 +8,7 @@ import com.sseulang.domain.notice.presentation.dto.NoticeUpsertRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -37,6 +38,7 @@ public class AdminNoticeController {
         this.noticeService = noticeService;
     }
 
+    @Operation(summary = "[관리자] 공지 전체 목록", description = "미공개/윈도우 외 공지 모두 포함.")
     @GetMapping
     public ApiResponse<PageResponse<NoticeResponse>> list(
             @RequestParam(value = "type", required = false) NoticeType type,
@@ -47,11 +49,13 @@ public class AdminNoticeController {
         ));
     }
 
+    @Operation(summary = "[관리자] 공지 단건 조회")
     @GetMapping("/{id}")
     public ApiResponse<NoticeResponse> getOne(@PathVariable("id") Long id) {
         return ApiResponse.ok(NoticeResponse.from(noticeService.adminFindById(id)));
     }
 
+    @Operation(summary = "[관리자] 공지 생성")
     @PostMapping
     public ResponseEntity<ApiResponse<Long>> create(
             @AuthenticationPrincipal Long adminId,
@@ -61,6 +65,7 @@ public class AdminNoticeController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(id));
     }
 
+    @Operation(summary = "[관리자] 공지 전체 수정")
     @PatchMapping("/{id}")
     public ApiResponse<Void> update(
             @PathVariable("id") Long id,
@@ -70,6 +75,7 @@ public class AdminNoticeController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "[관리자] 공지 상단 고정 토글")
     @PatchMapping("/{id}/pin")
     public ApiResponse<Void> setPinned(
             @PathVariable("id") Long id,
@@ -79,6 +85,7 @@ public class AdminNoticeController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "[관리자] 공지 게시/비게시 토글")
     @PatchMapping("/{id}/publish")
     public ApiResponse<Void> setPublished(
             @PathVariable("id") Long id,
@@ -88,6 +95,7 @@ public class AdminNoticeController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "[관리자] 공지 삭제 (hard delete)")
     @DeleteMapping("/{id}")
     public ApiResponse<Void> delete(@PathVariable("id") Long id) {
         noticeService.delete(id);

--- a/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
@@ -8,6 +8,7 @@ import com.sseulang.domain.notice.presentation.dto.NoticeUpsertRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 관리자 공지 CRUD + 상태 토글. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
  */
+@Tag(name = "AdminNotice", description = "관리자 — 공지 작성/관리")
 @RestController
 @RequestMapping("/api/v1/admin/notices")
 public class AdminNoticeController {

--- a/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.notice.domain.NoticeType;
 import com.sseulang.domain.notice.presentation.dto.NoticeResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +28,8 @@ public class NoticeController {
         this.noticeService = noticeService;
     }
 
+    @Operation(summary = "공지 목록 (공개)",
+            description = "노출 윈도우 통과한 published 공지만. type 필터 옵션. pinned 우선 정렬.")
     @GetMapping
     public ApiResponse<PageResponse<NoticeResponse>> list(
             @RequestParam(value = "type", required = false) NoticeType type,
@@ -37,7 +40,8 @@ public class NoticeController {
         ));
     }
 
-    /** 단건 조회 시 view_count++. 미공개·윈도우 외 공지는 NOT_FOUND. */
+    @Operation(summary = "공지 단건 조회 (공개)",
+            description = "조회 시 viewCount 1 증가. 미공개·윈도우 외 공지는 404 NOTICE_NOT_FOUND.")
     @GetMapping("/{id}")
     public ApiResponse<NoticeResponse> getOne(@PathVariable("id") Long id) {
         return ApiResponse.ok(NoticeResponse.from(noticeService.viewById(id)));

--- a/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.notice.domain.NoticeType;
 import com.sseulang.domain.notice.presentation.dto.NoticeResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 사용자 공지 조회 — 노출 윈도우 통과한 공지만. SecurityConfig user chain 으로 ROLE_USER 강제.
  */
+@Tag(name = "Notice", description = "공지 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/notices")
 public class NoticeController {

--- a/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeResponse.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeResponse.java
@@ -2,19 +2,21 @@ package com.sseulang.domain.notice.presentation.dto;
 
 import com.sseulang.domain.notice.application.dto.NoticeResult;
 import com.sseulang.domain.notice.domain.NoticeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "공지사항 — 관리자 작성. pinned 는 상단 고정, published+startsAt~endsAt 로 노출 제어.")
 public record NoticeResponse(
-        Long id,
-        Long adminId,
+        @Schema(example = "3") Long id,
+        @Schema(example = "1", description = "작성한 관리자 id") Long adminId,
         NoticeType type,
-        String title,
-        String content,
-        String imageUrl,
-        boolean pinned,
-        boolean published,
-        int viewCount,
+        @Schema(example = "결제 시스템 점검 안내") String title,
+        @Schema(example = "5/3 03:00~05:00 결제 일시 중단됩니다.") String content,
+        @Schema(description = "본문 상단 이미지 (선택)") String imageUrl,
+        @Schema(example = "true", description = "상단 고정 여부") boolean pinned,
+        @Schema(example = "true", description = "게시 여부") boolean published,
+        @Schema(example = "152") int viewCount,
         LocalDateTime startsAt,
         LocalDateTime endsAt,
         LocalDateTime createdAt

--- a/src/main/java/com/sseulang/domain/notification/domain/NotificationType.java
+++ b/src/main/java/com/sseulang/domain/notification/domain/NotificationType.java
@@ -1,6 +1,8 @@
 package com.sseulang.domain.notification.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /** 알림 유형 — 가이드 §4.10 시스템 → 사용자 단방향. */
+@Schema(description = "알림 유형 — 메시지 / 거래 / 리뷰 / 공지 / 시스템.")
 public enum NotificationType {
     메시지,
     거래,

--- a/src/main/java/com/sseulang/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/sseulang/domain/notification/presentation/NotificationController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.notification.application.NotificationApplicationServi
 import com.sseulang.domain.notification.presentation.dto.NotificationResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Notification", description = "알림 조회/읽음 처리")
 @RestController
 @RequestMapping("/api/v1/notifications")
 public class NotificationController {

--- a/src/main/java/com/sseulang/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/sseulang/domain/notification/presentation/NotificationController.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.notification.application.NotificationApplicationServi
 import com.sseulang.domain.notification.presentation.dto.NotificationResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -29,6 +30,8 @@ public class NotificationController {
         this.notificationService = notificationService;
     }
 
+    @Operation(summary = "내 알림 목록",
+            description = "본인 알림 페이징. read=false 필터는 클라이언트 책임 (현재 서버 필터 X — follow-up).")
     @GetMapping
     public ApiResponse<PageResponse<NotificationResponse>> listMine(
             @AuthenticationPrincipal Long userId,
@@ -44,6 +47,8 @@ public class NotificationController {
         return ApiResponse.ok(PageResponse.from(result));
     }
 
+    @Operation(summary = "알림 읽음 처리",
+            description = "본인 알림만 (그 외 무시). id 는 MongoDB ObjectId hex 24자.")
     @PatchMapping("/{id}/read")
     public ApiResponse<Void> markAsRead(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/sseulang/domain/notification/presentation/dto/NotificationResponse.java
+++ b/src/main/java/com/sseulang/domain/notification/presentation/dto/NotificationResponse.java
@@ -2,17 +2,19 @@ package com.sseulang.domain.notification.presentation.dto;
 
 import com.sseulang.domain.notification.application.dto.NotificationResult;
 import com.sseulang.domain.notification.domain.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 
+@Schema(description = "알림 — MongoDB 저장. linkType+linkId 로 클라이언트가 화면 라우팅.")
 public record NotificationResponse(
-        String id,
+        @Schema(example = "65a1b2c3d4e5f60001234567") String id,
         NotificationType type,
-        String title,
-        String content,
-        String linkType,
-        Long linkId,
-        boolean read,
+        @Schema(example = "새 메시지") String title,
+        @Schema(example = "안녕하세요, 거래 가능할까요?") String content,
+        @Schema(example = "CHAT_ROOM", description = "라우팅 종류 (CHAT_ROOM / TRANSACTION / DELIVERY 등)") String linkType,
+        @Schema(example = "8") Long linkId,
+        @Schema(description = "읽음 여부", example = "false") boolean read,
         Instant createdAt
 ) {
     public static NotificationResponse from(NotificationResult r) {

--- a/src/main/java/com/sseulang/domain/payment/application/dto/PaymentStatsResult.java
+++ b/src/main/java/com/sseulang/domain/payment/application/dto/PaymentStatsResult.java
@@ -1,6 +1,12 @@
 package com.sseulang.domain.payment.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * 결제 통계 — 완료된 결제 건수 + 누적 금액. 미완료/실패/환불 결제는 제외.
  */
-public record PaymentStatsResult(long paidCount, long totalPaidAmount) {}
+@Schema(description = "관리자 dashboard — 결제 통계 (완료된 결제만).")
+public record PaymentStatsResult(
+        @Schema(example = "342", description = "완료(PAID) 상태 결제 수") long paidCount,
+        @Schema(example = "12500000", description = "완료된 결제 누적 금액 합계 (KRW)") long totalPaidAmount
+) {}

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentMethod.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentMethod.java
@@ -1,9 +1,11 @@
 package com.sseulang.domain.payment.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 결제 수단. 토스가 응답에 String 으로 반환 (CARD / TRANSFER / VIRTUAL_ACCOUNT 등).
  * DB는 VARCHAR(30) — Java enum 으로는 그대로 영문 식별자 사용.
  */
+@Schema(description = "결제 수단 — CARD(카드) / TRANSFER(계좌이체) / VIRTUAL_ACCOUNT(가상계좌) / POINT(포인트). 토스 SDK 응답을 그대로 매핑.")
 public enum PaymentMethod {
     CARD,
     TRANSFER,

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentStatus.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.payment.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 결제 상태. DB ENUM('대기','진행중','완료','실패','환불진행중','환불완료','환불실패') 1:1.
  * <p>상태 머신:</p>
@@ -10,6 +11,7 @@ package com.sseulang.domain.payment.domain;
  *                    ↘ 환불실패
  * </pre>
  */
+@Schema(description = "결제 상태. 대기→진행중→완료/실패. 완료→환불진행중→환불완료/환불실패.")
 public enum PaymentStatus {
     대기,
     진행중,

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentType.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentType.java
@@ -1,9 +1,11 @@
 package com.sseulang.domain.payment.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 결제 종류. DB ENUM('충전','대여금','보증금','수수료','환불') 1:1.
  * 본 PR(Day 7) 은 {@link #충전} 에 집중. 거래 결제(대여금/보증금)는 Day 8 영역.
  */
+@Schema(description = "결제 종류 — 충전(잔액 충전) / 대여금 / 보증금 / 수수료 / 환불.")
 public enum PaymentType {
     충전,
     대여금,

--- a/src/main/java/com/sseulang/domain/payment/presentation/PaymentController.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/PaymentController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.payment.presentation.dto.ChargeStartRequest;
 import com.sseulang.domain.payment.presentation.dto.ChargeStartResponse;
 import com.sseulang.domain.payment.presentation.dto.PaymentResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,8 @@ public class PaymentController {
         this.paymentService = paymentService;
     }
 
+    @Operation(summary = "충전 시작",
+            description = "백엔드가 merchantUid 발급 + tossClientKey 반환. 응답 받은 즉시 토스 SDK 결제창 호출. 이메일 인증 필수.")
     @PostMapping("/charge")
     public ResponseEntity<ApiResponse<ChargeStartResponse>> startCharge(
             @AuthenticationPrincipal Long userId,
@@ -41,6 +44,9 @@ public class PaymentController {
                 )));
     }
 
+    @Operation(summary = "충전 확정",
+            description = "토스 SDK 결제 성공 콜백 후 호출. 백엔드가 토스 confirm API 로 amount 재검증 (위변조 차단) → 잔액 충전. "
+                    + "amount mismatch 400 PAYMENT_AMOUNT_MISMATCH, 같은 merchantUid 재호출 409 PAYMENT_DUPLICATED.")
     @PostMapping("/charge/confirm")
     public ApiResponse<PaymentResponse> confirmCharge(
             @AuthenticationPrincipal Long userId,
@@ -66,6 +72,9 @@ public class PaymentController {
      *
      * <p>SecurityConfig 의 CSRF / auth 면제 이미 적용 (Day 7).</p>
      */
+    @Operation(summary = "토스 결제 webhook (외부)",
+            description = "토스에서 호출. 인증/CSRF 면제. transmission-id 로 멱등성 보장. "
+                    + "위변조 방지는 토스 lookup API 재조회로 검증. 프론트는 호출하지 않음.")
     @PostMapping("/webhook/toss")
     public ApiResponse<Void> tossWebhook(
             @RequestBody String rawPayload,
@@ -75,6 +84,8 @@ public class PaymentController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "결제 단건 조회",
+            description = "본인 결제만. status 가 PENDING 이면 webhook 또는 5분 reconciliation scheduler 대기 중.")
     @GetMapping("/{id}")
     public ApiResponse<PaymentResponse> getOne(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/sseulang/domain/payment/presentation/dto/ChargeStartResponse.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/dto/ChargeStartResponse.java
@@ -1,12 +1,14 @@
 package com.sseulang.domain.payment.presentation.dto;
 
 import com.sseulang.domain.payment.application.dto.ChargeStartResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "충전 시작 응답 — 받은 merchantUid + amount + tossClientKey 로 토스 SDK 결제창 호출.")
 public record ChargeStartResponse(
-        Long paymentId,
-        String merchantUid,
-        long amount,
-        String tossClientKey
+        @Schema(example = "78") Long paymentId,
+        @Schema(example = "merchant-9f2c8c5b", description = "토스 결제창에 전달할 주문번호 (UNIQUE, 백엔드 발급)") String merchantUid,
+        @Schema(example = "50000") long amount,
+        @Schema(example = "test_ck_...", description = "프론트가 토스 SDK 초기화에 사용") String tossClientKey
 ) {
     public static ChargeStartResponse from(ChargeStartResult r) {
         return new ChargeStartResponse(r.paymentId(), r.merchantUid(), r.amount(), r.tossClientKey());

--- a/src/main/java/com/sseulang/domain/payment/presentation/dto/PaymentResponse.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/dto/PaymentResponse.java
@@ -4,18 +4,20 @@ import com.sseulang.domain.payment.application.dto.PaymentResult;
 import com.sseulang.domain.payment.domain.PaymentMethod;
 import com.sseulang.domain.payment.domain.PaymentStatus;
 import com.sseulang.domain.payment.domain.PaymentType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "결제 — 토스페이먼츠 충전. paidAt 채워지면 잔액 충전 완료. status 가 PENDING 이면 webhook 또는 reconciliation 대기.")
 public record PaymentResponse(
-        Long id,
-        Long userId,
-        Long transactionId,
+        @Schema(example = "78") Long id,
+        @Schema(example = "100") Long userId,
+        @Schema(description = "거래 결제용일 때만 채워짐 (충전형은 null)", example = "12") Long transactionId,
         PaymentType paymentType,
         PaymentMethod method,
-        long amount,
+        @Schema(example = "50000") long amount,
         PaymentStatus status,
-        String merchantUid,
+        @Schema(example = "merchant-9f2c8c5b") String merchantUid,
         LocalDateTime paidAt,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/sseulang/domain/report/domain/ReportStatus.java
+++ b/src/main/java/com/sseulang/domain/report/domain/ReportStatus.java
@@ -1,9 +1,11 @@
 package com.sseulang.domain.report.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 신고 처리 상태. DB ENUM('접수','처리중','처리완료','반려') 1:1.
  * 상태 전이는 관리자가 트리거 (Day 9 admin 도메인).
  */
+@Schema(description = "신고 처리 상태. 접수→처리중→처리완료/반려.")
 public enum ReportStatus {
     접수,
     처리중,

--- a/src/main/java/com/sseulang/domain/report/presentation/AdminReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/AdminReportController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.report.presentation.dto.AdminReportResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "AdminReport", description = "관리자 — 신고 처리")
 @RestController
 @RequestMapping("/api/v1/admin/reports")
 public class AdminReportController {

--- a/src/main/java/com/sseulang/domain/report/presentation/AdminReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/AdminReportController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.report.presentation.dto.AdminReportResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,6 +30,7 @@ public class AdminReportController {
         this.reportService = reportService;
     }
 
+    @Operation(summary = "[관리자] 신고 목록", description = "status 필터 (PENDING/IN_PROGRESS/COMPLETED/REJECTED) + 페이징.")
     @GetMapping
     public ApiResponse<PageResponse<AdminReportResponse>> list(
             @RequestParam(value = "status", required = false) ReportStatus status,
@@ -39,11 +41,14 @@ public class AdminReportController {
         ));
     }
 
+    @Operation(summary = "[관리자] 신고 단건 조회")
     @GetMapping("/{id}")
     public ApiResponse<AdminReportResponse> getOne(@PathVariable("id") Long id) {
         return ApiResponse.ok(AdminReportResponse.from(reportService.adminFindById(id)));
     }
 
+    @Operation(summary = "[관리자] 신고 처리",
+            description = "action: MARK_IN_PROGRESS(검토 시작) / COMPLETE(처리 완료) / REJECT(반려).")
     @PatchMapping("/{id}")
     public ApiResponse<Void> decide(
             @AuthenticationPrincipal Long adminId,

--- a/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.report.presentation.dto.ReportIdResponse;
 import com.sseulang.domain.report.presentation.dto.ReportRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 사용자/물품 신고 진입점. Item 신고는 가이드 §6.1 의 {@code POST /api/v1/items/{id}/report},
  * User 신고는 별도 {@code POST /api/v1/users/{id}/report}.
  */
+@Tag(name = "Report", description = "사용자 신고 등록")
 @RestController
 public class UserReportController {
 

--- a/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.report.presentation.dto.ReportIdResponse;
 import com.sseulang.domain.report.presentation.dto.ReportRequest;
 import com.sseulang.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,6 +29,7 @@ public class UserReportController {
         this.reportService = reportService;
     }
 
+    @Operation(summary = "물품 신고", description = "이메일 인증 필수. 본인 물품 신고도 허용 (자기 보호 케이스).")
     @PostMapping("/api/v1/items/{itemId}/report")
     public ResponseEntity<ApiResponse<ReportIdResponse>> reportItem(
             @AuthenticationPrincipal Long reporterId,
@@ -39,6 +41,7 @@ public class UserReportController {
                 .body(ApiResponse.ok(new ReportIdResponse(id)));
     }
 
+    @Operation(summary = "사용자 신고", description = "이메일 인증 필수. 신고 후 관리자가 PENDING → 처리.")
     @PostMapping("/api/v1/users/{userId}/report")
     public ResponseEntity<ApiResponse<ReportIdResponse>> reportUser(
             @AuthenticationPrincipal Long reporterId,

--- a/src/main/java/com/sseulang/domain/report/presentation/dto/AdminReportResponse.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/dto/AdminReportResponse.java
@@ -2,19 +2,21 @@ package com.sseulang.domain.report.presentation.dto;
 
 import com.sseulang.domain.report.domain.ReportStatus;
 import com.sseulang.domain.report.domain.UserReport;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "관리자 — 사용자 신고 단건.")
 public record AdminReportResponse(
-        Long id,
-        Long reporterId,
-        Long reportedId,
-        Long itemId,
-        String reason,
-        String detail,
+        @Schema(example = "17") Long id,
+        @Schema(example = "100", description = "신고한 사용자") Long reporterId,
+        @Schema(example = "200", description = "신고당한 사용자") Long reportedId,
+        @Schema(description = "관련 물품 (없으면 null)", example = "42") Long itemId,
+        @Schema(example = "FRAUD", description = "FRAUD / SPAM / HARASSMENT 등") String reason,
+        @Schema(example = "결제 후 물품을 보내지 않습니다") String detail,
         ReportStatus status,
-        Long adminId,
-        String adminMemo,
+        @Schema(description = "처리한 관리자 (PENDING 단계는 null)") Long adminId,
+        @Schema(example = "확인 후 경고 처리") String adminMemo,
         LocalDateTime processedAt,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/sseulang/domain/report/presentation/dto/ReportIdResponse.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/dto/ReportIdResponse.java
@@ -1,3 +1,6 @@
 package com.sseulang.domain.report.presentation.dto;
 
-public record ReportIdResponse(Long id) { }
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "신고 등록 후 발급된 id 응답.")
+public record ReportIdResponse(@Schema(example = "17") Long id) { }

--- a/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
@@ -8,6 +8,7 @@ import com.sseulang.domain.review.presentation.dto.ReviewWriteRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -34,6 +35,9 @@ public class ReviewController {
         this.reviewService = reviewService;
     }
 
+    @Operation(summary = "리뷰 작성",
+            description = "거래완료 후 7일 이내 + 거래 참여자만. 같은 거래 본인 리뷰 중복 시 409 REVIEW_DUPLICATED. "
+                    + "작성 후 reviewee 의 trust_score 자동 재계산 (atomic UPDATE).")
     @PostMapping("/api/v1/reviews")
     public ResponseEntity<ApiResponse<ReviewIdResponse>> write(
             @AuthenticationPrincipal Long reviewerId,
@@ -44,6 +48,8 @@ public class ReviewController {
                 .body(ApiResponse.ok(new ReviewIdResponse(id)));
     }
 
+    @Operation(summary = "사용자가 받은 리뷰 목록",
+            description = "userId 가 reviewee 인 리뷰 페이징. 한줄평(comment)은 작성자 본인에게만 노출, 그 외엔 null 마스킹.")
     @GetMapping("/api/v1/users/{userId}/reviews")
     public ApiResponse<PageResponse<ReviewResponse>> listReceived(
             @AuthenticationPrincipal Long requesterId,
@@ -60,10 +66,8 @@ public class ReviewController {
         return ApiResponse.ok(PageResponse.from(result));
     }
 
-    /**
-     * Review 작성 대기 거래 (follow-up #56). 본인이 reviewer 로 아직 작성 안 한 7일 이내 완료 거래.
-     * 인증 필수 — SecurityFilter 가 보호.
-     */
+    @Operation(summary = "리뷰 작성 대기 목록",
+            description = "본인이 reviewer 로 아직 작성 안 한 7일 이내 완료 거래. deadline 필드로 남은 시간 카운트다운 UI 가능.")
     @GetMapping("/api/v1/reviews/pending")
     public ApiResponse<PageResponse<PendingReviewResponse>> listPending(
             @AuthenticationPrincipal Long requesterId,

--- a/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/ReviewController.java
@@ -8,6 +8,7 @@ import com.sseulang.domain.review.presentation.dto.ReviewWriteRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Review", description = "거래 리뷰 작성/조회/대기 목록")
 @RestController
 public class ReviewController {
 

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/PendingReviewResponse.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/PendingReviewResponse.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.review.presentation.dto;
 
 import com.sseulang.domain.item.domain.TradeType;
 import com.sseulang.domain.transaction.application.dto.PendingReviewableResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
@@ -10,14 +11,15 @@ import java.time.LocalDateTime;
  *
  * <p>{@code deadline = completedAt + 7d} — 클라이언트가 남은 시간 카운트다운 UI 에 직접 사용.</p>
  */
+@Schema(description = "리뷰 작성 대기 거래 — 본인이 reviewer 로 아직 작성 안 한 7일 이내 완료 거래.")
 public record PendingReviewResponse(
-        Long transactionId,
-        Long itemId,
-        Long revieweeId,
+        @Schema(example = "12") Long transactionId,
+        @Schema(example = "42") Long itemId,
+        @Schema(description = "상대방 (reviewee) id", example = "200") Long revieweeId,
         TradeType tradeType,
-        long price,
+        @Schema(example = "1200000") long price,
         LocalDateTime completedAt,
-        LocalDateTime deadline
+        @Schema(description = "완료일 + 7일. 이 시간 지나면 작성 불가") LocalDateTime deadline
 ) {
     public static PendingReviewResponse from(PendingReviewableResult r) {
         return new PendingReviewResponse(

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewIdResponse.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewIdResponse.java
@@ -1,3 +1,6 @@
 package com.sseulang.domain.review.presentation.dto;
 
-public record ReviewIdResponse(Long id) { }
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "리뷰 작성 후 발급된 id 응답.")
+public record ReviewIdResponse(@Schema(example = "9") Long id) { }

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewResponse.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/ReviewResponse.java
@@ -1,16 +1,18 @@
 package com.sseulang.domain.review.presentation.dto;
 
 import com.sseulang.domain.review.application.dto.ReviewResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "리뷰 — 거래 완료 후 7일 이내 작성. 한줄평(comment)은 작성자 본인에게만 노출 (그 외엔 마스킹).")
 public record ReviewResponse(
-        Long id,
-        Long transactionId,
-        Long reviewerId,
-        Long revieweeId,
-        int rating,
-        String comment,
+        @Schema(example = "9") Long id,
+        @Schema(example = "12") Long transactionId,
+        @Schema(example = "200") Long reviewerId,
+        @Schema(example = "100") Long revieweeId,
+        @Schema(example = "5", description = "1~5") int rating,
+        @Schema(example = "친절하고 빠른 거래", description = "한줄평. 작성자 본인 외엔 null 마스킹") String comment,
         LocalDateTime createdAt
 ) {
     public static ReviewResponse from(ReviewResult r) {

--- a/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
@@ -3,11 +3,13 @@ package com.sseulang.domain.stats.presentation;
 import com.sseulang.domain.stats.application.AdminStatsService;
 import com.sseulang.domain.stats.presentation.dto.AdminDashboardResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /** 관리자 통계 dashboard. SecurityConfig admin chain 으로 ROLE_ADMIN 강제. */
+@Tag(name = "AdminStats", description = "관리자 — dashboard 통계")
 @RestController
 @RequestMapping("/api/v1/admin/stats")
 public class AdminStatsController {

--- a/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.stats.presentation;
 import com.sseulang.domain.stats.application.AdminStatsService;
 import com.sseulang.domain.stats.presentation.dto.AdminDashboardResponse;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +21,8 @@ public class AdminStatsController {
         this.statsService = statsService;
     }
 
+    @Operation(summary = "관리자 dashboard",
+            description = "5개 도메인(User/Transaction/Payment/Withdrawal/Delivery) 집계. ROLE_ADMIN 필수. SQL 11개 단일 호출.")
     @GetMapping("/dashboard")
     public ApiResponse<AdminDashboardResponse> dashboard() {
         return ApiResponse.ok(AdminDashboardResponse.from(statsService.dashboard()));

--- a/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardResponse.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardResponse.java
@@ -6,11 +6,13 @@ import com.sseulang.domain.stats.application.AdminDashboardResult;
 import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
 import com.sseulang.domain.user.application.dto.UserStatsResult;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * 관리자 dashboard JSON 응답. presentation layer 응답 — application Result 를 그대로 노출하지만
  * 향후 응답 shape 분리(예: 일부 필드 마스킹)에 대비해 wrapper 유지.
  */
+@Schema(description = "관리자 dashboard — 5개 도메인 (User/Transaction/Payment/Withdrawal/Delivery) 통계 묶음.")
 public record AdminDashboardResponse(
         UserStatsResult users,
         TransactionStatsResult transactions,

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionStatsResult.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionStatsResult.java
@@ -1,10 +1,16 @@
 package com.sseulang.domain.transaction.application.dto;
 
 import com.sseulang.domain.transaction.domain.TransactionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 
 /**
  * 거래 통계 — total + status 별 카운트. byStatus 는 모든 enum 값 포함 (0 이면 0L).
  */
-public record TransactionStatsResult(long total, Map<TransactionStatus, Long> byStatus) {}
+@Schema(description = "관리자 dashboard — 거래 통계. byStatus 는 모든 status 포함 (0 건도 0L).")
+public record TransactionStatsResult(
+        @Schema(example = "568", description = "전체 거래 수") long total,
+        @Schema(description = "status 별 카운트 — 채팅중/예약/거래완료/취소", example = "{\"채팅중\":120,\"예약\":35,\"거래완료\":380,\"취소\":33}")
+        Map<TransactionStatus, Long> byStatus
+) {}

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatus.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatus.java
@@ -1,9 +1,11 @@
 package com.sseulang.domain.transaction.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 거래 상태. DB ENUM('채팅중','예약','거래완료','취소') 1:1 매핑.
  * 가이드 §5.1: {@code 채팅중 → 예약 → 거래완료} (또는 {@code 취소}).
  */
+@Schema(description = "거래 상태 머신. 채팅중→예약→거래완료 (또는 취소).")
 public enum TransactionStatus {
     채팅중,
     예약,

--- a/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
@@ -8,6 +8,7 @@ import com.sseulang.domain.transaction.presentation.dto.TransactionResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,8 @@ public class TransactionController {
         this.transactionService = transactionService;
     }
 
+    @Operation(summary = "거래 생성 (buyer)",
+            description = "이메일 인증 필수. 본인 물품 / 비활성(예약/삭제) 물품 거부. 생성 즉시 status=채팅중.")
     @PostMapping
     public ResponseEntity<ApiResponse<TransactionIdResponse>> create(
             @AuthenticationPrincipal Long buyerId,
@@ -42,6 +45,8 @@ public class TransactionController {
                 .body(ApiResponse.ok(new TransactionIdResponse(id)));
     }
 
+    @Operation(summary = "거래 단건 조회",
+            description = "거래 참여자(seller/buyer) 만 조회 가능. 그 외 403 TRANSACTION_FORBIDDEN.")
     @GetMapping("/{id}")
     public ApiResponse<TransactionResponse> getOne(
             @AuthenticationPrincipal Long requesterId,
@@ -59,6 +64,9 @@ public class TransactionController {
      * </ul>
      * action={@code 채팅중} 은 거부 — 채팅중은 create 시점에만 부여되는 초기 상태.
      */
+    @Operation(summary = "거래 상태 전이 (예약 / 거래완료 / 취소)",
+            description = "action 분기 — 예약: seller, 거래완료: seller(잔액 부족 시 INSUFFICIENT_POINT), 취소: 양쪽. "
+                    + "예약→취소 시 Item 판매중으로 복원. 동시 reserve 는 한 건만 성공(409 TRANSACTION_RESERVED_BY_OTHER).")
     @PatchMapping("/{id}")
     public ApiResponse<Void> patch(
             @AuthenticationPrincipal Long requesterId,

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionIdResponse.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionIdResponse.java
@@ -1,3 +1,6 @@
 package com.sseulang.domain.transaction.presentation.dto;
 
-public record TransactionIdResponse(Long id) { }
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "거래 생성 후 발급된 id 응답.")
+public record TransactionIdResponse(@Schema(example = "12") Long id) { }

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionResponse.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionResponse.java
@@ -3,24 +3,26 @@ package com.sseulang.domain.transaction.presentation.dto;
 import com.sseulang.domain.item.domain.TradeType;
 import com.sseulang.domain.transaction.application.dto.TransactionResult;
 import com.sseulang.domain.transaction.domain.TransactionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "거래 — 채팅중→예약→거래완료 상태 머신. 정산은 거래완료 시 buyer 차감/seller 적립.")
 public record TransactionResponse(
-        Long id,
-        Long itemId,
-        Long sellerId,
-        Long buyerId,
+        @Schema(example = "12") Long id,
+        @Schema(example = "42") Long itemId,
+        @Schema(example = "100") Long sellerId,
+        @Schema(example = "200") Long buyerId,
         TradeType tradeType,
-        long price,
-        Long deposit,
+        @Schema(example = "1200000") long price,
+        @Schema(example = "100000", description = "대여 보증금 (판매/나눔은 null)") Long deposit,
         LocalDateTime rentalStart,
         LocalDateTime rentalEnd,
         TransactionStatus status,
         LocalDateTime reservedAt,
         LocalDateTime completedAt,
         LocalDateTime canceledAt,
-        String cancelReason,
+        @Schema(example = "구매자 변심") String cancelReason,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/sseulang/domain/user/application/dto/UserStatsResult.java
+++ b/src/main/java/com/sseulang/domain/user/application/dto/UserStatsResult.java
@@ -1,8 +1,16 @@
 package com.sseulang.domain.user.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * 회원 통계 — total / blocked / deleted 의 단순 카운트.
  * active = total − (blocked + deleted) 는 derived. 단, blocked && deleted 인 사용자가 있으면
  * active 계산에 음수가 나올 수 있어 service 에서 max(0, ...) 가드.
  */
-public record UserStatsResult(long total, long blocked, long deleted, long active) {}
+@Schema(description = "관리자 dashboard — 회원 통계.")
+public record UserStatsResult(
+        @Schema(example = "1234", description = "전체 회원 수 (탈퇴/차단 포함)") long total,
+        @Schema(example = "12", description = "차단된 회원 수") long blocked,
+        @Schema(example = "8", description = "탈퇴(soft delete) 회원 수") long deleted,
+        @Schema(example = "1214", description = "활성 회원 수 (차단/탈퇴 제외, 음수 가드)") long active
+) {}

--- a/src/main/java/com/sseulang/domain/user/domain/SocialProvider.java
+++ b/src/main/java/com/sseulang/domain/user/domain/SocialProvider.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.user.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 사용자 가입 출처. V1 스키마의 {@code users.social_provider} 컬럼(VARCHAR(20))과 1:1 매핑.
  * <ul>
@@ -8,6 +9,7 @@ package com.sseulang.domain.user.domain;
  *   <li>{@link #DEV} — 로컬 smoke test 전용 (Codex 게이트 1 보강 — KAKAO provider 의미 오염 차단)</li>
  * </ul>
  */
+@Schema(description = "사용자 가입 출처. LOCAL(이메일/비밀번호) / KAKAO / GOOGLE / DEV(로컬 전용).")
 public enum SocialProvider {
     LOCAL,
     KAKAO,

--- a/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.user.presentation.dto.UserBlockRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 관리자 회원 관리. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
  */
+@Tag(name = "AdminUser", description = "관리자 — 사용자 목록/차단")
 @RestController
 @RequestMapping("/api/v1/admin/users")
 public class AdminUserController {

--- a/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
@@ -6,6 +6,7 @@ import com.sseulang.domain.user.presentation.dto.UserBlockRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,6 +30,7 @@ public class AdminUserController {
         this.userService = userService;
     }
 
+    @Operation(summary = "[관리자] 회원 목록", description = "차단/탈퇴 포함 전체.")
     @GetMapping
     public ApiResponse<PageResponse<AdminUserResponse>> list(Pageable pageable) {
         return ApiResponse.ok(PageResponse.from(
@@ -36,11 +38,13 @@ public class AdminUserController {
         ));
     }
 
+    @Operation(summary = "[관리자] 회원 단건 조회 (민감 정보 제외)")
     @GetMapping("/{id}")
     public ApiResponse<AdminUserResponse> getOne(@PathVariable("id") Long id) {
         return ApiResponse.ok(AdminUserResponse.from(userService.getById(id)));
     }
 
+    @Operation(summary = "[관리자] 회원 차단/해제 토글", description = "blocked=true 면 로그인 차단 + 토큰 폐기.")
     @PatchMapping("/{id}/block")
     public ApiResponse<Void> setBlocked(
             @PathVariable("id") Long id,

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
@@ -2,22 +2,24 @@ package com.sseulang.domain.user.presentation.dto;
 
 import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /** 관리자용 회원 단건 응답 — 비밀번호/소셜 토큰 등 민감 정보는 제외. */
+@Schema(description = "관리자 — 회원 단건 (민감 정보 제외).")
 public record AdminUserResponse(
-        Long id,
-        String email,
-        String nickname,
-        String profileImage,
-        SocialProvider socialProvider,
-        boolean blocked,
-        boolean deleted,
-        BigDecimal trustScore,
-        int reviewCount,
-        long pointBalance,
+        @Schema(example = "100") Long id,
+        @Schema(example = "user@example.com") String email,
+        @Schema(example = "쓸랭이") String nickname,
+        @Schema(example = "https://cdn.sseulang.com/profile/100/avatar.jpg") String profileImage,
+        @Schema(description = "LOCAL / KAKAO / GOOGLE") SocialProvider socialProvider,
+        @Schema(example = "false") boolean blocked,
+        @Schema(example = "false") boolean deleted,
+        @Schema(example = "4.7", description = "받은 리뷰 평균 (1.0~5.0). 리뷰 0건이면 null") BigDecimal trustScore,
+        @Schema(example = "12") int reviewCount,
+        @Schema(example = "50000", description = "현재 포인트 잔액 (KRW)") long pointBalance,
         LocalDateTime createdAt
 ) {
     public static AdminUserResponse from(User u) {

--- a/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
+++ b/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.wishlist.presentation;
 
 import com.sseulang.domain.wishlist.application.WishlistApplicationService;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Wishlist 진입점은 Item 자원 하위로 둔다 (가이드 §6.1):
  * {@code POST /api/v1/items/{id}/wishlist}, {@code DELETE /api/v1/items/{id}/wishlist}.
  */
+@Tag(name = "Wishlist", description = "물품 찜 추가/해제")
 @RestController
 @RequestMapping("/api/v1/items/{itemId}/wishlist")
 public class WishlistController {

--- a/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
+++ b/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.wishlist.presentation;
 
 import com.sseulang.domain.wishlist.application.WishlistApplicationService;
 import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,6 +26,7 @@ public class WishlistController {
         this.wishlistService = wishlistService;
     }
 
+    @Operation(summary = "찜 추가", description = "멱등 — 이미 찜한 물품 재호출 OK. wishlist_count 자동 증가.")
     @PostMapping
     public ApiResponse<Void> add(
             @AuthenticationPrincipal Long userId,
@@ -34,6 +36,7 @@ public class WishlistController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "찜 해제", description = "멱등 — 찜 안 한 상태 재호출 OK. wishlist_count 자동 감소(음수 방지).")
     @DeleteMapping
     public ApiResponse<Void> remove(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalStatsResult.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalStatsResult.java
@@ -1,14 +1,18 @@
 package com.sseulang.domain.withdrawal.application.dto;
 
 import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 
 /**
  * 출금 통계 — total + status 별 카운트 + 완료된 출금 누적 금액.
  */
+@Schema(description = "관리자 dashboard — 출금 통계.")
 public record WithdrawalStatsResult(
-        long total,
+        @Schema(example = "87", description = "전체 출금 신청 수") long total,
+        @Schema(description = "status 별 카운트 — 신청/승인/완료/거부",
+                example = "{\"신청\":3,\"승인\":1,\"완료\":80,\"거부\":3}")
         Map<WithdrawalStatus, Long> byStatus,
-        long completedAmount
+        @Schema(example = "8000000", description = "완료된 출금 누적 금액 (KRW)") long completedAmount
 ) {}

--- a/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalStatus.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalStatus.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.withdrawal.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 출금 상태. V1 스키마 ENUM 1:1 매핑. 가이드 §4.8 출금 흐름.
  *
@@ -9,6 +10,7 @@ package com.sseulang.domain.withdrawal.domain;
  *     └── 취소 (사용자, 신청 상태만)
  * </pre>
  */
+@Schema(description = "출금 상태. 신청→승인→완료 또는 거부(잔액 자동 환불).")
 public enum WithdrawalStatus {
     신청,
     승인,

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 관리자 출금 처리 — SecurityConfig 의 admin chain 이 ROLE_ADMIN 강제. AuthenticationPrincipal 은
  * adminId (현재 SecurityFilter 정책 그대로 사용).
  */
+@Tag(name = "AdminWithdrawal", description = "관리자 — 출금 신청 승인/거부")
 @RestController
 @RequestMapping("/api/v1/admin/withdrawals")
 public class AdminWithdrawalController {

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
@@ -7,6 +7,7 @@ import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,6 +34,7 @@ public class AdminWithdrawalController {
         this.withdrawalService = withdrawalService;
     }
 
+    @Operation(summary = "[관리자] 출금 신청 목록", description = "status 필터 (신청/승인/완료/거부) + 페이징.")
     @GetMapping
     public ApiResponse<PageResponse<WithdrawalResponse>> list(
             @RequestParam(value = "status", required = false) WithdrawalStatus status,
@@ -43,6 +45,8 @@ public class AdminWithdrawalController {
         ));
     }
 
+    @Operation(summary = "[관리자] 출금 처리",
+            description = "action: APPROVE(승인) / REJECT(거부, 잔액 자동 환불) / COMPLETE(외부 이체 완료 표시).")
     @PatchMapping("/{id}")
     public ApiResponse<Void> decide(
             @AuthenticationPrincipal Long adminId,

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/WithdrawalController.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/WithdrawalController.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalRequest;
 import com.sseulang.domain.withdrawal.presentation.dto.WithdrawalResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
@@ -30,6 +31,9 @@ public class WithdrawalController {
         this.withdrawalService = withdrawalService;
     }
 
+    @Operation(summary = "출금 신청",
+            description = "잔액 즉시 차감(원자 UPDATE) + 신청 생성. idempotencyKey 로 중복 차단 — 같은 키 재호출은 동일 신청 반환. "
+                    + "잔액 부족 400 INSUFFICIENT_POINT.")
     @PostMapping
     public ResponseEntity<ApiResponse<Long>> request(
             @AuthenticationPrincipal Long userId,
@@ -39,6 +43,8 @@ public class WithdrawalController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(id));
     }
 
+    @Operation(summary = "내 출금 신청 목록",
+            description = "본인이 신청한 출금 페이징 (최신순).")
     @GetMapping
     public ApiResponse<PageResponse<WithdrawalResponse>> getMyWithdrawals(
             @AuthenticationPrincipal Long userId,
@@ -49,6 +55,8 @@ public class WithdrawalController {
         ));
     }
 
+    @Operation(summary = "출금 신청 단건 조회",
+            description = "본인 신청만. 그 외 403 WITHDRAWAL_FORBIDDEN.")
     @GetMapping("/{id}")
     public ApiResponse<WithdrawalResponse> getOne(
             @AuthenticationPrincipal Long userId,
@@ -57,6 +65,8 @@ public class WithdrawalController {
         return ApiResponse.ok(WithdrawalResponse.from(withdrawalService.getById(id, userId)));
     }
 
+    @Operation(summary = "출금 신청 취소",
+            description = "신청 상태(관리자 미처리)일 때만 가능. 잔액 자동 환불. 승인/완료 후 취소는 400 WITHDRAWAL_NOT_CANCELABLE.")
     @DeleteMapping("/{id}")
     public ApiResponse<Void> cancel(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalResponse.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalResponse.java
@@ -2,19 +2,21 @@ package com.sseulang.domain.withdrawal.presentation.dto;
 
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalResult;
 import com.sseulang.domain.withdrawal.domain.WithdrawalStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "출금 신청 — 신청→승인→완료 / 거부. 신청 즉시 잔액 차감, 거부 시 자동 환불.")
 public record WithdrawalResponse(
-        Long id,
-        Long userId,
-        long amount,
-        String bankName,
-        String accountNumber,
-        String accountHolder,
+        @Schema(example = "31") Long id,
+        @Schema(example = "100") Long userId,
+        @Schema(example = "100000") long amount,
+        @Schema(example = "신한") String bankName,
+        @Schema(example = "110-123-456789") String accountNumber,
+        @Schema(example = "홍길동") String accountHolder,
         WithdrawalStatus status,
-        Long adminId,
-        String adminMemo,
+        @Schema(description = "처리한 관리자 id (신청 단계는 null)") Long adminId,
+        @Schema(description = "거부 사유 등 관리자 메모", example = "본인 계좌 미일치") String adminMemo,
         LocalDateTime requestedAt,
         LocalDateTime processedAt
 ) {

--- a/src/main/java/com/sseulang/global/common/ApiResponse.java
+++ b/src/main/java/com/sseulang/global/common/ApiResponse.java
@@ -1,9 +1,15 @@
 package com.sseulang.global.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ApiResponse<T>(boolean success, T data, ErrorBody error) {
+@Schema(description = "API 표준 응답 — 성공이면 data, 실패면 error 만 채워진다.")
+public record ApiResponse<T>(
+        @Schema(description = "성공 여부", example = "true") boolean success,
+        @Schema(description = "성공 시 데이터 (실패 시 null)") T data,
+        @Schema(description = "실패 시 에러 본문 (성공 시 null)") ErrorBody error
+) {
 
     public static <T> ApiResponse<T> ok(T data) {
         return new ApiResponse<>(true, data, null);
@@ -17,5 +23,10 @@ public record ApiResponse<T>(boolean success, T data, ErrorBody error) {
         return new ApiResponse<>(false, null, new ErrorBody(code, message, traceId));
     }
 
-    public record ErrorBody(String code, String message, String traceId) {}
+    @Schema(description = "에러 본문 — 코드는 ErrorCode enum 값, message 는 한국어, traceId 는 서버 로그 추적용.")
+    public record ErrorBody(
+            @Schema(description = "ErrorCode enum 값", example = "AUTH_TOKEN_EXPIRED") String code,
+            @Schema(description = "한국어 사용자 노출 메시지", example = "만료된 토큰입니다.") String message,
+            @Schema(description = "서버 로그 traceId (지원 요청 시 첨부)", example = "9f2c8c5b") String traceId
+    ) {}
 }

--- a/src/main/java/com/sseulang/global/common/PageResponse.java
+++ b/src/main/java/com/sseulang/global/common/PageResponse.java
@@ -1,16 +1,19 @@
 package com.sseulang.global.common;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 import org.springframework.data.domain.Page;
 
+@Schema(description = "페이징 응답 — page 는 0-based, size 는 1~100. 채팅 메시지 등 일부 영역은 커서 페이징 사용.")
 public record PageResponse<T>(
-        List<T> content,
-        int page,
-        int size,
-        long totalElements,
-        int totalPages,
-        boolean hasNext,
-        boolean hasPrevious
+        @Schema(description = "현재 페이지 항목 리스트") List<T> content,
+        @Schema(description = "현재 페이지 번호 (0-based)", example = "0") int page,
+        @Schema(description = "페이지 크기", example = "20") int size,
+        @Schema(description = "전체 항목 수", example = "123") long totalElements,
+        @Schema(description = "전체 페이지 수", example = "7") int totalPages,
+        @Schema(description = "다음 페이지 존재 여부", example = "true") boolean hasNext,
+        @Schema(description = "이전 페이지 존재 여부", example = "false") boolean hasPrevious
 ) {
 
     public static <T> PageResponse<T> from(Page<T> page) {

--- a/src/main/java/com/sseulang/global/config/OpenApiConfig.java
+++ b/src/main/java/com/sseulang/global/config/OpenApiConfig.java
@@ -2,30 +2,58 @@ package com.sseulang.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
 
     private static final String COOKIE_AUTH = "cookieAuth";
+    private static final String CSRF_HEADER = "csrfToken";
 
     @Bean
     public OpenAPI sseulangOpenApi() {
         return new OpenAPI()
                 .info(new Info()
                         .title("쓸랭(Sseulang) API")
-                        .description("중고 거래 + 대여 + 나눔 + 배달대행 통합 C2C 플랫폼 API")
-                        .version("v1"))
-                .addSecurityItem(new SecurityRequirement().addList(COOKIE_AUTH))
+                        .description("""
+                                중고 거래 + 대여 + 나눔 + 배달대행 통합 C2C 플랫폼.
+
+                                **인증**: HttpOnly 쿠키 `at` (Access) / `rt` (Refresh) — 브라우저가 자동 동봉.
+                                Swagger UI 에서 테스트하려면 먼저 `POST /api/v1/auth/login` 으로 로그인하세요.
+
+                                **CSRF**: 모든 mutating(POST/PATCH/PUT/DELETE) 요청은 `X-XSRF-TOKEN` 헤더 필수.
+                                값은 `XSRF-TOKEN` 쿠키에서 읽어 echo. (`/api/v1/auth/**`, `/api/v1/payments/webhook/**`,
+                                `/ws-stomp*` 는 면제)
+
+                                **응답 포맷**: 성공 `{success:true, data}`, 실패 `{success:false, error:{code,message,traceId}}`,
+                                페이징 `{content, page, size, totalElements, totalPages, hasNext, hasPrevious}`.
+
+                                **상세 ErrorCode + 연동 가이드**: `docs/FRONTEND_INTEGRATION.md`.
+                                """)
+                        .version("v1")
+                        .contact(new Contact().name("쓸랭 백엔드").email("noreply@sseulang.test")))
+                .servers(List.of(
+                        new Server().url("/").description("현재 서버"),
+                        new Server().url("http://localhost:8080").description("로컬")))
+                .addSecurityItem(new SecurityRequirement().addList(COOKIE_AUTH).addList(CSRF_HEADER))
                 .components(new Components()
                         .addSecuritySchemes(COOKIE_AUTH, new SecurityScheme()
                                 .type(SecurityScheme.Type.APIKEY)
                                 .in(SecurityScheme.In.COOKIE)
-                                .name("ACCESS_TOKEN")
-                                .description("HttpOnly 쿠키로 자동 전송됩니다. 브라우저에서 테스트하려면 로그인 후 사용하세요.")));
+                                .name("at")
+                                .description("HttpOnly Access Token. 로그인 후 자동 발급. Swagger 에서는 직접 설정 X — 로그인 응답 후 자동 동봉됨."))
+                        .addSecuritySchemes(CSRF_HEADER, new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .name("X-XSRF-TOKEN")
+                                .description("XSRF-TOKEN 쿠키 값을 echo. mutating 요청 필수.")));
     }
 }

--- a/src/main/java/com/sseulang/global/config/OpenApiErrorResponseCustomizer.java
+++ b/src/main/java/com/sseulang/global/config/OpenApiErrorResponseCustomizer.java
@@ -1,0 +1,170 @@
+package com.sseulang.global.config;
+
+import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 모든 endpoint 에 표준 에러 응답을 일괄 등록 (401/403/404/500 + 메서드별 400).
+ *
+ * <p>{@link com.sseulang.global.exception.GlobalExceptionHandler} 가 실제로 던지는 응답 shape 와 일치하는
+ * {@link ApiResponse} schema 를 reference 로 사용. controller 마다 {@code @ApiResponses} 를
+ * 반복 작성하지 않아도 Swagger UI 에서 같은 에러 응답이 노출된다.</p>
+ *
+ * <p>경로/HTTP 메서드 별 분기:
+ * <ul>
+ *   <li>모든 operation: 401(AUTH_TOKEN_*) / 500(INTERNAL_SERVER_ERROR)</li>
+ *   <li>POST/PATCH/PUT/DELETE: 400(INVALID_REQUEST) — body validation 실패</li>
+ *   <li>경로에 PathVariable 포함: 404(RESOURCE_NOT_FOUND)</li>
+ *   <li>{@code /api/v1/admin/**}: 403(FORBIDDEN — ROLE_ADMIN 필요)</li>
+ *   <li>일반 mutating endpoint: 403(FORBIDDEN / AUTH_EMAIL_NOT_VERIFIED)</li>
+ * </ul>
+ *
+ * <p>특정 endpoint 가 다른 응답 코드를 가지면 controller 메서드의 {@code @io.swagger.v3.oas.annotations.responses.ApiResponses}
+ * 가 본 customizer 가 추가한 항목을 덮어쓴다 (springdoc merge 정책).</p>
+ */
+@Configuration
+public class OpenApiErrorResponseCustomizer {
+
+    private static final String JSON = "application/json";
+    private static final String SCHEMA_REF = "#/components/schemas/ApiResponse";
+
+    @Bean
+    public OperationCustomizer commonErrorResponses() {
+        return (operation, handlerMethod) -> {
+            ApiResponses responses = operation.getResponses();
+            String path = resolvePath(handlerMethod);
+            String method = resolveHttpMethod(handlerMethod);
+
+            // 401 — 모든 endpoint 공통
+            putIfAbsent(responses, "401", "인증 실패 — 토큰 누락/만료/위변조/폐기 또는 OAuth 검증 실패",
+                    Map.of(
+                            "토큰 없음", example("AUTH_TOKEN_MISSING", "인증 토큰이 없습니다."),
+                            "토큰 만료", example("AUTH_TOKEN_EXPIRED", "만료된 토큰입니다."),
+                            "토큰 위변조", example("AUTH_TOKEN_INVALID", "유효하지 않은 토큰입니다."),
+                            "토큰 폐기", example("AUTH_TOKEN_REVOKED", "폐기된 토큰입니다.")
+                    ));
+
+            // 500 — 모든 endpoint 공통
+            putIfAbsent(responses, "500", "서버 내부 오류 — traceId 로 백엔드에 문의",
+                    Map.of("default", example("INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.")));
+
+            // 400 — mutating 요청
+            if (isMutating(method)) {
+                putIfAbsent(responses, "400", "요청 형식/값 오류 — body validation 실패",
+                        Map.of("default", example("INVALID_REQUEST", "요청 형식이 올바르지 않습니다.")));
+            }
+
+            // 404 — PathVariable 가진 endpoint
+            if (path != null && path.contains("{")) {
+                putIfAbsent(responses, "404", "자원을 찾을 수 없음",
+                        Map.of("default", example("RESOURCE_NOT_FOUND", "리소스를 찾을 수 없습니다.")));
+            }
+
+            // 403 — 관리자 영역 vs 일반 mutating
+            if (path != null && path.startsWith("/api/v1/admin")) {
+                putIfAbsent(responses, "403", "관리자 권한 필요 — ROLE_ADMIN 미보유",
+                        Map.of("default", example("FORBIDDEN", "접근 권한이 없습니다.")));
+            } else if (path != null && path.startsWith("/api/v1/")
+                    && !path.startsWith("/api/v1/auth/oauth2")
+                    && !path.startsWith("/api/v1/auth/signup")
+                    && !path.startsWith("/api/v1/auth/login")
+                    && !path.startsWith("/api/v1/auth/refresh")
+                    && !path.startsWith("/api/v1/auth/logout")
+                    && !path.startsWith("/api/v1/auth/verify-email")
+                    && !path.startsWith("/api/v1/payments/webhook")
+                    && !"GET".equals(method)) {
+                putIfAbsent(responses, "403", "권한 거부 — ROLE_USER 미보유 또는 이메일 미인증",
+                        Map.of(
+                                "역할 부족", example("FORBIDDEN", "접근 권한이 없습니다."),
+                                "이메일 미인증", example("AUTH_EMAIL_NOT_VERIFIED", "이메일 인증이 필요합니다.")
+                        ));
+            }
+
+            return operation;
+        };
+    }
+
+    private static io.swagger.v3.oas.models.responses.ApiResponse buildResponse(
+            String description, Map<String, Example> examples
+    ) {
+        Schema<?> schema = new Schema<>().$ref(SCHEMA_REF);
+        MediaType mt = new MediaType().schema(schema);
+        Map<String, Example> orderedExamples = new LinkedHashMap<>(examples);
+        mt.setExamples(orderedExamples);
+        Content content = new Content().addMediaType(JSON, mt);
+        return new io.swagger.v3.oas.models.responses.ApiResponse()
+                .description(description)
+                .content(content);
+    }
+
+    private static Example example(String code, String message) {
+        Example ex = new Example();
+        ex.setSummary(code);
+        ex.setValue(Map.of(
+                "success", false,
+                "error", Map.of("code", code, "message", message, "traceId", "9f2c8c5b")
+        ));
+        return ex;
+    }
+
+    private static void putIfAbsent(
+            ApiResponses responses, String code, String description, Map<String, Example> examples
+    ) {
+        if (responses.containsKey(code)) return;
+        responses.addApiResponse(code, buildResponse(description, examples));
+    }
+
+    private static boolean isMutating(String method) {
+        return method != null && (method.equals("POST") || method.equals("PUT")
+                || method.equals("PATCH") || method.equals("DELETE"));
+    }
+
+    private static String resolvePath(HandlerMethod handlerMethod) {
+        RequestMapping classMapping = handlerMethod.getBeanType().getAnnotation(RequestMapping.class);
+        String classPath = (classMapping != null && classMapping.value().length > 0) ? classMapping.value()[0] : "";
+        RequestMapping methodMapping = handlerMethod.getMethodAnnotation(RequestMapping.class);
+        String methodPath = (methodMapping != null && methodMapping.value().length > 0) ? methodMapping.value()[0] : "";
+        // method 레벨 매핑은 GetMapping 등에 path 가 있을 수 있음 — value() 추출
+        if (methodPath.isEmpty()) {
+            methodPath = extractMethodLevelPath(handlerMethod);
+        }
+        return classPath + methodPath;
+    }
+
+    private static String extractMethodLevelPath(HandlerMethod handlerMethod) {
+        var get = handlerMethod.getMethodAnnotation(org.springframework.web.bind.annotation.GetMapping.class);
+        if (get != null && get.value().length > 0) return get.value()[0];
+        var post = handlerMethod.getMethodAnnotation(org.springframework.web.bind.annotation.PostMapping.class);
+        if (post != null && post.value().length > 0) return post.value()[0];
+        var patch = handlerMethod.getMethodAnnotation(org.springframework.web.bind.annotation.PatchMapping.class);
+        if (patch != null && patch.value().length > 0) return patch.value()[0];
+        var put = handlerMethod.getMethodAnnotation(org.springframework.web.bind.annotation.PutMapping.class);
+        if (put != null && put.value().length > 0) return put.value()[0];
+        var del = handlerMethod.getMethodAnnotation(org.springframework.web.bind.annotation.DeleteMapping.class);
+        if (del != null && del.value().length > 0) return del.value()[0];
+        return "";
+    }
+
+    private static String resolveHttpMethod(HandlerMethod handlerMethod) {
+        if (handlerMethod.hasMethodAnnotation(org.springframework.web.bind.annotation.GetMapping.class)) return "GET";
+        if (handlerMethod.hasMethodAnnotation(org.springframework.web.bind.annotation.PostMapping.class)) return "POST";
+        if (handlerMethod.hasMethodAnnotation(org.springframework.web.bind.annotation.PatchMapping.class)) return "PATCH";
+        if (handlerMethod.hasMethodAnnotation(org.springframework.web.bind.annotation.PutMapping.class)) return "PUT";
+        if (handlerMethod.hasMethodAnnotation(org.springframework.web.bind.annotation.DeleteMapping.class)) return "DELETE";
+        RequestMapping mapping = handlerMethod.getMethodAnnotation(RequestMapping.class);
+        if (mapping != null && mapping.method().length > 0) return mapping.method()[0].name();
+        return null;
+    }
+}

--- a/src/main/java/com/sseulang/global/dev/DevAuthController.java
+++ b/src/main/java/com/sseulang/global/dev/DevAuthController.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>OAuth 콘솔 키 없이도 임의 user 시드 + JWT 쿠키 받아서 Swagger / curl 시나리오 가능.
  * 정식 OAuth 흐름 (가이드 §4.4) 과는 무관 — local 작업 편의 용이며 실서비스 배포 시 등록 X.</p>
  */
+@Tag(name = "DevAuth", description = "로컬 개발 인증 우회 (prod 비활성)")
 @RestController
 @RequestMapping("/api/v1/auth/dev")
 @Profile("local")

--- a/src/main/java/com/sseulang/global/dev/DevAuthController.java
+++ b/src/main/java/com/sseulang/global/dev/DevAuthController.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
@@ -55,10 +56,9 @@ public class DevAuthController {
         this.cookieUtil = cookieUtil;
     }
 
-    /**
-     * 임시 user 를 시드(또는 기존 user 재사용)하고 JWT 쿠키 발급.
-     * 동일 nickname 으로 재호출 시 같은 user 반환 (멱등).
-     */
+    @Operation(summary = "[로컬 전용] 임시 user 시드 + JWT 쿠키 발급",
+            description = "OAuth 콘솔 키 없이 Swagger/curl 로 인증된 시나리오 테스트. "
+                    + "prod 비활성 (Profile=local + app.dev-auth.enabled=true 둘 다 만족 시만). 동일 nickname 멱등.")
     @PostMapping("/seed-and-login")
     public ResponseEntity<ApiResponse<DevLoginResponse>> seedAndLogin(
             HttpServletRequest request,


### PR DESCRIPTION
## Summary

프론트 연동 직전 Swagger UI 명세를 작업 가능 수준으로 종합 보강. 4개 commit 으로 영역별로 나눠 작업 후 본 PR 로 통합.

원래 PR #61, #62, #63 으로 분할되어 있었으나 같은 토픽이라 본 PR 에 누적 (#61~#63 close).

## Changes (4 commits)

### 1. Controller @Tag + OpenApiConfig + 표준 wrapper @Schema
- 모든 Controller `@Tag` (20건 추가, 총 26건) — USER/ADMIN/DEV 그룹
- OpenApiConfig:
  - info.description — 인증/CSRF/응답 포맷 + FRONTEND_INTEGRATION.md 참조
  - servers — 현재 / localhost
  - securitySchemes — `cookieAuth` (cookie `at`) + `csrfToken` (X-XSRF-TOKEN)
  - 🔧 쿠키 이름 ACCESS_TOKEN → at 정정 (CookieUtil 정합)
- `ApiResponse<T>` + `ErrorBody` 필드별 description/example
- `PageResponse<T>` 필드별 description/example

### 2. Response DTO 26개 @Schema
도메인별 — Item(4), Transaction(2), Payment(2), Withdrawal, Delivery, Review(3), Chat/Message/Notification(3), Notice/Banner/Category(4), File, Admin(3), 기타(2). 각 record class @Schema description + 필드별 description/example.

### 3. OperationCustomizer + 80+ @Operation summary
- 신규 `OpenApiErrorResponseCustomizer`: 모든 endpoint 에 표준 에러 응답 자동 등록 (401/403/404/500 + mutating 400). 각 응답에 ErrorBody 예시.
- 80+ endpoint 에 `@Operation summary` (한국어 + 인증 정책/주요 에러/UX 흐름 명시) — Auth/Item/Transaction/Payment/Withdrawal/Delivery/Review/Message/ChatRoom/File/Notification/EmailVerification/Wishlist/UserBlock/Report/Notice/Banner/Category + Admin 7 + DevAuth.

### 4. Stats DTO 5 + Domain enum 14 @Schema
- Stats Result DTO (admin dashboard nested): UserStats/TransactionStats/PaymentStats/WithdrawalStats/DeliveryStats. 필드별 description+example.
- Domain enum 14건: PaymentStatus/Method/Type, TradeType, ItemStatus, RentalUnit, TransactionStatus, DeliveryStatus, WithdrawalStatus, ReportStatus, NotificationType, NoticeType, SocialProvider, FilePurpose. 한국어 의미 + 상태 머신 description.

## 머지 후 Swagger UI 완성도

✅ 26 Tag 그룹 + 한국어 description
✅ 80+ endpoint 모두 summary + 핵심 에러/UX 흐름
✅ 모든 응답에 401/403/404/500/400 표준 ErrorBody 예시
✅ Request 25 + Response 26 + Stats 5 = 56 DTO 필드별 description+example
✅ 14 enum description (상태 머신 포함)
✅ cookieAuth + csrfToken 인증 스키마

## Test plan

- [x] `./gradlew test` — 597 PASS / 0 FAIL (4 commit 모두)
- [ ] 수동 — `/swagger-ui.html` 26 Tag 그룹화 확인
- [ ] 수동 — Authorize 버튼 cookieAuth/csrfToken 노출 확인
- [ ] 수동 — Try It Out 으로 로그인 + 보호된 endpoint 호출

## Notes

- 시작 분할 (#61~#63) 은 작업 흐름상 commit 단위로 PR 생성한 결과 — 동일 토픽이라 본 PR 에 통합.
- 추가 가능 영역 (마진 작음): endpoint specific @ApiResponses (PAYMENT_AMOUNT_MISMATCH 등), AsyncAPI for STOMP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)