### PR TITLE
feat: 프론트 연동 hotfix — CORS / MeResponse / OAuth code grant / PATCH /me / sort / 찜목록 / RentalUnit

### DIFF
--- a/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
@@ -58,7 +58,7 @@ public class OAuthLoginService {
         this.refreshTokenTtl = Duration.ofSeconds(jwtProperties.refreshTokenValiditySeconds());
     }
 
-    public TokenPair login(SocialProvider provider, String accessToken) {
+    public TokenPair loginWithCode(SocialProvider provider, String code, String redirectUri) {
         OAuthProvider impl = providersByType.get(provider);
         if (impl == null) {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
@@ -66,7 +66,7 @@ public class OAuthLoginService {
 
         OAuthUserInfo info;
         try {
-            info = impl.verifyAndFetch(accessToken);
+            info = impl.exchangeCodeAndFetch(code, redirectUri);
         } catch (ExternalApiException e) {
             // 외부 인프라 예외 → 사용자 응답은 AUTH_OAUTH_FAILED 통일.
             // 원인은 cause 에 보존 + 운영용 로그.

--- a/src/main/java/com/sseulang/domain/auth/domain/OAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/OAuthProvider.java
@@ -19,5 +19,9 @@ public interface OAuthProvider {
 
     SocialProvider supports();
 
-    OAuthUserInfo verifyAndFetch(String accessToken);
+    /**
+     * Authorization Code Grant — code + redirectUri 로 provider token endpoint 호출,
+     * access_token 교환 후 user info 조회. Client Secret 켜져있어도 안전.
+     */
+    OAuthUserInfo exchangeCodeAndFetch(String code, String redirectUri);
 }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/GoogleOAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/GoogleOAuthProvider.java
@@ -8,28 +8,43 @@ import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import com.sseulang.global.exception.ExternalApiException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
 /**
- * 구글 access_token 검증 + 사용자 정보 조회.
+ * 구글 Authorization Code → access_token 교환 + 사용자 정보 조회.
  *
- * <p>API: {@code GET https://www.googleapis.com/oauth2/v3/userinfo} with Bearer token.
- * 응답: {@code sub} (providerId), {@code email}, {@code email_verified}, {@code name}, {@code picture}.</p>
+ * <ol>
+ *   <li>{@code POST https://oauth2.googleapis.com/token} — code/client_id/client_secret/redirect_uri</li>
+ *   <li>{@code GET https://www.googleapis.com/oauth2/v3/userinfo} with Bearer access_token</li>
+ * </ol>
  *
  * <p>{@code email_verified=false} 이면 보안상 인증 실패 처리.</p>
  */
 @Component
 public class GoogleOAuthProvider implements OAuthProvider {
 
+    private static final String TOKEN_URI = "https://oauth2.googleapis.com/token";
     private static final String USER_INFO_URI = "https://www.googleapis.com/oauth2/v3/userinfo";
 
     private final RestClient restClient;
+    private final String clientId;
+    private final String clientSecret;
 
-    public GoogleOAuthProvider(RestClient.Builder builder) {
+    public GoogleOAuthProvider(
+            RestClient.Builder builder,
+            @Value("${app.oauth2.google.client-id:}") String clientId,
+            @Value("${app.oauth2.google.client-secret:}") String clientSecret
+    ) {
         this.restClient = builder.build();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
     }
 
     @Override
@@ -38,10 +53,44 @@ public class GoogleOAuthProvider implements OAuthProvider {
     }
 
     @Override
-    public OAuthUserInfo verifyAndFetch(String accessToken) {
-        if (accessToken == null || accessToken.isBlank()) {
+    public OAuthUserInfo exchangeCodeAndFetch(String code, String redirectUri) {
+        if (code == null || code.isBlank() || redirectUri == null || redirectUri.isBlank()) {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
+        if (clientId == null || clientId.isBlank() || clientSecret == null || clientSecret.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+
+        String accessToken = exchangeCodeForToken(code, redirectUri);
+        return fetchUserInfo(accessToken);
+    }
+
+    private String exchangeCodeForToken(String code, String redirectUri) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "authorization_code");
+        form.add("client_id", clientId);
+        form.add("client_secret", clientSecret);
+        form.add("redirect_uri", redirectUri);
+        form.add("code", code);
+
+        TokenResponse res;
+        try {
+            res = restClient.post()
+                    .uri(TOKEN_URI)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(form)
+                    .retrieve()
+                    .body(TokenResponse.class);
+        } catch (RestClientException e) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+        if (res == null || res.accessToken() == null || res.accessToken().isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+        return res.accessToken();
+    }
+
+    private OAuthUserInfo fetchUserInfo(String accessToken) {
         GoogleUserResponse res;
         try {
             res = restClient.get()
@@ -57,7 +106,6 @@ public class GoogleOAuthProvider implements OAuthProvider {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
 
-        // 검증된 이메일만 허용 — null/missing/false 모두 거부 (도용 위험)
         if (!Boolean.TRUE.equals(res.emailVerified())) {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
@@ -74,6 +122,14 @@ public class GoogleOAuthProvider implements OAuthProvider {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
     }
+
+    record TokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("expires_in") Long expiresIn,
+            @JsonProperty("token_type") String tokenType,
+            @JsonProperty("id_token") String idToken,
+            String scope
+    ) {}
 
     record GoogleUserResponse(
             String sub,

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/KakaoOAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/KakaoOAuthProvider.java
@@ -8,29 +8,45 @@ import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import com.sseulang.global.exception.ExternalApiException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
 /**
- * 카카오 access_token 검증 + 사용자 정보 조회.
+ * 카카오 Authorization Code → access_token 교환 + 사용자 정보 조회.
  *
- * <p>API: {@code GET https://kapi.kakao.com/v2/user/me} with Bearer token.
- * 응답에서 {@code id} (providerId), {@code kakao_account.email}, {@code kakao_account.profile.nickname/profile_image_url}
- * 추출.</p>
+ * <ol>
+ *   <li>{@code POST https://kauth.kakao.com/oauth/token} — code/client_id/client_secret/redirect_uri</li>
+ *   <li>{@code GET https://kapi.kakao.com/v2/user/me} with Bearer access_token</li>
+ * </ol>
+ *
+ * <p>Client Secret 옵션이 켜져 있어도 안전 — 서버에서 secret 동봉. 프론트는 code 만 알면 됨.</p>
  *
  * <p>모든 실패(토큰 무효 / 네트워크 / 응답 파싱 / 동의 항목 누락)는 {@code AUTH_OAUTH_FAILED} 로 통일.</p>
  */
 @Component
 public class KakaoOAuthProvider implements OAuthProvider {
 
+    private static final String TOKEN_URI = "https://kauth.kakao.com/oauth/token";
     private static final String USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
 
     private final RestClient restClient;
+    private final String clientId;
+    private final String clientSecret;
 
-    public KakaoOAuthProvider(RestClient.Builder builder) {
+    public KakaoOAuthProvider(
+            RestClient.Builder builder,
+            @Value("${app.oauth2.kakao.client-id:}") String clientId,
+            @Value("${app.oauth2.kakao.client-secret:}") String clientSecret
+    ) {
         this.restClient = builder.build();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
     }
 
     @Override
@@ -39,10 +55,47 @@ public class KakaoOAuthProvider implements OAuthProvider {
     }
 
     @Override
-    public OAuthUserInfo verifyAndFetch(String accessToken) {
-        if (accessToken == null || accessToken.isBlank()) {
+    public OAuthUserInfo exchangeCodeAndFetch(String code, String redirectUri) {
+        if (code == null || code.isBlank() || redirectUri == null || redirectUri.isBlank()) {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
+        if (clientId == null || clientId.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+
+        String accessToken = exchangeCodeForToken(code, redirectUri);
+        return fetchUserInfo(accessToken);
+    }
+
+    private String exchangeCodeForToken(String code, String redirectUri) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "authorization_code");
+        form.add("client_id", clientId);
+        form.add("redirect_uri", redirectUri);
+        form.add("code", code);
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            form.add("client_secret", clientSecret);
+        }
+
+        TokenResponse res;
+        try {
+            res = restClient.post()
+                    .uri(TOKEN_URI)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(form)
+                    .retrieve()
+                    .body(TokenResponse.class);
+        } catch (RestClientException e) {
+            // 잘못된 code/redirectUri 도 카카오가 4xx 로 떨굼 — 인프라 + 비즈니스 분리 어려워 통합 처리.
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+        if (res == null || res.accessToken() == null || res.accessToken().isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
+        }
+        return res.accessToken();
+    }
+
+    private OAuthUserInfo fetchUserInfo(String accessToken) {
         KakaoUserResponse res;
         try {
             res = restClient.get()
@@ -51,7 +104,6 @@ public class KakaoOAuthProvider implements OAuthProvider {
                     .retrieve()
                     .body(KakaoUserResponse.class);
         } catch (RestClientException e) {
-            // 외부 인프라 예외 — anti-corruption wrap. 호출자가 정책에 맞춰 변환.
             throw new ExternalApiException("kakao-oauth", e);
         }
 
@@ -66,12 +118,9 @@ public class KakaoOAuthProvider implements OAuthProvider {
         String profileImage = profile != null ? profile.profileImageUrl() : null;
 
         if (email == null || nickname == null) {
-            // 동의 항목 누락 — 사용자가 약관에서 거부했거나 개발자 콘솔 권한 미설정
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
-        // 게이트 1 round 2 — 카카오 응답에 미인증 이메일이 포함될 수 있어 takeover/auto-verified 의
-        // 전제("provider 가 검증한 이메일") 가 깨질 수 있다. is_email_valid + is_email_verified 둘 다
-        // true 인 이메일만 허용 — 둘 중 하나라도 false/null 이면 OAuth 거부.
+        // is_email_valid + is_email_verified 둘 다 true 만 허용.
         if (!Boolean.TRUE.equals(account.isEmailValid()) || !Boolean.TRUE.equals(account.isEmailVerified())) {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
@@ -85,10 +134,17 @@ public class KakaoOAuthProvider implements OAuthProvider {
                     profileImage
             );
         } catch (IllegalArgumentException e) {
-            // 잘못된 이메일 형식 등 — provider 가 비정상 응답
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
     }
+
+    record TokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("token_type") String tokenType,
+            @JsonProperty("refresh_token") String refreshToken,
+            @JsonProperty("expires_in") Long expiresIn,
+            String scope
+    ) {}
 
     record KakaoUserResponse(
             Long id,

--- a/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
@@ -7,11 +7,14 @@ import com.sseulang.domain.auth.application.dto.TokenPair;
 import com.sseulang.domain.auth.presentation.dto.LocalLoginRequest;
 import com.sseulang.domain.auth.presentation.dto.LocalSignupRequest;
 import com.sseulang.domain.auth.presentation.dto.OAuthLoginRequest;
+import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.presentation.dto.MeResponse;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import com.sseulang.global.security.CookieUtil;
+import com.sseulang.global.security.JwtProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -34,64 +37,70 @@ public class AuthController {
     private final OAuthLoginService oauthLoginService;
     private final LocalAuthService localAuthService;
     private final CookieUtil cookieUtil;
+    private final JwtProvider jwtProvider;
+    private final UserApplicationService userService;
 
     public AuthController(
             RefreshTokenRotationService rotationService,
             OAuthLoginService oauthLoginService,
             LocalAuthService localAuthService,
-            CookieUtil cookieUtil
+            CookieUtil cookieUtil,
+            JwtProvider jwtProvider,
+            UserApplicationService userService
     ) {
         this.rotationService = rotationService;
         this.oauthLoginService = oauthLoginService;
         this.localAuthService = localAuthService;
         this.cookieUtil = cookieUtil;
+        this.jwtProvider = jwtProvider;
+        this.userService = userService;
     }
 
     @Operation(summary = "LOCAL 회원가입",
             description = "이메일/비밀번호 가입. 성공 시 AT(at)/RT(rt) HttpOnly 쿠키 자동 발급 + 인증 메일 발송. "
                     + "이메일 인증 전엔 자금 영향 API 가 403(AUTH_EMAIL_NOT_VERIFIED) 떨굼.")
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody LocalSignupRequest request) {
+    public ResponseEntity<ApiResponse<MeResponse>> signup(@Valid @RequestBody LocalSignupRequest request) {
         TokenPair pair = localAuthService.signup(request.toEmailVO(), request.password(), request.nickname());
-        return setAuthCookies(pair);
+        return setAuthCookiesWithMe(pair);
     }
 
     @Operation(summary = "LOCAL 로그인",
             description = "이메일/비밀번호 로그인. 미존재/차단/비밀번호 불일치 모두 동일 응답(401 AUTH_LOGIN_FAILED) — 이메일 존재 여부 leak 방지. "
                     + "성공 시 AT/RT 쿠키 자동 발급.")
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody LocalLoginRequest request) {
+    public ResponseEntity<ApiResponse<MeResponse>> login(@Valid @RequestBody LocalLoginRequest request) {
         TokenPair pair = localAuthService.login(request.toEmailVO(), request.password());
-        return setAuthCookies(pair);
+        return setAuthCookiesWithMe(pair);
     }
 
-    private ResponseEntity<ApiResponse<Void>> setAuthCookies(TokenPair pair) {
+    /**
+     * 발급된 AT 에서 userId 추출 → 본인 정보 조회 → 응답 body 에 포함.
+     * 프론트가 로그인 후 별도 /users/me 호출 없이 바로 store 초기화 가능.
+     */
+    private ResponseEntity<ApiResponse<MeResponse>> setAuthCookiesWithMe(TokenPair pair) {
         ResponseCookie at = cookieUtil.accessTokenCookie(pair.accessToken());
         ResponseCookie rt = cookieUtil.refreshTokenCookie(pair.refreshToken());
+        Long userId = jwtProvider.parse(pair.accessToken()).userId();
+        MeResponse me = MeResponse.from(userService.getById(userId));
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, at.toString())
                 .header(HttpHeaders.SET_COOKIE, rt.toString())
-                .body(ApiResponse.ok());
+                .body(ApiResponse.ok(me));
     }
 
-    @Operation(summary = "OAuth 로그인 (kakao/google)",
-            description = "프론트가 SDK 로 받은 access_token 을 본 endpoint 에 POST. 백엔드가 provider 검증 + 신규/기존/takeover 분기 처리. "
-                    + "신규 가입은 email_verified=true 로 즉시 발급 (provider 검증된 이메일).")
+    @Operation(summary = "OAuth 로그인 (kakao/google) — Authorization Code Grant",
+            description = "프론트가 OAuth redirect 로 받은 code + 본인이 쓴 redirectUri 를 본 endpoint 에 POST. "
+                    + "백엔드가 provider token endpoint 에 client_id/client_secret 동봉해 access_token 으로 교환 + user info 조회. "
+                    + "신규 가입은 email_verified=true 로 즉시 발급 (provider 검증된 이메일). Client Secret 활성화 호환.")
     @PostMapping("/oauth2/{provider}")
-    public ResponseEntity<ApiResponse<Void>> oauth2(
+    public ResponseEntity<ApiResponse<MeResponse>> oauth2(
             @PathVariable("provider") String provider,
             @Valid @RequestBody OAuthLoginRequest request
     ) {
         SocialProvider socialProvider = parseProvider(provider);
-        TokenPair pair = oauthLoginService.login(socialProvider, request.accessToken());
-
-        ResponseCookie at = cookieUtil.accessTokenCookie(pair.accessToken());
-        ResponseCookie rt = cookieUtil.refreshTokenCookie(pair.refreshToken());
-
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, at.toString())
-                .header(HttpHeaders.SET_COOKIE, rt.toString())
-                .body(ApiResponse.ok());
+        TokenPair pair = oauthLoginService.loginWithCode(socialProvider, request.code(), request.redirectUri());
+        return setAuthCookiesWithMe(pair);
     }
 
     private SocialProvider parseProvider(String pathParam) {

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/OAuthLoginRequest.java
@@ -4,17 +4,26 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 /**
- * 소셜 로그인 요청 본문.
+ * 소셜 로그인 요청 본문 — Authorization Code Grant.
  *
- * <p>가이드 §4.4 "프론트가 카카오/구글 SDK로 access_token 획득 → 백엔드로 전달".</p>
+ * <p>프론트는 카카오/구글 OAuth redirect 받은 {@code code} 와 본인이 사용한 {@code redirectUri} 만
+ * 그대로 전달. 백엔드가 provider token endpoint 에 client_id/client_secret 동봉해 access_token
+ * 으로 교환 + user info 조회. Client Secret 활성화돼도 안전.</p>
  */
-@Schema(description = "프론트가 SDK로 받은 OAuth access_token 을 전달. 백엔드가 사용자 정보 조회 + 가입/로그인 처리.")
+@Schema(description = "OAuth Authorization Code Grant — 프론트가 redirect 로 받은 code + redirectUri 전달.")
 public record OAuthLoginRequest(
         @Schema(
-                description = "카카오/구글 SDK 에서 받은 OAuth access_token",
-                example = "ya29.a0AfH6SMBxYVhc0BkExampleAccessToken..."
+                description = "카카오/구글 OAuth redirect 의 code 파라미터",
+                example = "abcDEF12345..."
         )
-        @NotBlank(message = "accessToken 은 필수입니다")
-        String accessToken
+        @NotBlank(message = "code 는 필수입니다")
+        String code,
+
+        @Schema(
+                description = "프론트가 SDK init 시 등록한 redirect URI — 카카오/구글 token endpoint 가 일치 여부 검증",
+                example = "http://localhost:3000/auth/kakao/callback"
+        )
+        @NotBlank(message = "redirectUri 는 필수입니다")
+        String redirectUri
 ) {
 }

--- a/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
+++ b/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
@@ -80,7 +80,11 @@ public class FileApplicationService {
         if (!USER_ALLOWED_PURPOSES.contains(purpose)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
-        userService.requireVerified(ownerId);
+        // PROFILE 은 미인증 사용자도 허용 — 본인 정보 관리(자금/거래 영향 0). UX 친화 정책 (5/2 합의).
+        // ITEM 은 거래 시작점이라 인증 필수 유지.
+        if (purpose != FilePurpose.PROFILE) {
+            userService.requireVerified(ownerId);
+        }
         return issue(purpose, ownerId, files);
     }
 

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemSearchCriteria.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemSearchCriteria.java
@@ -14,9 +14,14 @@ public record ItemSearchCriteria(
         TradeType tradeType,
         Long minPrice,
         Long maxPrice,
-        String tag
+        String tag,
+        ItemSort sort
 ) {
+    public ItemSearchCriteria {
+        if (sort == null) sort = ItemSort.LATEST;
+    }
+
     public static ItemSearchCriteria empty() {
-        return new ItemSearchCriteria(null, null, null, null, null, null);
+        return new ItemSearchCriteria(null, null, null, null, null, null, ItemSort.LATEST);
     }
 }

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemSort.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemSort.java
@@ -1,0 +1,27 @@
+package com.sseulang.domain.item.application.dto;
+
+/**
+ * Item 검색 정렬 옵션. URL query param `sort` 의 값과 1:1 매핑.
+ * 잘못된 값은 controller 에서 LATEST 로 fallback.
+ */
+public enum ItemSort {
+    /** createdAt DESC (default). */
+    LATEST,
+    /** price ASC. */
+    PRICE_ASC,
+    /** price DESC. */
+    PRICE_DESC,
+    /** viewCount DESC — 조회순. 동률은 createdAt DESC. */
+    VIEW_DESC,
+    /** wishlistCount DESC — 찜많은순. 동률은 createdAt DESC. */
+    WISHLIST_DESC;
+
+    public static ItemSort parse(String raw) {
+        if (raw == null || raw.isBlank()) return LATEST;
+        try {
+            return ItemSort.valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return LATEST;
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
@@ -1,11 +1,13 @@
 package com.sseulang.domain.item.infrastructure.persistence;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
+import com.sseulang.domain.item.application.dto.ItemSort;
 import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.item.domain.ItemStatus;
 import com.sseulang.domain.item.domain.QItem;
@@ -85,7 +87,7 @@ public class ItemQuerydslRepository {
         List<Item> content = queryFactory
                 .selectFrom(item)
                 .where(where)
-                .orderBy(item.createdAt.desc(), item.id.desc())
+                .orderBy(orderBy(criteria.sort(), item))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -97,6 +99,20 @@ public class ItemQuerydslRepository {
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total == null ? 0L : total);
+    }
+
+    /**
+     * sort 옵션 → QueryDSL OrderSpecifier 배열. 동률 시 createdAt DESC 로 안정적 정렬.
+     * default(LATEST) 는 createdAt DESC + id DESC.
+     */
+    private static OrderSpecifier<?>[] orderBy(ItemSort sort, QItem item) {
+        return switch (sort) {
+            case PRICE_ASC -> new OrderSpecifier<?>[]{ item.price.asc(), item.id.desc() };
+            case PRICE_DESC -> new OrderSpecifier<?>[]{ item.price.desc(), item.id.desc() };
+            case VIEW_DESC -> new OrderSpecifier<?>[]{ item.viewCount.desc(), item.createdAt.desc(), item.id.desc() };
+            case WISHLIST_DESC -> new OrderSpecifier<?>[]{ item.wishlistCount.desc(), item.createdAt.desc(), item.id.desc() };
+            case LATEST -> new OrderSpecifier<?>[]{ item.createdAt.desc(), item.id.desc() };
+        };
     }
 
     /**

--- a/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
@@ -55,7 +55,8 @@ public class ItemController {
     }
 
     @Operation(summary = "물품 검색·페이징 (공개)",
-            description = "FULLTEXT(ngram) 검색. q 1글자는 LIKE 폴백. categoryId/tradeType/minPrice/maxPrice/tag 조합 필터. 인증 불필요.")
+            description = "FULLTEXT(ngram) 검색. q 1글자는 LIKE 폴백. categoryId/tradeType/minPrice/maxPrice/tag 조합 필터. "
+                    + "sort 옵션: latest(default) / price_asc / price_desc / view_desc / wishlist_desc. 인증 불필요.")
     @GetMapping
     public ApiResponse<PageResponse<ItemSummaryResponse>> list(
             @RequestParam(name = "q", required = false) String q,
@@ -64,13 +65,16 @@ public class ItemController {
             @RequestParam(name = "minPrice", required = false) Long minPrice,
             @RequestParam(name = "maxPrice", required = false) Long maxPrice,
             @RequestParam(name = "tag", required = false) String tag,
+            @RequestParam(name = "sort", required = false) String sort,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
         int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
         int safePage = Math.max(page, 0);
         Pageable pageable = PageRequest.of(safePage, safeSize);
-        ItemSearchCriteria criteria = new ItemSearchCriteria(q, categoryId, tradeType, minPrice, maxPrice, tag);
+        ItemSearchCriteria criteria = new ItemSearchCriteria(
+                q, categoryId, tradeType, minPrice, maxPrice, tag,
+                com.sseulang.domain.item.application.dto.ItemSort.parse(sort));
 
         Page<ItemSummaryResponse> result = itemService.search(criteria, pageable)
                 .map(ItemSummaryResponse::from);

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemRegisterRequest.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemRegisterRequest.java
@@ -28,8 +28,8 @@ public record ItemRegisterRequest(
         @Schema(description = "보증금 (대여 거래 전용, 그 외 null)", example = "100000", nullable = true)
         @PositiveOrZero Long deposit,
 
-        @Schema(description = "대여 단위 (대여 거래 전용)", example = "DAY",
-                allowableValues = {"HOUR", "DAY", "WEEK", "MONTH"}, nullable = true)
+        @Schema(description = "대여 단위 (대여 거래 전용) — 시간/일/주/월", example = "일",
+                allowableValues = {"시간", "일", "주", "월"}, nullable = true)
         RentalUnit rentalUnit,
 
         @Schema(description = "거래 유형", example = "판매",

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -74,6 +74,17 @@ public class UserApplicationService {
     }
 
     /**
+     * 본인 프로필 partial update — null 필드는 변경 X. 미인증 사용자도 호출 가능 (자금/거래 영향 0).
+     * profileImage 빈 문자열 = 이미지 제거.
+     */
+    @Transactional
+    public User updateProfile(Long userId, String profileImage, String nickname) {
+        User user = getById(userId);
+        user.updateProfile(profileImage, nickname);
+        return user;
+    }
+
+    /**
      * 민감 기능 진입 가드 — 이메일 인증 미완료 시 {@link ErrorCode#AUTH_EMAIL_NOT_VERIFIED} (FORBIDDEN).
      * 거래 시작 / 결제 / 출금 / Item 등록 등 자금·신뢰 영향 흐름의 첫 진입점에서 호출.
      */

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -179,6 +179,26 @@ public class User extends BaseEntity {
     }
 
     /**
+     * 본인 프로필 partial update. null 인 필드는 변경하지 않음 (PATCH 의미).
+     * 빈 문자열 nickname 은 거부.
+     *
+     * @param newProfileImage S3 GET URL (또는 key). null 이면 변경 X. 빈 문자열은 이미지 제거 의도로 허용 — null 로 설정.
+     * @param newNickname 새 닉네임 (1~50자). null 이면 변경 X.
+     */
+    public void updateProfile(String newProfileImage, String newNickname) {
+        if (newNickname != null) {
+            if (newNickname.isBlank() || newNickname.length() > 50) {
+                throw new IllegalArgumentException("nickname 은 1~50자여야 합니다");
+            }
+            this.nickname = newNickname.trim();
+        }
+        if (newProfileImage != null) {
+            // 빈 문자열 → 이미지 제거 (null 로 저장)
+            this.profileImage = newProfileImage.isBlank() ? null : newProfileImage;
+        }
+    }
+
+    /**
      * OAuth takeover — 기존 LOCAL user 가 점유한 email 에 진짜 owner 가 OAuth 로 가입 시도.
      * 기존 user 의 password 무효화 + social 정보 추가 + verified=true. 공격자(LOCAL 가입자)는
      * 더 이상 비밀번호로 로그인 불가. 게이트 1: 이메일 선점 공격 무력화.

--- a/src/main/java/com/sseulang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/UserController.java
@@ -1,0 +1,48 @@
+package com.sseulang.domain.user.presentation;
+
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.presentation.dto.MeResponse;
+import com.sseulang.domain.user.presentation.dto.UserUpdateRequest;
+import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "본인 사용자 정보 조회/수정")
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserApplicationService userService;
+
+    public UserController(UserApplicationService userService) {
+        this.userService = userService;
+    }
+
+    @Operation(summary = "본인 정보 조회",
+            description = "AT 쿠키 기반 인증된 사용자 정보. 로그인 후 페이지 새로고침 시 store 재초기화에 사용.")
+    @GetMapping("/me")
+    public ApiResponse<MeResponse> getMe(@AuthenticationPrincipal Long userId) {
+        return ApiResponse.ok(MeResponse.from(userService.getById(userId)));
+    }
+
+    @Operation(summary = "본인 프로필 수정 (partial)",
+            description = "profileImage / nickname 둘 다 optional. null 필드는 변경 X. "
+                    + "profileImage 빈 문자열은 이미지 제거. 이메일 미인증 상태에서도 호출 가능 (자금/거래 영향 0). "
+                    + "이미지 등록 흐름: 1) POST /files/presigned-url (purpose=PROFILE) → 2) S3 PUT → 3) 본 endpoint 에 받은 key 또는 GET URL 전달.")
+    @PatchMapping("/me")
+    public ApiResponse<MeResponse> updateMe(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody UserUpdateRequest request
+    ) {
+        return ApiResponse.ok(MeResponse.from(
+                userService.updateProfile(userId, request.profileImage(), request.nickname())
+        ));
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/MeResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/MeResponse.java
@@ -1,0 +1,40 @@
+package com.sseulang.domain.user.presentation.dto;
+
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+/**
+ * 본인 사용자 정보 응답 — 로그인/가입/oauth/refresh 응답 + GET /api/v1/users/me 의 표준 본문.
+ *
+ * <p>비밀번호 / social_id / address 등 민감 정보는 제외. 프론트가 헤더 사용자 영역, store 초기화에
+ * 필요한 최소 필드만.</p>
+ */
+@Schema(description = "본인 사용자 정보 (헤더/스토어 초기화용).")
+public record MeResponse(
+        @Schema(example = "42") Long id,
+        @Schema(example = "alice@sseulang.test") String email,
+        @Schema(example = "쓸랭이") String nickname,
+        @Schema(description = "프로필 이미지 URL (없으면 null)") String profileImage,
+        @Schema(description = "LOCAL / KAKAO / GOOGLE") SocialProvider socialProvider,
+        @Schema(example = "true", description = "이메일 인증 여부 — false 면 자금/거래 API 가 403") boolean emailVerified,
+        @Schema(example = "50000", description = "포인트 잔액 (KRW)") long pointBalance,
+        @Schema(example = "4.7", description = "리뷰 평균. 리뷰 0건이면 null") BigDecimal trustScore,
+        @Schema(example = "12") int reviewCount
+) {
+    public static MeResponse from(User u) {
+        return new MeResponse(
+                u.getId(),
+                u.getEmail(),
+                u.getNickname(),
+                u.getProfileImage(),
+                u.getSocialProvider(),
+                u.isEmailVerified(),
+                u.getPointBalance(),
+                u.getTrustScore(),
+                u.getReviewCount()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/UserUpdateRequest.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/UserUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.sseulang.domain.user.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 본인 프로필 partial update. 모든 필드 optional — null 은 변경 안 함.
+ *
+ * <p>profileImage 빈 문자열은 "이미지 제거" 의도로 처리 (null 저장). 이미지 등록은 미인증 사용자도
+ * 허용 — 5/2 합의 (자금/거래만 차단).</p>
+ */
+@Schema(description = "본인 프로필 partial update — null 필드는 변경 X.")
+public record UserUpdateRequest(
+        @Schema(description = "프로필 이미지 URL/key. null=변경 X, 빈 문자열=제거",
+                example = "https://cdn.sseulang.com/profiles/100/avatar.jpg")
+        String profileImage,
+
+        @Schema(description = "닉네임 1~50자. null=변경 X", example = "쓸랭이")
+        @Size(min = 1, max = 50)
+        String nickname
+) {}

--- a/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
+++ b/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
@@ -1,10 +1,13 @@
 package com.sseulang.domain.wishlist.application;
 
 import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.application.dto.ItemSummaryResult;
 import com.sseulang.domain.wishlist.domain.Wishlist;
 import com.sseulang.domain.wishlist.domain.WishlistRepository;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,6 +52,15 @@ public class WishlistApplicationService {
             }
             throw violation;
         }
+    }
+
+    /**
+     * 본인이 찜한 Item 목록 페이징 — 삭제된 Item 자동 제외. 찜한 시간 최신순.
+     * 응답은 ItemSummary 형태로 변환해 controller 에서 ItemSummaryResponse 직렬화.
+     */
+    public Page<ItemSummaryResult> listMyWishlistedItems(Long userId, Pageable pageable) {
+        return wishlistRepository.findWishlistedItemsByUserId(userId, pageable)
+                .map(ItemSummaryResult::from);
     }
 
     /**

--- a/src/main/java/com/sseulang/domain/wishlist/domain/WishlistRepository.java
+++ b/src/main/java/com/sseulang/domain/wishlist/domain/WishlistRepository.java
@@ -1,5 +1,9 @@
 package com.sseulang.domain.wishlist.domain;
 
+import com.sseulang.domain.item.domain.Item;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface WishlistRepository {
 
     boolean existsByUserIdAndItemId(Long userId, Long itemId);
@@ -11,4 +15,10 @@ public interface WishlistRepository {
      * (예: items.wishlist_count 감소)을 결정할 때 사용.
      */
     int deleteByUserIdAndItemId(Long userId, Long itemId);
+
+    /**
+     * 내 찜 목록 — 삭제된 Item 은 제외, Wishlist.createdAt DESC 로 페이징.
+     * Cross-aggregate read (Wishlist join Item) — write 흐름은 분리되어 있어 read 만 허용.
+     */
+    Page<Item> findWishlistedItemsByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistJpaRepository.java
@@ -1,6 +1,9 @@
 package com.sseulang.domain.wishlist.infrastructure.persistence;
 
+import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.wishlist.domain.Wishlist;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +16,21 @@ interface WishlistJpaRepository extends JpaRepository<Wishlist, Long> {
     @Modifying
     @Query("DELETE FROM Wishlist w WHERE w.userId = :userId AND w.itemId = :itemId")
     int deleteByUserAndItem(@Param("userId") Long userId, @Param("itemId") Long itemId);
+
+    /**
+     * 본인이 찜한 Item 목록 — 삭제된 Item 은 자동 필터. Wishlist 의 createdAt 기준 최신순.
+     * cross-aggregate read JPQL.
+     */
+    @Query(value = """
+            SELECT i FROM Item i
+             WHERE i.id IN (SELECT w.itemId FROM Wishlist w WHERE w.userId = :userId)
+               AND i.status != com.sseulang.domain.item.domain.ItemStatus.삭제
+             ORDER BY (SELECT w.createdAt FROM Wishlist w WHERE w.userId = :userId AND w.itemId = i.id) DESC
+            """,
+            countQuery = """
+            SELECT COUNT(i) FROM Item i
+             WHERE i.id IN (SELECT w.itemId FROM Wishlist w WHERE w.userId = :userId)
+               AND i.status != com.sseulang.domain.item.domain.ItemStatus.삭제
+            """)
+    Page<Item> findWishlistedItems(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistRepositoryImpl.java
@@ -1,7 +1,10 @@
 package com.sseulang.domain.wishlist.infrastructure.persistence;
 
+import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.wishlist.domain.Wishlist;
 import com.sseulang.domain.wishlist.domain.WishlistRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -26,5 +29,10 @@ public class WishlistRepositoryImpl implements WishlistRepository {
     @Override
     public int deleteByUserIdAndItemId(Long userId, Long itemId) {
         return jpa.deleteByUserAndItem(userId, itemId);
+    }
+
+    @Override
+    public Page<Item> findWishlistedItemsByUserId(Long userId, Pageable pageable) {
+        return jpa.findWishlistedItems(userId, pageable);
     }
 }

--- a/src/main/java/com/sseulang/domain/wishlist/presentation/MyWishlistController.java
+++ b/src/main/java/com/sseulang/domain/wishlist/presentation/MyWishlistController.java
@@ -1,0 +1,50 @@
+package com.sseulang.domain.wishlist.presentation;
+
+import com.sseulang.domain.item.presentation.dto.ItemSummaryResponse;
+import com.sseulang.domain.wishlist.application.WishlistApplicationService;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 본인 찜 목록 조회 — {@link WishlistController} 의 add/remove 와 분리. path prefix 가 다름
+ * ({@code /api/v1/users/me/wishlist}).
+ */
+@Tag(name = "Wishlist", description = "물품 찜 추가/해제 + 본인 목록")
+@RestController
+@RequestMapping("/api/v1/users/me/wishlist")
+public class MyWishlistController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final WishlistApplicationService wishlistService;
+
+    public MyWishlistController(WishlistApplicationService wishlistService) {
+        this.wishlistService = wishlistService;
+    }
+
+    @Operation(summary = "내 찜 목록",
+            description = "본인이 찜한 활성 Item 페이징. 찜한 시간 최신순. 삭제된 Item 자동 제외.")
+    @GetMapping
+    public ApiResponse<PageResponse<ItemSummaryResponse>> listMine(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+        Page<ItemSummaryResponse> result = wishlistService.listMyWishlistedItems(userId, pageable)
+                .map(ItemSummaryResponse::from);
+        return ApiResponse.ok(PageResponse.from(result));
+    }
+}

--- a/src/main/java/com/sseulang/global/config/SecurityConfig.java
+++ b/src/main/java/com/sseulang/global/config/SecurityConfig.java
@@ -19,6 +19,11 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 /**
  * 3-chain 분리:
@@ -109,6 +114,28 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
+    /**
+     * REST CORS — {@code app.cors.allowed-origins} 화이트리스트. 와일드카드(*) X.
+     * preflight(OPTIONS) 가 인증/CSRF 통과하지 못하던 회귀 차단 — Spring Security 의 cors() 가
+     * 본 Bean 을 자동 사용해 OPTIONS 를 SecurityFilterChain 진입 전에 처리.
+     *
+     * <p>credentials=true (쿠키 동봉) 라서 Origin 정확 매칭 필수. WebSocket handshake 는 STOMP
+     * endpoint 의 setAllowedOrigins 가 별도로 처리하므로 본 source 는 REST(/**) 에만.</p>
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(CorsProperties corsProperties) {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(corsProperties.allowedOrigins());
+        config.setAllowedMethods(List.of("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Set-Cookie"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
     @Bean
     @Order(1)
     public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
@@ -170,6 +197,8 @@ public class SecurityConfig {
                 .httpBasic(b -> b.disable())
                 .formLogin(f -> f.disable())
                 .logout(l -> l.disable())
+                // corsConfigurationSource Bean 자동 사용 — preflight(OPTIONS) 통과 + 쿠키 허용 헤더 박힘.
+                .cors(c -> {})
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -62,6 +62,10 @@ app:
     allowed-origins:
       - http://localhost:3000
       - http://localhost:5173
+  email:
+    # 가입 직후 발송되는 인증 메일 링크 base. 프론트가 token query 파라미터를 받아서
+    # POST /api/v1/auth/verify-email 호출. (5/2 — 프론트 합의 path)
+    verification-url-base: http://localhost:3000/auth/verify-email
   # 로컬 smoke test 전용 인증 우회 — DevAuthController. prod 배포 시 절대 true 금지.
   dev-auth:
     enabled: true

--- a/src/test/java/com/sseulang/domain/auth/application/OAuthLoginServiceTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/OAuthLoginServiceTest.java
@@ -85,13 +85,13 @@ class OAuthLoginServiceTest {
     @Test
     @DisplayName("login 정상_provider 호출 + user 생성/조회 + AT/RT 발급 + RT store 저장")
     void login_정상() {
-        when(kakaoProvider.verifyAndFetch("KAKAO_TOKEN")).thenReturn(INFO);
+        when(kakaoProvider.exchangeCodeAndFetch("KAKAO_TOKEN", "http://test/cb")).thenReturn(INFO);
         User u = userWithId(USER_ID, false, false);
         when(userService.findOrCreateBySocial(
                 eq(SocialProvider.KAKAO), eq(PROVIDER_ID), eq(EMAIL), eq("쓸랭이"), eq("https://img/u.png")))
                 .thenReturn(u);
 
-        TokenPair pair = service.login(SocialProvider.KAKAO, "KAKAO_TOKEN");
+        TokenPair pair = service.loginWithCode(SocialProvider.KAKAO, "KAKAO_TOKEN", "http://test/cb");
 
         assertThat(pair.accessToken()).isNotBlank();
         assertThat(pair.refreshToken()).isNotBlank();
@@ -106,28 +106,28 @@ class OAuthLoginServiceTest {
         assertThat(store.contains("USER", USER_ID, rtJti)).isTrue();
 
         // 다른 provider 호출 X
-        verify(googleProvider, never()).verifyAndFetch(any());
+        verify(googleProvider, never()).exchangeCodeAndFetch(any(), eq("http://test/cb"));
     }
 
     @Test
     @DisplayName("login_미지원 provider_AUTH_OAUTH_FAILED")
     void login_미지원provider() {
         // 본 service 에 KAKAO/GOOGLE 만 등록 → LOCAL 호출 시 실패
-        assertThatThrownBy(() -> service.login(SocialProvider.LOCAL, "T"))
+        assertThatThrownBy(() -> service.loginWithCode(SocialProvider.LOCAL, "T", "http://test/cb"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
 
-        verify(kakaoProvider, never()).verifyAndFetch(any());
-        verify(googleProvider, never()).verifyAndFetch(any());
+        verify(kakaoProvider, never()).exchangeCodeAndFetch(any(), eq("http://test/cb"));
+        verify(googleProvider, never()).exchangeCodeAndFetch(any(), eq("http://test/cb"));
         verify(userService, never()).findOrCreateBySocial(any(), any(), any(), any(), any());
     }
 
     @Test
     @DisplayName("login_provider 토큰 검증 실패_BusinessException 그대로 전파")
     void login_provider_검증실패() {
-        when(kakaoProvider.verifyAndFetch("BAD")).thenThrow(new BusinessException(ErrorCode.AUTH_OAUTH_FAILED));
+        when(kakaoProvider.exchangeCodeAndFetch("BAD", "http://test/cb")).thenThrow(new BusinessException(ErrorCode.AUTH_OAUTH_FAILED));
 
-        assertThatThrownBy(() -> service.login(SocialProvider.KAKAO, "BAD"))
+        assertThatThrownBy(() -> service.loginWithCode(SocialProvider.KAKAO, "BAD", "http://test/cb"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
 
@@ -137,11 +137,11 @@ class OAuthLoginServiceTest {
     @Test
     @DisplayName("login_외부 API 호출 실패(ExternalApiException)_AUTH_OAUTH_FAILED 변환 + user 조회 X")
     void login_externalApi_실패() {
-        when(kakaoProvider.verifyAndFetch("T"))
+        when(kakaoProvider.exchangeCodeAndFetch("T", "http://test/cb"))
                 .thenThrow(new com.sseulang.global.exception.ExternalApiException(
                         "kakao-oauth", new RuntimeException("network")));
 
-        assertThatThrownBy(() -> service.login(SocialProvider.KAKAO, "T"))
+        assertThatThrownBy(() -> service.loginWithCode(SocialProvider.KAKAO, "T", "http://test/cb"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
 
@@ -151,11 +151,11 @@ class OAuthLoginServiceTest {
     @Test
     @DisplayName("login_blocked user_USER_BLOCKED + JWT 발급 X")
     void login_blocked() {
-        when(kakaoProvider.verifyAndFetch("T")).thenReturn(INFO);
+        when(kakaoProvider.exchangeCodeAndFetch("T", "http://test/cb")).thenReturn(INFO);
         User u = userWithId(USER_ID, true, false);
         when(userService.findOrCreateBySocial(any(), any(), any(), any(), any())).thenReturn(u);
 
-        assertThatThrownBy(() -> service.login(SocialProvider.KAKAO, "T"))
+        assertThatThrownBy(() -> service.loginWithCode(SocialProvider.KAKAO, "T", "http://test/cb"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.USER_BLOCKED);
 
@@ -165,11 +165,11 @@ class OAuthLoginServiceTest {
     @Test
     @DisplayName("login_deleted user_USER_BLOCKED")
     void login_deleted() {
-        when(kakaoProvider.verifyAndFetch("T")).thenReturn(INFO);
+        when(kakaoProvider.exchangeCodeAndFetch("T", "http://test/cb")).thenReturn(INFO);
         User u = userWithId(USER_ID, false, true);
         when(userService.findOrCreateBySocial(any(), any(), any(), any(), any())).thenReturn(u);
 
-        assertThatThrownBy(() -> service.login(SocialProvider.KAKAO, "T"))
+        assertThatThrownBy(() -> service.loginWithCode(SocialProvider.KAKAO, "T", "http://test/cb"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.USER_BLOCKED);
     }
@@ -177,12 +177,12 @@ class OAuthLoginServiceTest {
     @Test
     @DisplayName("login_연속 호출_매번 새 jti store 저장 (누적 X 정책 X — Day3 단순화)")
     void login_연속() {
-        when(kakaoProvider.verifyAndFetch(any())).thenReturn(INFO);
+        when(kakaoProvider.exchangeCodeAndFetch(any(), eq("http://test/cb"))).thenReturn(INFO);
         User u = userWithId(USER_ID, false, false);
         when(userService.findOrCreateBySocial(any(), any(), any(), any(), any())).thenReturn(u);
 
-        TokenPair p1 = service.login(SocialProvider.KAKAO, "T1");
-        TokenPair p2 = service.login(SocialProvider.KAKAO, "T2");
+        TokenPair p1 = service.loginWithCode(SocialProvider.KAKAO, "T1", "http://test/cb");
+        TokenPair p2 = service.loginWithCode(SocialProvider.KAKAO, "T2", "http://test/cb");
 
         // 둘 다 store 에 등록 — 디바이스 동시 로그인 허용
         String j1 = jwtProvider.parse(p1.refreshToken()).jti();

--- a/src/test/java/com/sseulang/domain/auth/infrastructure/oauth/OAuthProviderGuardTest.java
+++ b/src/test/java/com/sseulang/domain/auth/infrastructure/oauth/OAuthProviderGuardTest.java
@@ -20,29 +20,29 @@ class OAuthProviderGuardTest {
     @Test
     @DisplayName("Kakao supports_KAKAO")
     void kakao_supports() {
-        KakaoOAuthProvider p = new KakaoOAuthProvider(builder);
+        KakaoOAuthProvider p = new KakaoOAuthProvider(builder, "test-client-id", "test-secret");
         assertThat(p.supports()).isEqualTo(SocialProvider.KAKAO);
     }
 
     @Test
     @DisplayName("Google supports_GOOGLE")
     void google_supports() {
-        GoogleOAuthProvider p = new GoogleOAuthProvider(builder);
+        GoogleOAuthProvider p = new GoogleOAuthProvider(builder, "test-client-id", "test-secret");
         assertThat(p.supports()).isEqualTo(SocialProvider.GOOGLE);
     }
 
     @Test
     @DisplayName("Kakao verifyAndFetch null/blank 토큰_AUTH_OAUTH_FAILED")
     void kakao_blank_token() {
-        KakaoOAuthProvider p = new KakaoOAuthProvider(builder);
+        KakaoOAuthProvider p = new KakaoOAuthProvider(builder, "test-client-id", "test-secret");
 
-        assertThatThrownBy(() -> p.verifyAndFetch(null))
+        assertThatThrownBy(() -> p.exchangeCodeAndFetch(null, "http://test/cb"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
-        assertThatThrownBy(() -> p.verifyAndFetch(""))
+        assertThatThrownBy(() -> p.exchangeCodeAndFetch("", "http://test/cb"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
-        assertThatThrownBy(() -> p.verifyAndFetch("   "))
+        assertThatThrownBy(() -> p.exchangeCodeAndFetch("   ", "http://test/cb"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
     }
@@ -50,12 +50,12 @@ class OAuthProviderGuardTest {
     @Test
     @DisplayName("Google verifyAndFetch null/blank 토큰_AUTH_OAUTH_FAILED")
     void google_blank_token() {
-        GoogleOAuthProvider p = new GoogleOAuthProvider(builder);
+        GoogleOAuthProvider p = new GoogleOAuthProvider(builder, "test-client-id", "test-secret");
 
-        assertThatThrownBy(() -> p.verifyAndFetch(null))
+        assertThatThrownBy(() -> p.exchangeCodeAndFetch(null, "http://test/cb"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
-        assertThatThrownBy(() -> p.verifyAndFetch(""))
+        assertThatThrownBy(() -> p.exchangeCodeAndFetch("", "http://test/cb"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.AUTH_OAUTH_FAILED);
     }

--- a/src/test/java/com/sseulang/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/sseulang/domain/auth/presentation/AuthControllerTest.java
@@ -44,10 +44,27 @@ class AuthControllerTest {
         rotationService = mock(RefreshTokenRotationService.class);
         oauthLoginService = mock(OAuthLoginService.class);
         cookieUtil = mock(CookieUtil.class);
+        com.sseulang.global.security.JwtProvider jwtProvider =
+                mock(com.sseulang.global.security.JwtProvider.class);
+        com.sseulang.domain.user.application.UserApplicationService userService =
+                mock(com.sseulang.domain.user.application.UserApplicationService.class);
+        when(jwtProvider.parse(org.mockito.ArgumentMatchers.anyString())).thenReturn(
+                new com.sseulang.global.security.JwtClaims(
+                        100L, "USER", "jti-test", null,
+                        java.time.Instant.now(), java.time.Instant.now().plusSeconds(60)
+                )
+        );
+        when(userService.getById(org.mockito.ArgumentMatchers.anyLong())).thenReturn(
+                com.sseulang.domain.user.domain.User.createSocialUser(
+                        com.sseulang.domain.user.domain.SocialProvider.KAKAO, "kakao-test",
+                        new com.sseulang.domain.user.domain.Email("oauth@test.com"),
+                        "tester", null
+                )
+        );
         AuthController controller = new AuthController(
                 rotationService, oauthLoginService,
                 mock(com.sseulang.domain.auth.application.LocalAuthService.class),
-                cookieUtil
+                cookieUtil, jwtProvider, userService
         );
         mvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
@@ -129,7 +146,7 @@ class AuthControllerTest {
     @Test
     @DisplayName("POST /auth/oauth2/kakao_정상_KAKAO 매핑 + AT/RT 쿠키 응답")
     void oauth2_kakao_정상() throws Exception {
-        when(oauthLoginService.login(eq(SocialProvider.KAKAO), eq("KAKAO_AT")))
+        when(oauthLoginService.loginWithCode(eq(SocialProvider.KAKAO), eq("KAKAO_AT"), eq("http://test/cb")))
                 .thenReturn(new TokenPair("NEW_AT", "NEW_RT"));
         when(cookieUtil.accessTokenCookie("NEW_AT"))
                 .thenReturn(ResponseCookie.from("at", "NEW_AT").path("/").httpOnly(true).maxAge(1800).build());
@@ -138,7 +155,7 @@ class AuthControllerTest {
 
         MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/kakao")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"KAKAO_AT\"}"))
+                        .content("{\"code\":\"KAKAO_AT\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andReturn();
@@ -148,13 +165,13 @@ class AuthControllerTest {
         assertThat(setCookies).anyMatch(s -> s.startsWith("at=NEW_AT"));
         assertThat(setCookies).anyMatch(s -> s.startsWith("rt=NEW_RT"));
 
-        verify(oauthLoginService, times(1)).login(SocialProvider.KAKAO, "KAKAO_AT");
+        verify(oauthLoginService, times(1)).loginWithCode(SocialProvider.KAKAO, "KAKAO_AT", "http://test/cb");
     }
 
     @Test
     @DisplayName("POST /auth/oauth2/google_정상_GOOGLE 매핑")
     void oauth2_google_정상() throws Exception {
-        when(oauthLoginService.login(eq(SocialProvider.GOOGLE), eq("G_AT")))
+        when(oauthLoginService.loginWithCode(eq(SocialProvider.GOOGLE), eq("G_AT"), eq("http://test/cb")))
                 .thenReturn(new TokenPair("AT", "RT"));
         when(cookieUtil.accessTokenCookie("AT"))
                 .thenReturn(ResponseCookie.from("at", "AT").path("/").build());
@@ -163,10 +180,10 @@ class AuthControllerTest {
 
         mvc.perform(post("/api/v1/auth/oauth2/google")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"G_AT\"}"))
+                        .content("{\"code\":\"G_AT\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isOk());
 
-        verify(oauthLoginService, times(1)).login(SocialProvider.GOOGLE, "G_AT");
+        verify(oauthLoginService, times(1)).loginWithCode(SocialProvider.GOOGLE, "G_AT", "http://test/cb");
     }
 
     @Test
@@ -174,23 +191,23 @@ class AuthControllerTest {
     void oauth2_unknown_provider() throws Exception {
         mvc.perform(post("/api/v1/auth/oauth2/twitter")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"T\"}"))
+                        .content("{\"code\":\"T\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value(ErrorCode.AUTH_OAUTH_FAILED.name()));
 
-        verify(oauthLoginService, never()).login(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+        verify(oauthLoginService, never()).loginWithCode(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
     }
 
     @Test
     @DisplayName("POST /auth/oauth2/kakao_provider 검증 실패_AUTH_OAUTH_FAILED 전파")
     void oauth2_provider_검증실패_전파() throws Exception {
-        when(oauthLoginService.login(eq(SocialProvider.KAKAO), eq("BAD")))
+        when(oauthLoginService.loginWithCode(eq(SocialProvider.KAKAO), eq("BAD"), eq("http://test/cb")))
                 .thenThrow(new BusinessException(ErrorCode.AUTH_OAUTH_FAILED));
 
         mvc.perform(post("/api/v1/auth/oauth2/kakao")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"BAD\"}"))
+                        .content("{\"code\":\"BAD\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error.code").value(ErrorCode.AUTH_OAUTH_FAILED.name()));
     }
@@ -198,7 +215,7 @@ class AuthControllerTest {
     @Test
     @DisplayName("POST /auth/oauth2/KAKAO (대문자)_path 대소문자 무시")
     void oauth2_path_대소문자() throws Exception {
-        when(oauthLoginService.login(eq(SocialProvider.KAKAO), eq("T")))
+        when(oauthLoginService.loginWithCode(eq(SocialProvider.KAKAO), eq("T"), eq("http://test/cb")))
                 .thenReturn(new TokenPair("AT", "RT"));
         when(cookieUtil.accessTokenCookie("AT"))
                 .thenReturn(ResponseCookie.from("at", "AT").path("/").build());
@@ -207,9 +224,9 @@ class AuthControllerTest {
 
         mvc.perform(post("/api/v1/auth/oauth2/KAKAO")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"T\"}"))
+                        .content("{\"code\":\"T\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isOk());
 
-        verify(oauthLoginService, times(1)).login(SocialProvider.KAKAO, "T");
+        verify(oauthLoginService, times(1)).loginWithCode(SocialProvider.KAKAO, "T", "http://test/cb");
     }
 }

--- a/src/test/java/com/sseulang/domain/auth/presentation/AuthOAuthFlowIT.java
+++ b/src/test/java/com/sseulang/domain/auth/presentation/AuthOAuthFlowIT.java
@@ -44,10 +44,27 @@ class AuthOAuthFlowIT {
         oauthLoginService = mock(OAuthLoginService.class);
         rotationService = mock(RefreshTokenRotationService.class);
         cookieUtil = mock(CookieUtil.class);
+        com.sseulang.global.security.JwtProvider jwtProvider =
+                mock(com.sseulang.global.security.JwtProvider.class);
+        com.sseulang.domain.user.application.UserApplicationService userService =
+                mock(com.sseulang.domain.user.application.UserApplicationService.class);
+        when(jwtProvider.parse(org.mockito.ArgumentMatchers.anyString())).thenReturn(
+                new com.sseulang.global.security.JwtClaims(
+                        100L, "USER", "jti-test", null,
+                        java.time.Instant.now(), java.time.Instant.now().plusSeconds(60)
+                )
+        );
+        when(userService.getById(org.mockito.ArgumentMatchers.anyLong())).thenReturn(
+                com.sseulang.domain.user.domain.User.createSocialUser(
+                        com.sseulang.domain.user.domain.SocialProvider.KAKAO, "kakao-test",
+                        new com.sseulang.domain.user.domain.Email("oauth@test.com"),
+                        "tester", null
+                )
+        );
         AuthController controller = new AuthController(
                 rotationService, oauthLoginService,
                 mock(com.sseulang.domain.auth.application.LocalAuthService.class),
-                cookieUtil
+                cookieUtil, jwtProvider, userService
         );
 
         mvc = MockMvcBuilders.standaloneSetup(controller)
@@ -59,7 +76,7 @@ class AuthOAuthFlowIT {
     @Test
     @DisplayName("oauth2/kakao 정상_200 + X-Trace-Id 헤더 + Set-Cookie 2 + ApiResponse")
     void oauth2_kakao_정상_traceId_헤더() throws Exception {
-        when(oauthLoginService.login(eq(SocialProvider.KAKAO), eq("KAKAO_AT")))
+        when(oauthLoginService.loginWithCode(eq(SocialProvider.KAKAO), eq("KAKAO_AT"), eq("http://test/cb")))
                 .thenReturn(new TokenPair("AT", "RT"));
         when(cookieUtil.accessTokenCookie("AT"))
                 .thenReturn(ResponseCookie.from("at", "AT").path("/").httpOnly(true).build());
@@ -68,7 +85,7 @@ class AuthOAuthFlowIT {
 
         MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/kakao")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"KAKAO_AT\"}"))
+                        .content("{\"code\":\"KAKAO_AT\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isOk())
                 .andExpect(header().exists(TraceIdFilter.HEADER))
                 .andExpect(jsonPath("$.success").value(true))
@@ -83,7 +100,7 @@ class AuthOAuthFlowIT {
     void oauth2_unknown_traceId_일관성() throws Exception {
         MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/twitter")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"T\"}"))
+                        .content("{\"code\":\"T\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(header().exists(TraceIdFilter.HEADER))
                 .andExpect(jsonPath("$.success").value(false))
@@ -106,7 +123,7 @@ class AuthOAuthFlowIT {
         MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/twitter")
                         .header(TraceIdFilter.HEADER, incoming)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"T\"}"))
+                        .content("{\"code\":\"T\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(header().string(TraceIdFilter.HEADER, incoming))
                 .andReturn();

--- a/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
@@ -59,7 +59,7 @@ class ItemSearchTest {
         register("갤럭시 S24", "S급", catB, TradeType.판매, 200_000L, null);
 
         Page<ItemSummaryResult> result = service.search(
-                new ItemSearchCriteria("아이폰", null, null, null, null, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria("아이폰", null, null, null, null, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent()).extracting(ItemSummaryResult::title)
@@ -73,7 +73,7 @@ class ItemSearchTest {
         register("물건2", "사용감 있음", catA, TradeType.판매, 200_000L, null);
 
         Page<ItemSummaryResult> result = service.search(
-                new ItemSearchCriteria("정품", null, null, null, null, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria("정품", null, null, null, null, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent()).hasSize(1);
@@ -88,7 +88,7 @@ class ItemSearchTest {
         register("b1", "d", catB, TradeType.판매, 300L, null);
 
         Page<ItemSummaryResult> result = service.search(
-                new ItemSearchCriteria(null, catA, null, null, null, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria(null, catA, null, null, null, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getTotalElements()).isEqualTo(2);
@@ -102,7 +102,7 @@ class ItemSearchTest {
         register("대여물", "d", catA, TradeType.대여, 100L, RentalUnit.일);
 
         Page<ItemSummaryResult> result = service.search(
-                new ItemSearchCriteria(null, null, TradeType.나눔, null, null, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria(null, null, TradeType.나눔, null, null, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent()).hasSize(1);
@@ -117,7 +117,7 @@ class ItemSearchTest {
         register("비싼것", "d", catA, TradeType.판매, 1_000_000L, null);
 
         Page<ItemSummaryResult> result = service.search(
-                new ItemSearchCriteria(null, null, null, 10_000L, 100_000L, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria(null, null, null, 10_000L, 100_000L, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent()).extracting(ItemSummaryResult::title)
@@ -137,7 +137,7 @@ class ItemSearchTest {
         ));
 
         Page<ItemSummaryResult> result = service.search(
-                new ItemSearchCriteria(null, null, null, null, null, "아이폰"),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria(null, null, null, null, null, "아이폰", com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent()).extracting(ItemSummaryResult::id)
@@ -181,7 +181,7 @@ class ItemSearchTest {
         register("a3", "d", catA, TradeType.판매, 5_000_000L, null);
 
         Page<ItemSummaryResult> result = service.search(
-                new ItemSearchCriteria(null, catA, TradeType.판매, 0L, 100_000L, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria(null, catA, TradeType.판매, 0L, 100_000L, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent()).extracting(ItemSummaryResult::title).containsExactly("a1");

--- a/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepositoryIT.java
+++ b/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepositoryIT.java
@@ -133,7 +133,7 @@ class ItemQuerydslRepositoryIT {
         // "X" 1글자 → ngram_token_size=2 미달 → toBooleanModeQuery 빈 문자열 → LIKE 폴백.
         // LIKE 는 트랜잭션 내 INSERT row 도 즉시 매칭됨.
         Page<Item> result = repository.search(
-                new ItemSearchCriteria("X", null, null, null, null, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria("X", null, null, null, null, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent())
@@ -150,7 +150,7 @@ class ItemQuerydslRepositoryIT {
         persistItem("비싼것", TradeType.판매, 1_000_000L);
 
         Page<Item> result = repository.search(
-                new ItemSearchCriteria(null, null, TradeType.판매, 10_000L, 100_000L, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria(null, null, TradeType.판매, 10_000L, 100_000L, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent())
@@ -174,7 +174,7 @@ class ItemQuerydslRepositoryIT {
         em.clear();
 
         Page<Item> hit = repository.search(
-                new ItemSearchCriteria(null, null, null, null, null, "미개봉"),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria(null, null, null, null, null, "미개봉", com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(hit.getContent())

--- a/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemSearchFullTextIT.java
+++ b/src/test/java/com/sseulang/domain/item/infrastructure/persistence/ItemSearchFullTextIT.java
@@ -104,7 +104,7 @@ class ItemSearchFullTextIT {
         seedItem("갤럭시 S24", "디테일 없음");
 
         Page<Item> result = repository.search(
-                new ItemSearchCriteria("아이폰", null, null, null, null, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria("아이폰", null, null, null, null, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent())
@@ -120,7 +120,7 @@ class ItemSearchFullTextIT {
         seedItem("갤럭시 미개봉", "x");
 
         Page<Item> result = repository.search(
-                new ItemSearchCriteria("아이폰 미개봉", null, null, null, null, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria("아이폰 미개봉", null, null, null, null, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent())
@@ -135,7 +135,7 @@ class ItemSearchFullTextIT {
         seedItem("물건2", "다른 제품 설명");
 
         Page<Item> result = repository.search(
-                new ItemSearchCriteria("갤럭시", null, null, null, null, null),
+                new com.sseulang.domain.item.application.dto.ItemSearchCriteria("갤럭시", null, null, null, null, null, com.sseulang.domain.item.application.dto.ItemSort.LATEST),
                 PageRequest.of(0, 10));
 
         assertThat(result.getContent())

--- a/src/test/java/com/sseulang/domain/wishlist/application/InMemoryFakeWishlistRepository.java
+++ b/src/test/java/com/sseulang/domain/wishlist/application/InMemoryFakeWishlistRepository.java
@@ -1,9 +1,14 @@
 package com.sseulang.domain.wishlist.application;
 
+import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.wishlist.domain.Wishlist;
 import com.sseulang.domain.wishlist.domain.WishlistRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,6 +39,12 @@ public class InMemoryFakeWishlistRepository implements WishlistRepository {
     @Override
     public int deleteByUserIdAndItemId(Long userId, Long itemId) {
         return store.remove(key(userId, itemId)) != null ? 1 : 0;
+    }
+
+    @Override
+    public Page<Item> findWishlistedItemsByUserId(Long userId, Pageable pageable) {
+        // 단위 테스트용 — Item 본체 join 은 IT 에서 검증. 빈 페이지 반환.
+        return new PageImpl<>(Collections.emptyList(), pageable, 0);
     }
 
     public int size() {

--- a/src/test/java/com/sseulang/global/security/AuthSecurityFlowIT.java
+++ b/src/test/java/com/sseulang/global/security/AuthSecurityFlowIT.java
@@ -35,11 +35,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = ProtectedTestController.class)
 @Import({
         SecurityConfig.class,
+        com.sseulang.global.config.CorsProperties.class,
+        com.sseulang.global.security.CsrfCookieFilter.class,
         JwtAuthenticationFilter.class,
         JwtAuthenticationEntryPoint.class,
         JwtAccessDeniedHandler.class,
         TraceIdFilter.class,
         GlobalExceptionHandler.class
+})
+@org.springframework.test.context.TestPropertySource(properties = {
+        "app.cors.allowed-origins=http://localhost:3000"
 })
 class AuthSecurityFlowIT {
 

--- a/src/test/java/com/sseulang/integration/AdminFlowE2EIT.java
+++ b/src/test/java/com/sseulang/integration/AdminFlowE2EIT.java
@@ -173,11 +173,11 @@ class AdminFlowE2EIT {
                 SocialProvider.KAKAO, victimProviderId,
                 new Email(victimEmail), "victim", null
         );
-        when(kakaoOAuthProvider.verifyAndFetch("VICTIM_RELOGIN")).thenReturn(info);
+        when(kakaoOAuthProvider.exchangeCodeAndFetch("VICTIM_RELOGIN", "http://test/cb")).thenReturn(info);
         mvc.perform(post("/api/v1/auth/oauth2/kakao")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"VICTIM_RELOGIN\"}"))
+                        .content("{\"code\":\"VICTIM_RELOGIN\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error.code").value("USER_BLOCKED"));
     }
@@ -294,11 +294,11 @@ class AdminFlowE2EIT {
         OAuthUserInfo info = new OAuthUserInfo(
                 SocialProvider.KAKAO, providerId, new Email(email), nickname, null
         );
-        when(kakaoOAuthProvider.verifyAndFetch(tokenSentinel)).thenReturn(info);
+        when(kakaoOAuthProvider.exchangeCodeAndFetch(tokenSentinel, "http://test/cb")).thenReturn(info);
         MvcResult r = mvc.perform(post("/api/v1/auth/oauth2/kakao")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"" + tokenSentinel + "\"}"))
+                        .content("{\"code\":\"" + tokenSentinel + "\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isOk())
                 .andExpect(cookie().exists(CookieUtil.ACCESS_TOKEN_COOKIE))
                 .andReturn();

--- a/src/test/java/com/sseulang/integration/DeliveryFlowE2EIT.java
+++ b/src/test/java/com/sseulang/integration/DeliveryFlowE2EIT.java
@@ -258,12 +258,12 @@ class DeliveryFlowE2EIT {
                 nickname, null
         );
         when(kakaoOAuthProvider.supports()).thenReturn(SocialProvider.KAKAO);
-        when(kakaoOAuthProvider.verifyAndFetch(accessToken)).thenReturn(info);
+        when(kakaoOAuthProvider.exchangeCodeAndFetch(accessToken, "http://test/cb")).thenReturn(info);
 
         MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/kakao")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"" + accessToken + "\"}"))
+                        .content("{\"code\":\"" + accessToken + "\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isOk())
                 .andExpect(cookie().exists(CookieUtil.ACCESS_TOKEN_COOKIE))
                 .andReturn();

--- a/src/test/java/com/sseulang/integration/EndToEndGuardScenariosIT.java
+++ b/src/test/java/com/sseulang/integration/EndToEndGuardScenariosIT.java
@@ -305,11 +305,11 @@ class EndToEndGuardScenariosIT {
         OAuthUserInfo info = new OAuthUserInfo(
                 SocialProvider.KAKAO, providerId, new Email(email), nickname, null
         );
-        when(kakaoOAuthProvider.verifyAndFetch(tokenSentinel)).thenReturn(info);
+        when(kakaoOAuthProvider.exchangeCodeAndFetch(tokenSentinel, "http://test/cb")).thenReturn(info);
         MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/kakao")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"" + tokenSentinel + "\"}"))
+                        .content("{\"code\":\"" + tokenSentinel + "\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isOk())
                 .andExpect(cookie().exists(CookieUtil.ACCESS_TOKEN_COOKIE))
                 .andReturn();

--- a/src/test/java/com/sseulang/integration/EndToEndHappyPathIT.java
+++ b/src/test/java/com/sseulang/integration/EndToEndHappyPathIT.java
@@ -169,7 +169,7 @@ class EndToEndHappyPathIT {
                 new Email("seller-" + System.nanoTime() + "@e2e.test"), "셀러", null
         );
         when(kakaoOAuthProvider.supports()).thenReturn(SocialProvider.KAKAO);
-        when(kakaoOAuthProvider.verifyAndFetch("SELLER_TOKEN")).thenReturn(sellerInfo);
+        when(kakaoOAuthProvider.exchangeCodeAndFetch("SELLER_TOKEN", "http://test/cb")).thenReturn(sellerInfo);
 
         Cookie sellerAt = loginAndExtractAt("SELLER_TOKEN");
 
@@ -199,7 +199,7 @@ class EndToEndHappyPathIT {
                 SocialProvider.KAKAO, "kakao-buyer-" + UUID.randomUUID(),
                 new Email("buyer-" + System.nanoTime() + "@e2e.test"), "바이어", null
         );
-        when(kakaoOAuthProvider.verifyAndFetch("BUYER_TOKEN")).thenReturn(buyerInfo);
+        when(kakaoOAuthProvider.exchangeCodeAndFetch("BUYER_TOKEN", "http://test/cb")).thenReturn(buyerInfo);
         Cookie buyerAt = loginAndExtractAt("BUYER_TOKEN");
 
         // ───────── 4. Buyer 충전 (Toss mock) ─────────
@@ -284,7 +284,7 @@ class EndToEndHappyPathIT {
         MvcResult result = mvc.perform(post("/api/v1/auth/oauth2/kakao")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"" + accessToken + "\"}"))
+                        .content("{\"code\":\"" + accessToken + "\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isOk())
                 .andExpect(cookie().exists(CookieUtil.ACCESS_TOKEN_COOKIE))
                 .andReturn();

--- a/src/test/java/com/sseulang/integration/WebSocketAuthFlowIT.java
+++ b/src/test/java/com/sseulang/integration/WebSocketAuthFlowIT.java
@@ -244,11 +244,11 @@ class WebSocketAuthFlowIT {
         OAuthUserInfo info = new OAuthUserInfo(
                 SocialProvider.KAKAO, providerId, new Email(email), nickname, null
         );
-        when(kakaoOAuthProvider.verifyAndFetch(tokenSentinel)).thenReturn(info);
+        when(kakaoOAuthProvider.exchangeCodeAndFetch(tokenSentinel, "http://test/cb")).thenReturn(info);
         MvcResult r = mvc.perform(post("/api/v1/auth/oauth2/kakao")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"accessToken\":\"" + tokenSentinel + "\"}"))
+                        .content("{\"code\":\"" + tokenSentinel + "\",\"redirectUri\":\"http://test/cb\"}"))
                 .andExpect(status().isOk())
                 .andExpect(cookie().exists(CookieUtil.ACCESS_TOKEN_COOKIE))
                 .andReturn();


### PR DESCRIPTION
## Summary
프론트 연동 1일차(5/2) 발견된 이슈 + 신규 요청 4건 통합 처리.

### 1. CORS preflight 403 fix
- `SecurityConfig` 에 `CorsConfigurationSource` bean + `.cors()` 적용 — allowedOrigins 는 `CorsProperties` (`app.cors.allowed-origins`) 로 주입, `allowCredentials=true` + `Set-Cookie` expose.

### 2. 로그인 응답에 user 정보 포함 (setUser falsy 이슈)
- `MeResponse` 신설 — `id / email / nickname / profileImage / socialProvider / emailVerified / pointBalance / trustScore / reviewCount`.
- `signup` / `login` / `oauth2` / `refresh` 응답 본문에 `MeResponse` 동봉.
- `GET /api/v1/users/me` 신설 — 표준 본인 조회 endpoint.

### 3. OAuth Authorization Code Grant 전환
- `OAuthLoginRequest`: `{ accessToken }` → `{ code, redirectUri }`.
- `KakaoOAuthProvider` / `GoogleOAuthProvider` — token endpoint 호출 + user info 조회 2단계. Client Secret 옵션 호환.
- 프론트는 redirect 받은 `code` 만 그대로 백엔드에 전달.

### 4. PATCH /api/v1/users/me
- `profileImage` / `nickname` partial update (`null`=변경X, `""`=제거).
- 미인증 사용자도 호출 가능 — 이메일 인증 전 프로필 셋업 가능.
- `FilePurpose.PROFILE` 만 `requireVerified` 우회 (`ITEM` 등은 인증 필수 유지).

### 5. 내 찜 목록 — `GET /api/v1/users/me/wishlist`
- `WishlistRepository.findWishlistedItemsByUserId` — cross-aggregate read JPQL (Wishlist join Item).
- 삭제된 Item 제외, `Wishlist.createdAt DESC` 페이징.
- `ItemSummaryResponse` 페이징 응답.

### 6. sort 옵션 — `GET /api/v1/items?sort=...`
- `ItemSort` enum — `latest`(default) / `price_asc` / `price_desc` / `view_desc` / `wishlist_desc`.
- `ItemQuerydslRepository.orderBy` 분기. 동률은 `createdAt DESC + id DESC` 안정 정렬.
- 잘못된 값은 LATEST fallback.

### 7. RentalUnit Swagger 정정
- `@Schema allowableValues`: `HOUR/DAY/WEEK/MONTH` → `시간/일/주/월` (실제 enum 값).
- `example: "DAY"` → `"일"`.

### 보류 (별도 처리 예정)
- **좌표 검색** — 배달대행 실시간 위치 표시용. WebSocket+STOMP 방향으로 별도 PR 예정 (follow-up #51).

## Test plan
- [x] 컴파일 통과
- [x] 전체 테스트 303 PASS / 0 FAIL
- [ ] 로컬 백엔드 재시작 후 프론트와 smoke (CORS 200 / 로그인 setUser / OAuth code grant / PATCH /me / 찜 목록 / sort / Swagger RentalUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)