### PR TITLE
feat: ItemSummary 카드 필드 + 마이페이지 + 찜 토글 응답 — 프론트 연동 라운드 2

### DIFF
--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -12,6 +12,7 @@ import com.sseulang.domain.item.application.dto.ItemUpdateCommand;
 import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.item.domain.ItemRepository;
 import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.WishlistView;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import org.springframework.data.domain.Page;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @Transactional(readOnly = true)
@@ -30,17 +32,20 @@ public class ItemApplicationService {
     private final CategoryApplicationService categoryApplicationService;
     private final UserApplicationService userApplicationService;
     private final PresignedUrlGenerator presignedUrlGenerator;
+    private final WishlistView wishlistView;
 
     public ItemApplicationService(
             ItemRepository itemRepository,
             CategoryApplicationService categoryApplicationService,
             UserApplicationService userApplicationService,
-            PresignedUrlGenerator presignedUrlGenerator
+            PresignedUrlGenerator presignedUrlGenerator,
+            WishlistView wishlistView
     ) {
         this.itemRepository = itemRepository;
         this.categoryApplicationService = categoryApplicationService;
         this.userApplicationService = userApplicationService;
         this.presignedUrlGenerator = presignedUrlGenerator;
+        this.wishlistView = wishlistView;
     }
 
     @Transactional
@@ -74,8 +79,34 @@ public class ItemApplicationService {
         return ItemDetailResult.from(item);
     }
 
+    /**
+     * 공개 검색·필터. viewerId 가 null 이면 비로그인 — isWishlisted 는 항상 false.
+     * Page 결과의 itemId 들에 대해 단일 SELECT 로 viewer 의 찜 여부 enrich (N+1 회피).
+     */
+    public Page<ItemSummaryResult> search(ItemSearchCriteria criteria, Pageable pageable, Long viewerId) {
+        return enrich(itemRepository.search(criteria, pageable), viewerId);
+    }
+
+    /** viewer 모름 — 비로그인 entry / 시스템 호출용. */
     public Page<ItemSummaryResult> search(ItemSearchCriteria criteria, Pageable pageable) {
-        return itemRepository.search(criteria, pageable).map(ItemSummaryResult::from);
+        return search(criteria, pageable, null);
+    }
+
+    /**
+     * 마이페이지용 본인 물품 목록. status null = 삭제 제외 전체. viewer = sellerId 본인이므로
+     * 본인이 찜한 자기 물품은 표시 (서비스 정책상 가능). viewerId 명시로 isWishlisted 계산.
+     */
+    public Page<ItemSummaryResult> findMyItems(Long sellerId, ItemStatus status, Pageable pageable) {
+        return enrich(itemRepository.findBySellerIdAndStatus(sellerId, status, pageable), sellerId);
+    }
+
+    private Page<ItemSummaryResult> enrich(Page<Item> page, Long viewerId) {
+        if (page.isEmpty()) {
+            return page.map(item -> ItemSummaryResult.from(item, false));
+        }
+        List<Long> ids = page.getContent().stream().map(Item::getId).toList();
+        Set<Long> wishlisted = wishlistView.findWishlistedItemIds(viewerId, ids);
+        return page.map(item -> ItemSummaryResult.from(item, wishlisted.contains(item.getId())));
     }
 
     @Transactional
@@ -203,6 +234,15 @@ public class ItemApplicationService {
     @Transactional
     public void decrementWishlistCount(Long itemId) {
         itemRepository.decrementWishlistCount(itemId);
+    }
+
+    /**
+     * Fresh wishlist_count 조회 — bulk update 직후 호출해도 정확한 DB 값. 본인 토글 응답에 즉시 반영용.
+     * row 가 없으면 ITEM_NOT_FOUND.
+     */
+    public int getWishlistCount(Long itemId) {
+        return itemRepository.getWishlistCount(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
     }
 
     private Item findOrThrow(Long id) {

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemSummaryResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemSummaryResult.java
@@ -7,7 +7,8 @@ import com.sseulang.domain.item.domain.TradeType;
 import java.time.LocalDateTime;
 
 /**
- * 목록용 요약. 썸네일은 N+1 회피를 위해 본 PR 에선 미포함 — 검색·필터 PR 에서 fetch 최적화 후 추가.
+ * 목록·검색·찜·내물품 공통 요약. {@code thumbnailUrl} 은 V11 denormalize 컬럼에서 직접,
+ * {@code isWishlisted} 는 ApplicationService 가 viewer 기준으로 enrich 단계에서 매핑한다.
  */
 public record ItemSummaryResult(
         Long id,
@@ -18,9 +19,17 @@ public record ItemSummaryResult(
         TradeType tradeType,
         ItemStatus status,
         String region,
+        String thumbnailUrl,
+        int wishlistCount,
+        boolean isWishlisted,
         LocalDateTime createdAt
 ) {
+    /** viewer 가 없거나 비로그인 사용자 — isWishlisted = false. */
     public static ItemSummaryResult from(Item item) {
+        return from(item, false);
+    }
+
+    public static ItemSummaryResult from(Item item, boolean isWishlisted) {
         return new ItemSummaryResult(
                 item.getId(),
                 item.getSellerId(),
@@ -30,6 +39,9 @@ public record ItemSummaryResult(
                 item.getTradeType(),
                 item.getStatus(),
                 item.getRegion(),
+                item.getThumbnailUrl(),
+                item.getWishlistCount(),
+                isWishlisted,
                 item.getCreatedAt()
         );
     }

--- a/src/main/java/com/sseulang/domain/item/domain/Item.java
+++ b/src/main/java/com/sseulang/domain/item/domain/Item.java
@@ -81,6 +81,13 @@ public class Item extends BaseEntity {
     @Column(name = "region", length = REGION_MAX_LENGTH)
     private String region;
 
+    /**
+     * 썸네일 image_url denormalize. {@link #addImage}/{@link #clearImages} 시 자동 갱신 — Aggregate
+     * 외부에서 직접 set 금지. ItemSummary 응답을 N+1 없이 내려주기 위한 V11 컬럼.
+     */
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
+
     @Column(name = "view_count", nullable = false)
     private int viewCount;
 
@@ -140,10 +147,14 @@ public class Item extends BaseEntity {
             throw new BusinessException(ErrorCode.ITEM_IMAGE_LIMIT_EXCEEDED);
         }
         images.add(new ItemImage(this, imageUrl, sortOrder, thumbnail));
+        if (thumbnail) {
+            this.thumbnailUrl = imageUrl;
+        }
     }
 
     public void clearImages() {
         images.clear();
+        this.thumbnailUrl = null;
     }
 
     /** 외부에 노출되는 이미지 컬렉션은 immutable. 변경은 {@link #addImage} / {@link #clearImages}. */

--- a/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
@@ -24,6 +24,12 @@ public interface ItemRepository {
     /** 동적 검색·필터 + 최신순 정렬. criteria 의 모든 필드가 null 이면 전체 (status != 삭제) 최신순. */
     Page<Item> search(ItemSearchCriteria criteria, Pageable pageable);
 
+    /**
+     * 본인 등록 물품 페이징 — 마이페이지 탭 분리용. status 가 null 이면 삭제만 자동 제외하고 전체.
+     * status 명시 시 정확히 일치 (예: 판매중 / 예약 / 거래완료 / 비공개).
+     */
+    Page<Item> findBySellerIdAndStatus(Long sellerId, ItemStatus status, Pageable pageable);
+
     Item save(Item item);
 
     void delete(Item item);
@@ -38,4 +44,10 @@ public interface ItemRepository {
      * 영향받은 행 수 반환.
      */
     int decrementWishlistCount(Long itemId);
+
+    /**
+     * 현재 wishlist_count 값. JPQL 스칼라 projection 으로 fresh DB 조회 — 같은 트랜잭션 내 bulk
+     * update 직후 호출해도 stale 캐시 회피. row 가 없으면 빈 Optional.
+     */
+    Optional<Integer> getWishlistCount(Long itemId);
 }

--- a/src/main/java/com/sseulang/domain/item/domain/WishlistView.java
+++ b/src/main/java/com/sseulang/domain/item/domain/WishlistView.java
@@ -1,0 +1,19 @@
+package com.sseulang.domain.item.domain;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Item 도메인이 viewer 의 찜 여부를 알아야 할 때 쓰는 read-only 포트.
+ * 구현은 {@code wishlist.infrastructure} 의 어댑터.
+ *
+ * <p>CLAUDE.md §3.3 — 다른 도메인 Repository 직접 호출 금지. 여기서는 cross-aggregate read 용
+ * 포트만 정의하고 wishlist 인프라가 구현 (anti-corruption + 단방향 의존).</p>
+ */
+public interface WishlistView {
+
+    /**
+     * 주어진 itemId 들 중 userId 가 찜한 것만 반환. userId / itemIds 가 비어있으면 {@code Set.of()}.
+     */
+    Set<Long> findWishlistedItemIds(Long userId, Collection<Long> itemIds);
+}

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
@@ -1,7 +1,10 @@
 package com.sseulang.domain.item.infrastructure.persistence;
 
 import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemStatus;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -24,4 +27,31 @@ interface ItemJpaRepository extends JpaRepository<Item, Long> {
     @Modifying
     @Query("UPDATE Item i SET i.wishlistCount = i.wishlistCount - 1 WHERE i.id = :id AND i.wishlistCount > 0")
     int decrementWishlistCount(@Param("id") Long id);
+
+    /** Fresh wishlist_count read — JPQL 스칼라 projection 으로 persistence context 우회. */
+    @Query("SELECT i.wishlistCount FROM Item i WHERE i.id = :id")
+    Optional<Integer> getWishlistCount(@Param("id") Long id);
+
+    /**
+     * 본인 물품 — status 명시 시 정확 일치, null 이면 삭제 제외 전체.
+     * status 가 null 이면 cross-product 가 안 되므로 두 쿼리로 분기.
+     */
+    @Query("""
+            SELECT i FROM Item i
+             WHERE i.sellerId = :sellerId AND i.status = :status
+             ORDER BY i.createdAt DESC, i.id DESC
+            """)
+    Page<Item> findBySellerIdAndStatus(
+            @Param("sellerId") Long sellerId,
+            @Param("status") ItemStatus status,
+            Pageable pageable);
+
+    @Query("""
+            SELECT i FROM Item i
+             WHERE i.sellerId = :sellerId AND i.status <> com.sseulang.domain.item.domain.ItemStatus.삭제
+             ORDER BY i.createdAt DESC, i.id DESC
+            """)
+    Page<Item> findBySellerIdExcludingDeleted(
+            @Param("sellerId") Long sellerId,
+            Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.item.infrastructure.persistence;
 import com.sseulang.domain.item.application.dto.ItemSearchCriteria;
 import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.item.domain.ItemRepository;
+import com.sseulang.domain.item.domain.ItemStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -36,6 +37,14 @@ public class ItemRepositoryImpl implements ItemRepository {
     }
 
     @Override
+    public Page<Item> findBySellerIdAndStatus(Long sellerId, ItemStatus status, Pageable pageable) {
+        if (status == null) {
+            return jpa.findBySellerIdExcludingDeleted(sellerId, pageable);
+        }
+        return jpa.findBySellerIdAndStatus(sellerId, status, pageable);
+    }
+
+    @Override
     public Item save(Item item) {
         return jpa.save(item);
     }
@@ -53,5 +62,10 @@ public class ItemRepositoryImpl implements ItemRepository {
     @Override
     public int decrementWishlistCount(Long itemId) {
         return jpa.decrementWishlistCount(itemId);
+    }
+
+    @Override
+    public Optional<Integer> getWishlistCount(Long itemId) {
+        return jpa.getWishlistCount(itemId);
     }
 }

--- a/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
@@ -59,6 +59,7 @@ public class ItemController {
                     + "sort 옵션: latest(default) / price_asc / price_desc / view_desc / wishlist_desc. 인증 불필요.")
     @GetMapping
     public ApiResponse<PageResponse<ItemSummaryResponse>> list(
+            @AuthenticationPrincipal(errorOnInvalidType = false) Long viewerId,
             @RequestParam(name = "q", required = false) String q,
             @RequestParam(name = "categoryId", required = false) Long categoryId,
             @RequestParam(name = "tradeType", required = false) TradeType tradeType,
@@ -76,7 +77,8 @@ public class ItemController {
                 q, categoryId, tradeType, minPrice, maxPrice, tag,
                 com.sseulang.domain.item.application.dto.ItemSort.parse(sort));
 
-        Page<ItemSummaryResponse> result = itemService.search(criteria, pageable)
+        // 비로그인 — viewerId null → isWishlisted 항상 false. 로그인 시 단일 SELECT 로 enrich.
+        Page<ItemSummaryResponse> result = itemService.search(criteria, pageable, viewerId)
                 .map(ItemSummaryResponse::from);
         return ApiResponse.ok(PageResponse.from(result));
     }

--- a/src/main/java/com/sseulang/domain/item/presentation/MyItemsController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/MyItemsController.java
@@ -1,0 +1,55 @@
+package com.sseulang.domain.item.presentation;
+
+import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.presentation.dto.ItemSummaryResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 마이페이지용 본인 등록 물품 목록. {@link ItemController} 의 공개 검색과 분리 — 본인만 접근.
+ *
+ * <p>{@code status} 쿼리로 탭 분리 가능: 판매중 / 예약 / 거래완료 / 비공개. 미지정 시 삭제만 자동 제외.</p>
+ */
+@Tag(name = "Item", description = "마이페이지 본인 물품 목록")
+@RestController
+@RequestMapping("/api/v1/users/me/items")
+public class MyItemsController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final ItemApplicationService itemService;
+
+    public MyItemsController(ItemApplicationService itemService) {
+        this.itemService = itemService;
+    }
+
+    @Operation(summary = "내 물품 목록",
+            description = "본인이 등록한 물품 페이징. status 미지정 시 삭제 외 전체 (판매중/예약/거래완료/비공개). "
+                    + "잘못된 status 값은 400 으로 반환됨.")
+    @GetMapping
+    public ApiResponse<PageResponse<ItemSummaryResponse>> listMine(
+            @AuthenticationPrincipal Long sellerId,
+            @RequestParam(name = "status", required = false) ItemStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+
+        Page<ItemSummaryResponse> result = itemService.findMyItems(sellerId, status, pageable)
+                .map(ItemSummaryResponse::from);
+        return ApiResponse.ok(PageResponse.from(result));
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemSummaryResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemSummaryResponse.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(description = "물품 목록 row — 검색/페이징 응답에 포함.")
+@Schema(description = "물품 목록 row — 검색·찜·내물품 응답 공통.")
 public record ItemSummaryResponse(
         @Schema(example = "42") Long id,
         @Schema(example = "100") Long sellerId,
@@ -17,6 +17,14 @@ public record ItemSummaryResponse(
         TradeType tradeType,
         ItemStatus status,
         @Schema(example = "서울 강남구") String region,
+        @Schema(example = "https://cdn.sseulang.com/items/42/abc.jpg",
+                description = "썸네일 1장 URL — 등록된 이미지가 없으면 null")
+        String thumbnailUrl,
+        @Schema(example = "8", description = "찜 누적 카운트")
+        int wishlistCount,
+        @Schema(example = "false",
+                description = "본인 찜 여부 — 비로그인은 항상 false")
+        boolean isWishlisted,
         LocalDateTime createdAt
 ) {
     public static ItemSummaryResponse from(ItemSummaryResult r) {
@@ -24,6 +32,7 @@ public record ItemSummaryResponse(
                 r.id(), r.sellerId(), r.categoryId(),
                 r.title(), r.price(),
                 r.tradeType(), r.status(), r.region(),
+                r.thumbnailUrl(), r.wishlistCount(), r.isWishlisted(),
                 r.createdAt()
         );
     }

--- a/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
+++ b/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.wishlist.application;
 
 import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.domain.item.application.dto.ItemSummaryResult;
+import com.sseulang.domain.wishlist.application.dto.WishlistToggleResult;
 import com.sseulang.domain.wishlist.domain.Wishlist;
 import com.sseulang.domain.wishlist.domain.WishlistRepository;
 import org.hibernate.exception.ConstraintViolationException;
@@ -36,42 +37,47 @@ public class WishlistApplicationService {
      * 찜 추가. Item 존재 검증은 {@link ItemApplicationService#requireActiveItem} 위임 (CLAUDE.md
      * §3.3 — 다른 도메인 Repository 직접 호출 금지). 이미 있으면 멱등하게 무시.
      * UNIQUE(user_id, item_id) race 는 catch 후 무시 — 그 외 무결성 위반은 재던지기.
+     *
+     * <p>응답으로 fresh wishlistCount 를 반환 — 프론트가 detail 재조회 없이 즉시 UI 갱신.</p>
      */
     @Transactional
-    public void add(Long userId, Long itemId) {
+    public WishlistToggleResult add(Long userId, Long itemId) {
         itemApplicationService.requireActiveItem(itemId);
         if (wishlistRepository.existsByUserIdAndItemId(userId, itemId)) {
-            return;
+            return new WishlistToggleResult(true, itemApplicationService.getWishlistCount(itemId));
         }
         try {
             wishlistRepository.save(Wishlist.create(userId, itemId));
             itemApplicationService.incrementWishlistCount(itemId);
         } catch (DataIntegrityViolationException violation) {
-            if (isUniqueUserItemConflict(violation)) {
-                return;
+            if (!isUniqueUserItemConflict(violation)) {
+                throw violation;
             }
-            throw violation;
+            // race — 다른 트랜잭션이 먼저 추가. 멱등 처리하고 fresh count 만 응답.
         }
+        return new WishlistToggleResult(true, itemApplicationService.getWishlistCount(itemId));
     }
 
     /**
      * 본인이 찜한 Item 목록 페이징 — 삭제된 Item 자동 제외. 찜한 시간 최신순.
-     * 응답은 ItemSummary 형태로 변환해 controller 에서 ItemSummaryResponse 직렬화.
+     * 본인 찜 목록이라 isWishlisted 는 모두 true — DB 조회 없이 ItemSummaryResult 직접 매핑.
      */
     public Page<ItemSummaryResult> listMyWishlistedItems(Long userId, Pageable pageable) {
         return wishlistRepository.findWishlistedItemsByUserId(userId, pageable)
-                .map(ItemSummaryResult::from);
+                .map(item -> ItemSummaryResult.from(item, true));
     }
 
     /**
      * 멱등 삭제. 실제 삭제된 row 가 1 건일 때만 wishlist_count 감소 — 동시 remove 시 underflow 방지.
+     * 응답으로 fresh wishlistCount 반환 — 호출 후 상태는 wishlisted=false.
      */
     @Transactional
-    public void remove(Long userId, Long itemId) {
+    public WishlistToggleResult remove(Long userId, Long itemId) {
         int deleted = wishlistRepository.deleteByUserIdAndItemId(userId, itemId);
         if (deleted > 0) {
             itemApplicationService.decrementWishlistCount(itemId);
         }
+        return new WishlistToggleResult(false, itemApplicationService.getWishlistCount(itemId));
     }
 
     /**

--- a/src/main/java/com/sseulang/domain/wishlist/application/dto/WishlistToggleResult.java
+++ b/src/main/java/com/sseulang/domain/wishlist/application/dto/WishlistToggleResult.java
@@ -1,0 +1,9 @@
+package com.sseulang.domain.wishlist.application.dto;
+
+/**
+ * 찜 추가/해제 직후 응답 — 프론트가 detail 재조회 없이 카드 UI 즉시 갱신할 수 있도록.
+ *
+ * @param wishlisted 호출 후 viewer 가 해당 item 을 찜하고 있는 상태인지
+ * @param wishlistCount 호출 후 item 의 누적 찜 수 (fresh DB 값)
+ */
+public record WishlistToggleResult(boolean wishlisted, int wishlistCount) { }

--- a/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistJpaRepository.java
@@ -18,6 +18,15 @@ interface WishlistJpaRepository extends JpaRepository<Wishlist, Long> {
     int deleteByUserAndItem(@Param("userId") Long userId, @Param("itemId") Long itemId);
 
     /**
+     * Item 도메인의 {@link com.sseulang.domain.item.domain.WishlistView} 어댑터 백킹 쿼리.
+     * userId 가 itemIds 중 어느 것을 찜했는지 단일 SELECT 로 반환 — N+1 회피용.
+     */
+    @Query("SELECT w.itemId FROM Wishlist w WHERE w.userId = :userId AND w.itemId IN :itemIds")
+    java.util.List<Long> findItemIdsByUserIdAndItemIds(
+            @Param("userId") Long userId,
+            @Param("itemIds") java.util.Collection<Long> itemIds);
+
+    /**
      * 본인이 찜한 Item 목록 — 삭제된 Item 은 자동 필터. Wishlist 의 createdAt 기준 최신순.
      * cross-aggregate read JPQL.
      */

--- a/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistViewAdapter.java
@@ -1,0 +1,31 @@
+package com.sseulang.domain.wishlist.infrastructure.persistence;
+
+import com.sseulang.domain.item.domain.WishlistView;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * {@link WishlistView} 어댑터. {@code item} 도메인이 viewer 의 찜한 itemId 집합을 알아야 할 때
+ * (목록·검색·내물품 응답의 isWishlisted 매핑) 단일 SELECT 로 응답.
+ *
+ * <p>userId 가 null 또는 itemIds 가 비면 즉시 {@code Set.of()} — DB 호출 안 함.</p>
+ */
+@Component
+class WishlistViewAdapter implements WishlistView {
+
+    private final WishlistJpaRepository jpa;
+
+    WishlistViewAdapter(WishlistJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Set<Long> findWishlistedItemIds(Long userId, Collection<Long> itemIds) {
+        if (userId == null || itemIds == null || itemIds.isEmpty()) {
+            return Set.of();
+        }
+        return Set.copyOf(jpa.findItemIdsByUserIdAndItemIds(userId, itemIds));
+    }
+}

--- a/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
+++ b/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
@@ -1,6 +1,7 @@
 package com.sseulang.domain.wishlist.presentation;
 
 import com.sseulang.domain.wishlist.application.WishlistApplicationService;
+import com.sseulang.domain.wishlist.presentation.dto.WishlistToggleResponse;
 import com.sseulang.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * Wishlist 진입점은 Item 자원 하위로 둔다 (가이드 §6.1):
  * {@code POST /api/v1/items/{id}/wishlist}, {@code DELETE /api/v1/items/{id}/wishlist}.
+ *
+ * <p>응답에 fresh {@code wishlisted + wishlistCount} 동봉 — 프론트가 detail 재조회 없이 즉시 UI 갱신.</p>
  */
 @Tag(name = "Wishlist", description = "물품 찜 추가/해제")
 @RestController
@@ -26,23 +29,21 @@ public class WishlistController {
         this.wishlistService = wishlistService;
     }
 
-    @Operation(summary = "찜 추가", description = "멱등 — 이미 찜한 물품 재호출 OK. wishlist_count 자동 증가.")
+    @Operation(summary = "찜 추가", description = "멱등 — 이미 찜한 물품 재호출 OK. 응답에 fresh wishlistCount.")
     @PostMapping
-    public ApiResponse<Void> add(
+    public ApiResponse<WishlistToggleResponse> add(
             @AuthenticationPrincipal Long userId,
             @PathVariable("itemId") Long itemId
     ) {
-        wishlistService.add(userId, itemId);
-        return ApiResponse.ok();
+        return ApiResponse.ok(WishlistToggleResponse.from(wishlistService.add(userId, itemId)));
     }
 
-    @Operation(summary = "찜 해제", description = "멱등 — 찜 안 한 상태 재호출 OK. wishlist_count 자동 감소(음수 방지).")
+    @Operation(summary = "찜 해제", description = "멱등 — 찜 안 한 상태 재호출 OK. wishlist_count 자동 감소(음수 방지). 응답에 fresh wishlistCount.")
     @DeleteMapping
-    public ApiResponse<Void> remove(
+    public ApiResponse<WishlistToggleResponse> remove(
             @AuthenticationPrincipal Long userId,
             @PathVariable("itemId") Long itemId
     ) {
-        wishlistService.remove(userId, itemId);
-        return ApiResponse.ok();
+        return ApiResponse.ok(WishlistToggleResponse.from(wishlistService.remove(userId, itemId)));
     }
 }

--- a/src/main/java/com/sseulang/domain/wishlist/presentation/dto/WishlistToggleResponse.java
+++ b/src/main/java/com/sseulang/domain/wishlist/presentation/dto/WishlistToggleResponse.java
@@ -1,0 +1,16 @@
+package com.sseulang.domain.wishlist.presentation.dto;
+
+import com.sseulang.domain.wishlist.application.dto.WishlistToggleResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "찜 추가/해제 직후 응답 — 프론트가 즉시 카드 UI 갱신할 수 있도록 wishlisted + 누적 wishlistCount 동봉.")
+public record WishlistToggleResponse(
+        @Schema(example = "true", description = "호출 후 찜 상태")
+        boolean wishlisted,
+        @Schema(example = "9", description = "호출 후 해당 item 의 누적 wishlistCount")
+        int wishlistCount
+) {
+    public static WishlistToggleResponse from(WishlistToggleResult r) {
+        return new WishlistToggleResponse(r.wishlisted(), r.wishlistCount());
+    }
+}

--- a/src/main/resources/db/migration/V11__add_items_thumbnail_url.sql
+++ b/src/main/resources/db/migration/V11__add_items_thumbnail_url.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- V11 — items.thumbnail_url 컬럼 추가
+-- 목록·검색·찜·내물품 응답(ItemSummaryResponse)에서 카드 UI 썸네일 1장을 N+1 없이
+-- 내려주기 위한 denormalize. sortOrder=1 + is_thumbnail=true 의 image_url 과 동기화.
+-- 동기화 책임: Item Aggregate Root (addImage / clearImages 메서드).
+-- =============================================================================
+ALTER TABLE items
+    ADD COLUMN thumbnail_url VARCHAR(500) NULL AFTER region;
+
+-- 기존 행 backfill — 각 item 의 썸네일(is_thumbnail=true) 이미지의 url 로 업데이트.
+-- 다중 row 가 동시에 thumbnail=true 일 일은 없지만 안전하게 ANY_VALUE 사용.
+UPDATE items i
+   SET i.thumbnail_url = (
+        SELECT img.image_url
+          FROM item_images img
+         WHERE img.item_id = i.id AND img.is_thumbnail = TRUE
+         ORDER BY img.sort_order ASC
+         LIMIT 1
+   );

--- a/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
@@ -34,7 +34,7 @@ class ChatRoomApplicationServiceTest {
         roomRepo = new InMemoryFakeChatRoomRepository();
         itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         service = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
 
         Item item = itemRepo.save(Item.create(

--- a/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
+++ b/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
@@ -107,4 +107,28 @@ public class InMemoryFakeItemRepository implements ItemRepository {
         ReflectionTestUtils.setField(item, "wishlistCount", item.getWishlistCount() - 1);
         return 1;
     }
+
+    @Override
+    public Optional<Integer> getWishlistCount(Long itemId) {
+        Item item = store.get(itemId);
+        if (item == null) return Optional.empty();
+        return Optional.of(item.getWishlistCount());
+    }
+
+    @Override
+    public Page<Item> findBySellerIdAndStatus(Long sellerId, ItemStatus status, Pageable pageable) {
+        Stream<Item> stream = store.values().stream()
+                .filter(i -> sellerId.equals(i.getSellerId()));
+        if (status == null) {
+            stream = stream.filter(i -> i.getStatus() != ItemStatus.삭제);
+        } else {
+            stream = stream.filter(i -> i.getStatus() == status);
+        }
+        List<Item> filtered = stream
+                .sorted(Comparator.comparingLong(Item::getId).reversed())
+                .toList();
+        int start = Math.min((int) pageable.getOffset(), filtered.size());
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
+    }
 }

--- a/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
@@ -36,7 +36,7 @@ class ItemApplicationServiceTest {
         categoryRepo = new InMemoryFakeCategoryRepository();
         CategoryApplicationService categoryService = new CategoryApplicationService(categoryRepo);
         // requireVerified 가드는 기본 통과 (mock void no-op) — 단위 테스트는 비즈니스 로직 검증.
-        service = new ItemApplicationService(itemRepo, categoryService, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
+        service = new ItemApplicationService(itemRepo, categoryService, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         categoryId = categoryRepo.insert(Category.createRoot("디지털/가전", 1)).getId();
     }
 

--- a/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
@@ -36,7 +36,7 @@ class ItemSearchTest {
         InMemoryFakeCategoryRepository categoryRepo = new InMemoryFakeCategoryRepository();
         com.sseulang.domain.category.application.CategoryApplicationService catSvc =
                 new com.sseulang.domain.category.application.CategoryApplicationService(categoryRepo);
-        service = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
+        service = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         catA = categoryRepo.insert(Category.createRoot("A", 1)).getId();
         catB = categoryRepo.insert(Category.createRoot("B", 2)).getId();
     }

--- a/src/test/java/com/sseulang/domain/item/application/NoOpWishlistView.java
+++ b/src/test/java/com/sseulang/domain/item/application/NoOpWishlistView.java
@@ -1,0 +1,19 @@
+package com.sseulang.domain.item.application;
+
+import com.sseulang.domain.item.domain.WishlistView;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * 단위 테스트용 fake — 항상 빈 Set 반환. 즉 isWishlisted = 항상 false.
+ *
+ * <p>테스트가 wishlisted 상태를 검증하려면 이 클래스 대신 stub 또는 in-memory 구현으로 교체.</p>
+ */
+public class NoOpWishlistView implements WishlistView {
+
+    @Override
+    public Set<Long> findWishlistedItemIds(Long userId, Collection<Long> itemIds) {
+        return Set.of();
+    }
+}

--- a/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
@@ -47,7 +47,7 @@ class MessageApplicationServiceTest {
         publisher = new FakeRealtimePublisher();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
         NotificationApplicationService notifSvc = new NotificationApplicationService(notifRepo);
         // 단위 테스트에선 트랜잭션 컨텍스트 X — AFTER_COMMIT listener 직접 호출하는 fake event publisher.

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -47,7 +47,7 @@ class ReviewApplicationServiceTest {
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         UserApplicationService userSvc = new UserApplicationService(userRepo);
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, new InMemoryFakePointHistoryRepository());
         TransactionApplicationService txSvc = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());
         service = new ReviewApplicationService(reviewRepo, txSvc, userSvc);

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -47,7 +47,7 @@ class TransactionApplicationServiceTest {
         pointHistoryRepo = new InMemoryFakePointHistoryRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         UserApplicationService userSvc = new UserApplicationService(userRepo);
-        itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
+        itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, pointHistoryRepo);
         service = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());
 

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -5,6 +5,7 @@ import com.sseulang.domain.category.infrastructure.persistence.CategoryRepositor
 import com.sseulang.domain.file.application.NoOpPresignedUrlGenerator;
 import com.sseulang.domain.file.domain.PresignedUrlGenerator;
 import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.application.NoOpWishlistView;
 import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
 import com.sseulang.domain.item.domain.Item;
 import com.sseulang.domain.item.domain.ItemRepository;
@@ -76,6 +77,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         ItemRepositoryImpl.class,
         ItemApplicationService.class,
         NoOpPresignedUrlGenerator.class,
+        NoOpWishlistView.class,
         CategoryRepositoryImpl.class,
         CategoryApplicationService.class,
         UserRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.transaction.integration;
 import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.infrastructure.persistence.CategoryRepositoryImpl;
 import com.sseulang.domain.file.application.NoOpPresignedUrlGenerator;
+import com.sseulang.domain.item.application.NoOpWishlistView;
 import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.domain.item.application.dto.ItemRegisterCommand;
 import com.sseulang.domain.item.domain.Item;
@@ -66,6 +67,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         ItemRepositoryImpl.class,
         ItemApplicationService.class,
         NoOpPresignedUrlGenerator.class,
+        NoOpWishlistView.class,
         CategoryRepositoryImpl.class,
         CategoryApplicationService.class,
         UserRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
@@ -29,7 +29,7 @@ class WishlistApplicationServiceTest {
         wishRepo = new InMemoryFakeWishlistRepository();
         itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         service = new WishlistApplicationService(wishRepo, itemSvc);
 
         Item item = itemRepo.save(Item.create(

--- a/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
@@ -53,7 +53,7 @@ class StompAuthChannelInterceptorTest {
         InMemoryFakeChatRoomRepository roomRepo = new InMemoryFakeChatRoomRepository();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
 
         validTokens.clear();


### PR DESCRIPTION
## Summary
프론트 연동 2일차(5/3) 요청 통합 — 카드 UI 필수 필드 + 마이페이지 본인 물품 + 찜 토글 즉시 반영.

⭐4 (분리 `/items/{id}/images` endpoint) 는 follow-up 이슈로 분리.

### ⭐1 ItemSummaryResponse 카드 필드 확장
검색·찜·내물품·홈 리스트 응답 row 에 다음 필드 추가:
- `thumbnailUrl` (string | null) — V11 denormalize 컬럼. `addImage`/`clearImages` 시 Item Aggregate 가 자동 동기화
- `wishlistCount` (int) — 카드 UI 찜 수
- `isWishlisted` (boolean) — viewer 기준. 비로그인 항상 false. 페이지 결과 itemId 들에 대해 단일 SELECT 로 enrich (N+1 회피)

### ⭐2 GET /api/v1/users/me/items
- 본인 등록 물품 페이징, 마이페이지 탭 분리용
- `status` 쿼리 (`판매중` / `예약` / `거래완료` / `비공개`) — 미지정 시 삭제만 자동 제외
- 응답: `Page<ItemSummaryResponse>`

### ⭐3 찜 추가/해제 응답 `{wishlisted, wishlistCount}`
- `POST /api/v1/items/{id}/wishlist` → `WishlistToggleResponse`
- `DELETE` 동일. fresh DB 값 — 프론트가 detail 재조회 없이 즉시 카드 UI 갱신

### 도메인 정리 (CLAUDE.md §3.3 준수)
- `WishlistView` 포트 (`item.domain`) + `WishlistViewAdapter` (`wishlist.infrastructure`) — 단방향 의존, 다른 도메인 Repository 직접 호출 금지 룰 준수
- `ItemApplicationService.search(criteria, pageable, viewerId)` 시그니처 추가 — 비로그인은 viewerId=null

### 인프라
- V11 마이그레이션 — `items.thumbnail_url VARCHAR(500) NULLABLE` + 기존 row backfill
- `ItemJpaRepository.findBySellerIdAndStatus`, `getWishlistCount` (JPQL 스칼라 projection — bulk update 직후 fresh 값 보장)

### 보류 (follow-up issue 등록 예정)
- ⭐4 `POST/DELETE/PATCH /api/v1/items/{id}/images` 분리 endpoint
- `OffsetDateTime` 마이그레이션 (5/6 이후)
- 좌표/거리 검색 (V12+)

## Test plan
- [x] 컴파일 통과
- [x] 전체 테스트 597 PASS / 0 FAIL
- [ ] 백엔드 재시작 → 프론트 smoke
  - GET /items 응답에 thumbnailUrl/wishlistCount/isWishlisted 박힘
  - GET /users/me/items?status=판매중 페이징
  - POST /items/{id}/wishlist 응답에 {wishlisted: true, wishlistCount}
  - DELETE 동일 응답 wishlisted: false

🤖 Generated with [Claude Code](https://claude.com/claude-code)