### PR TITLE
feat: GET /users/me/transactions — 마이페이지 본인 거래 목록

### DIFF
--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -9,6 +9,7 @@ import com.sseulang.domain.transaction.application.dto.PendingReviewableResult;
 import com.sseulang.domain.transaction.application.dto.ReviewableTransactionResult;
 import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
 import com.sseulang.domain.transaction.application.dto.TransactionResult;
+import com.sseulang.domain.transaction.application.dto.TransactionRole;
 import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
 import com.sseulang.domain.transaction.domain.Transaction;
 import com.sseulang.domain.transaction.domain.TransactionRepository;
@@ -201,6 +202,16 @@ public class TransactionApplicationService {
      * <p>completedAt 이 7일 이내인 것만 — 작성 가능 기간이 지난 거래는 제외 (가이드 §5.5).
      * 응답 DTO 의 deadline = completedAt + 7d → 클라이언트가 남은 시간 UI 작성에 사용.</p>
      */
+    /**
+     * 마이페이지 내 거래 목록 — viewer 가 buyer/seller/양쪽 으로 참여한 거래 페이징.
+     * role null = 양쪽, status null = 전체. 정렬: createdAt DESC + id DESC.
+     */
+    public Page<TransactionResult> findMyTransactions(
+            Long userId, TransactionRole role, TransactionStatus status, Pageable pageable) {
+        return transactionRepository.findMyTransactions(userId, role, status, pageable)
+                .map(TransactionResult::from);
+    }
+
     public Page<PendingReviewableResult> findPendingReviewable(Long userId, Pageable pageable) {
         LocalDateTime since = LocalDateTime.now(clock).minusDays(7);
         return transactionRepository.findPendingReviewable(userId, since, pageable)

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionRole.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionRole.java
@@ -1,0 +1,26 @@
+package com.sseulang.domain.transaction.application.dto;
+
+/**
+ * 내 거래 목록 query 의 viewer 역할 필터.
+ *
+ * <ul>
+ *   <li>{@link #BUYER} — viewer 가 buyer 인 거래만</li>
+ *   <li>{@link #SELLER} — viewer 가 seller 인 거래만</li>
+ *   <li>null — 양쪽 모두 (기본)</li>
+ * </ul>
+ *
+ * <p>잘못된 query 값은 controller 에서 null 로 fallback (= 양쪽).</p>
+ */
+public enum TransactionRole {
+    BUYER,
+    SELLER;
+
+    public static TransactionRole parse(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            return TransactionRole.valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.transaction.domain;
 
+import com.sseulang.domain.transaction.application.dto.TransactionRole;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -42,4 +43,14 @@ public interface TransactionRepository {
      * @param since     completedAt 하한 (보통 now - 7일) — 작성 가능 기간 밖은 제외
      */
     Page<Transaction> findPendingReviewable(Long userId, LocalDateTime since, Pageable pageable);
+
+    /**
+     * 마이페이지 거래 목록 — viewer 가 buyer/seller/양쪽 으로 참여한 거래 페이징.
+     *
+     * @param userId 조회 주체
+     * @param role   {@link TransactionRole#BUYER} = buyer 만, {@link TransactionRole#SELLER} = seller 만, null = 양쪽
+     * @param status null = 전체 (취소 포함), 명시 시 정확 일치
+     */
+    Page<Transaction> findMyTransactions(
+            Long userId, TransactionRole role, TransactionStatus status, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -1,6 +1,7 @@
 package com.sseulang.domain.transaction.infrastructure.persistence;
 
 import com.sseulang.domain.transaction.domain.Transaction;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
 import com.sseulang.domain.transaction.domain.TransactionStatusCount;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
@@ -62,4 +63,55 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
     Page<Transaction> findPendingReviewableJpql(@Param("userId") Long userId,
                                                  @Param("since") LocalDateTime since,
                                                  Pageable pageable);
+
+    // ───────── 내 거래 목록 (마이페이지) ─────────
+    // role 4 분기 × status null/!=null 2 분기 = 6 메서드. role/status 모두 null 이 가장 흔한 케이스.
+
+    @Query("""
+            SELECT t FROM Transaction t
+             WHERE (t.sellerId = :userId OR t.buyerId = :userId)
+             ORDER BY t.createdAt DESC, t.id DESC
+            """)
+    Page<Transaction> findByParticipant(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+            SELECT t FROM Transaction t
+             WHERE (t.sellerId = :userId OR t.buyerId = :userId) AND t.status = :status
+             ORDER BY t.createdAt DESC, t.id DESC
+            """)
+    Page<Transaction> findByParticipantAndStatus(@Param("userId") Long userId,
+                                                  @Param("status") TransactionStatus status,
+                                                  Pageable pageable);
+
+    @Query("""
+            SELECT t FROM Transaction t
+             WHERE t.buyerId = :userId
+             ORDER BY t.createdAt DESC, t.id DESC
+            """)
+    Page<Transaction> findByBuyer(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+            SELECT t FROM Transaction t
+             WHERE t.buyerId = :userId AND t.status = :status
+             ORDER BY t.createdAt DESC, t.id DESC
+            """)
+    Page<Transaction> findByBuyerAndStatus(@Param("userId") Long userId,
+                                            @Param("status") TransactionStatus status,
+                                            Pageable pageable);
+
+    @Query("""
+            SELECT t FROM Transaction t
+             WHERE t.sellerId = :userId
+             ORDER BY t.createdAt DESC, t.id DESC
+            """)
+    Page<Transaction> findBySeller(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+            SELECT t FROM Transaction t
+             WHERE t.sellerId = :userId AND t.status = :status
+             ORDER BY t.createdAt DESC, t.id DESC
+            """)
+    Page<Transaction> findBySellerAndStatus(@Param("userId") Long userId,
+                                             @Param("status") TransactionStatus status,
+                                             Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.sseulang.domain.transaction.infrastructure.persistence;
 
+import com.sseulang.domain.transaction.application.dto.TransactionRole;
 import com.sseulang.domain.transaction.domain.Transaction;
 import com.sseulang.domain.transaction.domain.TransactionRepository;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
 import com.sseulang.domain.transaction.domain.TransactionStatusCount;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -43,5 +45,23 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     @Override
     public Page<Transaction> findPendingReviewable(Long userId, LocalDateTime since, Pageable pageable) {
         return jpa.findPendingReviewableJpql(userId, since, pageable);
+    }
+
+    @Override
+    public Page<Transaction> findMyTransactions(
+            Long userId, TransactionRole role, TransactionStatus status, Pageable pageable) {
+        if (role == null) {
+            return (status == null)
+                    ? jpa.findByParticipant(userId, pageable)
+                    : jpa.findByParticipantAndStatus(userId, status, pageable);
+        }
+        if (role == TransactionRole.BUYER) {
+            return (status == null)
+                    ? jpa.findByBuyer(userId, pageable)
+                    : jpa.findByBuyerAndStatus(userId, status, pageable);
+        }
+        return (status == null)
+                ? jpa.findBySeller(userId, pageable)
+                : jpa.findBySellerAndStatus(userId, status, pageable);
     }
 }

--- a/src/main/java/com/sseulang/domain/transaction/presentation/MyTransactionsController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/MyTransactionsController.java
@@ -1,0 +1,61 @@
+package com.sseulang.domain.transaction.presentation;
+
+import com.sseulang.domain.transaction.application.TransactionApplicationService;
+import com.sseulang.domain.transaction.application.dto.TransactionRole;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+import com.sseulang.domain.transaction.presentation.dto.TransactionResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 마이페이지 본인 거래 목록 — {@link TransactionController} 의 단건 조회와 별개로 페이징 list 제공.
+ *
+ * <p>role 쿼리 (buyer/seller) 로 탭 분리, status 쿼리 (한글 enum) 로 상태별 필터.
+ * 둘 다 미지정 시 전체 (취소 포함).</p>
+ */
+@Tag(name = "Transaction", description = "마이페이지 본인 거래 목록")
+@RestController
+@RequestMapping("/api/v1/users/me/transactions")
+public class MyTransactionsController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final TransactionApplicationService transactionService;
+
+    public MyTransactionsController(TransactionApplicationService transactionService) {
+        this.transactionService = transactionService;
+    }
+
+    @Operation(summary = "내 거래 목록",
+            description = "본인이 buyer/seller 로 참여한 거래 페이징. "
+                    + "role 미지정 = 양쪽, status 미지정 = 전체(취소 포함). 잘못된 role 값은 양쪽으로 fallback. "
+                    + "정렬: createdAt DESC.")
+    @GetMapping
+    public ApiResponse<PageResponse<TransactionResponse>> listMine(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(name = "role", required = false) String role,
+            @RequestParam(name = "status", required = false) TransactionStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+        TransactionRole roleFilter = TransactionRole.parse(role);
+
+        Page<TransactionResponse> result = transactionService
+                .findMyTransactions(userId, roleFilter, status, pageable)
+                .map(TransactionResponse::from);
+        return ApiResponse.ok(PageResponse.from(result));
+    }
+}

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.transaction.application;
 
+import com.sseulang.domain.transaction.application.dto.TransactionRole;
 import com.sseulang.domain.transaction.domain.Transaction;
 import com.sseulang.domain.transaction.domain.TransactionRepository;
 import com.sseulang.domain.transaction.domain.TransactionStatus;
@@ -61,6 +62,27 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
 
     public void markReviewed(Long transactionId, Long reviewerId) {
         reviewedPairs.add(transactionId + ":" + reviewerId);
+    }
+
+    @Override
+    public Page<Transaction> findMyTransactions(
+            Long userId, TransactionRole role, TransactionStatus status, Pageable pageable) {
+        List<Transaction> filtered = store.values().stream()
+                .filter(t -> {
+                    if (role == null) {
+                        return userId.equals(t.getSellerId()) || userId.equals(t.getBuyerId());
+                    }
+                    if (role == TransactionRole.BUYER) {
+                        return userId.equals(t.getBuyerId());
+                    }
+                    return userId.equals(t.getSellerId());
+                })
+                .filter(t -> status == null || t.getStatus() == status)
+                .sorted(Comparator.comparingLong(Transaction::getId).reversed())
+                .toList();
+        int start = Math.min((int) pageable.getOffset(), filtered.size());
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
     }
 
     @Override


### PR DESCRIPTION
## Summary
프론트 연동 라운드 4 — 거래 도메인 명세 확인 중 발견된 누락 endpoint 보강.

마이페이지에 본인 거래 리스트가 필요한데 기존 TransactionController 에는 단건 조회(`GET /transactions/{id}`)만 있고 list 가 없었음.

## 신규 endpoint
```
GET /api/v1/users/me/transactions?role=buyer|seller&status=&page=&size=
```

| param | 값 | 비고 |
|---|---|---|
| `role` | `buyer` / `seller` | 미지정 시 양쪽. 잘못된 값은 양쪽으로 fallback |
| `status` | `채팅중` / `예약` / `거래완료` / `취소` | 미지정 시 전체 |
| `page` / `size` | int | default 0/20, max 100 |

응답: `Page<TransactionResponse>` (기존 GET /{id} 와 동일 schema)
정렬: createdAt DESC, id DESC

## 도메인 / 인프라
- `TransactionRole` enum 신설 — `BUYER` / `SELLER` + `parse(raw)` fallback
- `TransactionRepository.findMyTransactions(userId, role, status, pageable)`
- JpaRepository 6 메서드 (role 4 분기 × status null/!=null 2 분기)
- N+1 없음 — 단일 쿼리 페이징

## 사용 예 (프론트)
```
// 구매한 거래 — 거래완료 탭
GET /api/v1/users/me/transactions?role=buyer&status=거래완료

// 판매한 거래 — 진행 중 (채팅중+예약)
GET /api/v1/users/me/transactions?role=seller&status=예약
GET /api/v1/users/me/transactions?role=seller&status=채팅중

// 전체 (구매 + 판매, 모든 상태)
GET /api/v1/users/me/transactions
```

## Test plan
- [x] 컴파일 통과
- [x] 전체 테스트 597 PASS / 0 FAIL
- [ ] 백엔드 재시작 → smoke (역할/상태 조합 페이징)

🤖 Generated with [Claude Code](https://claude.com/claude-code)