### PR TITLE
feat: 채팅 읽음 처리 + ChatRoomResponse 보강 + 프론트 통합 doc 정확성 재작성

### DIFF
--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -1,15 +1,16 @@
 # 프론트엔드 연동 가이드
 
-> 쓸랭 백엔드 + 프론트엔드 연동을 위한 종합 가이드. 5/6 마감 → 5/11 연동·배포 페이즈에 사용.
+> 쓸랭 백엔드 + 프론트엔드 연동을 위한 종합 가이드. 최신 갱신: 2026-05-03 (라운드 5 — 채팅 schema/STOMP 정확성 보강).
 
 ## 0. 빠른 시작
 
 | 항목 | 로컬 | 프로덕션 |
 |---|---|---|
 | Base URL | `http://localhost:8080` | (배포 후 결정) |
-| Swagger | `http://localhost:8080/swagger-ui.html` | (정책 결정 중 — `/swagger-ui.html`) |
-| WebSocket | `http://localhost:8080/ws-stomp` (SockJS) / `/ws-stomp-native` (native) | 동일 |
+| Swagger | `http://localhost:8080/swagger-ui.html` | (정책 결정 중) |
+| WebSocket | `http://localhost:8080/ws-stomp` (SockJS) / `ws://localhost:8080/ws-stomp-native` (native) | 동일 |
 | 응답 포맷 | `{success, data, error}` | 동일 |
+| Time format | `LocalDateTime` (KST naive, 예: `2026-05-03T10:00:00`) — Message 만 `Instant` (UTC offset 포함) | 동일 |
 
 ---
 
@@ -51,14 +52,33 @@ CORS_ALLOWED_ORIGINS=https://sseulang.com,https://www.sseulang.com
 
 ```
 POST /api/v1/auth/signup       (이메일/비밀번호) → 201 + 인증 메일 발송
-POST /api/v1/auth/login        (이메일/비밀번호) → 200 + Set-Cookie: AT, RT
-POST /api/v1/auth/oauth2/{provider}  (KAKAO|GOOGLE, accessToken) → 200 + Set-Cookie: AT, RT
+POST /api/v1/auth/login        (이메일/비밀번호) → 200 + Set-Cookie: AT, RT + MeResponse
+POST /api/v1/auth/oauth2/{provider}  (KAKAO|GOOGLE) → 200 + Set-Cookie + MeResponse
+POST /api/v1/auth/refresh                          → 200 + 새 AT/RT (rotation) + MeResponse
+```
+
+**signup / login / oauth2 / refresh 응답 본문 (`MeResponse`)** — 페이지 새로고침 시 store 재초기화에 그대로 사용:
+```json
+{
+  "success": true,
+  "data": {
+    "id": 42,
+    "email": "alice@sseulang.test",
+    "nickname": "쓸랭이",
+    "profileImage": null,
+    "socialProvider": "LOCAL",                // LOCAL | KAKAO | GOOGLE
+    "emailVerified": false,                    // false 면 자금/거래/채팅/신고 API 가 403
+    "pointBalance": 50000,
+    "trustScore": 4.7,                         // null = 리뷰 0건 신규
+    "reviewCount": 12
+  }
+}
 ```
 
 응답 쿠키 (서버가 자동 설정):
 - `access_token` — HttpOnly, Secure(prod), SameSite=Strict(prod)/Lax(local), Max-Age=1800
 - `refresh_token` — HttpOnly, Secure(prod), SameSite=Strict(prod)/Lax(local), Max-Age=604800
-- `XSRF-TOKEN` — HttpOnly **X** (JS에서 읽어 CSRF 헤더로 다시 보내야 함)
+- `XSRF-TOKEN` — HttpOnly **X** (JS 가 읽어 CSRF 헤더로 다시 보내야 함)
 
 ### 2.2 인증된 요청
 
@@ -79,7 +99,7 @@ AT 만료 시 `401 AUTH_TOKEN_EXPIRED`:
 POST /api/v1/auth/refresh
 Cookie: refresh_token=...
 ```
-응답: 새 AT + RT 발급 (RT rotation). 실패 시 `401 AUTH_REFRESH_TOKEN_INVALID` → 로그인 화면.
+응답: 새 AT + RT 발급 (RT rotation) + `MeResponse`. 실패 시 `401 AUTH_REFRESH_TOKEN_INVALID` → 로그인 화면.
 
 **axios interceptor 패턴**:
 ```js
@@ -102,15 +122,45 @@ POST /api/v1/auth/logout
 ```
 - AT 즉시 blacklist + RT 폐기 + 쿠키 만료 (`Max-Age=0`).
 
-### 2.5 이메일 인증 가드
+### 2.5 본인 정보 조회 / 수정
 
-`signup` 직후 사용자는 `email_verified=false`. 다음 API 는 `403 AUTH_EMAIL_NOT_VERIFIED` 떨굼:
+```
+GET   /api/v1/users/me                   → MeResponse
+PATCH /api/v1/users/me                   → MeResponse (갱신된 값)
+  Body: { profileImage?: string|"", nickname?: string }
+  - null/생략 = 변경 X
+  - "" (빈 문자열) = profileImage 제거
+  - 이메일 미인증 사용자도 호출 가능 (자금/거래 영향 0)
+```
+
+### 2.6 다른 사용자 공개 프로필 조회
+
+```
+GET /api/v1/users/{id}/profile           → 비로그인 접근 가능
+```
+응답:
+```json
+{
+  "id": 100,
+  "nickname": "쓸랭이",
+  "profileImage": null,
+  "socialProvider": "LOCAL",
+  "trustScore": 4.7,                  // null = 신규
+  "reviewCount": 12,
+  "createdAt": "2026-04-01T12:00:00"
+}
+```
+**민감 정보 (이메일/잔액/emailVerified) 미노출.** ItemDetail 의 sellerId, ChatRoom 의 opponentId 등에서 호출.
+
+### 2.7 이메일 인증 가드
+
+`signup` 직후 사용자는 `emailVerified=false`. 다음 API 는 `403 AUTH_EMAIL_NOT_VERIFIED` 떨굼:
 - 거래/결제/포인트 출금/배달대행 등 자금 영향
 - 채팅방 개설 / 메시지 전송
 - 신고
-- 파일 presigned URL 발급
+- 파일 presigned URL 발급 (단 `purpose=PROFILE` 은 우회 — 가입 직후 프로필 셋업)
 
-→ 인증 메일 링크 클릭 → `POST /api/v1/auth/verify-email?token=...` 호출하면 `email_verified=true`.
+→ 인증 메일 링크 클릭 → `POST /api/v1/auth/verify-email?token=...` 호출하면 `emailVerified=true`.
 
 재발송: `POST /api/v1/auth/resend-verification` (인증 필수, rate-limited).
 
@@ -153,6 +203,24 @@ POST /api/v1/auth/logout
 
 `error.message` 는 한국어. 프론트에서 그대로 노출 OK. 단, 보안 민감 케이스는 통합 메시지(`AUTH_LOGIN_FAILED` 등) 사용.
 
+### 시간 포맷 — 중요
+
+| 도메인 | 타입 | 형식 | 비고 |
+|---|---|---|---|
+| 거의 전부 (Item, Transaction, ChatRoom, User, Payment, Withdrawal, ...) | `LocalDateTime` | `"2026-05-03T10:00:00"` | **TZ 정보 없음. KST 가정.** |
+| Message (채팅 메시지) 만 | `Instant` | `"2026-05-03T10:00:00.123Z"` | UTC offset 포함 |
+
+**프론트 처리 권장**: KST 강제 헬퍼 1개 만들어서 모든 timestamp 파싱 통과시키기 (해외 브라우저 케이스 방어).
+
+```js
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import tz from 'dayjs/plugin/timezone';
+dayjs.extend(utc); dayjs.extend(tz);
+
+export const parseKst = (iso) => dayjs.tz(iso, 'Asia/Seoul');
+```
+
 ---
 
 ## 4. 주요 ErrorCode 참조
@@ -168,7 +236,7 @@ POST /api/v1/auth/logout
 | `AUTH_TOKEN_INVALID` | 401 | AT 위변조/포맷 오류 | 로그인 화면 |
 | `AUTH_TOKEN_REVOKED` | 401 | 로그아웃된 AT 재사용 | 로그인 화면 |
 | `AUTH_REFRESH_TOKEN_INVALID` | 401 | RT 만료/폐기 | 로그인 화면 |
-| `AUTH_OAUTH_FAILED` | 401 | OAuth provider 검증 실패 | 토큰 재발급 후 재시도 |
+| `AUTH_OAUTH_FAILED` | 401 | OAuth code 검증 실패 | 사용자 다시 로그인 유도 |
 | `AUTH_EMAIL_NOT_VERIFIED` | 403 | 이메일 인증 필요 | 인증 메일 안내 모달 |
 | `AUTH_VERIFICATION_TOKEN_INVALID` | 400 | 잘못된 인증 토큰 | "유효하지 않은 링크" |
 | `AUTH_VERIFICATION_TOKEN_EXPIRED` | 400 | 만료된 인증 토큰 | resend 버튼 |
@@ -176,11 +244,17 @@ POST /api/v1/auth/logout
 | `AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER` | 409 | 같은 이메일 다른 SNS | "이미 X로 가입된 이메일" |
 | `USER_BLOCKED` | 403 | 차단 계정 | 로그인 차단 화면 |
 
-### 거래/결제/포인트
+### Item / Transaction / Payment / Point
 | code | HTTP | 의미 |
 |---|---|---|
 | `ITEM_NOT_FOUND` | 404 | 물품 없음 또는 삭제됨 |
+| `ITEM_FORBIDDEN` | 403 | 본인 물품 아님 |
 | `ITEM_INVALID_STATE` | 400 | 비공개/예약 등 현재 상태 불가 |
+| `ITEM_IMAGE_LIMIT_EXCEEDED` | 400 | 이미지 5장 초과 |
+| `ITEM_IMAGE_NOT_FOUND` | 404 | 이미지 부분 제거 시 미존재 url |
+| `ITEM_IMAGE_ORDER_MISMATCH` | 400 | 순서 변경 입력이 기존 set 과 불일치 |
+| `TRANSACTION_NOT_FOUND` | 404 | 거래 없음 |
+| `TRANSACTION_FORBIDDEN` | 403 | 거래 참여자 아님 |
 | `TRANSACTION_RESERVED_BY_OTHER` | 409 | 다른 사용자가 먼저 예약 |
 | `TRANSACTION_INVALID_STATE` | 400 | 거래 상태 머신 위반 |
 | `TRANSACTION_SELF_NOT_ALLOWED` | 400 | 본인 물품에 거래 시도 |
@@ -188,8 +262,16 @@ POST /api/v1/auth/logout
 | `PAYMENT_AMOUNT_MISMATCH` | 400 | 토스 결제 금액 위변조 |
 | `PAYMENT_DUPLICATED` | 409 | 같은 merchant_uid 재결제 |
 | `WITHDRAWAL_IDEMPOTENCY_MISMATCH` | 409 | 같은 idempotencyKey 다른 내용 |
+| `WITHDRAWAL_NOT_CANCELABLE` | 400 | 승인/완료 후 취소 시도 |
 | `REVIEW_DUPLICATED` | 409 | 같은 거래 본인 리뷰 중복 |
 | `REVIEW_PERIOD_EXPIRED` | 400 | 7일 지남 |
+
+### Chat / Wishlist / Report
+| code | HTTP | 의미 |
+|---|---|---|
+| `CHAT_ROOM_NOT_FOUND` | 404 | 채팅방 없음 |
+| `CHAT_FORBIDDEN` | 403 | 채팅방 참여자 아님 / 본인 물품에 채팅 시도 |
+| `CHAT_MESSAGE_EMPTY` | 400 | content 와 imageUrls 모두 비어있음 |
 
 ### 배달
 | code | HTTP | 의미 |
@@ -208,99 +290,192 @@ POST /api/v1/auth/logout
 
 ---
 
-## 5. OAuth 흐름 (카카오/구글)
+## 5. OAuth 흐름 (카카오/구글) — Authorization Code Grant
+
+> ⚠️ Token Grant 가 아니라 **Authorization Code Grant**. 프론트가 access_token 받아서 보내는 거 아님.
 
 ```
-[Frontend]                     [SDK]                    [Backend]
-   │                              │                         │
-   │── 로그인 버튼 클릭 ──────────►│                         │
-   │                              │── 사용자 동의 화면 ────►│
-   │                              │◄── access_token ────────│
-   │◄── access_token ─────────────│                         │
-   │                                                         │
-   │── POST /api/v1/auth/oauth2/{provider} ──────────────►   │
-   │   { accessToken: "..." }                                │
-   │                                                         │
-   │◄── 200 + Set-Cookie: AT, RT ──────────────────────────  │
-   │   { success: true, data: { userId, email, ... } }       │
+[Frontend]                       [Provider]                    [Backend]
+   │                                 │                            │
+   │── 로그인 버튼 클릭 ──────────────────►                       │
+   │                                 │                            │
+   │── Provider redirect URL 이동 (외부 redirect) ────►          │
+   │      ?client_id=...&redirect_uri=...                          │
+   │                                 │                            │
+   │   (사용자 동의)                                              │
+   │                                 │                            │
+   │◄── /auth/{provider}/callback?code=XXX  (브라우저 redirect)──│
+   │                                                                │
+   │── POST /api/v1/auth/oauth2/{provider} ─────────────────►   │
+   │   { code: "XXX", redirectUri: "https://app.../auth/{provider}/callback" }
+   │                                                                │
+   │                                  ── token endpoint ──────► provider
+   │                                  ◄── access_token ───────  provider
+   │                                  ── user info ─────────► provider
+   │                                  ◄── id, email, ... ──── provider
+   │                                                                │
+   │◄── 200 + Set-Cookie: AT, RT + MeResponse ────────────────  │
 ```
 
-### Provider 별 SDK 가이드
-- **KAKAO**: `Kakao.Auth.login()` → `getAccessToken()` → 백엔드 호출
-- **GOOGLE**: `tokenClient = google.accounts.oauth2.initTokenClient({...})` → `requestAccessToken()` → `access_token` → 백엔드 호출
+### Body 형식
+```json
+POST /api/v1/auth/oauth2/kakao
+{
+  "code": "...",
+  "redirectUri": "https://app.../auth/kakao/callback"  // 콘솔 등록된 URI 와 정확히 일치
+}
+```
+
+### Provider 별 redirectUri
+- 카카오: 콘솔 등록한 URI 와 **정확히** 일치 (대소문자/슬래시 포함)
+- 구글: 동일
 
 ### 첫 가입 vs 재로그인
-백엔드가 자동 분기 — SocialId 매핑 있으면 로그인, 없으면 신규 가입 + email_verified=true (provider 가 검증한 이메일).
+백엔드가 자동 분기 — `(provider, providerId)` 매핑 있으면 로그인, 없으면 신규 가입 (`emailVerified=true`, provider 가 검증한 이메일).
 
 ### LOCAL 가입 사용자가 OAuth 호출 시
-같은 이메일이면 takeover (provider 마이그레이션) — 사용자 동의 절차 후 진행. 자세히는 백엔드와 별도 합의.
+같은 이메일이면 takeover (provider 마이그레이션 + verified=true). 자동.
+
+### customerKey (토스 SDK)
+일반 결제는 백엔드 customerKey 사용 X. 프론트 토스 SDK 가 호출할 때 `String(user.id)` 넘기면 OK (정기결제 미사용).
 
 ---
 
 ## 6. 결제 흐름 (토스페이먼츠)
 
 ```
-[Frontend]                      [Backend]                  [Toss]
-   │                               │                         │
-   │── POST /api/v1/payments/start ►                         │
-   │   { amount }                  │                         │
-   │◄── { merchantUid } ───────────│                         │
-   │                                                         │
-   │── Toss SDK 결제창 호출 ──────────────────────────────►   │
-   │   { merchantUid, amount, ... }                          │
-   │                                                         │
-   │◄── 결제 성공 콜백 ──────────────────────────────────────│
-   │   { paymentKey, orderId, amount }                       │
-   │                                                         │
-   │── POST /api/v1/payments/confirm ►                       │
-   │   { paymentKey, orderId, amount }                       │
-   │                                  ── 토스 confirm API ─►│
-   │                                  ◄── 검증 OK ──────────│
-   │◄── 200 + 잔액 충전 완료 ──────│                         │
+[Frontend]                              [Backend]                  [Toss]
+   │                                       │                         │
+   │── POST /api/v1/payments/charge ──────►│                         │
+   │   { amount }                          │                         │
+   │◄── { paymentId, merchantUid, amount, tossClientKey } ──        │
+   │                                                                  │
+   │── Toss SDK 결제창 호출 ────────────────────────────────────►   │
+   │   { merchantUid, amount, successUrl, failUrl, ... }              │
+   │                                                                  │
+   │◄── successUrl 로 redirect (paymentKey, orderId, amount) ────── │
+   │                                                                  │
+   │── POST /api/v1/payments/charge/confirm ─────────────────────►  │
+   │   { paymentKey, orderId, amount }                                │
+   │                                  ── confirm API ─────────────► │
+   │                                  ◄── 검증 OK ──────────────── │
+   │◄── 200 + 잔액 충전 완료 (PaymentResponse) ────────────────────│
+```
+
+### Endpoint 정확한 path
+- `POST /api/v1/payments/charge` — 충전 시작 (백엔드가 merchantUid + tossClientKey 발급)
+- `POST /api/v1/payments/charge/confirm` — 토스 redirect 후 확정
+- `GET  /api/v1/payments/{id}` — 본인 결제 단건 조회
+- `POST /api/v1/payments/webhook/toss` — 토스 webhook (프론트 호출 X)
+
+### ChargeStartResponse 응답
+```json
+{
+  "paymentId": 78,
+  "merchantUid": "merchant-9f2c8c5b",   // 토스 결제창의 orderId 로 사용
+  "amount": 50000,
+  "tossClientKey": "test_ck_..."         // 프론트 SDK 초기화에 사용
+}
+```
+
+### PaymentResponse (charge/confirm + GET 응답)
+```json
+{
+  "id": 78,
+  "userId": 100,
+  "transactionId": null,           // 충전형은 항상 null. 거래 결제는 현재 미사용 (PointHistory 로 추적)
+  "paymentType": "충전",            // 충전 | 거래 | 배달
+  "method": "카드",                 // 카드 | 가상계좌 | 계좌이체 | 휴대폰 | 토스페이 등
+  "amount": 50000,
+  "status": "완료",                 // 대기 | 진행중 | 완료 | 실패 | 환불진행중 | 환불완료 | 환불실패
+  "merchantUid": "merchant-9f2c8c5b",
+  "paidAt": "2026-05-03T10:00:00", // status=완료 일 때만 채워짐
+  "createdAt": "2026-05-03T09:59:50"
+}
 ```
 
 ### 핵심 룰
 - `merchantUid` 는 백엔드가 발급 (UNIQUE) — 프론트 임의 생성 금지.
-- confirm 호출 시 amount 가 토스 응답과 mismatch → `PAYMENT_AMOUNT_MISMATCH` (위변조 차단).
+- confirm 호출 시 `amount` 가 토스 응답과 mismatch → `PAYMENT_AMOUNT_MISMATCH` (위변조 차단).
 - 같은 `merchantUid` 재호출 → `PAYMENT_DUPLICATED` (멱등성).
 - 결제 페이지 자체는 토스 SDK가 렌더 — 별도 백엔드 페이지 X.
 
+### 결제 fail redirect 정책
+백엔드는 `successUrl`/`failUrl` 받지 않음. 프론트 SDK 측 결정:
+- success 라우트 → `POST /charge/confirm` 호출 → 잔액 갱신
+- fail 라우트 → 백엔드 호출 X. 사용자에게 메시지만 표시
+- 5분 reconciliation scheduler 가 자동으로 PENDING 정리
+
+### 잔액 / 포인트 히스토리
+- 잔액 자체는 `GET /api/v1/users/me` 의 `pointBalance` 사용 — 별도 endpoint X
+- 변동 내역: `GET /api/v1/users/me/point/history?type=&page=&size=`
+  - `type` (옵션): `충전 | 결제 | 판매정산 | 출금 | 환불 | 배달결제 | 배달정산`
+
 ---
 
-## 7. S3 파일 업로드 (presigned URL)
+## 7. 출금 (Withdrawal)
 
 ```
-[Frontend]                       [Backend]                       [S3]
-   │                                │                              │
-   │── POST /api/v1/files/presigned-url ─►                         │
-   │   { purpose: "ITEM",           │                              │
-   │     files: [{contentType, contentLength}] }                   │
-   │◄── { uploads: [{presignedUrl, key}] } ────│                   │
-   │                                                                │
-   │── PUT {presignedUrl} ──────────────────────────────────────►  │
-   │   body: <binary>                                               │
-   │   Content-Type: image/jpeg                                     │
-   │◄── 200 ──────────────────────────────────────────────────────│
-   │                                                                │
-   │── POST /api/v1/items ─────────►                                │
-   │   { ..., imageUrls: [<key 또는 GET URL>] }                     │
-   │   백엔드가 items/{userId}/* → items/{itemId}/* S3 copy        │
-   │◄── 201 + itemId ──────────────│                              │
+POST /api/v1/withdrawals
+{
+  "idempotencyKey": "uuid",        // 필수, ≤64. 같은 키 재호출은 멱등
+  "amount": 30000,                  // ≥1
+  "bankName": "신한",               // 자유 문자열 (enum 아님), ≤50
+  "accountNumber": "110-...",
+  "accountHolder": "홍길동"
+}
+→ 201 { success, data: <withdrawalId> }
 ```
+
+추가 endpoint:
+- `GET /api/v1/withdrawals?page=&size=` — 본인 출금 신청 목록
+- `GET /api/v1/withdrawals/{id}` — 단건 (본인만)
+- `DELETE /api/v1/withdrawals/{id}` — 신청 상태일 때만 취소 (자동 환불)
+
+---
+
+## 8. S3 파일 업로드 (presigned URL)
+
+```
+[Frontend]                              [Backend]                       [S3]
+   │                                       │                              │
+   │── POST /api/v1/files/presigned-url ──►│                              │
+   │   { purpose: "ITEM",                  │                              │
+   │     items: [{contentType, contentLength}] }                          │
+   │◄── { uploads: [{presignedUrl, key}] } │                              │
+   │                                                                       │
+   │── PUT {presignedUrl} ─────────────────────────────────────────────► │
+   │   body: <binary>                                                      │
+   │   Content-Type: image/jpeg                                            │
+   │◄── 200 ─────────────────────────────────────────────────────────── │
+   │                                                                       │
+   │── POST /api/v1/items                                                 │
+   │   { ..., imageUrls: [<key 또는 GET URL>] }                           │
+   │   백엔드가 items/{userId}/* → items/{itemId}/* 자동 promote           │
+   │◄── 201 + itemId                                                      │
+```
+
+### purpose 값
+| purpose | 폴더 | 용도 | 인증 필요 |
+|---|---|---|---|
+| `PROFILE` | `profiles/{userId}/...` | 본인 프로필 이미지 | 로그인만 (이메일 인증 우회) |
+| `ITEM` | `items/{userId}/...` (임시) → `items/{itemId}/...` (등록 후) | 물품 이미지 | 이메일 인증 |
+| `MESSAGE` | `messages/{userId}/...` | 채팅 첨부 이미지 | 이메일 인증 |
+| `NOTICE` / `BANNER` | 도메인 전용 | 관리자 |
 
 ### 룰
-- `purpose`: `PROFILE` 또는 `ITEM` (일반 사용자). 그 외는 도메인 전용 endpoint.
 - Content-Type: `image/jpeg|jpg|png|webp|gif` 만 허용.
 - Content-Length: ≤ 5MB.
 - 파일 한 번에 ≤ 10건.
 - presigned URL 만료: 5분.
-- 응답의 `key` 필드를 그대로 Item 등록 요청의 `imageUrls` 에 포함시키면 백엔드가 정식 폴더로 promote.
+- Item: 응답의 `key` (또는 GET URL) 를 그대로 `imageUrls` 에 포함시키면 백엔드가 정식 폴더로 promote.
+- Message: promote 단계 없음 — 등록 시점에 바로 final 폴더.
 
 ---
 
-## 8. WebSocket / STOMP (실시간 채팅·알림)
+## 9. WebSocket / STOMP (실시간 채팅·알림)
 
-### 8.1 SockJS 클라이언트 (브라우저, 쿠키 기반)
+### 9.1 SockJS 클라이언트 (브라우저, 쿠키 기반)
 
 ```js
 import SockJS from 'sockjs-client';
@@ -310,16 +485,22 @@ const client = new Client({
   webSocketFactory: () => new SockJS('http://localhost:8080/ws-stomp'),
   // 쿠키 자동 동봉 — handshake 단계에서 SecurityContext 주입
   onConnect: () => {
-    // 채팅방 토픽 구독
-    client.subscribe('/topic/chat-room/123', msg => { ... });
-    // 본인 알림 큐 구독 (Spring 자동 라우팅)
-    client.subscribe('/user/queue/notifications', msg => { ... });
+    // 현재 보고 있는 채팅방 토픽 구독
+    client.subscribe('/topic/chat-room/123', msg => {
+      const message = JSON.parse(msg.body);   // MessageResponse
+      // 메시지 화면에 추가
+    });
+    // 본인 알림 큐 구독 — 다른 방 새 메시지 / 시스템 알림
+    client.subscribe('/user/queue/notifications', msg => {
+      const noti = JSON.parse(msg.body);
+      // 알림 리스트 / 토스트 표시
+    });
   },
 });
 client.activate();
 ```
 
-### 8.2 Native WebSocket 클라이언트 (모바일, 쿠키 X)
+### 9.2 Native WebSocket 클라이언트 (모바일, 쿠키 X)
 
 ```js
 const client = new Client({
@@ -333,28 +514,277 @@ client.activate();
 ```
 - AT 만료 시 SECURITY 에러 → refresh 후 재연결.
 
-### 8.3 메시지 전송
-```js
-client.publish({
-  destination: '/app/chat/send',
-  body: JSON.stringify({ chatRoomId: 123, content: '안녕' }),
-  headers: { 'X-XSRF-TOKEN': xsrf },  // SockJS 면 필요
-});
-```
-또는 REST `POST /api/v1/chat-rooms/{id}/messages` — 어느 쪽이든 결과는 동일하게 broadcast.
+### 9.3 메시지 전송 — REST 만 사용
 
-### 8.4 destination 화이트리스트
-| destination | 의미 | 권한 |
-|---|---|---|
-| `/topic/chat-room/{roomId}` | 채팅방 메시지 broadcast | 참여자만 |
-| `/user/queue/messages` | 본인 메시지 큐 (Spring 자동) | 본인 |
-| `/user/queue/notifications` | 본인 알림 큐 | 본인 |
+⚠️ **주의: STOMP `/app/chat/send` destination 은 백엔드에 미구현.** 메시지 전송은 **REST 만**:
+
+```
+POST /api/v1/chat-rooms/{roomId}/messages
+Body: {
+  "content": "안녕하세요",        // content / imageUrls 둘 중 하나 이상 필수
+  "imageUrls": []                  // 또는 ["https://cdn.../messages/200/abc.jpg"]
+}
+→ 201 + MessageResponse
+```
+
+전송 후 백엔드가 자동으로:
+1. MongoDB 에 메시지 저장
+2. ChatRoom 메타 갱신 (last_message, 상대 unread +1)
+3. STOMP `/topic/chat-room/{roomId}` 로 broadcast — 양쪽 참여자 모두 수신
+4. 상대방 `/user/queue/notifications` 로 알림 push
+
+### 9.4 destination 화이트리스트
+
+| destination | 방향 | 용도 | 권한 |
+|---|---|---|---|
+| `/topic/chat-room/{roomId}` | 백엔드→클라 | 채팅방 메시지 broadcast | 참여자만 SUBSCRIBE 가능 |
+| `/user/queue/notifications` | 백엔드→클라 (본인) | 알림 (다른 방 새 메시지, 시스템) | 본인만 |
+
+⚠️ **사용 안 하는 destination** (이전 doc 잘못 기재):
+- ~~`/app/chat/send`~~ — 백엔드 미구현. 메시지 전송은 REST `POST /chat-rooms/{id}/messages` 만.
+- ~~`/user/queue/messages`~~ — 백엔드 발행 안 함. 무시.
 
 그 외 destination subscribe → `FORBIDDEN`.
 
 ---
 
-## 9. 페이징 표준
+## 10. 도메인 schema 정리 (응답 본문)
+
+### 10.1 Item
+
+#### ItemSummaryResponse — 검색·찜·내물품·내목록 공통
+```json
+{
+  "id": 42,
+  "sellerId": 100,
+  "categoryId": 5,
+  "title": "아이폰 14 Pro 미개봉",
+  "price": 1200000,
+  "tradeType": "판매",                  // 판매 | 대여 | 나눔
+  "status": "판매중",                    // 판매중 | 예약 | 거래완료 | 비공개 | 삭제
+  "region": "서울 강남구",
+  "thumbnailUrl": "https://cdn.../items/42/abc.jpg",  // null 가능
+  "wishlistCount": 8,
+  "isWishlisted": false,                 // 본인 찜 여부. 비로그인 항상 false
+  "createdAt": "2026-05-03T10:00:00"
+}
+```
+
+#### ItemDetailResponse
+Summary + 추가 필드:
+```json
+{
+  // Summary 모든 필드 +
+  "description": "박스 미개봉, 색상 딥퍼플",
+  "deposit": 100000,                    // 대여만, 그 외 null
+  "rentalUnit": "일",                    // 대여만 ("시간"|"일"|"주"|"월"), 그 외 null
+  "viewCount": 127,
+  "images": [
+    { "imageUrl": "...", "sortOrder": 1, "thumbnail": true }
+  ],
+  "hashtags": ["아이폰","미개봉"],
+  "updatedAt": "2026-05-03T10:00:00"
+}
+```
+
+#### Item endpoints
+```
+POST   /api/v1/items                           — 등록 (이메일 인증)
+GET    /api/v1/items?q=&categoryId=&tradeType=&minPrice=&maxPrice=&tag=&sort=&page=&size=
+                                                — 검색 (공개)
+                                                  sort: latest | price_asc | price_desc | view_desc | wishlist_desc
+GET    /api/v1/items/{id}                      — 단건 (공개, viewCount +1)
+PATCH  /api/v1/items/{id}                      — 본인 수정 (전체 교체 패턴)
+DELETE /api/v1/items/{id}                      — 본인 soft delete
+
+POST   /api/v1/items/{id}/images               — 이미지 부분 추가 (5장 한도)
+DELETE /api/v1/items/{id}/images?imageUrl=...  — 이미지 단건 제거
+PATCH  /api/v1/items/{id}/images/order         — 순서 변경 (set 일치 검증)
+
+GET    /api/v1/users/me/items?status=&page=&size=
+                                                — 본인 등록 물품 (마이페이지)
+                                                  status: 판매중|예약|거래완료|비공개
+```
+
+#### 등록/수정 body (ItemRegisterRequest / ItemUpdateRequest)
+```json
+{
+  "categoryId": 5,                       // optional
+  "title": "아이폰 14 Pro 미개봉",       // 필수 ≤200
+  "description": "박스 미개봉...",        // 필수
+  "price": 1200000,                      // 필수 ≥0 (나눔이면 0)
+  "tradeType": "판매",                    // 필수, 등록 시만 (수정 불가)
+  "deposit": null,                        // 대여만 필수, 그 외 null
+  "rentalUnit": null,                     // 대여만 필수 ("시간"|"일"|"주"|"월")
+  "region": "서울 강남구",                // optional ≤100
+  "imageUrls": ["https://..."],           // optional, 최대 5장
+  "hashtags": ["아이폰"]                  // optional
+}
+```
+- **PATCH 의 imageUrls non-null = 전체 교체** (4장 유지하려면 4장 다시 보내야 함). 부분 편집은 분리 endpoint 사용.
+
+### 10.2 Wishlist
+
+```
+POST   /api/v1/items/{id}/wishlist     → { wishlisted: true,  wishlistCount: 9 }
+DELETE /api/v1/items/{id}/wishlist     → { wishlisted: false, wishlistCount: 8 }
+GET    /api/v1/users/me/wishlist?page=&size=    → Page<ItemSummaryResponse>
+```
+- 토글 응답 즉시 반영 — detail 재조회 X.
+- 멱등 (이미 찜한 상태 POST OK, 안 찜한 상태 DELETE OK).
+
+### 10.3 Transaction
+
+#### 상태 머신
+```
+채팅중 → 예약 → 거래완료
+   └─→ 취소 (채팅중/예약 양쪽에서 가능)
+```
+- 상태값은 모두 **한글**: `채팅중 | 예약 | 거래완료 | 취소`. "진행중" 없음.
+
+#### TransactionResponse
+```json
+{
+  "id": 12,
+  "itemId": 42,
+  "sellerId": 100,
+  "buyerId": 200,
+  "tradeType": "판매",
+  "price": 1200000,
+  "deposit": null,                        // 대여만
+  "rentalStart": null,                    // 대여만
+  "rentalEnd": null,                      // 대여만
+  "status": "채팅중",
+  "reservedAt": null,
+  "completedAt": null,
+  "canceledAt": null,
+  "cancelReason": null,
+  "createdAt": "...",
+  "updatedAt": "..."
+}
+```
+
+#### endpoints
+```
+POST  /api/v1/transactions                    → 201 + { id }
+  Body: { itemId, rentalStart?, rentalEnd? }   (대여는 rentalStart/End 필수)
+  - 본인 물품 거부 (TRANSACTION_SELF_NOT_ALLOWED)
+  - 생성 즉시 status=채팅중. Item.status 는 변화 X (예약 액션 호출 시점에 잠김)
+
+GET   /api/v1/transactions/{id}               → TransactionResponse (참여자만)
+
+PATCH /api/v1/transactions/{id}               → null
+  Body: { action: "예약"|"거래완료"|"취소", cancelReason?: string }
+  - 예약: seller, 채팅중→예약, Item 자동 → 예약
+  - 거래완료: seller, 예약→거래완료, Item 자동 → 거래완료, 포인트 정산
+  - 취소: 양쪽 참여자, Item 예약이었으면 → 판매중 복원
+
+GET   /api/v1/users/me/transactions?role=buyer|seller&status=&page=&size=
+  - role 미지정 = 양쪽. status 미지정 = 전체
+```
+
+⚠️ **거래 정산은 잔액 이동만** (PG 안 거침). PaymentResponse.transactionId 는 항상 null. 거래 추적은 PointHistory.
+
+⚠️ **대여 반납 별도 endpoint 없음** — 일반 거래완료와 동일하게 PATCH action=거래완료. 보증금 환불 흐름 미지원 (관리자 수동, Day 9+).
+
+### 10.4 ChatRoom
+
+#### ChatRoomResponse
+```json
+{
+  "id": 8,
+  "itemId": 42,
+  // viewer 기준 — 프론트는 이것만 보면 됨
+  "opponentId": 200,
+  "opponentNickname": "쓸랭이",
+  "opponentProfileImage": "https://...",   // null 가능
+  "myUnread": 3,
+  "itemTitle": "아이폰 14 Pro",
+  "itemThumbnailUrl": "https://...",       // null 가능
+  // 메타
+  "lastMessage": "안녕하세요...",
+  "lastMessageAt": "2026-05-03T10:00:00",
+  "active": true,
+  // raw — 호환용 (향후 v2 에서 제거 예정. 신규 코드는 위 derived 필드 사용)
+  "user1Id": 100,
+  "user2Id": 200,
+  "user1Unread": 0,
+  "user2Unread": 3,
+  "createdAt": "...",
+  "updatedAt": "..."
+}
+```
+
+#### endpoints
+```
+POST  /api/v1/chat-rooms                        → ChatRoomResponse (멱등)
+  Body: { itemId }
+  - 같은 (요청자, 상대, 물품) 채팅방이 있으면 기존 반환
+  - 본인 물품 거부 (CHAT_FORBIDDEN)
+  - 이메일 인증 필수
+
+GET   /api/v1/chat-rooms?page=&size=             → Page<ChatRoomResponse>
+  - lastMessageAt DESC
+
+GET   /api/v1/chat-rooms/{id}                    → ChatRoomResponse (참여자만)
+
+PATCH /api/v1/chat-rooms/{id}/read               → ChatRoomResponse (myUnread=0 반영됨)
+  - 본인 unread 만 0 으로 atomic UPDATE
+  - 채팅방 진입 시 / 새 메시지 수신 후 호출
+```
+
+### 10.5 Message
+
+#### MessageResponse
+```json
+{
+  "id": "65a1b2c3d4e5f60001234567",         // ⚠️ String (MongoDB ObjectId hex)
+  "chatRoomId": 8,                            // ⚠️ "roomId" 아님
+  "senderId": 200,
+  "content": "안녕하세요",                     // null 가능 (이미지만 보낼 때)
+  "imageUrls": ["https://cdn.../messages/200/abc.jpg"],   // ⚠️ 배열, 단수 아님
+  "createdAt": "2026-05-03T10:00:00.123Z"     // ⚠️ Instant — UTC offset 포함
+}
+```
+- `id` 는 MongoDB ObjectId hex string. 커서 페이징의 `before=` 값으로 그대로 사용.
+- `content` 또는 `imageUrls` 둘 중 하나 이상 채워짐.
+- 발신자 닉네임/프로필 미포함 → ChatRoom 의 user1/user2 + opponent 정보로 매칭하거나 `/users/{senderId}/profile` 호출.
+
+#### endpoints
+```
+POST  /api/v1/chat-rooms/{roomId}/messages       → 201 + MessageResponse (broadcast 자동)
+  Body: { content?: string, imageUrls?: string[] }   (둘 중 하나 이상)
+
+GET   /api/v1/chat-rooms/{roomId}/messages?before=&size=30
+                                                  → List<MessageResponse> (참여자만, 최신순)
+  - before 생략 = 최신부터
+  - before = 메시지 id (MongoDB ObjectId hex string) → 그 이전 size 개
+```
+
+### 10.6 Report (신고)
+
+```
+POST /api/v1/items/{itemId}/report             → 201 + { id } (이메일 인증)
+POST /api/v1/users/{userId}/report             → 201 + { id } (이메일 인증)
+
+Body:
+{
+  "reason": "사기 의심",                      // 필수 ≤50
+  "detail": "결제 후 연락 끊김..."             // optional ≤5000
+}
+```
+
+### 10.7 Category
+
+```
+GET /api/v1/categories                         → 활성 카테고리 트리 (root → children 재귀)
+GET /api/v1/categories/{id}                    → 단건
+```
+- DB 시드된 트리 (2단 깊이). enum 고정 X.
+
+---
+
+## 11. 페이징 표준
 
 ```http
 GET /api/v1/items?page=0&size=20&...
@@ -367,10 +797,11 @@ GET /api/v1/items?page=0&size=20&...
 GET /api/v1/chat-rooms/{id}/messages?before={messageId}&size=30
 ```
 - `before` 생략하면 최신부터 size 만큼.
+- `before` 는 MongoDB ObjectId hex string (Long 아님).
 
 ---
 
-## 10. 환경별 차이 요약
+## 12. 환경별 차이 요약
 
 | 항목 | local | prod |
 |---|---|---|
@@ -381,6 +812,7 @@ GET /api/v1/chat-rooms/{id}/messages?before={messageId}&size=30
 | Toss 키 | 테스트 키 | 운영 키 |
 | dev-auth bypass | `enabled: true` (`/dev/auth/login`) | **반드시 false** |
 | Email sender | 로그만 (`LogEmailSender`) | SMTP (`SmtpEmailSender`) |
+| JVM TZ | KST | KST 강제 (`-Duser.timezone=Asia/Seoul`) |
 
 ### dev-auth bypass (로컬 전용)
 ```http
@@ -391,7 +823,7 @@ POST /dev/auth/login
 
 ---
 
-## 11. 흔한 통합 이슈 트러블슈팅
+## 13. 흔한 통합 이슈 트러블슈팅
 
 | 증상 | 원인 / 해결 |
 |---|---|
@@ -400,13 +832,16 @@ POST /dev/auth/login
 | `AUTH_EMAIL_NOT_VERIFIED` 자주 발생 | 신규 가입 사용자가 인증 안 함 — `/api/v1/auth/verify-email` 안내 |
 | WebSocket CONNECT 즉시 끊김 | Origin 화이트리스트 누락 또는 인증 누락 |
 | Item 등록 후 이미지 안 보임 | imageUrl 의 `items/{userId}/` 가 `items/{itemId}/` 로 promote 됐는지 확인 (응답 imageUrls 사용) |
-| 결제 후 잔액 미반영 | webhook 도착 전 — `GET /api/v1/payments/{paymentKey}` 폴링 또는 reconciliation scheduler (5분) 대기 |
+| 결제 후 잔액 미반영 | webhook 도착 전 — `GET /api/v1/payments/{id}` 폴링 또는 reconciliation scheduler (5분) 대기 |
+| 채팅 unread 카운터 0 으로 안 됨 | `PATCH /chat-rooms/{id}/read` 안 부른 것 — 채팅방 진입 시 호출 |
+| 해외 출장자 시간 1시간 어긋남 | LocalDateTime 은 KST naive — `parseKst()` 헬퍼로 강제 해석 |
+| Message.createdAt 만 형식 다름 | Instant 타입 (UTC offset). 다른 도메인 LocalDateTime 과 혼동 주의 |
 
 ---
 
-## 12. 참조 문서
+## 14. 참조 문서
 
-- Swagger UI: 모든 endpoint 명세 + Request/Response 예시 (PR #48 에서 보강됨).
+- Swagger UI: 모든 endpoint 명세 + Request/Response 예시.
 - `docs/AUTH_SECURITY.md` — 인증/보안 결정 사항.
 - `docs/SSEULANG_BACKEND_GUIDE.md` — 도메인 결정 사항.
 - `docs/migration/V4_DEPLOYMENT.md` — DB 마이그 절차.
@@ -414,12 +849,22 @@ POST /dev/auth/login
 
 ---
 
-## 13. 합의 필요 항목 (PM/프론트와 합의 후 확정)
+## 15. 합의 필요 항목 (PM/프론트와 합의 후 확정)
 
 - [ ] prod 도메인 + CORS origins 확정
 - [ ] 쿠키 도메인 (`.sseulang.com` vs subdomain)
-- [ ] OAuth redirect URI (현재 백엔드는 access_token POST 받는 구조 — frontend 가 SDK 직접 호출)
 - [ ] WebSocket prod 엔드포인트 (`wss://` 인증서)
 - [ ] Swagger prod 노출 정책 (인증 필요 / IP 제한 / 비활성)
 
 PM·프론트 합의 후 본 문서 갱신 + `application-prod.yml` 환경변수 채움.
+
+---
+
+## 16. 변경 이력
+
+- **2026-05-03 (라운드 5)** — 채팅 도메인 schema 정확성 보강, STOMP destination 잘못된 매핑 수정, Item/ChatRoom 부분 편집 endpoint 추가, 도메인 schema 통합 §10 신설.
+- 2026-05-02 (라운드 4) — `GET /users/me/transactions` 추가, 거래 도메인 명세 정리.
+- 2026-05-02 (라운드 3) — 판매자 프로필 + 포인트 히스토리 + Item 이미지 부분편집 endpoint 추가.
+- 2026-05-02 (라운드 2) — ItemSummary 카드 필드 (thumbnail/wishlistCount/isWishlisted), 마이페이지 본인 물품, 찜 토글 응답 변경.
+- 2026-05-02 (라운드 1 hotfix) — CORS preflight, MeResponse, OAuth code grant, PATCH /me, sort, RentalUnit 정정.
+- 2026-04-28 (초안) — 인증/응답/CORS/WebSocket/S3 기본.

--- a/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
+++ b/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
@@ -3,6 +3,8 @@ package com.sseulang.domain.chat.application;
 import com.sseulang.domain.chat.application.dto.ChatRoomResult;
 import com.sseulang.domain.chat.domain.ChatRoom;
 import com.sseulang.domain.chat.domain.ChatRoomRepository;
+import com.sseulang.domain.chat.domain.ItemView;
+import com.sseulang.domain.chat.domain.UserView;
 import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
@@ -12,6 +14,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 @Transactional(readOnly = true)
@@ -23,15 +30,21 @@ public class ChatRoomApplicationService {
     private final ChatRoomRepository chatRoomRepository;
     private final ItemApplicationService itemApplicationService;
     private final com.sseulang.domain.user.application.UserApplicationService userApplicationService;
+    private final UserView userView;
+    private final ItemView itemView;
 
     public ChatRoomApplicationService(
             ChatRoomRepository chatRoomRepository,
             ItemApplicationService itemApplicationService,
-            com.sseulang.domain.user.application.UserApplicationService userApplicationService
+            com.sseulang.domain.user.application.UserApplicationService userApplicationService,
+            UserView userView,
+            ItemView itemView
     ) {
         this.chatRoomRepository = chatRoomRepository;
         this.itemApplicationService = itemApplicationService;
         this.userApplicationService = userApplicationService;
+        this.userView = userView;
+        this.itemView = itemView;
     }
 
     /**
@@ -46,13 +59,29 @@ public class ChatRoomApplicationService {
         if (sellerId.equals(requesterId)) {
             throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
         }
-        return chatRoomRepository.findByItemAndUsers(itemId, requesterId, sellerId)
-                .map(ChatRoomResult::from)
+        ChatRoom room = chatRoomRepository.findByItemAndUsers(itemId, requesterId, sellerId)
                 .orElseGet(() -> createWithRaceGuard(itemId, requesterId, sellerId));
+        return enrichOne(room, requesterId);
     }
 
+    /**
+     * 본인 채팅방 페이징 — 페이지 결과의 opponent userId / itemId 들을 모아 단일 SELECT IN 으로 batch
+     * fetch (N+1 회피). viewer 기준 derive 후 응답.
+     */
     public Page<ChatRoomResult> listMine(Long userId, Pageable pageable) {
-        return chatRoomRepository.findMine(userId, pageable).map(ChatRoomResult::from);
+        Page<ChatRoom> page = chatRoomRepository.findMine(userId, pageable);
+        if (page.isEmpty()) {
+            return page.map(c -> ChatRoomResult.from(c, userId, null, null, null, null));
+        }
+        Set<Long> opponentIds = new HashSet<>();
+        Set<Long> itemIds = new HashSet<>();
+        for (ChatRoom c : page.getContent()) {
+            opponentIds.add(userId.equals(c.getUser1Id()) ? c.getUser2Id() : c.getUser1Id());
+            itemIds.add(c.getItemId());
+        }
+        Map<Long, UserView.UserProjection> userMap = userView.findByIds(opponentIds);
+        Map<Long, ItemView.ItemProjection> itemMap = itemView.findByIds(itemIds);
+        return page.map(c -> enrichWithMaps(c, userId, userMap, itemMap));
     }
 
     public ChatRoomResult getOne(Long id, Long requesterId) {
@@ -61,7 +90,24 @@ public class ChatRoomApplicationService {
         if (!room.isParticipant(requesterId)) {
             throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
         }
-        return ChatRoomResult.from(room);
+        return enrichOne(room, requesterId);
+    }
+
+    /**
+     * 본인 unread 0 으로 리셋. 본인이 참여자가 아니면 atomic UPDATE 가 영향 0 — 그 경우 사전 권한
+     * 검증 후 CHAT_FORBIDDEN. 응답으로 갱신된 채팅방 반환 (myUnread = 0).
+     */
+    @Transactional
+    public ChatRoomResult markAsRead(Long roomId, Long userId) {
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (!room.isParticipant(userId)) {
+            throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
+        }
+        chatRoomRepository.markAsRead(roomId, userId);
+        // entity 메모리 상태도 동기화 (응답에 fresh 값 반영)
+        room.markAsRead(userId);
+        return enrichOne(room, userId);
     }
 
     /** Message 도메인이 메시지 보낼 권한 검증 시 호출. 참여자 아니면 CHAT_FORBIDDEN. */
@@ -95,14 +141,39 @@ public class ChatRoomApplicationService {
         chatRoomRepository.recordIncomingMessage(chatRoomId, senderId, preview);
     }
 
-    private ChatRoomResult createWithRaceGuard(Long itemId, Long requesterId, Long sellerId) {
+    /** 단건 enrich — opponent + item batch fetch 후 ChatRoomResult.from. */
+    private ChatRoomResult enrichOne(ChatRoom room, Long viewerId) {
+        Long opponentId = viewerId.equals(room.getUser1Id()) ? room.getUser2Id() : room.getUser1Id();
+        Map<Long, UserView.UserProjection> userMap = userView.findByIds(List.of(opponentId));
+        Map<Long, ItemView.ItemProjection> itemMap = itemView.findByIds(List.of(room.getItemId()));
+        return enrichWithMaps(room, viewerId, userMap, itemMap);
+    }
+
+    private static ChatRoomResult enrichWithMaps(
+            ChatRoom c,
+            Long viewerId,
+            Map<Long, UserView.UserProjection> userMap,
+            Map<Long, ItemView.ItemProjection> itemMap
+    ) {
+        Long opponentId = viewerId.equals(c.getUser1Id()) ? c.getUser2Id() : c.getUser1Id();
+        UserView.UserProjection u = userMap.get(opponentId);
+        ItemView.ItemProjection i = itemMap.get(c.getItemId());
+        return ChatRoomResult.from(
+                c, viewerId,
+                u != null ? u.nickname() : null,
+                u != null ? u.profileImage() : null,
+                i != null ? i.title() : null,
+                i != null ? i.thumbnailUrl() : null
+        );
+    }
+
+    private ChatRoom createWithRaceGuard(Long itemId, Long requesterId, Long sellerId) {
         ChatRoom newRoom = ChatRoom.openFor(itemId, requesterId, sellerId);
         try {
-            return ChatRoomResult.from(chatRoomRepository.save(newRoom));
+            return chatRoomRepository.save(newRoom);
         } catch (DataIntegrityViolationException violation) {
             if (isUniqueConflict(violation)) {
                 return chatRoomRepository.findByItemAndUsers(itemId, requesterId, sellerId)
-                        .map(ChatRoomResult::from)
                         .orElseThrow(() -> violation);
             }
             throw violation;

--- a/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
+++ b/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
@@ -4,25 +4,67 @@ import com.sseulang.domain.chat.domain.ChatRoom;
 
 import java.time.LocalDateTime;
 
+/**
+ * 채팅방 응답 — viewer 기준으로 자동 enrich. ApplicationService 가 batch fetch 로 채움.
+ *
+ * <p>raw 필드 (user1Id/user2Id/user1Unread/user2Unread) 는 호환을 위해 유지하되, 프론트는
+ * viewer 기준 derived 필드 ({@code opponentId} / {@code myUnread} / {@code opponent*})만 봐도 됨.
+ * raw 필드는 향후 v2 API 에서 제거 예정.</p>
+ */
 public record ChatRoomResult(
         Long id,
         Long itemId,
+        // raw 필드 (정규화 — user1Id < user2Id) — 호환용
         Long user1Id,
         Long user2Id,
-        String lastMessage,
-        LocalDateTime lastMessageAt,
         int user1Unread,
         int user2Unread,
+        // viewer-aware enrich
+        Long opponentId,
+        String opponentNickname,
+        String opponentProfileImage,
+        int myUnread,
+        String itemTitle,
+        String itemThumbnailUrl,
+        // 메타
+        String lastMessage,
+        LocalDateTime lastMessageAt,
         boolean active,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-    public static ChatRoomResult from(ChatRoom c) {
+    /**
+     * viewerId 기준 derive. opponent / item join 정보는 호출자가 fetch 후 전달 (없으면 null/빈 문자열 OK).
+     * viewerId 가 참여자 아니면 IAE — 서비스가 사전 권한 검증 책임.
+     */
+    public static ChatRoomResult from(
+            ChatRoom c,
+            Long viewerId,
+            String opponentNickname,
+            String opponentProfileImage,
+            String itemTitle,
+            String itemThumbnailUrl
+    ) {
+        Long opponentId;
+        int myUnread;
+        if (viewerId != null && viewerId.equals(c.getUser1Id())) {
+            opponentId = c.getUser2Id();
+            myUnread = c.getUser1Unread();
+        } else if (viewerId != null && viewerId.equals(c.getUser2Id())) {
+            opponentId = c.getUser1Id();
+            myUnread = c.getUser2Unread();
+        } else {
+            // viewer 가 참여자 아님 — 호출자가 사전 검증 책임. enrich 못 하므로 null/0 으로 둠.
+            opponentId = null;
+            myUnread = 0;
+        }
         return new ChatRoomResult(
                 c.getId(), c.getItemId(),
                 c.getUser1Id(), c.getUser2Id(),
-                c.getLastMessage(), c.getLastMessageAt(),
                 c.getUser1Unread(), c.getUser2Unread(),
+                opponentId, opponentNickname, opponentProfileImage, myUnread,
+                itemTitle, itemThumbnailUrl,
+                c.getLastMessage(), c.getLastMessageAt(),
                 c.isActive(),
                 c.getCreatedAt(), c.getUpdatedAt()
         );

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoom.java
@@ -86,4 +86,19 @@ public class ChatRoom extends BaseEntity {
     public boolean isParticipant(Long userId) {
         return userId != null && (userId.equals(user1Id) || userId.equals(user2Id));
     }
+
+    /**
+     * 본인이 user1 이면 user1Unread = 0, user2 면 user2Unread = 0. 상대방 unread 는 그대로.
+     * 호출자가 사전에 isParticipant 검증해야 함 (서비스 책임).
+     */
+    public void markAsRead(Long userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId 는 필수입니다");
+        }
+        if (userId.equals(user1Id)) {
+            this.user1Unread = 0;
+        } else if (userId.equals(user2Id)) {
+            this.user2Unread = 0;
+        }
+    }
 }

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoomRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoomRepository.java
@@ -24,4 +24,9 @@ public interface ChatRoomRepository {
      * 가이드 §4.10 — 동시 메시지 발신 race 안전 (마지막 SQL 이 win).
      */
     int recordIncomingMessage(Long chatRoomId, Long senderId, String preview);
+
+    /**
+     * 본인 unread 만 0 으로 atomic UPDATE. 비참여자는 영향 0. 권한 검증은 서비스 책임.
+     */
+    int markAsRead(Long chatRoomId, Long userId);
 }

--- a/src/main/java/com/sseulang/domain/chat/domain/ItemView.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ItemView.java
@@ -1,0 +1,22 @@
+package com.sseulang.domain.chat.domain;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Chat 도메인이 채팅방 응답에 아이템 제목/썸네일을 자동 join 으로 채울 때 쓰는 read-only 포트.
+ * 구현은 {@code item.infrastructure} 어댑터.
+ *
+ * <p>CLAUDE.md §3.3 — 단방향 의존, N+1 회피용 batch read.</p>
+ */
+public interface ItemView {
+
+    /**
+     * itemId 들에 대한 (id → projection) 맵. 미존재 id 는 맵에서 빠짐 (삭제된 아이템 등).
+     * 비어있으면 빈 맵 반환 — DB 호출 안 함.
+     */
+    Map<Long, ItemProjection> findByIds(Collection<Long> itemIds);
+
+    /** 채팅 응답용 아이템 최소 projection. 제목 + 썸네일 URL 만. */
+    record ItemProjection(Long id, String title, String thumbnailUrl) { }
+}

--- a/src/main/java/com/sseulang/domain/chat/domain/UserView.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/UserView.java
@@ -1,0 +1,22 @@
+package com.sseulang.domain.chat.domain;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Chat 도메인이 채팅방 응답에 상대방 닉네임/프로필을 자동 join 으로 채울 때 쓰는 read-only 포트.
+ * 구현은 {@code user.infrastructure} 어댑터.
+ *
+ * <p>CLAUDE.md §3.3 — 다른 도메인 Repository 직접 호출 금지. 단방향 의존 + N+1 회피용 batch read.</p>
+ */
+public interface UserView {
+
+    /**
+     * userId 들에 대한 (id → projection) 맵. 미존재 id 는 맵에서 빠짐.
+     * 비어있으면 빈 맵 반환 — DB 호출 안 함.
+     */
+    Map<Long, UserProjection> findByIds(Collection<Long> userIds);
+
+    /** 채팅 응답용 사용자 최소 projection. 닉네임 + 프로필이미지만. */
+    record UserProjection(Long id, String nickname, String profileImage) { }
+}

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomJpaRepository.java
@@ -54,4 +54,15 @@ interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, Long> {
             @Param("preview") String preview,
             @Param("sentAt") LocalDateTime sentAt
     );
+
+    /** 본인 unread 0 으로 atomic UPDATE. 비참여자는 영향 0. */
+    @Modifying
+    @Query("""
+        UPDATE ChatRoom c
+        SET c.user1Unread = CASE WHEN c.user1Id = :userId THEN 0 ELSE c.user1Unread END,
+            c.user2Unread = CASE WHEN c.user2Id = :userId THEN 0 ELSE c.user2Unread END
+        WHERE c.id = :roomId
+          AND (c.user1Id = :userId OR c.user2Id = :userId)
+    """)
+    int markAsRead(@Param("roomId") Long roomId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomRepositoryImpl.java
@@ -43,4 +43,9 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
     public int recordIncomingMessage(Long chatRoomId, Long senderId, String preview) {
         return jpa.recordIncomingMessage(chatRoomId, senderId, preview, java.time.LocalDateTime.now());
     }
+
+    @Override
+    public int markAsRead(Long chatRoomId, Long userId) {
+        return jpa.markAsRead(chatRoomId, userId);
+    }
 }

--- a/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -70,5 +71,16 @@ public class ChatRoomController {
             @PathVariable("id") Long id
     ) {
         return ApiResponse.ok(ChatRoomResponse.from(chatRoomService.getOne(id, requesterId)));
+    }
+
+    @Operation(summary = "채팅방 읽음 처리",
+            description = "본인 unread 카운트를 0 으로 atomic UPDATE. 상대방 unread 는 영향 X. "
+                    + "참여자만 호출 (그 외 403 CHAT_FORBIDDEN). 응답에 myUnread=0 반영된 ChatRoomResponse.")
+    @PatchMapping("/{id}/read")
+    public ApiResponse<ChatRoomResponse> markAsRead(
+            @AuthenticationPrincipal Long requesterId,
+            @PathVariable("id") Long id
+    ) {
+        return ApiResponse.ok(ChatRoomResponse.from(chatRoomService.markAsRead(id, requesterId)));
     }
 }

--- a/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
@@ -5,27 +5,37 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(description = "1:1 채팅방 — (user1, user2, item) UNIQUE. user1Id < user2Id 정규화.")
+@Schema(description = "1:1 채팅방. viewer 기준 enrich — opponent* / myUnread / item* 자동 join. raw user1/user2 필드는 호환용 유지.")
 public record ChatRoomResponse(
         @Schema(example = "8") Long id,
         @Schema(example = "42") Long itemId,
-        @Schema(description = "정규화된 첫 사용자 (id 작은 쪽)", example = "100") Long user1Id,
-        @Schema(description = "정규화된 두번째 사용자", example = "200") Long user2Id,
-        @Schema(example = "안녕하세요, 거래 가능할까요?", description = "최근 메시지 미리보기") String lastMessage,
+        // viewer 기준 derived 필드 — 프론트는 이것만 보면 됨
+        @Schema(example = "200", description = "viewer 의 상대방 사용자 id") Long opponentId,
+        @Schema(example = "쓸랭이", description = "상대방 닉네임") String opponentNickname,
+        @Schema(description = "상대방 프로필 이미지 URL (없으면 null)") String opponentProfileImage,
+        @Schema(example = "3", description = "viewer 의 미읽음 카운트") int myUnread,
+        @Schema(example = "아이폰 14 Pro", description = "아이템 제목") String itemTitle,
+        @Schema(description = "아이템 썸네일 URL (없으면 null)") String itemThumbnailUrl,
+        // 메타
+        @Schema(example = "안녕하세요...", description = "최근 메시지 미리보기") String lastMessage,
         LocalDateTime lastMessageAt,
-        @Schema(example = "0", description = "user1 의 미읽음 카운트") int user1Unread,
-        @Schema(example = "3", description = "user2 의 미읽음 카운트") int user2Unread,
         @Schema(description = "false 면 차단/예약 등으로 비활성") boolean active,
+        // raw — 호환용 (향후 제거 예정)
+        @Schema(description = "정규화 raw — user1Id < user2Id. 호환용 유지, 신규 코드는 opponentId 사용 권장") Long user1Id,
+        @Schema(description = "정규화 raw — 호환용 유지") Long user2Id,
+        @Schema(description = "raw — user1 미읽음. 호환용 유지, 신규 코드는 myUnread 사용 권장") int user1Unread,
+        @Schema(description = "raw — user2 미읽음. 호환용 유지") int user2Unread,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
     public static ChatRoomResponse from(ChatRoomResult r) {
         return new ChatRoomResponse(
                 r.id(), r.itemId(),
-                r.user1Id(), r.user2Id(),
-                r.lastMessage(), r.lastMessageAt(),
-                r.user1Unread(), r.user2Unread(),
-                r.active(),
+                r.opponentId(), r.opponentNickname(), r.opponentProfileImage(),
+                r.myUnread(),
+                r.itemTitle(), r.itemThumbnailUrl(),
+                r.lastMessage(), r.lastMessageAt(), r.active(),
+                r.user1Id(), r.user2Id(), r.user1Unread(), r.user2Unread(),
                 r.createdAt(), r.updatedAt()
         );
     }

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemViewAdapter.java
@@ -1,0 +1,35 @@
+package com.sseulang.domain.item.infrastructure.persistence;
+
+import com.sseulang.domain.chat.domain.ItemView;
+import com.sseulang.domain.item.domain.Item;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link ItemView} 어댑터. chat 도메인이 채팅방 응답에 아이템 제목/썸네일을 자동 채울 때 사용.
+ * 단일 SELECT IN — N+1 회피.
+ */
+@Component
+class ItemViewAdapter implements ItemView {
+
+    private final ItemJpaRepository jpa;
+
+    ItemViewAdapter(ItemJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Map<Long, ItemProjection> findByIds(Collection<Long> itemIds) {
+        if (itemIds == null || itemIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, ItemProjection> result = new HashMap<>();
+        for (Item i : jpa.findAllById(itemIds)) {
+            result.put(i.getId(), new ItemProjection(i.getId(), i.getTitle(), i.getThumbnailUrl()));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserViewAdapter.java
@@ -1,0 +1,35 @@
+package com.sseulang.domain.user.infrastructure.persistence;
+
+import com.sseulang.domain.chat.domain.UserView;
+import com.sseulang.domain.user.domain.User;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link UserView} 어댑터. chat 도메인이 채팅방 응답에 상대방 닉네임/프로필을 자동 채울 때 사용.
+ * 단일 SELECT IN — N+1 회피.
+ */
+@Component
+class UserViewAdapter implements UserView {
+
+    private final UserJpaRepository jpa;
+
+    UserViewAdapter(UserJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public Map<Long, UserProjection> findByIds(Collection<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, UserProjection> result = new HashMap<>();
+        for (User u : jpa.findAllById(userIds)) {
+            result.put(u.getId(), new UserProjection(u.getId(), u.getNickname(), u.getProfileImage()));
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
@@ -35,7 +35,7 @@ class ChatRoomApplicationServiceTest {
         itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
-        service = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        service = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView());
 
         Item item = itemRepo.save(Item.create(
                 SELLER, null, "물건", "설명", 50_000L, null, null, TradeType.판매, null

--- a/src/test/java/com/sseulang/domain/chat/application/InMemoryFakeChatRoomRepository.java
+++ b/src/test/java/com/sseulang/domain/chat/application/InMemoryFakeChatRoomRepository.java
@@ -69,4 +69,16 @@ public class InMemoryFakeChatRoomRepository implements ChatRoomRepository {
         }
         return 1;
     }
+
+    @Override
+    public int markAsRead(Long chatRoomId, Long userId) {
+        ChatRoom room = store.get(chatRoomId);
+        if (room == null || !room.isParticipant(userId)) return 0;
+        if (userId.equals(room.getUser1Id())) {
+            ReflectionTestUtils.setField(room, "user1Unread", 0);
+        } else {
+            ReflectionTestUtils.setField(room, "user2Unread", 0);
+        }
+        return 1;
+    }
 }

--- a/src/test/java/com/sseulang/domain/chat/application/NoOpItemView.java
+++ b/src/test/java/com/sseulang/domain/chat/application/NoOpItemView.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.chat.application;
+
+import com.sseulang.domain.chat.domain.ItemView;
+
+import java.util.Collection;
+import java.util.Map;
+
+/** 단위 테스트용 fake — 항상 빈 맵 반환. itemTitle/thumbnailUrl 는 null. */
+public class NoOpItemView implements ItemView {
+    @Override
+    public Map<Long, ItemProjection> findByIds(Collection<Long> itemIds) {
+        return Map.of();
+    }
+}

--- a/src/test/java/com/sseulang/domain/chat/application/NoOpUserView.java
+++ b/src/test/java/com/sseulang/domain/chat/application/NoOpUserView.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.chat.application;
+
+import com.sseulang.domain.chat.domain.UserView;
+
+import java.util.Collection;
+import java.util.Map;
+
+/** 단위 테스트용 fake — 항상 빈 맵 반환. opponentNickname/profileImage 는 null. */
+public class NoOpUserView implements UserView {
+    @Override
+    public Map<Long, UserProjection> findByIds(Collection<Long> userIds) {
+        return Map.of();
+    }
+}

--- a/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
@@ -48,7 +48,7 @@ class MessageApplicationServiceTest {
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
-        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView());
         NotificationApplicationService notifSvc = new NotificationApplicationService(notifRepo);
         // 단위 테스트에선 트랜잭션 컨텍스트 X — AFTER_COMMIT listener 직접 호출하는 fake event publisher.
         ChatRealtimeEventListener listener = new ChatRealtimeEventListener(publisher);

--- a/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
@@ -54,7 +54,7 @@ class StompAuthChannelInterceptorTest {
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
-        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class));
+        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView());
 
         validTokens.clear();
         jwtProvider = mock(JwtProvider.class);


### PR DESCRIPTION
## Summary
프론트 연동 라운드 5 — 채팅 도메인 schema 추측 / 잘못된 STOMP 매핑으로 인한 반복 질문 정리.

## 신규 endpoint
```
PATCH /api/v1/chat-rooms/{id}/read
```
- 본인 unread 카운트 0 으로 atomic UPDATE (CASE WHEN 분기로 user1/user2 자동)
- 상대방 unread 영향 X
- 참여자만, 그 외 403 `CHAT_FORBIDDEN`
- 응답: myUnread=0 반영된 `ChatRoomResponse`

## ChatRoomResponse viewer-aware 보강
기존 raw `user1Id` / `user2Id` / `user1Unread` / `user2Unread` 는 **호환용으로 유지**하되 viewer 기준 derive 필드를 응답에 추가:

| 신규 필드 | 의미 |
|---|---|
| `opponentId` | viewer 의 상대방 사용자 id |
| `opponentNickname` | 상대방 닉네임 |
| `opponentProfileImage` | 상대방 프로필 이미지 URL |
| `myUnread` | viewer 입장의 미읽음 |
| `itemTitle` | 아이템 제목 |
| `itemThumbnailUrl` | 아이템 썸네일 |

→ 프론트가 매번 `/users/{id}/profile`, `/items/{id}` 추가 호출 안 해도 카드 UI 렌더 가능.

## 도메인 layer (CLAUDE.md §3.3 단방향 의존 + N+1 회피)
- `chat.domain` 에 `UserView` / `ItemView` 포트 신설 — read-only batch 조회
- 어댑터: `user.infrastructure.UserViewAdapter`, `item.infrastructure.ItemViewAdapter`
- `ChatRoomApplicationService.listMine` — 페이지 결과의 opponentId / itemId 들을 모아 단일 SELECT IN 으로 batch fetch
- `ChatRoom.markAsRead(userId)` — user1/user2 분기로 본인만 0 리셋
- `ChatRoomRepository.markAsRead` — atomic UPDATE

## docs/FRONTEND_INTEGRATION.md 재작성

### 수정
- ❌ 잘못된 STOMP destination 제거:
  - `/app/chat/send` — 백엔드 `@MessageMapping` 미구현. 메시지 전송은 **REST 만**.
  - `/user/queue/messages` — 백엔드 발행 코드 없음. 무시.
- ❌ 결제 endpoint path 정정: `/payments/start` → `/payments/charge`, `/payments/confirm` → `/payments/charge/confirm`
- ❌ OAuth 흐름 재정리 — `{ accessToken }` 가 아니라 **Authorization Code Grant** (`{ code, redirectUri }`)

### 추가
- §10 **도메인 schema 통합** 섹션 신설 — Item / Wishlist / Transaction / ChatRoom / Message / Report / Category 응답 schema 일괄 정리 + endpoints 표
- ChatRoomResponse / MessageResponse 정확한 schema (필드명/타입/예시) 명시 — Message.id 가 String (MongoDB ObjectId hex), createdAt 이 Instant 인 점 강조
- 채팅 첨부 이미지 흐름 (FilePurpose.MESSAGE) 명시
- 시간 포맷 차이 (LocalDateTime vs Message Instant) §3 에 표로 정리
- 거래 상태 머신 (채팅중→예약→거래완료) + Item.status 자동 연동 표
- 트러블슈팅 § 에 unread 0 안 되는 케이스 / 시간 어긋남 케이스 추가
- 변경 이력 §16 추가

## Test plan
- [x] 컴파일 통과
- [x] 전체 테스트 597 PASS / 0 FAIL
- [ ] 백엔드 재시작 → smoke
  - PATCH /chat-rooms/{id}/read → myUnread=0
  - GET /chat-rooms 응답에 opponent* / itemTitle / itemThumbnailUrl 박힘
  - GET /chat-rooms/{id} 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)