### PR TITLE
deploy: Dockerfile + docker-compose.prod.yml + .env.prod.example + 배포 가이드

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# 빌드 산출물 / 로컬 환경 — image 에 포함 X
+.git
+.gitignore
+.idea
+.vscode
+*.iml
+
+build
+out
+.gradle
+
+# 환경변수 (image 에 절대 포함 금지)
+.env
+.env.*
+!.env.example
+!.env.prod.example
+
+# 로그 / OS 파일
+*.log
+logs
+.DS_Store
+Thumbs.db
+
+# 노드 / 프론트 (백엔드 image 에 불필요)
+node_modules
+
+# 테스트 결과
+build/test-results
+build/reports
+
+# Docker 자체
+Dockerfile
+docker-compose*.yml

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,90 @@
+# ========================================================================
+# 쓸랭 PROD 환경변수 템플릿
+#
+# 사용법:
+#   1. 본 파일을 .env.prod 로 복사:  cp .env.prod.example .env.prod
+#   2. 모든 값을 실제 운영 값으로 채움 (default 없는 항목은 미채우면 컨테이너 시작 실패)
+#   3. docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+#
+# ⚠️ .env.prod 는 .gitignore — 절대 커밋 금지.
+# ⚠️ 모든 비밀번호 / 키는 32자 이상 random 권장. JWT_SECRET 은 64자 이상.
+# ⚠️ 각 항목 옆 [필수] / [옵션] 표시 확인.
+# ========================================================================
+
+# =============== Application ===============
+SPRING_PROFILES_ACTIVE=prod
+APP_IMAGE_TAG=latest                              # CI 가 빌드한 image tag. latest 또는 git sha
+
+
+# =============== JWT [필수] ===============
+# 64자 이상 random. 예: openssl rand -hex 64
+JWT_SECRET=
+
+
+# =============== Cookie [필수] ===============
+# 운영 도메인. 서브도메인 공유면 .sseulang.com / 단일이면 sseulang.com
+COOKIE_DOMAIN=
+
+
+# =============== CORS [필수] ===============
+# 콤마 구분. 프론트 운영 도메인 화이트리스트.
+CORS_ALLOWED_ORIGINS=https://sseulang.com,https://www.sseulang.com
+
+
+# =============== MySQL [필수] — compose 내부 mysql container ===============
+MYSQL_ROOT_PASSWORD=
+MYSQL_DATABASE=sseulang
+MYSQL_USER=sseulang
+MYSQL_PASSWORD=
+
+
+# =============== Redis [필수] — compose 내부 redis container ===============
+REDIS_PASSWORD=
+
+
+# =============== MongoDB [필수] — compose 내부 mongo container ===============
+MONGO_USER=sseulang
+MONGO_PASSWORD=
+MONGO_DATABASE=sseulang
+
+
+# =============== OAuth [필수] ===============
+# 카카오 REST API Key (콘솔 — 내 애플리케이션 → 앱 키 → REST API 키)
+KAKAO_REST_API_KEY=
+# Client Secret 옵션 (콘솔 — 보안 → Client Secret 활성화 시). 옵션이라 기본 생략 가능.
+KAKAO_CLIENT_SECRET=
+
+# 구글 OAuth Client ID/Secret (Google Cloud Console)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+
+# =============== AWS S3 [필수] ===============
+# IAM 사용자 — 권한: s3:PutObject / GetObject / DeleteObject / CopyObject (S3_BUCKET 한정)
+AWS_ACCESS_KEY=
+AWS_SECRET_KEY=
+AWS_REGION=ap-northeast-2
+S3_BUCKET=
+
+
+# =============== 토스페이먼츠 [필수] ===============
+# 토스 개발자센터 — 운영 키 (테스트 키 X)
+TOSS_CLIENT_KEY=
+TOSS_SECRET_KEY=
+# Webhook secret (콘솔에서 발급). 미주입 시 시그니처 검증 비활성 — 위험 (반드시 채울 것).
+TOSS_WEBHOOK_SECRET=
+
+
+# =============== SMTP / Email [필수] ===============
+# Gmail/AWS SES/Naver Works 등. 이메일 인증 메일 발송용.
+MAIL_HOST=
+MAIL_PORT=587
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_FROM=noreply@sseulang.com
+
+
+# =============== Email verification URL base [옵션] ===============
+# 인증 메일 본문의 클릭 URL prefix. 미주입 시 application-prod.yml 에서 default.
+# 예: https://sseulang.com/auth/verify-email
+APP_EMAIL_VERIFICATION_URL_BASE=

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 .env
 .env.*
 !.env.example
+!.env.prod.example
 application-secret.yml
 application-local-secret.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# =============================================================================
+# 쓸랭 백엔드 Dockerfile — multi-stage build
+#
+# stage 1 (builder) : Gradle 8 + JDK 21 → bootJar
+# stage 2 (runtime) : Eclipse Temurin 21 JRE alpine + 비특권 user + Asia/Seoul TZ
+#
+# 빌드:    docker build -t sseulang-backend:latest .
+# 실행 예: docker run --rm --env-file .env.prod -p 8080:8080 sseulang-backend
+# =============================================================================
+
+# -------- stage 1: builder --------
+FROM gradle:8.14-jdk21-jammy AS builder
+WORKDIR /workspace
+
+# 의존성 캐시 — settings/build 만 먼저 복사해 layer 재사용 (소스 변경 시 dependency 재다운로드 X)
+COPY settings.gradle build.gradle gradle.properties* ./
+COPY gradle ./gradle
+COPY gradlew ./
+RUN gradle dependencies --no-daemon || true
+
+# 소스 + 빌드
+COPY src ./src
+RUN gradle bootJar -x test --no-daemon
+
+# -------- stage 2: runtime --------
+FROM eclipse-temurin:21-jre-alpine
+
+# Asia/Seoul TZ — LocalDateTime KST 일관성 보장 (FRONTEND_INTEGRATION.md §3 참조).
+RUN apk add --no-cache tzdata curl \
+ && cp /usr/share/zoneinfo/Asia/Seoul /etc/localtime \
+ && echo "Asia/Seoul" > /etc/timezone \
+ && apk del tzdata
+
+# 비특권 user — root 로 JVM 실행 X
+RUN addgroup -g 1000 sseulang && adduser -u 1000 -G sseulang -s /bin/sh -D sseulang
+
+WORKDIR /app
+COPY --from=builder --chown=sseulang:sseulang /workspace/build/libs/*.jar app.jar
+
+USER sseulang
+
+# JVM 옵션 — heap 은 컨테이너 메모리에 맞게 자동 조정. -XX:+UseContainerSupport 는 21 default.
+ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0 -Duser.timezone=Asia/Seoul"
+ENV SPRING_PROFILES_ACTIVE=prod
+
+EXPOSE 8080
+
+# Spring Boot Actuator health 가 살아있을 때만 healthy
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD curl -fsS http://localhost:8080/actuator/health || exit 1
+
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,145 @@
+# =============================================================================
+# 쓸랭 prod 배포 compose
+#
+# - 모든 비밀번호 / 키 / DB 접속 정보는 `.env.prod` 에서 (gitignored).
+# - DB/Redis/Mongo 는 외부 노출 X (internal bridge network 만). app → DB 만 접근.
+# - app 컨테이너는 nginx (호스트) reverse proxy 가 8080 → 80/443 으로 노출.
+# - 사용:
+#     1) cp .env.prod.example .env.prod    (값 채움)
+#     2) docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+# =============================================================================
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: sseulang-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?required}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:?required}
+      MYSQL_USER: ${MYSQL_USER:?required}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?required}
+      TZ: Asia/Seoul
+    command:
+      - "--character-set-server=utf8mb4"
+      - "--collation-server=utf8mb4_unicode_ci"
+      - "--default-time-zone=+09:00"
+      - "--ngram_token_size=2"
+    volumes:
+      - "mysql-data:/var/lib/mysql"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks: [internal]
+    # ⚠️ ports 미노출 — 외부 인터넷에서 직접 접근 금지. 동일 host 의 nginx/admin SSH tunnel 만 사용.
+
+  redis:
+    image: redis:7-alpine
+    container_name: sseulang-redis
+    restart: unless-stopped
+    command:
+      - "redis-server"
+      - "--appendonly"
+      - "yes"
+      - "--requirepass"
+      - "${REDIS_PASSWORD:?required}"
+    volumes:
+      - "redis-data:/data"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a $${REDIS_PASSWORD} ping | grep PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks: [internal]
+
+  mongo:
+    image: mongo:7
+    container_name: sseulang-mongo
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER:?required}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD:?required}
+      MONGO_INITDB_DATABASE: ${MONGO_DATABASE:?required}
+      TZ: Asia/Seoul
+    volumes:
+      - "mongo-data:/data/db"
+    healthcheck:
+      test:
+        - "CMD"
+        - "mongosh"
+        - "--quiet"
+        - "--eval"
+        - "db.adminCommand('ping').ok"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks: [internal]
+
+  app:
+    image: sseulang-backend:${APP_IMAGE_TAG:-latest}
+    # 또는 build context — CI 가 image push 안 하면 아래 주석 해제:
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    container_name: sseulang-app
+    restart: unless-stopped
+    depends_on:
+      mysql:   { condition: service_healthy }
+      redis:   { condition: service_healthy }
+      mongo:   { condition: service_healthy }
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      # === DB (compose 내부 service name 으로 접근) ===
+      DB_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&rewriteBatchedStatements=true
+      DB_USERNAME: ${MYSQL_USER}
+      DB_PASSWORD: ${MYSQL_PASSWORD}
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      MONGO_URI: mongodb://${MONGO_USER}:${MONGO_PASSWORD}@mongo:27017/${MONGO_DATABASE}?authSource=admin
+      # === 보안 (.env.prod 에서 주입) ===
+      JWT_SECRET: ${JWT_SECRET:?required}
+      COOKIE_DOMAIN: ${COOKIE_DOMAIN:?required}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:?required}
+      # === OAuth ===
+      KAKAO_REST_API_KEY: ${KAKAO_REST_API_KEY:?required}
+      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET:-}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:?required}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:?required}
+      # === AWS S3 ===
+      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY:?required}
+      AWS_SECRET_KEY: ${AWS_SECRET_KEY:?required}
+      AWS_REGION: ${AWS_REGION:-ap-northeast-2}
+      S3_BUCKET: ${S3_BUCKET:?required}
+      # === 토스페이먼츠 ===
+      TOSS_CLIENT_KEY: ${TOSS_CLIENT_KEY:?required}
+      TOSS_SECRET_KEY: ${TOSS_SECRET_KEY:?required}
+      TOSS_WEBHOOK_SECRET: ${TOSS_WEBHOOK_SECRET:-}
+      # === SMTP (이메일 인증) ===
+      MAIL_HOST: ${MAIL_HOST:?required}
+      MAIL_PORT: ${MAIL_PORT:-587}
+      MAIL_USERNAME: ${MAIL_USERNAME:?required}
+      MAIL_PASSWORD: ${MAIL_PASSWORD:?required}
+      MAIL_FROM: ${MAIL_FROM:-noreply@sseulang.com}
+    ports:
+      # nginx 가 호스트 80/443 → app 의 8080 으로 reverse proxy.
+      # 외부에 8080 직접 노출하려면 "8080:8080" 으로 변경 (권장 X — TLS 없이 노출).
+      - "127.0.0.1:8080:8080"
+    networks: [internal]
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/actuator/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 60s
+      retries: 3
+
+volumes:
+  mysql-data:
+  redis-data:
+  mongo-data:
+
+networks:
+  internal:
+    driver: bridge

--- a/docs/PROD_DEPLOY.md
+++ b/docs/PROD_DEPLOY.md
@@ -1,0 +1,215 @@
+# 쓸랭 프로덕션 배포 가이드
+
+> Docker Compose 기반. 호스트(EC2)에 nginx 가 80/443 → app:8080 으로 reverse proxy.
+> EC2 + Let's Encrypt 절차는 별도 문서 (`#91 task` 작업 후 추가).
+
+---
+
+## 1. 사전 준비
+
+### 1.1 EC2 호스트
+- Amazon Linux 2023 또는 Ubuntu 22.04+
+- 최소 t3.small (2GB RAM) 권장 — JVM heap + 3개 DB 컨테이너
+- Docker + Docker Compose plugin 설치
+  ```bash
+  sudo yum install -y docker
+  sudo systemctl enable --now docker
+  sudo usermod -aG docker $USER   # 재로그인 필요
+  ```
+- nginx 설치 (호스트 패키지 — 컨테이너 외부)
+  ```bash
+  sudo yum install -y nginx
+  ```
+
+### 1.2 외부 서비스 키 발급 (.env.prod 채우기 전)
+- **JWT_SECRET**: `openssl rand -hex 64`
+- **카카오**: 콘솔 → 앱 키 → REST API 키
+  - 사이트 도메인 / Redirect URI 등록 (https://sseulang.com 등)
+- **구글 OAuth**: Google Cloud Console → OAuth 2.0 클라이언트
+  - 승인된 redirect URI: `https://sseulang.com/auth/google/callback`
+- **AWS IAM**: S3 PutObject/GetObject/DeleteObject/CopyObject 권한 (특정 버킷 한정)
+- **토스페이먼츠**: 운영 키 (테스트 키 X). webhook secret 도 콘솔에서 발급
+- **SMTP**: Gmail App Password / AWS SES / Naver Works 중 택
+
+---
+
+## 2. 코드 + 환경 설정
+
+```bash
+# 1. 프로젝트 clone
+git clone git@github.com:sseullaeng/sl-server.git
+cd sl-server
+
+# 2. 환경변수 파일 복사 + 채우기
+cp .env.prod.example .env.prod
+vim .env.prod   # 모든 [필수] 항목 채움
+
+# 3. 권한 — 다른 사용자 읽기 차단 (비밀키 노출 방지)
+chmod 600 .env.prod
+```
+
+`.env.prod` 미채움 항목 확인 — 필수 변수에 `:?required` 가드가 걸려 있어 빠지면 컨테이너가 즉시 실패합니다.
+
+---
+
+## 3. 빌드 + 기동
+
+### 3.1 Image 빌드
+```bash
+docker build -t sseulang-backend:latest .
+```
+- Multi-stage build — Gradle 8 + JDK 21 → JRE 21 alpine
+- Asia/Seoul TZ 강제 (`-Duser.timezone=Asia/Seoul`)
+- 비특권 user (`sseulang`, uid 1000)
+- HEALTHCHECK: `/actuator/health`
+
+### 3.2 Compose 기동
+```bash
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+docker compose -f docker-compose.prod.yml ps
+```
+서비스:
+- `sseulang-mysql`   :3306 (internal only)
+- `sseulang-redis`   :6379 (internal only)
+- `sseulang-mongo`   :27017 (internal only)
+- `sseulang-app`     :8080 (host loopback 만 노출 — `127.0.0.1:8080`)
+
+전부 healthy 확인:
+```bash
+docker compose -f docker-compose.prod.yml ps --format json | jq '.[].Health'
+```
+
+### 3.3 첫 기동 검증
+```bash
+# 직접 접근 (호스트에서)
+curl -fsS http://127.0.0.1:8080/actuator/health
+# → {"status":"UP"}
+
+# 로그
+docker logs -f sseulang-app
+# Flyway 마이그레이션 V1 ~ V11 적용 + Tomcat 8080 LISTEN 확인
+```
+
+---
+
+## 4. nginx reverse proxy
+
+`/etc/nginx/conf.d/sseulang.conf`:
+```nginx
+server {
+    listen 80;
+    server_name sseulang.com www.sseulang.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name sseulang.com www.sseulang.com;
+
+    # Let's Encrypt 인증서 (#91 작업)
+    ssl_certificate     /etc/letsencrypt/live/sseulang.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/sseulang.com/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    # WebSocket 업그레이드
+    location /ws-stomp {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade           $http_upgrade;
+        proxy_set_header   Connection        "upgrade";
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_read_timeout 3600s;
+    }
+    location /ws-stomp-native {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade           $http_upgrade;
+        proxy_set_header   Connection        "upgrade";
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_read_timeout 3600s;
+    }
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+        client_max_body_size 10m;   # S3 presigned 업로드 X — 백엔드 직접 업로드 없음. 여유 설정.
+    }
+}
+```
+
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+---
+
+## 5. 갱신 / 롤백
+
+### 갱신
+```bash
+git pull
+docker build -t sseulang-backend:$(git rev-parse --short HEAD) .
+APP_IMAGE_TAG=$(git rev-parse --short HEAD) \
+  docker compose -f docker-compose.prod.yml --env-file .env.prod up -d app
+# DB 컨테이너는 영향 X — app 만 새 image 로 교체
+```
+
+### 롤백
+```bash
+APP_IMAGE_TAG=<이전-sha> \
+  docker compose -f docker-compose.prod.yml --env-file .env.prod up -d app
+```
+
+### Flyway 롤백 시 주의
+Flyway 는 forward-only — 마이그레이션 거꾸로 돌리는 자동 도구 없음. 스키마 변경 동반 롤백은 사전 백업 + 수동 SQL.
+
+---
+
+## 6. 백업 / 운영
+
+### MySQL dump (cron 권장)
+```bash
+docker exec sseulang-mysql mysqldump \
+  -u root -p$MYSQL_ROOT_PASSWORD \
+  --single-transaction --quick sseulang > backup-$(date +%F).sql
+```
+
+### Mongo dump
+```bash
+docker exec sseulang-mongo mongodump \
+  --username sseulang --password $MONGO_PASSWORD \
+  --authenticationDatabase admin --db sseulang \
+  --archive | gzip > mongo-$(date +%F).gz
+```
+
+### Redis 는 RDB 자동 (`--appendonly yes`)
+- 컨테이너 volume `redis-data` 가 호스트에 영속.
+- AOF 만으로도 RT/blacklist 복원 가능.
+
+---
+
+## 7. 흔한 이슈
+
+| 증상 | 해결 |
+|---|---|
+| `mysql: Driver loading was attempted ...` | DB_URL 의 timezone parameter 누락. `serverTimezone=Asia/Seoul` 포함 |
+| 컨테이너 즉시 종료 + `required` 메시지 | `.env.prod` 의 `:?required` 변수 누락 |
+| Flyway `Validate failed` | local 에서 미적용 마이그 prod 에 먼저 들어가 hash mismatch — 보통 `baseline-on-migrate: true` 로 자동 해결 |
+| `503 from nginx` | app 컨테이너 healthy 안 됐거나 포트 차이. `docker logs sseulang-app` 확인 |
+| `Cookie SameSite=Strict 인데 OAuth 쿠키 안 박힘` | 외부 redirect 후 첫 요청 — Lax 가 아니면 누락. SDK redirect URI 도메인이 동일 site 인지 확인 |
+| Toss webhook 타임아웃 | nginx `proxy_read_timeout` ≥ 30s. 토스 default 30s 재시도 |
+
+---
+
+## 8. 다음 단계 (이 문서 외)
+
+- [ ] **#91** EC2 인스턴스 생성 + Let's Encrypt (`certbot --nginx`)
+- [ ] **#93** Swagger prod 노출 정책 결정 (인증 필수 / IP 제한 / 비활성)
+- [ ] CI/CD — GitHub Actions 로 image build → ECR/Docker Hub push → SSH 갱신 (선택)
+- [ ] CloudWatch 또는 Loki 로 로그 수집 (선택)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -79,6 +79,8 @@ app:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
   email:
     from: ${MAIL_FROM:noreply@sseulang.test}
+    # 인증 메일 본문 클릭 URL prefix. 프론트 라우트 (`/auth/verify-email?token=...`).
+    verification-url-base: ${APP_EMAIL_VERIFICATION_URL_BASE:https://sseulang.com/auth/verify-email}
 
 logging:
   level:


### PR DESCRIPTION
## Summary
배포 task #90 + #92 통합 — 프로덕션 환경 구축 기반. 코드 변경 X (배포 인프라만).

## Dockerfile (multi-stage)
- stage 1: `gradle:8.14-jdk21-jammy` → bootJar (의존성 layer 캐시 활용)
- stage 2: `eclipse-temurin:21-jre-alpine`
- Asia/Seoul TZ 강제 (`-Duser.timezone=Asia/Seoul`)
- 비특권 user (`sseulang`, uid 1000)
- HEALTHCHECK: `/actuator/health`
- JVM: G1GC + `MaxRAMPercentage=75` (컨테이너 메모리 적응)

## docker-compose.prod.yml
- 4 services — `mysql / redis / mongo / app` — internal bridge network
- 외부 노출: `app:8080` 만 (`127.0.0.1` loopback 한정 — nginx 가 80/443 reverse proxy)
- DB/Redis/Mongo **외부 노출 X** (보안)
- 모든 비밀번호 `${VAR:?required}` 가드 — 미설정 시 컨테이너 즉시 실패
- `depends_on` healthcheck — app 은 DB healthy 후에만 기동
- redis `--requirepass`, mongo auth, mysql 비밀번호 모두 `.env.prod` 주입

## .env.prod.example
prod 전용 모든 환경변수 — 섹션별 `[필수]/[옵션]` 표시:
- JWT / Cookie / CORS
- MySQL / Redis / MongoDB (compose 내부 service 접근)
- OAuth (KAKAO / GOOGLE)
- AWS S3
- 토스페이먼츠 (운영 키 + webhook secret)
- SMTP / Email
- `APP_EMAIL_VERIFICATION_URL_BASE` (이메일 인증 메일 본문 URL prefix)

## application-prod.yml
- `app.email.verification-url-base` 매핑 추가 — `.env.prod` 의 `APP_EMAIL_VERIFICATION_URL_BASE` 주입
- default: `https://sseulang.com/auth/verify-email`

## docs/PROD_DEPLOY.md
- 사전 준비 (EC2 + Docker + nginx + 외부 키 발급)
- 빌드/기동/검증 절차
- nginx reverse proxy 설정 (WebSocket 업그레이드 포함)
- 갱신/롤백 (image tag 교체)
- 백업 (mysqldump / mongodump / Redis AOF)
- 흔한 이슈 트러블슈팅
- 다음 단계 (#91 Let's Encrypt, #93 Swagger 정책, CI/CD)

## .gitignore
- `.env.prod.example` 예외 추가 (`.env.*` 무시 대상에서 제외)

## Test plan
- [x] 컴파일 통과 (`./gradlew compileJava`)
- [ ] **Image 빌드 검증** (PR 머지 후 user 가): `docker build -t sseulang-backend:latest .`
- [ ] **컴포즈 기동 검증** (PR 머지 후 user 가): `cp .env.prod.example .env.prod && vim .env.prod && docker compose -f docker-compose.prod.yml --env-file .env.prod up -d`
- [ ] 다음 작업: #91 EC2 + Let's Encrypt, #93 Swagger prod 정책

🤖 Generated with [Claude Code](https://claude.com/claude-code)