### PR TITLE
feat: delivery 실시간 위치 추적 (STOMP) — follow-up #51 closed

### DIFF
--- a/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
@@ -206,6 +206,28 @@ public class DeliveryApplicationService {
         return deliveryRepository.findOpenList(pageable).map(DeliveryResult::from);
     }
 
+    /**
+     * 외부 도메인이 참여자 검증할 때 사용 (예: STOMP location SUBSCRIBE 인가).
+     * 참여자 아니면 {@link ErrorCode#DELIVERY_FORBIDDEN}.
+     */
+    public void requireParticipant(Long deliveryId, Long userId) {
+        DeliveryRequest d = findOrThrow(deliveryId);
+        if (!d.isParticipant(userId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
+        }
+    }
+
+    /**
+     * 외부 도메인이 라이더 본인 검증할 때 사용 (예: STOMP location publish 권한).
+     * 수락된 라이더 아니면 {@link ErrorCode#DELIVERY_FORBIDDEN}.
+     */
+    public void requireRider(Long deliveryId, Long userId) {
+        DeliveryRequest d = findOrThrow(deliveryId);
+        if (!d.isRider(userId)) {
+            throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
+        }
+    }
+
     public Page<DeliveryResult> listMine(Long userId, Pageable pageable) {
         return deliveryRepository.findByParticipant(userId, pageable).map(DeliveryResult::from);
     }

--- a/src/main/java/com/sseulang/domain/delivery/application/DeliveryLocationApplicationService.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/DeliveryLocationApplicationService.java
@@ -1,0 +1,73 @@
+package com.sseulang.domain.delivery.application;
+
+import com.sseulang.domain.delivery.domain.DeliveryLocation;
+import com.sseulang.domain.delivery.domain.DeliveryLocationCache;
+import com.sseulang.global.websocket.RealtimePublisher;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * 배달 실시간 위치 publish/subscribe 흐름 (follow-up #51).
+ *
+ * <ul>
+ *   <li>{@link #publishLocation} — 라이더가 STOMP SEND 또는 REST 로 좌표 push.
+ *       권한 검증(rider 본인) → 좌표 검증({@link DeliveryLocation} VO) → Redis 캐시 → STOMP broadcast.</li>
+ *   <li>{@link #findLast} — 참여자가 마지막 위치 조회 (재연결 / 최초 진입). Redis 캐시만 read.</li>
+ * </ul>
+ *
+ * <p><b>저장 정책</b>: DB 저장 X — Redis 휘발 캐시 (TTL 30분, 마지막 1건만). history 보관 안 함.
+ * 정산완료 / 취소 후엔 자동 만료 또는 호출자가 evict.</p>
+ *
+ * <p><b>동시성</b>: 같은 deliveryId 에 라이더가 여러 device 로 push 하면 마지막 SET 이 win
+ * (race 무방 — UX 상 큰 문제 없음). DB 트랜잭션 외부라 잠금 없음.</p>
+ */
+@Service
+public class DeliveryLocationApplicationService {
+
+    private final DeliveryApplicationService deliveryApplicationService;
+    private final DeliveryLocationCache locationCache;
+    private final RealtimePublisher realtimePublisher;
+    private final Clock clock;
+
+    public DeliveryLocationApplicationService(
+            DeliveryApplicationService deliveryApplicationService,
+            DeliveryLocationCache locationCache,
+            RealtimePublisher realtimePublisher,
+            Clock clock
+    ) {
+        this.deliveryApplicationService = deliveryApplicationService;
+        this.locationCache = locationCache;
+        this.realtimePublisher = realtimePublisher;
+        this.clock = clock;
+    }
+
+    /**
+     * 라이더 좌표 push. 라이더 본인 검증 → 좌표 범위 검증(VO 생성자) → 캐시 + broadcast.
+     *
+     * <p>{@code recordedAt} 미주입 시 서버 시각으로 채움. 클라이언트 디바이스 시계가 어긋날 수 있어
+     * UI 표시는 서버 시각 기준 권장.</p>
+     */
+    public void publishLocation(
+            Long deliveryId, Long riderId,
+            double latitude, double longitude,
+            Double accuracyM, Instant recordedAt
+    ) {
+        deliveryApplicationService.requireRider(deliveryId, riderId);
+        Instant ts = (recordedAt != null) ? recordedAt : Instant.now(clock);
+        DeliveryLocation location = new DeliveryLocation(latitude, longitude, accuracyM, ts);
+
+        locationCache.save(deliveryId, location);
+        realtimePublisher.publishDeliveryLocation(deliveryId, location);
+    }
+
+    /**
+     * 참여자(요청자/라이더) 가 마지막 위치 조회. 캐시 미존재 / TTL 만료 시 빈 Optional.
+     */
+    public Optional<DeliveryLocation> findLast(Long deliveryId, Long viewerId) {
+        deliveryApplicationService.requireParticipant(deliveryId, viewerId);
+        return locationCache.findLast(deliveryId);
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryLocation.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryLocation.java
@@ -1,0 +1,43 @@
+package com.sseulang.domain.delivery.domain;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+
+import java.time.Instant;
+
+/**
+ * 라이더 실시간 위치 VO. WGS84 좌표 + 정확도 + 기록 시각.
+ *
+ * <p>DB 저장 X — Redis 휘발 캐시 (TTL 30분). 마지막 위치만 보존하므로 history 없음.
+ * 좌표 범위 검증은 생성 시 강제. 위경도가 한국 범위(33~39N / 124~132E) 밖이면
+ * {@link ErrorCode#DELIVERY_LOCATION_INVALID} — GPS 노이즈 / 변조 차단.</p>
+ *
+ * @param latitude   위도 (33.0 ~ 39.0, 한국 범위)
+ * @param longitude  경도 (124.0 ~ 132.0, 한국 범위)
+ * @param accuracyM  GPS 정확도 (m). null 허용. ≥ 0
+ * @param recordedAt 라이더 디바이스 측 기록 시각. null 허용 — 서버가 채움
+ */
+public record DeliveryLocation(
+        double latitude,
+        double longitude,
+        Double accuracyM,
+        Instant recordedAt
+) {
+
+    /** WGS84 위경도 한국 범위 (서비스 영역). 해외 배달 도입 시 확장. */
+    private static final double LAT_MIN = 33.0;
+    private static final double LAT_MAX = 39.0;
+    private static final double LNG_MIN = 124.0;
+    private static final double LNG_MAX = 132.0;
+
+    public DeliveryLocation {
+        if (Double.isNaN(latitude) || Double.isNaN(longitude)
+                || latitude < LAT_MIN || latitude > LAT_MAX
+                || longitude < LNG_MIN || longitude > LNG_MAX) {
+            throw new BusinessException(ErrorCode.DELIVERY_LOCATION_INVALID);
+        }
+        if (accuracyM != null && (accuracyM.isNaN() || accuracyM < 0)) {
+            throw new BusinessException(ErrorCode.DELIVERY_LOCATION_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryLocationCache.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryLocationCache.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.delivery.domain;
+
+import java.util.Optional;
+
+/**
+ * 배달의 마지막 위치를 휘발 저장하는 캐시 포트. 구현은 Redis 어댑터.
+ *
+ * <p>설계:</p>
+ * <ul>
+ *   <li>key: {@code delivery:loc:{deliveryId}}</li>
+ *   <li>TTL: 30분 (배달 시간 ≪ 30분 가정. 정산완료 후 자동 만료)</li>
+ *   <li>마지막 위치 1건만 — history X (DB 비저장 정책, 가이드 §4.13)</li>
+ * </ul>
+ */
+public interface DeliveryLocationCache {
+
+    /** 마지막 위치 저장 (덮어쓰기). TTL 갱신. */
+    void save(Long deliveryId, DeliveryLocation location);
+
+    /** 마지막 위치 조회. 미존재 / TTL 만료 시 빈 Optional. */
+    Optional<DeliveryLocation> findLast(Long deliveryId);
+
+    /** 강제 만료 — 정산완료 / 취소 시 즉시 정리 (선택). */
+    void evict(Long deliveryId);
+}

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/redis/RedisDeliveryLocationCache.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/redis/RedisDeliveryLocationCache.java
@@ -1,0 +1,70 @@
+package com.sseulang.domain.delivery.infrastructure.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sseulang.domain.delivery.domain.DeliveryLocation;
+import com.sseulang.domain.delivery.domain.DeliveryLocationCache;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * {@link DeliveryLocationCache} Redis 어댑터. JSON 직렬화 + TTL 30분.
+ *
+ * <p>키 패턴: {@code delivery:loc:{deliveryId}}. {@code save} 호출마다 TTL 갱신
+ * (라이더가 publish 멈추면 30분 후 자동 정리).</p>
+ *
+ * <p>Redis 미가용 / 직렬화 실패 시 RuntimeException — 호출자(ApplicationService) 가
+ * trans 안에서 호출하지만 broadcast 실패는 critical 아니라 호출자 측에서 catch 해 무시 가능.
+ * 본 어댑터는 단순 에러 그대로 던짐.</p>
+ */
+@Component
+class RedisDeliveryLocationCache implements DeliveryLocationCache {
+
+    private static final String KEY_PREFIX = "delivery:loc:";
+    private static final Duration TTL = Duration.ofMinutes(30);
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper objectMapper;
+
+    RedisDeliveryLocationCache(StringRedisTemplate redis, ObjectMapper objectMapper) {
+        this.redis = redis;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void save(Long deliveryId, DeliveryLocation location) {
+        try {
+            String json = objectMapper.writeValueAsString(location);
+            redis.opsForValue().set(key(deliveryId), json, TTL);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("DeliveryLocation 직렬화 실패 deliveryId=" + deliveryId, e);
+        }
+    }
+
+    @Override
+    public Optional<DeliveryLocation> findLast(Long deliveryId) {
+        String json = redis.opsForValue().get(key(deliveryId));
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, DeliveryLocation.class));
+        } catch (JsonProcessingException e) {
+            // 손상된 JSON — 삭제 + 빈 응답
+            redis.delete(key(deliveryId));
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void evict(Long deliveryId) {
+        redis.delete(key(deliveryId));
+    }
+
+    private static String key(Long deliveryId) {
+        return KEY_PREFIX + deliveryId;
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryLocationController.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryLocationController.java
@@ -1,0 +1,54 @@
+package com.sseulang.domain.delivery.presentation;
+
+import com.sseulang.domain.delivery.application.DeliveryLocationApplicationService;
+import com.sseulang.domain.delivery.domain.DeliveryLocation;
+import com.sseulang.domain.delivery.presentation.dto.DeliveryLocationMessage;
+import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 배달 실시간 위치 REST fallback (follow-up #51).
+ *
+ * <p>STOMP 구독을 막 시작한 클라이언트 (재연결 / 최초 진입) 가 마지막 좌표를 즉시 받기 위한
+ * snapshot endpoint. 이후 갱신은 STOMP topic 으로.</p>
+ *
+ * <p>참여자(요청자/라이더) 만. 그 외 403 DELIVERY_FORBIDDEN. 캐시 미존재 시 204 No Content.</p>
+ */
+@Tag(name = "Delivery", description = "배달 실시간 위치 (REST fallback)")
+@RestController
+@RequestMapping("/api/v1/deliveries/{id}/location")
+public class DeliveryLocationController {
+
+    private final DeliveryLocationApplicationService locationService;
+
+    public DeliveryLocationController(DeliveryLocationApplicationService locationService) {
+        this.locationService = locationService;
+    }
+
+    @Operation(summary = "마지막 위치 조회 (REST fallback)",
+            description = "참여자만. STOMP 구독 시작 직후 마지막 좌표 즉시 표시용. "
+                    + "캐시 미존재 / TTL 만료 시 204 No Content.")
+    @GetMapping("/last")
+    public ResponseEntity<ApiResponse<DeliveryLocationMessage>> getLast(
+            @AuthenticationPrincipal Long viewerId,
+            @PathVariable("id") Long deliveryId
+    ) {
+        return locationService.findLast(deliveryId, viewerId)
+                .map(loc -> ResponseEntity.ok(ApiResponse.ok(toMessage(loc))))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NO_CONTENT).build());
+    }
+
+    private static DeliveryLocationMessage toMessage(DeliveryLocation loc) {
+        return new DeliveryLocationMessage(
+                loc.latitude(), loc.longitude(), loc.accuracyM(), loc.recordedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryLocationStompController.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryLocationStompController.java
@@ -1,0 +1,50 @@
+package com.sseulang.domain.delivery.presentation;
+
+import com.sseulang.domain.delivery.application.DeliveryLocationApplicationService;
+import com.sseulang.domain.delivery.presentation.dto.DeliveryLocationMessage;
+import jakarta.validation.Valid;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+
+/**
+ * 라이더 좌표 STOMP SEND 핸들러 (follow-up #51).
+ *
+ * <pre>
+ *   destination: /app/delivery/{deliveryId}/location
+ *   payload    : DeliveryLocationMessage (lat, lng, accuracyM?, recordedAt?)
+ *   broadcast  : /topic/delivery/{deliveryId}/location  (참여자만 SUBSCRIBE 가능)
+ * </pre>
+ *
+ * <p>인증은 {@link com.sseulang.global.websocket.StompAuthChannelInterceptor} 의 CONNECT
+ * 단계에서 이미 처리. 본 핸들러는 Authentication 의 principal(userId) 만 추출 후 라이더 검증을
+ * ApplicationService 에 위임.</p>
+ *
+ * <p>SEND 자체는 화이트리스트 X — ApplicationService 가 라이더 본인 검증으로 거부.
+ * 다른 사용자가 임의의 destination 으로 SEND 보내도 publishLocation 의 requireRider 가 차단.</p>
+ */
+@Controller
+public class DeliveryLocationStompController {
+
+    private final DeliveryLocationApplicationService locationService;
+
+    public DeliveryLocationStompController(DeliveryLocationApplicationService locationService) {
+        this.locationService = locationService;
+    }
+
+    @MessageMapping("/delivery/{deliveryId}/location")
+    public void onLocation(
+            @DestinationVariable Long deliveryId,
+            @Valid @Payload DeliveryLocationMessage msg,
+            Authentication auth
+    ) {
+        Long riderId = (Long) auth.getPrincipal();
+        locationService.publishLocation(
+                deliveryId, riderId,
+                msg.latitude(), msg.longitude(),
+                msg.accuracyM(), msg.recordedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryLocationMessage.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryLocationMessage.java
@@ -1,0 +1,26 @@
+package com.sseulang.domain.delivery.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+/**
+ * 배달 실시간 위치 메시지 (STOMP SEND / 응답 broadcast / REST 응답 공용).
+ *
+ * <p>한국 좌표 범위(33~39N / 124~132E) 밖이면 백엔드에서 400 거절. accuracy/recordedAt 은 옵션.</p>
+ */
+@Schema(description = "배달 실시간 위치 — 한국 위경도 범위 강제. accuracy/recordedAt 옵션.")
+public record DeliveryLocationMessage(
+        @Schema(example = "37.4979", description = "WGS84 위도 (33.0~39.0)")
+        double latitude,
+
+        @Schema(example = "127.0276", description = "WGS84 경도 (124.0~132.0)")
+        double longitude,
+
+        @Schema(example = "8.5", description = "GPS 정확도 (m). 옵션", nullable = true)
+        Double accuracyM,
+
+        @Schema(example = "2026-05-03T10:00:00.123Z",
+                description = "라이더 디바이스 기록 시각 (ISO Instant). 미주입 시 서버 시각", nullable = true)
+        Instant recordedAt
+) { }

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -94,7 +94,8 @@ public enum ErrorCode {
     DELIVERY_FORBIDDEN(HttpStatus.FORBIDDEN, "배달 요청에 대한 권한이 없습니다."),
     DELIVERY_INVALID_STATE(HttpStatus.BAD_REQUEST, "현재 상태에서 수행할 수 없는 동작입니다."),
     DELIVERY_ALREADY_ACCEPTED(HttpStatus.CONFLICT, "이미 다른 라이더가 수락한 요청입니다."),
-    DELIVERY_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "본인이 등록한 요청은 수락할 수 없습니다.");
+    DELIVERY_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "본인이 등록한 요청은 수락할 수 없습니다."),
+    DELIVERY_LOCATION_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 위치 좌표입니다.");
 
     private final HttpStatus status;
     private final String defaultMessage;

--- a/src/main/java/com/sseulang/global/websocket/RealtimePublisher.java
+++ b/src/main/java/com/sseulang/global/websocket/RealtimePublisher.java
@@ -30,4 +30,12 @@ public class RealtimePublisher {
         // Spring UserDestinationMessageHandler 가 /user/{userId}/queue/notifications 로 라우팅.
         template.convertAndSendToUser(String.valueOf(userId), "/queue/notifications", payload);
     }
+
+    /**
+     * 배달 실시간 위치 broadcast — {@code /topic/delivery/{deliveryId}/location}.
+     * 참여자(요청자/라이더) 만 SUBSCRIBE 허용 — 인가 검증은 {@link com.sseulang.global.websocket.StompAuthChannelInterceptor}.
+     */
+    public void publishDeliveryLocation(Long deliveryId, Object payload) {
+        template.convertAndSend("/topic/delivery/" + deliveryId + "/location", payload);
+    }
 }

--- a/src/main/java/com/sseulang/global/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/sseulang/global/websocket/StompAuthChannelInterceptor.java
@@ -2,6 +2,7 @@ package com.sseulang.global.websocket;
 
 import com.sseulang.domain.auth.domain.AccessTokenBlacklist;
 import com.sseulang.domain.chat.application.ChatRoomApplicationService;
+import com.sseulang.domain.delivery.application.DeliveryApplicationService;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import com.sseulang.global.security.JwtClaims;
@@ -32,6 +33,7 @@ import java.util.List;
  *   <li>SUBSCRIBE — destination allowlist (Codex 게이트 1 보강):
  *     <ul>
  *       <li>{@code /topic/chat-room/{roomId}} — 채팅방 참여자만</li>
+ *       <li>{@code /topic/delivery/{deliveryId}/location} — 배달 참여자(요청자/라이더)만 (follow-up #51)</li>
  *       <li>{@code /user/queue/messages}, {@code /user/queue/notifications} — Spring 자동 본인 라우팅</li>
  *       <li>그 외 destination — {@link ErrorCode#FORBIDDEN}</li>
  *     </ul>
@@ -43,21 +45,26 @@ import java.util.List;
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
     private static final String CHAT_TOPIC_PREFIX = "/topic/chat-room/";
+    private static final String DELIVERY_LOCATION_TOPIC_PREFIX = "/topic/delivery/";
+    private static final String DELIVERY_LOCATION_TOPIC_SUFFIX = "/location";
     private static final String USER_QUEUE_MESSAGES = "/user/queue/messages";
     private static final String USER_QUEUE_NOTIFICATIONS = "/user/queue/notifications";
     private static final String AUTH_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
     private final ChatRoomApplicationService chatRoomService;
+    private final DeliveryApplicationService deliveryApplicationService;
     private final JwtProvider jwtProvider;
     private final AccessTokenBlacklist accessTokenBlacklist;
 
     public StompAuthChannelInterceptor(
             ChatRoomApplicationService chatRoomService,
+            DeliveryApplicationService deliveryApplicationService,
             JwtProvider jwtProvider,
             AccessTokenBlacklist accessTokenBlacklist
     ) {
         this.chatRoomService = chatRoomService;
+        this.deliveryApplicationService = deliveryApplicationService;
         this.jwtProvider = jwtProvider;
         this.accessTokenBlacklist = accessTokenBlacklist;
     }
@@ -126,6 +133,11 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             chatRoomService.requireParticipant(parseRoomId(destination), userId);
             return;
         }
+        if (destination.startsWith(DELIVERY_LOCATION_TOPIC_PREFIX)
+                && destination.endsWith(DELIVERY_LOCATION_TOPIC_SUFFIX)) {
+            deliveryApplicationService.requireParticipant(parseDeliveryId(destination), userId);
+            return;
+        }
         if (destination.equals(USER_QUEUE_MESSAGES) || destination.equals(USER_QUEUE_NOTIFICATIONS)) {
             // Spring UserDestinationMessageHandler 가 본인 destination 으로 자동 라우팅 — 통과.
             return;
@@ -138,6 +150,19 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         try {
             return Long.parseLong(destination.substring(CHAT_TOPIC_PREFIX.length()));
         } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    /** {@code /topic/delivery/{id}/location} 에서 id 추출. */
+    private static Long parseDeliveryId(String destination) {
+        try {
+            String mid = destination.substring(
+                    DELIVERY_LOCATION_TOPIC_PREFIX.length(),
+                    destination.length() - DELIVERY_LOCATION_TOPIC_SUFFIX.length()
+            );
+            return Long.parseLong(mid);
+        } catch (NumberFormatException | IndexOutOfBoundsException e) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST);
         }
     }

--- a/src/test/java/com/sseulang/domain/delivery/domain/DeliveryLocationTest.java
+++ b/src/test/java/com/sseulang/domain/delivery/domain/DeliveryLocationTest.java
@@ -1,0 +1,60 @@
+package com.sseulang.domain.delivery.domain;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DeliveryLocationTest {
+
+    @Test
+    @DisplayName("정상 한국 좌표_생성 OK")
+    void 정상_생성() {
+        DeliveryLocation loc = new DeliveryLocation(37.4979, 127.0276, 8.5, Instant.parse("2026-05-03T10:00:00Z"));
+        assertThat(loc.latitude()).isEqualTo(37.4979);
+        assertThat(loc.longitude()).isEqualTo(127.0276);
+        assertThat(loc.accuracyM()).isEqualTo(8.5);
+    }
+
+    @Test
+    @DisplayName("위도 한국 범위 밖_DELIVERY_LOCATION_INVALID")
+    void 위도_범위밖_거부() {
+        assertThatThrownBy(() -> new DeliveryLocation(45.0, 127.0276, null, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DELIVERY_LOCATION_INVALID);
+    }
+
+    @Test
+    @DisplayName("경도 한국 범위 밖_DELIVERY_LOCATION_INVALID")
+    void 경도_범위밖_거부() {
+        assertThatThrownBy(() -> new DeliveryLocation(37.5, 100.0, null, null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("NaN 좌표_거부")
+    void NaN_거부() {
+        assertThatThrownBy(() -> new DeliveryLocation(Double.NaN, 127.0, null, null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("음수 accuracy_거부")
+    void accuracy_음수_거부() {
+        assertThatThrownBy(() -> new DeliveryLocation(37.5, 127.0, -1.0, null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("accuracy null_허용")
+    void accuracy_null_OK() {
+        DeliveryLocation loc = new DeliveryLocation(37.5, 127.0, null, null);
+        assertThat(loc.accuracyM()).isNull();
+    }
+}

--- a/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
@@ -69,7 +69,9 @@ class StompAuthChannelInterceptorTest {
         blacklist = mock(AccessTokenBlacklist.class);
         when(blacklist.isBlacklisted(anyString())).thenReturn(false);
 
-        interceptor = new StompAuthChannelInterceptor(roomSvc, jwtProvider, blacklist);
+        com.sseulang.domain.delivery.application.DeliveryApplicationService deliverySvc =
+                org.mockito.Mockito.mock(com.sseulang.domain.delivery.application.DeliveryApplicationService.class);
+        interceptor = new StompAuthChannelInterceptor(roomSvc, deliverySvc, jwtProvider, blacklist);
 
         Item item = itemRepo.save(Item.create(SELLER, null, "물건", "d", 1L, null, null, TradeType.판매, null));
         roomId = roomSvc.openFor(BUYER, item.getId()).id();


### PR DESCRIPTION
## Summary
follow-up issue #51 처리. 배달 진행 중 라이더 좌표를 요청자가 실시간 확인. DB 저장 X (Redis 휘발 캐시).

Closes #51.

## STOMP 흐름
```
라이더 → SEND  /app/delivery/{id}/location  {lat, lng, accuracyM?, recordedAt?}
                  ↓
              백엔드: rider 본인 검증 + 좌표 검증 + Redis 캐시 + broadcast
                  ↓
요청자 → SUBSCRIBE /topic/delivery/{id}/location
재연결 → GET /api/v1/deliveries/{id}/location/last  (REST fallback)
```

## 도메인 (delivery.domain)
- `DeliveryLocation` VO — WGS84 위경도 **한국 범위 강제** (33~39N / 124~132E), NaN/음수 accuracy 거부
- `DeliveryLocationCache` 포트 — save/findLast/evict
- 잘못된 좌표 → 400 `DELIVERY_LOCATION_INVALID` (신규 ErrorCode)

## 인프라 (delivery.infrastructure.redis)
- `RedisDeliveryLocationCache` — Spring StringRedisTemplate + Jackson JSON
- key `delivery:loc:{id}`, TTL **30분** (배달 시간 ≪ 30분 가정)
- save 호출 시 TTL 갱신. publish 멈추면 자동 만료
- 손상된 JSON 즉시 evict 후 빈 응답

## 애플리케이션
- `DeliveryLocationApplicationService.publishLocation` — rider 본인 검증 → 좌표 검증(VO) → 캐시 + STOMP broadcast
- `DeliveryLocationApplicationService.findLast` — 참여자 검증 → 캐시 read
- `DeliveryApplicationService` 에 `requireParticipant` / `requireRider` 가드 추가 (외부 도메인 호출용)

## 프레젠테이션
- `DeliveryLocationStompController` `@MessageMapping("/delivery/{id}/location")` → SEND 처리
- `DeliveryLocationController` `GET /api/v1/deliveries/{id}/location/last` → REST fallback (참여자만, 캐시 미존재 시 204 No Content)

## STOMP 인가 (StompAuthChannelInterceptor)
- `/topic/delivery/{id}/location` SUBSCRIBE allowlist 추가
- 참여자 검증은 `DeliveryApplicationService.requireParticipant` 위임
- 그 외 → `FORBIDDEN`

## 보안 (게이트 1 영역)
- ✅ 라이더만 publish (다른 사용자가 임의 destination SEND 시도 → `DELIVERY_FORBIDDEN`)
- ✅ 참여자만 subscribe (interceptor allowlist)
- ✅ 좌표 범위 강제 (한국 밖 GPS 노이즈/변조 차단)
- ✅ DB 저장 X — 위치 정보 영속화 안 함 (개인정보 보존 최소화)

## Test plan
- [x] 컴파일 통과
- [x] DeliveryLocationTest 6 케이스 (정상 / 위경도 범위 밖 / NaN / 음수 accuracy)
- [x] 전체 603 PASS / 0 FAIL (기존 597 + 신규 6)
- [ ] 백엔드 재시작 후 STOMP 클라이언트로 SEND/SUBSCRIBE 검증 (수동)

## 다음 라운드 (PR #70 머지 후)
- `docs/FRONTEND_INTEGRATION.md` §10.13 Delivery 에 location section 추가 — 클라이언트 가이드 (publish 5초 주기, REST fallback 패턴)
- 또는 §9 WebSocket / STOMP 의 destination 화이트리스트 표 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)