### PR TITLE
feat: webhook body size + amount mismatch audit log — #53 운영 영향 우선 처리

### DIFF
--- a/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
@@ -108,7 +108,17 @@ public class PaymentApplicationService {
         }
 
         // 1차 검증 — 클라가 보낸 amount 와 저장 amount 일치 (위변조 방지).
-        payment.verifyAmount(cmd.amount());
+        try {
+            payment.verifyAmount(cmd.amount());
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == ErrorCode.PAYMENT_AMOUNT_MISMATCH) {
+                log.error("[toss-confirm][AUDIT-AMOUNT-MISMATCH-1] paymentId={} merchantUid={} "
+                        + "expectedAmount={} clientAmount={} requesterId={}",
+                        payment.getId(), payment.getMerchantUid(),
+                        payment.getAmount(), cmd.amount(), cmd.requesterId());
+            }
+            throw e;
+        }
 
         // 멱등 — 이미 완료된 결제는 토스 호출 없이 그대로 반환.
         if (payment.getStatus().isPaid()) {
@@ -134,7 +144,17 @@ public class PaymentApplicationService {
         if (!payment.getMerchantUid().equals(result.orderId())) {
             throw new BusinessException(ErrorCode.PAYMENT_VERIFY_FAILED);
         }
-        payment.verifyAmount(result.amount());
+        try {
+            payment.verifyAmount(result.amount());
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == ErrorCode.PAYMENT_AMOUNT_MISMATCH) {
+                log.error("[toss-confirm][AUDIT-AMOUNT-MISMATCH-2] paymentId={} merchantUid={} "
+                        + "expectedAmount={} tossAmount={} paymentKey={}",
+                        payment.getId(), payment.getMerchantUid(),
+                        payment.getAmount(), result.amount(), result.paymentKey());
+            }
+            throw e;
+        }
 
         boolean newlyPaid = payment.markAsPaid(
                 result.paymentKey(),
@@ -298,7 +318,19 @@ public class PaymentApplicationService {
             return true;  // confirm 흐름으로 이미 처리. 멱등 정상.
         }
         // amount 위변조 검증 — lookup amount 와 우리 저장 amount 일치 확인.
-        payment.verifyAmount(lookup.amount());
+        // mismatch 시 명시적 ERROR 로깅 — audit row 는 트랜잭션 롤백되므로 운영 모니터링이
+        // ERROR level 로그를 잡아 알림으로 활용 (follow-up #53 round 1).
+        try {
+            payment.verifyAmount(lookup.amount());
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == ErrorCode.PAYMENT_AMOUNT_MISMATCH) {
+                log.error("[toss-webhook][AUDIT-AMOUNT-MISMATCH] paymentId={} merchantUid={} "
+                        + "expectedAmount={} lookupAmount={} paymentKey={}",
+                        payment.getId(), payment.getMerchantUid(),
+                        payment.getAmount(), lookup.amount(), lookup.paymentKey());
+            }
+            throw e;
+        }
         boolean newlyPaid = payment.markAsPaid(
                 lookup.paymentKey(), lookup.method(), lookup.approvedAt(), lookup.rawResponse()
         );

--- a/src/main/java/com/sseulang/domain/payment/presentation/WebhookBodySizeFilter.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/WebhookBodySizeFilter.java
@@ -1,0 +1,58 @@
+package com.sseulang.domain.payment.presentation;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * 토스 결제 webhook 의 body size 제한 필터 (follow-up #53).
+ *
+ * <p>{@code @RequestBody String} 으로 전체 payload 를 메모리에 적재하는 구조라
+ * 외부에서 큰 body 를 던지면 OOM / GC 압박. nginx {@code client_max_body_size} 가 1차 방어,
+ * 본 필터는 nginx 우회 / 직결 케이스 (개발/내부 호출) 를 위한 application-단 2차 방어.</p>
+ *
+ * <p>한도 초과 시 413 Payload Too Large 즉시 응답 — Spring DispatcherServlet 까지 가지 않음.</p>
+ *
+ * <p>매칭 path: {@code /api/v1/payments/webhook/**}. 다른 endpoint 에는 영향 X.</p>
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+public class WebhookBodySizeFilter extends OncePerRequestFilter {
+
+    /** 토스 webhook payload 정상 크기는 ~3KB. 16KB 면 충분히 여유. */
+    static final long MAX_BODY_BYTES = 16L * 1024;
+
+    private static final String WEBHOOK_PATH_PREFIX = "/api/v1/payments/webhook/";
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getRequestURI().startsWith(WEBHOOK_PATH_PREFIX);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain
+    ) throws ServletException, IOException {
+        long contentLength = request.getContentLengthLong();
+        // Content-Length 미주입 (chunked 또는 누락) 도 거부 — webhook 은 Content-Length 명시 의무.
+        if (contentLength < 0 || contentLength > MAX_BODY_BYTES) {
+            response.setStatus(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write(
+                    "{\"success\":false,\"error\":{\"code\":\"PAYLOAD_TOO_LARGE\","
+                  + "\"message\":\"webhook body size limit exceeded\"}}"
+            );
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/test/java/com/sseulang/domain/payment/presentation/WebhookBodySizeFilterTest.java
+++ b/src/test/java/com/sseulang/domain/payment/presentation/WebhookBodySizeFilterTest.java
@@ -1,0 +1,83 @@
+package com.sseulang.domain.payment.presentation;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class WebhookBodySizeFilterTest {
+
+    private WebhookBodySizeFilter filter;
+    private FilterChain chain;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        filter = new WebhookBodySizeFilter();
+        chain = mock(FilterChain.class);
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    @DisplayName("webhook path + body 16KB 초과_413 + chain 미호출")
+    void webhook_초과_413() throws ServletException, IOException {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/api/v1/payments/webhook/toss");
+        req.setContentType("application/json");
+        req.addHeader("Content-Length", String.valueOf(WebhookBodySizeFilter.MAX_BODY_BYTES + 1));
+        req.setContent(new byte[(int) WebhookBodySizeFilter.MAX_BODY_BYTES + 1]);
+
+        filter.doFilter(req, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(413);
+        assertThat(response.getContentAsString()).contains("PAYLOAD_TOO_LARGE");
+        verify(chain, never()).doFilter(req, response);
+    }
+
+    @Test
+    @DisplayName("webhook path + body 정확히 16KB_통과")
+    void webhook_정확_16KB_통과() throws ServletException, IOException {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/api/v1/payments/webhook/toss");
+        req.setContent(new byte[(int) WebhookBodySizeFilter.MAX_BODY_BYTES]);
+
+        filter.doFilter(req, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(chain, times(1)).doFilter(req, response);
+    }
+
+    @Test
+    @DisplayName("webhook 외 path_size 무관 통과 (필터 미적용)")
+    void 비webhook_path_미적용() throws ServletException, IOException {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/api/v1/items");
+        req.setContent(new byte[1_000_000]);  // 1MB
+
+        filter.doFilter(req, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(chain, times(1)).doFilter(req, response);
+    }
+
+    @Test
+    @DisplayName("webhook path + Content-Length 미주입_413 거부")
+    void webhook_Content_Length_미주입_거부() throws ServletException, IOException {
+        // chunked 또는 누락 — getContentLengthLong() == -1
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/api/v1/payments/webhook/toss");
+        // setContent 호출 안 함 + Content-Length 헤더도 없음
+
+        filter.doFilter(req, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(413);
+        verify(chain, never()).doFilter(req, response);
+    }
+}


### PR DESCRIPTION
## Summary
follow-up #53 의 6개 항목 중 **운영 즉시 영향** 큰 2개 우선 처리. nginx rate limit + IT 보강은 후속 PR.

## 1. WebhookBodySizeFilter — OOM 방어
\`@RequestBody String\` 으로 payload 메모리 적재 구조 → 큰 body 던지면 OOM/GC 압박.

- \`/api/v1/payments/webhook/**\` 매처 한정
- Content-Length **16KB 초과** → 413 Payload Too Large + chain 차단 (`{"success":false,"error":{"code":"PAYLOAD_TOO_LARGE",...}}`)
- Content-Length 미주입 (chunked / 누락) → 413 (webhook 은 명시 의무)
- 다른 endpoint 영향 X (shouldNotFilter)
- nginx \`client_max_body_size\` 가 1차 방어, 본 필터는 nginx 우회 / 직결 케이스 (개발 / 내부 호출) 2차 방어

## 2. amount mismatch audit log — 운영 모니터링용
\`PaymentApplicationService\` 의 \`verifyAmount\` 호출 3곳 try-catch 로 감싸 \`PAYMENT_AMOUNT_MISMATCH\` 시 명시적 ERROR 로깅:

| 마커 | 시나리오 |
|---|---|
| \`[toss-confirm][AUDIT-AMOUNT-MISMATCH-1]\` | 클라이언트 위변조 시도 (1차 — cmd.amount vs DB) |
| \`[toss-confirm][AUDIT-AMOUNT-MISMATCH-2]\` | 토스 응답 vs 우리 DB 차이 (2차) |
| \`[toss-webhook][AUDIT-AMOUNT-MISMATCH]\` | webhook lookup vs DB 차이 |

운영에서 ERROR 로그 모니터링 (CloudWatch / Sentry / Datadog) 이 잡으면 즉시 알림. 별도 audit DB 테이블은 운영 모니터링 도입 시점에 follow-up.

## 다음 PR (보류)
- nginx \`limit_req_zone\` webhook rate limit — PROD_DEPLOY.md 갱신 (PR #71 머지 후)
- \`WebhookEvent\` UNIQUE 충돌 IT (Testcontainers)
- \`ExternalApiException\` 롤백 IT
- confirm/webhook race IT

## Test plan
- [x] 컴파일 통과
- [x] WebhookBodySizeFilterTest 4 케이스 (초과 413 / 정확 16KB 통과 / 비webhook 통과 / Content-Length 미주입 거부)
- [x] 전체 601 PASS / 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)