### PR TITLE
chore: 로컬 SMTP 활성화 옵션 (네이버 SMTP 검증 완료)

### DIFF
--- a/src/main/java/com/sseulang/domain/auth/infrastructure/email/LogEmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/email/LogEmailSender.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.auth.infrastructure.email;
 import com.sseulang.domain.auth.domain.EmailSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -13,9 +14,13 @@ import org.springframework.stereotype.Component;
  * <p>{@code @Profile({"local","dev","test"})} — 명시 allowlist. {@code @Profile("!prod")} 는
  * prod 프로필 누락(빈 active profile) 시 빈이 활성화돼 토큰 URL 이 운영 로그에 새는 회귀 위험.
  * prod 는 SMTP 어댑터 미등록 시 부팅 실패하도록 둔다 (게이트 1 round 2).</p>
+ *
+ * <p>또한 {@code app.email.smtp-enabled=true} 면 비활성 — local 에서도 SMTP 직접 테스트 가능하도록.
+ * matchIfMissing=true 라 미설정 (local default) 은 LogEmailSender 활성화.</p>
  */
 @Component
 @Profile({"local", "dev", "test"})
+@ConditionalOnProperty(name = "app.email.smtp-enabled", havingValue = "false", matchIfMissing = true)
 public class LogEmailSender implements EmailSender {
 
     private static final Logger log = LoggerFactory.getLogger(LogEmailSender.class);

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSender.java
@@ -3,7 +3,7 @@ package com.sseulang.domain.auth.infrastructure.email;
 import com.sseulang.domain.auth.domain.EmailSender;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import org.springframework.context.annotation.Profile;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -14,14 +14,15 @@ import java.nio.charset.StandardCharsets;
 /**
  * prod SMTP {@link EmailSender} 구현. Spring Mail (JavaMailSender) 사용.
  *
- * <p>{@code @Profile("prod")} — prod 환경 전용. local/dev/test 는 {@code LogEmailSender} 가 활성화.
- * SMTP 설정은 {@code application-prod.yml} 의 {@code spring.mail.*} 환경변수 주입.</p>
+ * <p>활성화: {@code app.email.smtp-enabled=true} (prod 는 application-prod.yml 에서 강제 true,
+ * local 은 .env 에서 SMTP 정보 채우면 켤 수 있음). false / 미설정 시 {@link LogEmailSender} 가 활성.
+ * SMTP 설정은 {@code spring.mail.*} 환경변수 주입.</p>
  *
  * <p>발송 실패 시 {@link RuntimeException} 으로 throw — 호출자(LocalAuthService.signup) 가 회원 가입
  * 실패로 트랜잭션 롤백. 5/6 이후 outbox 패턴 도입 시 비동기 발송으로 변경 가능.</p>
  */
 @Component
-@Profile("prod")
+@ConditionalOnProperty(name = "app.email.smtp-enabled", havingValue = "true")
 public class SmtpEmailSender implements EmailSender {
 
     private static final String SUBJECT = "[쓸랭] 이메일 인증을 완료해 주세요";

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,6 +30,28 @@ spring:
       port: 6380
     mongodb:
       uri: mongodb://sseulang:sseulangpw@localhost:27017/sseulang?authSource=admin
+  # 네이버 SMTP — 로컬 메일 발송 테스트용. .env 의 MAIL_* 채우면 활성화.
+  # 네이버 메일 설정 → 환경설정 → POP3/IMAP 설정 → SMTP 사용 ON
+  # MAIL_USERNAME = 네이버 이메일 전체 (예: alem6516@naver.com), MAIL_FROM 동일
+  # 587 (STARTTLS) 또는 465 (SSL) 둘 다 가능 — 본 설정은 587/STARTTLS.
+  mail:
+    host: ${MAIL_HOST:smtp.naver.com}
+    port: ${MAIL_PORT:587}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        # SMTP 디버그 로그 — true 로 켜면 EHLO/AUTH/MAIL FROM/RCPT TO 모두 stdout 찍힘.
+        # 진단 시에만 켜고 평소엔 false.
+        debug: ${MAIL_DEBUG:false}
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
 
 app:
   jwt:
@@ -63,6 +85,10 @@ app:
       - http://localhost:3000
       - http://localhost:5173
   email:
+    # SMTP 활성 — true 면 SmtpEmailSender (실제 메일 발송), false/미설정 이면 LogEmailSender (로그만).
+    # MAIL_USERNAME / MAIL_PASSWORD 가 .env 에 채워져 있어야 발송 성공.
+    smtp-enabled: ${APP_EMAIL_SMTP_ENABLED:false}
+    from: ${MAIL_FROM:noreply@sseulang.local}
     # 가입 직후 발송되는 인증 메일 링크 base. 프론트가 token query 파라미터를 받아서
     # POST /api/v1/auth/verify-email 호출. (5/2 — 프론트 합의 path)
     verification-url-base: http://localhost:3000/auth/verify-email

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -78,6 +78,8 @@ app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
   email:
+    # prod 는 SMTP 강제. SmtpEmailSender 만 활성화 — env 미주입 시 SmtpEmailSender 가 부팅에서 실패.
+    smtp-enabled: ${APP_EMAIL_SMTP_ENABLED:true}
     from: ${MAIL_FROM:noreply@sseulang.test}
     # 인증 메일 본문 클릭 URL prefix. 프론트 라우트 (`/auth/verify-email?token=...`).
     verification-url-base: ${APP_EMAIL_VERIFICATION_URL_BASE:https://sseulang.com/auth/verify-email}


### PR DESCRIPTION
## Summary
LogEmailSender / SmtpEmailSender 분기를 \`@Profile\` 단독 → \`@ConditionalOnProperty\` 보강. local 에서도 .env 의 \`APP_EMAIL_SMTP_ENABLED=true\` 로 SMTP 켤 수 있게.

## 변경
- **SmtpEmailSender**: \`@Profile("prod")\` → \`@ConditionalOnProperty("app.email.smtp-enabled" havingValue="true")\`
- **LogEmailSender**: \`@Profile({"local","dev","test"})\` 유지 + \`@ConditionalOnProperty(havingValue="false", matchIfMissing=true)\` 추가
  - local 에서 smtp-enabled=true 면 LogEmailSender 비활성, SmtpEmailSender 활성
- **application-local.yml**: \`spring.mail\` (네이버 STARTTLS 587) + \`app.email.smtp-enabled\` flag + \`mail.debug\` 옵션
- **application-prod.yml**: \`app.email.smtp-enabled = \${APP_EMAIL_SMTP_ENABLED:true}\` (prod 강제 true)

## prod 안전성 (이중 가드)
- smtp-enabled default=true → SmtpEmailSender 등록
- LogEmailSender 는 \`@Profile({"local","dev","test"})\` allowlist 라 prod 에서 절대 활성 X
- 두 layer 모두 prod 에서 토큰 URL 새는 회귀 차단

## 로컬 검증
실제 네이버 SMTP 통신:
\`\`\`
DEBUG SMTP: trying to connect to host "smtp.naver.com", port 587, isSSL false
220 smtp.naver.com ESMTP
DEBUG SMTP: AUTH LOGIN succeeded
MAIL FROM:<alem6516@naver.com>     → 250 OK
RCPT TO:<smtp-real-test-99@example.com>  → 250 OK
DEBUG SMTP: message successfully delivered to mail server
\`\`\`

## 사용법 (로컬)
\`.env\` 에서:
\`\`\`
APP_EMAIL_SMTP_ENABLED=true
MAIL_HOST=smtp.naver.com
MAIL_PORT=587
MAIL_USERNAME=<네이버 이메일 전체>
MAIL_PASSWORD=<네이버 SMTP 비밀번호>
MAIL_FROM=<MAIL_USERNAME 과 동일>
MAIL_DEBUG=false  # 진단 시에만 true
\`\`\`

## Test
- [x] 컴파일 통과
- [x] 612 PASS / 0 FAIL
- [x] 실제 네이버 SMTP 통신 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)