### PR TITLE
feat: round 8b — Admin 회원 보강 (tradeCount/reportCount/dormant/status/suspend) + 검색·필터

### DIFF
--- a/src/main/java/com/sseulang/domain/auth/application/LocalAuthService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/LocalAuthService.java
@@ -45,6 +45,7 @@ public class LocalAuthService {
     private static final String DUMMY_PASSWORD_PLAINTEXT = "__sseulang_dummy_user_sentinel_v1__";
 
     private final UserRepository userRepository;
+    private final com.sseulang.domain.user.application.UserApplicationService userService;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final RefreshTokenStore refreshTokenStore;
@@ -57,6 +58,7 @@ public class LocalAuthService {
 
     public LocalAuthService(
             UserRepository userRepository,
+            com.sseulang.domain.user.application.UserApplicationService userService,
             PasswordEncoder passwordEncoder,
             JwtProvider jwtProvider,
             RefreshTokenStore refreshTokenStore,
@@ -64,6 +66,7 @@ public class LocalAuthService {
             JwtProperties jwtProperties
     ) {
         this.userRepository = userRepository;
+        this.userService = userService;
         this.passwordEncoder = passwordEncoder;
         this.jwtProvider = jwtProvider;
         this.refreshTokenStore = refreshTokenStore;
@@ -128,6 +131,8 @@ public class LocalAuthService {
         if (user == null || !user.hasPassword() || user.isBlocked() || user.isDeleted() || !passwordOk) {
             throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
         }
+        // 휴면 판정 기준 — 응답 status 가 ACTIVE 로 자동 복귀.
+        userService.recordLogin(user.getId());
         return issueTokens(user);
     }
 

--- a/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
@@ -86,6 +86,9 @@ public class OAuthLoginService {
             throw new BusinessException(ErrorCode.USER_BLOCKED);
         }
 
+        // 휴면 판정 기준 — 응답 status 가 ACTIVE 로 자동 복귀.
+        userService.recordLogin(user.getId());
+
         String at = jwtProvider.issueAccessToken(user.getId(), DEFAULT_ROLE);
         // tv: store 의 현재 버전을 RT claim 에 박는다. 이후 revokeAll → INCR 시 본 RT 는 mismatch 로 거부됨.
         long tv = refreshTokenStore.currentTokenVersion(DEFAULT_ROLE, user.getId());

--- a/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
+++ b/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
@@ -13,4 +13,10 @@ public interface UserReportRepository {
 
     /** 관리자 — 상태별 페이징 (status null 이면 전체). created_at DESC. */
     Page<UserReport> findByStatus(ReportStatus status, Pageable pageable);
+
+    /**
+     * Admin 회원 카드용 — targetUserIds 가 신고당한 횟수의 (targetUserId → count) 맵.
+     * 빈 입력은 빈 맵. 단일 GROUP BY 쿼리 — N+1 회피.
+     */
+    java.util.Map<Long, Long> countByTargetUserIds(java.util.Collection<Long> targetUserIds);
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
@@ -16,4 +16,17 @@ interface UserReportJpaRepository extends JpaRepository<UserReport, Long> {
              ORDER BY r.id DESC
             """)
     Page<UserReport> findByStatusFilter(@Param("status") ReportStatus status, Pageable pageable);
+
+    /** Admin enrich — targetUserIds 의 신고 누적 수 (target_user_id, count). */
+    @Query("""
+            SELECT r.reportedId AS userId, COUNT(r) AS cnt FROM UserReport r
+             WHERE r.reportedId IN :ids
+             GROUP BY r.reportedId
+            """)
+    java.util.List<UserCountRow> countByTargetUserIdsRaw(@Param("ids") java.util.Collection<Long> ids);
+
+    interface UserCountRow {
+        Long getUserId();
+        Long getCnt();
+    }
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
@@ -32,4 +32,16 @@ public class UserReportRepositoryImpl implements UserReportRepository {
     public Page<UserReport> findByStatus(ReportStatus status, Pageable pageable) {
         return jpa.findByStatusFilter(status, pageable);
     }
+
+    @Override
+    public java.util.Map<Long, Long> countByTargetUserIds(java.util.Collection<Long> targetUserIds) {
+        if (targetUserIds == null || targetUserIds.isEmpty()) {
+            return java.util.Collections.emptyMap();
+        }
+        java.util.Map<Long, Long> result = new java.util.HashMap<>();
+        for (UserReportJpaRepository.UserCountRow row : jpa.countByTargetUserIdsRaw(targetUserIds)) {
+            result.put(row.getUserId(), row.getCnt());
+        }
+        return result;
+    }
 }

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -31,6 +31,12 @@ public interface TransactionRepository {
     /** 단일 GROUP BY 집계 — (status, count) 행 리스트 (가능한 모든 status 행 포함, 0 인 status 는 없음). */
     List<TransactionStatusCount> countGroupByStatus();
 
+    /**
+     * Admin 회원 카드용 — userId 가 buyer 또는 seller 로 참여한 transaction 의 (userId → count) 맵.
+     * 빈 입력은 빈 맵. 단일 GROUP BY 쿼리 — N+1 회피.
+     */
+    java.util.Map<Long, Long> countByUserIdsAsParticipant(java.util.Collection<Long> userIds);
+
     // ───────── Review pending (follow-up #56) ─────────
 
     /**

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -33,6 +33,27 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
             """)
     List<TransactionStatusCount> countGroupByStatusJpql();
 
+    /** Admin 회원 카드용 — sellerId 로 참여한 거래 (sellerId, count). */
+    @Query("""
+            SELECT t.sellerId AS userId, COUNT(t) AS cnt FROM Transaction t
+             WHERE t.sellerId IN :ids
+             GROUP BY t.sellerId
+            """)
+    List<UserCountRow> countAsSellerRaw(@Param("ids") java.util.Collection<Long> ids);
+
+    /** Admin 회원 카드용 — buyerId 로 참여한 거래 (buyerId, count). */
+    @Query("""
+            SELECT t.buyerId AS userId, COUNT(t) AS cnt FROM Transaction t
+             WHERE t.buyerId IN :ids
+             GROUP BY t.buyerId
+            """)
+    List<UserCountRow> countAsBuyerRaw(@Param("ids") java.util.Collection<Long> ids);
+
+    interface UserCountRow {
+        Long getUserId();
+        Long getCnt();
+    }
+
     /**
      * Review 작성 대기 거래 — completedAt 하한 + 본인 참여 + 본인이 reviewer 인 review 가 아직 없는 것.
      * Review 와 NOT EXISTS 로 cross-aggregate read (write 가 아니라 도메인 invariant 영향 X).

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -43,6 +43,21 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     }
 
     @Override
+    public java.util.Map<Long, Long> countByUserIdsAsParticipant(java.util.Collection<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return java.util.Collections.emptyMap();
+        }
+        java.util.Map<Long, Long> result = new java.util.HashMap<>();
+        for (TransactionJpaRepository.UserCountRow row : jpa.countAsSellerRaw(userIds)) {
+            result.merge(row.getUserId(), row.getCnt(), Long::sum);
+        }
+        for (TransactionJpaRepository.UserCountRow row : jpa.countAsBuyerRaw(userIds)) {
+            result.merge(row.getUserId(), row.getCnt(), Long::sum);
+        }
+        return result;
+    }
+
+    @Override
     public Page<Transaction> findPendingReviewable(Long userId, LocalDateTime since, Pageable pageable) {
         return jpa.findPendingReviewableJpql(userId, since, pageable);
     }

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -19,10 +19,24 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class UserApplicationService {
 
-    private final UserRepository userRepository;
+    /** 휴면 판정 — 90일 이상 미접속이면 dormant. status derive 와 search 양쪽에서 공유. */
+    private static final int DORMANT_THRESHOLD_DAYS = 90;
 
-    public UserApplicationService(UserRepository userRepository) {
+    private final UserRepository userRepository;
+    private final com.sseulang.domain.transaction.domain.TransactionRepository transactionRepository;
+    private final com.sseulang.domain.report.domain.UserReportRepository userReportRepository;
+    private final java.time.Clock clock;
+
+    public UserApplicationService(
+            UserRepository userRepository,
+            com.sseulang.domain.transaction.domain.TransactionRepository transactionRepository,
+            com.sseulang.domain.report.domain.UserReportRepository userReportRepository,
+            java.time.Clock clock
+    ) {
         this.userRepository = userRepository;
+        this.transactionRepository = transactionRepository;
+        this.userReportRepository = userReportRepository;
+        this.clock = clock;
     }
 
     /**
@@ -159,6 +173,40 @@ public class UserApplicationService {
     }
 
     /**
+     * Admin 회원 검색 + enrich. status/keyword/created_at 범위 필터 후 페이지의 userIds 로 batch
+     * tradeCount / reportCount 집계 (N+1 회피).
+     */
+    public Page<com.sseulang.domain.user.application.dto.AdminUserResult> adminSearch(
+            com.sseulang.domain.user.application.dto.AdminUserSearchCriteria criteria,
+            Pageable pageable
+    ) {
+        java.time.LocalDateTime now = java.time.LocalDateTime.now(clock);
+        Page<User> page = userRepository.searchForAdmin(criteria, now, DORMANT_THRESHOLD_DAYS, pageable);
+        if (page.isEmpty()) {
+            return page.map(u -> com.sseulang.domain.user.application.dto.AdminUserResult.from(
+                    u, now, DORMANT_THRESHOLD_DAYS, 0L, 0L));
+        }
+        java.util.List<Long> ids = page.getContent().stream().map(User::getId).toList();
+        java.util.Map<Long, Long> tradeCounts = transactionRepository.countByUserIdsAsParticipant(ids);
+        java.util.Map<Long, Long> reportCounts = userReportRepository.countByTargetUserIds(ids);
+        return page.map(u -> com.sseulang.domain.user.application.dto.AdminUserResult.from(
+                u, now, DORMANT_THRESHOLD_DAYS,
+                tradeCounts.getOrDefault(u.getId(), 0L),
+                reportCounts.getOrDefault(u.getId(), 0L)
+        ));
+    }
+
+    /** 단건 enrich — 관리자 단건 조회. */
+    public com.sseulang.domain.user.application.dto.AdminUserResult adminGetEnriched(Long userId) {
+        User u = getById(userId);
+        java.time.LocalDateTime now = java.time.LocalDateTime.now(clock);
+        java.util.List<Long> ids = java.util.List.of(userId);
+        long trades = transactionRepository.countByUserIdsAsParticipant(ids).getOrDefault(userId, 0L);
+        long reports = userReportRepository.countByTargetUserIds(ids).getOrDefault(userId, 0L);
+        return com.sseulang.domain.user.application.dto.AdminUserResult.from(u, now, DORMANT_THRESHOLD_DAYS, trades, reports);
+    }
+
+    /**
      * 관리자 차단/해제 — Aggregate {@code block()/unblock()} 위임. 미존재 userId → USER_NOT_FOUND.
      * 멱등 (이미 차단된 사용자를 또 차단해도 OK).
      */
@@ -166,6 +214,26 @@ public class UserApplicationService {
     public void adminSetBlocked(Long userId, boolean blocked) {
         User u = getById(userId);
         if (blocked) u.block(); else u.unblock();
+    }
+
+    /** 관리자 시한부 활동정지 — N일 동안. days >= 1. */
+    @Transactional
+    public void adminSuspend(Long userId, int days) {
+        User u = getById(userId);
+        u.suspend(days, java.time.LocalDateTime.now(clock));
+    }
+
+    /** 관리자 활동정지 즉시 해제. */
+    @Transactional
+    public void adminUnsuspend(Long userId) {
+        User u = getById(userId);
+        u.unsuspend();
+    }
+
+    /** 로그인 성공 직후 호출 — 마지막 로그인 시각 기록 (휴면 판정 기준). 미존재 userId 무시. */
+    @Transactional
+    public void recordLogin(Long userId) {
+        userRepository.findById(userId).ifPresent(u -> u.recordLogin(java.time.LocalDateTime.now(clock)));
     }
 
     /**

--- a/src/main/java/com/sseulang/domain/user/application/dto/AdminUserResult.java
+++ b/src/main/java/com/sseulang/domain/user/application/dto/AdminUserResult.java
@@ -1,0 +1,68 @@
+package com.sseulang.domain.user.application.dto;
+
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Admin 회원 카드용 enriched Result. tradeCount/reportCount 는 다른 도메인에서 batch fetch 후 채움.
+ *
+ * <p>{@code dormant}/{@code status} 는 User Aggregate 의 derive 결과 — DB 컬럼 X.</p>
+ */
+public record AdminUserResult(
+        Long id,
+        String email,
+        String nickname,
+        String profileImage,
+        SocialProvider socialProvider,
+        boolean blocked,
+        boolean deleted,
+        BigDecimal trustScore,
+        int reviewCount,
+        long pointBalance,
+        LocalDateTime lastLoginAt,
+        LocalDateTime suspendedAt,
+        Integer suspendDays,
+        LocalDateTime suspendedUntil,
+        boolean dormant,
+        UserStatus status,
+        long tradeCount,
+        long reportCount,
+        LocalDateTime createdAt
+) {
+    public static AdminUserResult from(
+            User u,
+            LocalDateTime now,
+            int dormantThresholdDays,
+            long tradeCount,
+            long reportCount
+    ) {
+        LocalDateTime suspendedUntil = (u.getSuspendedAt() != null && u.getSuspendDays() != null && u.getSuspendDays() > 0)
+                ? u.getSuspendedAt().plusDays(u.getSuspendDays())
+                : null;
+        return new AdminUserResult(
+                u.getId(),
+                u.getEmail(),
+                u.getNickname(),
+                u.getProfileImage(),
+                u.getSocialProvider(),
+                u.isBlocked(),
+                u.isDeleted(),
+                u.getTrustScore(),
+                u.getReviewCount(),
+                u.getPointBalance(),
+                u.getLastLoginAt(),
+                u.getSuspendedAt(),
+                u.getSuspendDays(),
+                suspendedUntil,
+                u.isDormantAt(now, dormantThresholdDays),
+                u.derivedStatus(now, dormantThresholdDays),
+                tradeCount,
+                reportCount,
+                u.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/application/dto/AdminUserSearchCriteria.java
+++ b/src/main/java/com/sseulang/domain/user/application/dto/AdminUserSearchCriteria.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.user.application.dto;
+
+import com.sseulang.domain.user.domain.UserStatus;
+
+import java.time.LocalDateTime;
+
+/**
+ * Admin 회원 검색 조건. null/blank 필드는 무시.
+ *
+ * <ul>
+ *   <li>{@code keyword} — 닉네임 또는 이메일 LIKE 검색</li>
+ *   <li>{@code status} — ACTIVE / SUSPENDED / WITHDRAWN / DORMANT (derive 기반)</li>
+ *   <li>{@code createdAfter} / {@code createdBefore} — created_at 범위 (각 inclusive)</li>
+ * </ul>
+ */
+public record AdminUserSearchCriteria(
+        String keyword,
+        UserStatus status,
+        LocalDateTime createdAfter,
+        LocalDateTime createdBefore
+) {
+    public static AdminUserSearchCriteria empty() {
+        return new AdminUserSearchCriteria(null, null, null, null);
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 /**
  * User Aggregate Root. V1 스키마 {@code users} 매핑.
@@ -70,8 +71,25 @@ public class User extends BaseEntity {
     @Column(name = "email_verified", nullable = false)
     private boolean emailVerified;
 
+    /**
+     * 마지막 로그인 시각 (V14). 휴면(dormant) 판정용 — 90일 이상 미접속이면 dormant.
+     * LocalAuthService / OAuthLoginService 가 로그인 성공 시 갱신.
+     */
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
     @Column(name = "is_blocked", nullable = false)
     private boolean blocked;
+
+    /**
+     * 시한부 활동정지 (V14). is_blocked(영구) 와 별개. suspended_at + suspend_days 가 만료시각.
+     * 만료 후엔 자동 해제 (status 계산 시점에 derive).
+     */
+    @Column(name = "suspended_at")
+    private LocalDateTime suspendedAt;
+
+    @Column(name = "suspend_days")
+    private Integer suspendDays;
 
     @Column(name = "is_deleted", nullable = false)
     private boolean deleted;
@@ -232,5 +250,53 @@ public class User extends BaseEntity {
     /** 관리자 차단 해제 — 멱등 호출. */
     public void unblock() {
         this.blocked = false;
+    }
+
+    /** 로그인 성공 시점 기록. dormant 판정 기준. */
+    public void recordLogin(LocalDateTime now) {
+        this.lastLoginAt = now;
+    }
+
+    /** 시한부 활동정지. days >= 1. now 부터 N일 동안. */
+    public void suspend(int days, LocalDateTime now) {
+        if (days < 1) {
+            throw new IllegalArgumentException("days 는 1 이상이어야 합니다");
+        }
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+        this.suspendedAt = now;
+        this.suspendDays = days;
+    }
+
+    /** 활동정지 즉시 해제. */
+    public void unsuspend() {
+        this.suspendedAt = null;
+        this.suspendDays = null;
+    }
+
+    /** 활동정지가 아직 유효 (만료 전). suspendedAt 없거나 만료됐으면 false. */
+    public boolean isSuspendedAt(LocalDateTime now) {
+        if (suspendedAt == null || suspendDays == null || suspendDays <= 0) {
+            return false;
+        }
+        LocalDateTime expiresAt = suspendedAt.plusDays(suspendDays);
+        return now != null && now.isBefore(expiresAt);
+    }
+
+    /** 휴면 — lastLoginAt 이 dormantThresholdDays 이상 과거. lastLoginAt 없으면 createdAt 기준. */
+    public boolean isDormantAt(LocalDateTime now, int dormantThresholdDays) {
+        if (now == null) return false;
+        LocalDateTime base = lastLoginAt != null ? lastLoginAt : getCreatedAt();
+        if (base == null) return false;
+        return base.plusDays(dormantThresholdDays).isBefore(now);
+    }
+
+    /** Admin 응답용 status derive — WITHDRAWN > SUSPENDED > DORMANT > ACTIVE 우선순위. */
+    public UserStatus derivedStatus(LocalDateTime now, int dormantThresholdDays) {
+        if (deleted) return UserStatus.WITHDRAWN;
+        if (isSuspendedAt(now)) return UserStatus.SUSPENDED;
+        if (isDormantAt(now, dormantThresholdDays)) return UserStatus.DORMANT;
+        return UserStatus.ACTIVE;
     }
 }

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -23,6 +23,18 @@ public interface UserRepository {
     Page<User> findAllForAdmin(Pageable pageable);
 
     /**
+     * Admin 회원 검색 — keyword(nickname/email LIKE), status filter, created_at 범위.
+     * status 는 derive 기반 — DB 컬럼 직접 매칭 대신 SQL 조건으로 변환.
+     * dormantThresholdDays / now 는 DORMANT/SUSPENDED 계산 기준.
+     */
+    Page<User> searchForAdmin(
+            com.sseulang.domain.user.application.dto.AdminUserSearchCriteria criteria,
+            java.time.LocalDateTime now,
+            int dormantThresholdDays,
+            Pageable pageable
+    );
+
+    /**
      * 가이드 §4.7 — 리뷰 작성 시점에 review_count / rating_sum 을 단일 원자 UPDATE 로 누적하고
      * trust_score 를 즉시 재계산. Codex 게이트 2 (2026-04-29) 보강 — REPEATABLE_READ + AVG 서브쿼리
      * 의 stale read view 회귀를 누적 컬럼으로 차단.

--- a/src/main/java/com/sseulang/domain/user/domain/UserStatus.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserStatus.java
@@ -1,0 +1,23 @@
+package com.sseulang.domain.user.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Admin 응답에서 derive 되는 회원 상태. DB 컬럼 X — {@link User#derivedStatus} 가 시점마다 계산.
+ *
+ * <p>우선순위: {@link #WITHDRAWN} &gt; {@link #SUSPENDED} &gt; {@link #DORMANT} &gt; {@link #ACTIVE}.</p>
+ *
+ * <ul>
+ *   <li>{@link #ACTIVE} — 정상</li>
+ *   <li>{@link #SUSPENDED} — 시한부 활동정지 중 (suspended_at + suspend_days 만료 전)</li>
+ *   <li>{@link #WITHDRAWN} — 탈퇴 (is_deleted=true)</li>
+ *   <li>{@link #DORMANT} — 휴면 (90일 이상 미접속)</li>
+ * </ul>
+ */
+@Schema(description = "회원 상태 (derived) — ACTIVE / SUSPENDED / WITHDRAWN / DORMANT")
+public enum UserStatus {
+    ACTIVE,
+    SUSPENDED,
+    WITHDRAWN,
+    DORMANT
+}

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -60,6 +60,85 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
 
     Page<User> findAllByOrderByIdDesc(Pageable pageable);
 
+    /**
+     * Admin 회원 검색 — keyword(nickname/email LIKE), created_at 범위, derive status.
+     *
+     * <p>NATIVE query 사용 이유: SUSPENDED 판정에 {@code suspended_at + INTERVAL suspend_days DAY > now}
+     * 가 필요한데 JPQL TIMESTAMPADD 가 DB 별 호환성 이슈가 큼. MySQL DATE_ADD 직접 사용.</p>
+     *
+     * <p>status 파라미터:
+     * <ul>
+     *   <li>{@code 'WITHDRAWN'} — is_deleted=TRUE</li>
+     *   <li>{@code 'SUSPENDED'} — 시한부 정지 만료 전</li>
+     *   <li>{@code 'DORMANT'} — deleted/suspended 아니고 마지막 로그인이 dormantThreshold 이전</li>
+     *   <li>{@code 'ACTIVE'} — 그 외 (탈퇴/정지/휴면 아님)</li>
+     *   <li>{@code NULL} — 필터 안 함 (전체)</li>
+     * </ul>
+     */
+    @Query(value = """
+            SELECT * FROM users u
+             WHERE (:kw IS NULL OR LOWER(u.email) LIKE LOWER(CONCAT('%', :kw, '%'))
+                                 OR LOWER(u.nickname) LIKE LOWER(CONCAT('%', :kw, '%')))
+               AND (:after  IS NULL OR u.created_at >= :after)
+               AND (:before IS NULL OR u.created_at <= :before)
+               AND (:status IS NULL
+                    OR (:status = 'WITHDRAWN' AND u.is_deleted = TRUE)
+                    OR (:status = 'SUSPENDED' AND u.is_deleted = FALSE
+                                              AND u.suspended_at IS NOT NULL
+                                              AND u.suspend_days IS NOT NULL
+                                              AND u.suspend_days > 0
+                                              AND DATE_ADD(u.suspended_at, INTERVAL u.suspend_days DAY) > :now)
+                    OR (:status = 'DORMANT'   AND u.is_deleted = FALSE
+                                              AND (u.suspended_at IS NULL
+                                                   OR u.suspend_days IS NULL
+                                                   OR u.suspend_days <= 0
+                                                   OR DATE_ADD(u.suspended_at, INTERVAL u.suspend_days DAY) <= :now)
+                                              AND COALESCE(u.last_login_at, u.created_at) <= :dormantThreshold)
+                    OR (:status = 'ACTIVE'    AND u.is_deleted = FALSE
+                                              AND (u.suspended_at IS NULL
+                                                   OR u.suspend_days IS NULL
+                                                   OR u.suspend_days <= 0
+                                                   OR DATE_ADD(u.suspended_at, INTERVAL u.suspend_days DAY) <= :now)
+                                              AND COALESCE(u.last_login_at, u.created_at) > :dormantThreshold))
+             ORDER BY u.id DESC
+            """,
+            countQuery = """
+            SELECT COUNT(*) FROM users u
+             WHERE (:kw IS NULL OR LOWER(u.email) LIKE LOWER(CONCAT('%', :kw, '%'))
+                                 OR LOWER(u.nickname) LIKE LOWER(CONCAT('%', :kw, '%')))
+               AND (:after  IS NULL OR u.created_at >= :after)
+               AND (:before IS NULL OR u.created_at <= :before)
+               AND (:status IS NULL
+                    OR (:status = 'WITHDRAWN' AND u.is_deleted = TRUE)
+                    OR (:status = 'SUSPENDED' AND u.is_deleted = FALSE
+                                              AND u.suspended_at IS NOT NULL
+                                              AND u.suspend_days IS NOT NULL
+                                              AND u.suspend_days > 0
+                                              AND DATE_ADD(u.suspended_at, INTERVAL u.suspend_days DAY) > :now)
+                    OR (:status = 'DORMANT'   AND u.is_deleted = FALSE
+                                              AND (u.suspended_at IS NULL
+                                                   OR u.suspend_days IS NULL
+                                                   OR u.suspend_days <= 0
+                                                   OR DATE_ADD(u.suspended_at, INTERVAL u.suspend_days DAY) <= :now)
+                                              AND COALESCE(u.last_login_at, u.created_at) <= :dormantThreshold)
+                    OR (:status = 'ACTIVE'    AND u.is_deleted = FALSE
+                                              AND (u.suspended_at IS NULL
+                                                   OR u.suspend_days IS NULL
+                                                   OR u.suspend_days <= 0
+                                                   OR DATE_ADD(u.suspended_at, INTERVAL u.suspend_days DAY) <= :now)
+                                              AND COALESCE(u.last_login_at, u.created_at) > :dormantThreshold))
+            """,
+            nativeQuery = true)
+    Page<User> searchAdmin(
+            @Param("kw") String kw,
+            @Param("after") java.time.LocalDateTime after,
+            @Param("before") java.time.LocalDateTime before,
+            @Param("status") String status,
+            @Param("dormantThreshold") java.time.LocalDateTime dormantThreshold,
+            @Param("now") java.time.LocalDateTime now,
+            Pageable pageable
+    );
+
     @Query("SELECT COUNT(u) FROM User u WHERE u.blocked = true")
     long countBlocked();
 

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -45,6 +45,28 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public Page<User> searchForAdmin(
+            com.sseulang.domain.user.application.dto.AdminUserSearchCriteria criteria,
+            java.time.LocalDateTime now,
+            int dormantThresholdDays,
+            Pageable pageable
+    ) {
+        String kw = (criteria.keyword() == null || criteria.keyword().isBlank())
+                ? null : criteria.keyword().strip();
+        String status = criteria.status() == null ? null : criteria.status().name();
+        java.time.LocalDateTime dormantThreshold = now.minusDays(dormantThresholdDays);
+        return jpa.searchAdmin(
+                kw,
+                criteria.createdAfter(),
+                criteria.createdBefore(),
+                status,
+                dormantThreshold,
+                now,
+                pageable
+        );
+    }
+
+    @Override
     public int recordReviewFor(Long revieweeId, int rating) {
         return jpa.recordReviewFor(revieweeId, rating);
     }

--- a/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
@@ -1,25 +1,35 @@
 package com.sseulang.domain.user.presentation;
 
 import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.application.dto.AdminUserSearchCriteria;
+import com.sseulang.domain.user.domain.UserStatus;
 import com.sseulang.domain.user.presentation.dto.AdminUserResponse;
 import com.sseulang.domain.user.presentation.dto.UserBlockRequest;
+import com.sseulang.domain.user.presentation.dto.UserSuspendRequest;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
-import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
 
 /**
  * 관리자 회원 관리. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
+ *
+ * <p>v8b: keyword/status/createdAfter/createdBefore 검색·필터, suspend/unsuspend, enriched response.</p>
  */
-@Tag(name = "AdminUser", description = "관리자 — 사용자 목록/차단")
+@Tag(name = "AdminUser", description = "관리자 — 사용자 목록/검색/차단/정지")
 @RestController
 @RequestMapping("/api/v1/admin/users")
 public class AdminUserController {
@@ -30,27 +40,55 @@ public class AdminUserController {
         this.userService = userService;
     }
 
-    @Operation(summary = "[관리자] 회원 목록", description = "차단/탈퇴 포함 전체.")
+    @Operation(summary = "[관리자] 회원 목록·검색",
+            description = "keyword(닉네임/이메일 LIKE), status(ACTIVE/SUSPENDED/WITHDRAWN/DORMANT), "
+                    + "createdAfter/createdBefore (ISO LocalDateTime). 모두 선택. tradeCount/reportCount enriched.")
     @GetMapping
-    public ApiResponse<PageResponse<AdminUserResponse>> list(Pageable pageable) {
+    public ApiResponse<PageResponse<AdminUserResponse>> list(
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "status", required = false) UserStatus status,
+            @RequestParam(value = "createdAfter", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdAfter,
+            @RequestParam(value = "createdBefore", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdBefore,
+            Pageable pageable
+    ) {
+        AdminUserSearchCriteria criteria = new AdminUserSearchCriteria(keyword, status, createdAfter, createdBefore);
         return ApiResponse.ok(PageResponse.from(
-                userService.adminFindAll(pageable).map(AdminUserResponse::from)
+                userService.adminSearch(criteria, pageable).map(AdminUserResponse::from)
         ));
     }
 
-    @Operation(summary = "[관리자] 회원 단건 조회 (민감 정보 제외)")
+    @Operation(summary = "[관리자] 회원 단건 조회 (enriched)")
     @GetMapping("/{id}")
     public ApiResponse<AdminUserResponse> getOne(@PathVariable("id") Long id) {
-        return ApiResponse.ok(AdminUserResponse.from(userService.getById(id)));
+        return ApiResponse.ok(AdminUserResponse.from(userService.adminGetEnriched(id)));
     }
 
-    @Operation(summary = "[관리자] 회원 차단/해제 토글", description = "blocked=true 면 로그인 차단 + 토큰 폐기.")
+    @Operation(summary = "[관리자] 회원 차단/해제 토글", description = "blocked=true 면 영구 차단.")
     @PatchMapping("/{id}/block")
     public ApiResponse<Void> setBlocked(
             @PathVariable("id") Long id,
             @Valid @RequestBody UserBlockRequest request
     ) {
         userService.adminSetBlocked(id, request.blocked());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "[관리자] 시한부 활동정지", description = "N일 동안 정지. 만료 후 status 자동 ACTIVE 복귀.")
+    @PatchMapping("/{id}/suspend")
+    public ApiResponse<Void> suspend(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody UserSuspendRequest request
+    ) {
+        userService.adminSuspend(id, request.days());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "[관리자] 활동정지 즉시 해제")
+    @DeleteMapping("/{id}/suspend")
+    public ApiResponse<Void> unsuspend(@PathVariable("id") Long id) {
+        userService.adminUnsuspend(id);
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
@@ -1,13 +1,15 @@
 package com.sseulang.domain.user.presentation.dto;
 
+import com.sseulang.domain.user.application.dto.AdminUserResult;
 import com.sseulang.domain.user.domain.SocialProvider;
 import com.sseulang.domain.user.domain.User;
+import com.sseulang.domain.user.domain.UserStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-/** 관리자용 회원 단건 응답 — 비밀번호/소셜 토큰 등 민감 정보는 제외. */
+/** 관리자용 회원 응답. v8b: tradeCount/reportCount/dormant/status/suspended* 추가. */
 @Schema(description = "관리자 — 회원 단건 (민감 정보 제외).")
 public record AdminUserResponse(
         @Schema(example = "100") Long id,
@@ -20,20 +22,39 @@ public record AdminUserResponse(
         @Schema(example = "4.7", description = "받은 리뷰 평균 (1.0~5.0). 리뷰 0건이면 null") BigDecimal trustScore,
         @Schema(example = "12") int reviewCount,
         @Schema(example = "50000", description = "현재 포인트 잔액 (KRW)") long pointBalance,
+        @Schema(description = "마지막 로그인 시각. null 이면 가입 후 미로그인.", nullable = true) LocalDateTime lastLoginAt,
+        @Schema(description = "시한부 활동정지 시작 시각. is_blocked(영구) 와 별개.", nullable = true) LocalDateTime suspendedAt,
+        @Schema(description = "활동정지 기간(일).", nullable = true) Integer suspendDays,
+        @Schema(description = "활동정지 만료 시각 (suspendedAt + suspendDays).", nullable = true) LocalDateTime suspendedUntil,
+        @Schema(example = "false", description = "휴면 여부 (lastLoginAt 90일 이상 미접속)") boolean dormant,
+        @Schema(description = "회원 상태 (derived). WITHDRAWN > SUSPENDED > DORMANT > ACTIVE 우선순위.") UserStatus status,
+        @Schema(example = "5", description = "이 회원이 buyer 또는 seller 로 참여한 거래 횟수") long tradeCount,
+        @Schema(example = "0", description = "이 회원이 신고당한 횟수") long reportCount,
         LocalDateTime createdAt
 ) {
+    public static AdminUserResponse from(AdminUserResult r) {
+        return new AdminUserResponse(
+                r.id(), r.email(), r.nickname(), r.profileImage(), r.socialProvider(),
+                r.blocked(), r.deleted(), r.trustScore(), r.reviewCount(), r.pointBalance(),
+                r.lastLoginAt(), r.suspendedAt(), r.suspendDays(), r.suspendedUntil(),
+                r.dormant(), r.status(),
+                r.tradeCount(), r.reportCount(),
+                r.createdAt()
+        );
+    }
+
+    /**
+     * @deprecated 호환용 — 도메인 enrich 정보 없이 entity 만으로 변환. 새 코드는 {@link AdminUserResult} 경유 권장.
+     * Codex 리뷰 + 테스트 갱신 끝나면 제거 예정.
+     */
+    @Deprecated
     public static AdminUserResponse from(User u) {
         return new AdminUserResponse(
-                u.getId(),
-                u.getEmail(),
-                u.getNickname(),
-                u.getProfileImage(),
-                u.getSocialProvider(),
-                u.isBlocked(),
-                u.isDeleted(),
-                u.getTrustScore(),
-                u.getReviewCount(),
-                u.getPointBalance(),
+                u.getId(), u.getEmail(), u.getNickname(), u.getProfileImage(), u.getSocialProvider(),
+                u.isBlocked(), u.isDeleted(), u.getTrustScore(), u.getReviewCount(), u.getPointBalance(),
+                u.getLastLoginAt(), u.getSuspendedAt(), u.getSuspendDays(), null,
+                false, UserStatus.ACTIVE,
+                0L, 0L,
                 u.getCreatedAt()
         );
     }

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/UserSuspendRequest.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/UserSuspendRequest.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.user.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+@Schema(description = "관리자 시한부 활동정지 요청. days >= 1.")
+public record UserSuspendRequest(
+        @Schema(example = "7", description = "정지 기간(일)")
+        @Min(1) @Max(365) int days
+) { }

--- a/src/main/resources/db/migration/V14__add_user_admin_signals.sql
+++ b/src/main/resources/db/migration/V14__add_user_admin_signals.sql
@@ -1,0 +1,16 @@
+-- =============================================================================
+-- V14 — Admin 회원 카드/필터용 컬럼
+--
+-- last_login_at  : 휴면(dormant) 판정용. 90일 이상 미접속이면 dormant=true.
+-- suspended_at   : 시한부 활동정지 시작 시각 (is_blocked 영구와 별개)
+-- suspend_days   : 정지 기간 (일). suspended_at + suspend_days 가 만료 시각.
+-- =============================================================================
+
+ALTER TABLE users
+    ADD COLUMN last_login_at  DATETIME NULL AFTER email_verified,
+    ADD COLUMN suspended_at   DATETIME NULL AFTER is_blocked,
+    ADD COLUMN suspend_days   INT      NULL AFTER suspended_at;
+
+-- 휴면 필터 / 활동정지 필터 인덱스. (idx_users_created_at 은 V1 에 이미 존재)
+CREATE INDEX idx_users_last_login   ON users (last_login_at);
+CREATE INDEX idx_users_suspended_at ON users (suspended_at);

--- a/src/test/java/com/sseulang/domain/auth/application/LocalAuthServiceTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/LocalAuthServiceTest.java
@@ -38,6 +38,7 @@ class LocalAuthServiceTest {
     private static final Email EMAIL = new Email("local@test.com");
 
     @Mock private UserRepository userRepository;
+    @Mock private com.sseulang.domain.user.application.UserApplicationService userService;
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private JwtProvider jwtProvider;
     @Mock private RefreshTokenStore refreshTokenStore;
@@ -48,7 +49,7 @@ class LocalAuthServiceTest {
     @BeforeEach
     void setUp() {
         JwtProperties props = new JwtProperties("0123456789012345678901234567890123", 1800L, 604800L);
-        service = new LocalAuthService(userRepository, passwordEncoder, jwtProvider, refreshTokenStore, verificationService, props);
+        service = new LocalAuthService(userRepository, userService, passwordEncoder, jwtProvider, refreshTokenStore, verificationService, props);
     }
 
     private User savedUser(String hashedPw) {
@@ -200,7 +201,7 @@ class LocalAuthServiceTest {
     void dummyHash_실제_BCrypt_패턴() {
         BCryptPasswordEncoder real = new BCryptPasswordEncoder();
         JwtProperties props = new JwtProperties("0123456789012345678901234567890123", 1800L, 604800L);
-        LocalAuthService realSvc = new LocalAuthService(userRepository, real, jwtProvider, refreshTokenStore, verificationService, props);
+        LocalAuthService realSvc = new LocalAuthService(userRepository, userService, real, jwtProvider, refreshTokenStore, verificationService, props);
 
         String dummyHash = (String) ReflectionTestUtils.getField(realSvc, "dummyPasswordHash");
         assertThat(dummyHash)

--- a/src/test/java/com/sseulang/domain/delivery/integration/DeliveryConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/delivery/integration/DeliveryConcurrencyIT.java
@@ -64,6 +64,10 @@ import static org.assertj.core.api.Assertions.assertThat;
         JpaAuditingConfig.class,
         UserRepositoryImpl.class,
         UserApplicationService.class,
+        // UserApplicationService 가 v8b 부터 Transaction/UserReport repo 의존 — slice 에 명시 추가.
+        // (Clock 은 SseulangApplication @Bean 이 자동 제공)
+        com.sseulang.domain.transaction.infrastructure.persistence.TransactionRepositoryImpl.class,
+        com.sseulang.domain.report.infrastructure.persistence.UserReportRepositoryImpl.class,
         PointHistoryRepositoryImpl.class,
         PointApplicationService.class,
         DeliveryRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
@@ -43,7 +43,7 @@ class PaymentApplicationServiceTest {
         gateway = new FakePaymentGateway();
         userRepo = new InMemoryFakeUserRepository();
         pointHistoryRepo = new InMemoryFakePointHistoryRepository();
-        userService = new UserApplicationService(userRepo);
+        userService = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), java.time.Clock.systemDefaultZone());
         PointApplicationService pointSvc = new PointApplicationService(userService, pointHistoryRepo);
         TossProperties tossProps = new TossProperties(CLIENT_KEY, "test_sk_secret", null, null, null);
         service = new PaymentApplicationService(

--- a/src/test/java/com/sseulang/domain/point/application/PointApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/point/application/PointApplicationServiceTest.java
@@ -35,7 +35,7 @@ class PointApplicationServiceTest {
     void setUp() {
         userRepo = new InMemoryFakeUserRepository();
         historyRepo = new InMemoryFakePointHistoryRepository();
-        UserApplicationService userSvc = new UserApplicationService(userRepo);
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), java.time.Clock.systemDefaultZone());
         service = new PointApplicationService(userSvc, historyRepo);
 
         buyerId = userRepo.save(User.createSocialUser(

--- a/src/test/java/com/sseulang/domain/report/application/InMemoryFakeUserReportRepository.java
+++ b/src/test/java/com/sseulang/domain/report/application/InMemoryFakeUserReportRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-class InMemoryFakeUserReportRepository implements UserReportRepository {
+public class InMemoryFakeUserReportRepository implements UserReportRepository {
 
     private final Map<Long, UserReport> store = new HashMap<>();
     private long sequence = 0;
@@ -40,5 +40,20 @@ class InMemoryFakeUserReportRepository implements UserReportRepository {
                 .sorted(Comparator.comparing(UserReport::getId).reversed())
                 .toList();
         return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+
+    @Override
+    public Map<Long, Long> countByTargetUserIds(java.util.Collection<Long> targetUserIds) {
+        if (targetUserIds == null || targetUserIds.isEmpty()) {
+            return java.util.Collections.emptyMap();
+        }
+        java.util.Set<Long> idSet = new java.util.HashSet<>(targetUserIds);
+        Map<Long, Long> result = new HashMap<>();
+        for (UserReport r : store.values()) {
+            if (idSet.contains(r.getReportedId())) {
+                result.merge(r.getReportedId(), 1L, Long::sum);
+            }
+        }
+        return result;
     }
 }

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -46,7 +46,7 @@ class ReviewApplicationServiceTest {
         userRepo = new InMemoryFakeUserRepository();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        UserApplicationService userSvc = new UserApplicationService(userRepo);
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), java.time.Clock.systemDefaultZone());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, new InMemoryFakePointHistoryRepository());
         TransactionApplicationService txSvc = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -98,4 +98,18 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
         int end = Math.min(start + pageable.getPageSize(), filtered.size());
         return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
     }
+
+    @Override
+    public Map<Long, Long> countByUserIdsAsParticipant(java.util.Collection<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return java.util.Collections.emptyMap();
+        }
+        Set<Long> idSet = new HashSet<>(userIds);
+        Map<Long, Long> result = new HashMap<>();
+        for (Transaction t : store.values()) {
+            if (idSet.contains(t.getSellerId())) result.merge(t.getSellerId(), 1L, Long::sum);
+            if (idSet.contains(t.getBuyerId())) result.merge(t.getBuyerId(), 1L, Long::sum);
+        }
+        return result;
+    }
 }

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -46,7 +46,7 @@ class TransactionApplicationServiceTest {
         userRepo = new InMemoryFakeUserRepository();
         pointHistoryRepo = new InMemoryFakePointHistoryRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        UserApplicationService userSvc = new UserApplicationService(userRepo);
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), java.time.Clock.systemDefaultZone());
         itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, pointHistoryRepo);
         service = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -85,7 +85,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         PointHistoryRepositoryImpl.class,
         PointApplicationService.class,
         TransactionRepositoryImpl.class,
-        TransactionApplicationService.class
+        TransactionApplicationService.class,
+        // v8b — UserApplicationService 가 UserReportRepository 도 의존
+        com.sseulang.domain.report.infrastructure.persistence.UserReportRepositoryImpl.class
 })
 @Testcontainers
 @Transactional(propagation = Propagation.NOT_SUPPORTED)

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -75,7 +75,9 @@ import static org.assertj.core.api.Assertions.assertThat;
         PointHistoryRepositoryImpl.class,
         PointApplicationService.class,
         TransactionRepositoryImpl.class,
-        TransactionApplicationService.class
+        TransactionApplicationService.class,
+        // v8b — UserApplicationService 가 UserReportRepository 도 의존
+        com.sseulang.domain.report.infrastructure.persistence.UserReportRepositoryImpl.class
 })
 @Testcontainers
 @Transactional(propagation = Propagation.NOT_SUPPORTED)

--- a/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
+++ b/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
@@ -111,4 +111,15 @@ public class InMemoryFakeUserRepository implements UserRepository {
     public long countActive() {
         return store.values().stream().filter(u -> !u.isBlocked() && !u.isDeleted()).count();
     }
+
+    @Override
+    public Page<User> searchForAdmin(
+            com.sseulang.domain.user.application.dto.AdminUserSearchCriteria criteria,
+            java.time.LocalDateTime now,
+            int dormantThresholdDays,
+            Pageable pageable
+    ) {
+        // 테스트 fake — 검색·필터 미구현. 기존 findAllForAdmin 으로 대체 위임.
+        return findAllForAdmin(pageable);
+    }
 }

--- a/src/test/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationServiceTest.java
@@ -40,7 +40,7 @@ class WithdrawalApplicationServiceTest {
         withdrawalRepo = new InMemoryFakeWithdrawalRepository();
         userRepo = new InMemoryFakeUserRepository();
         historyRepo = new InMemoryFakePointHistoryRepository();
-        UserApplicationService userSvc = new UserApplicationService(userRepo);
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), java.time.Clock.systemDefaultZone());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, historyRepo);
         // self 는 REQUIRES_NEW proxy 용 — 단위 테스트엔 Spring 컨텍스트 없으니 자기 자신을 주입.
         // 단위 테스트의 InMemoryFake 는 deadlock/duplicate 던지지 않으므로 catch 경로 미진입.

--- a/src/test/java/com/sseulang/domain/withdrawal/integration/WithdrawalSettlementIT.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/integration/WithdrawalSettlementIT.java
@@ -60,7 +60,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         PointHistoryRepositoryImpl.class,
         PointApplicationService.class,
         WithdrawalRepositoryImpl.class,
-        WithdrawalApplicationService.class
+        WithdrawalApplicationService.class,
+        // v8b — UserApplicationService 가 Transaction/UserReport repo 도 의존
+        com.sseulang.domain.transaction.infrastructure.persistence.TransactionRepositoryImpl.class,
+        com.sseulang.domain.report.infrastructure.persistence.UserReportRepositoryImpl.class
 })
 @Testcontainers
 @Transactional(propagation = Propagation.NOT_SUPPORTED)


### PR DESCRIPTION
## Summary
프론트 라운드 8 P1#1 + P1#2 — Admin 회원 카드/필터 차단 영역 해결.

## 변경 요약
| 항목 | 내용 |
|---|---|
| **V14 마이그레이션** | \`users.last_login_at\`, \`suspended_at\`, \`suspend_days\` + 인덱스 2 |
| **User 엔티티** | recordLogin / suspend / unsuspend / isSuspendedAt / isDormantAt / derivedStatus |
| **UserStatus enum** | ACTIVE / SUSPENDED / WITHDRAWN / DORMANT (derive 결과) |
| **AdminUserResponse** | + tradeCount, reportCount, dormant, suspendedAt, suspendDays, suspendedUntil, status, lastLoginAt |
| **검색·필터** | \`?keyword=&status=&createdAfter=&createdBefore=\` (NATIVE SQL) |
| **suspend endpoint** | \`PATCH /admin/users/{id}/suspend\` (body \`{days}\`) + \`DELETE\` |
| **lastLoginAt 기록** | LocalAuthService.login + OAuthLoginService.processOAuthLogin |

## 휴면 정의
- \`lastLoginAt\` 90일 이상 미접속 (없으면 createdAt 기준)
- 로그인 시 자동 갱신 → 응답 status 가 ACTIVE 로 자동 복귀

## 활동정지 vs 영구 차단
- \`is_blocked\` (영구) — 기존
- \`suspended_at + suspend_days\` (시한부) — 새로 추가. 만료 후 자동 ACTIVE 복귀

## 검색 필터 derive 룰
NATIVE SQL (\`DATE_ADD(suspended_at, INTERVAL suspend_days DAY) > now\`) 로 시점별 status 계산.

## Test plan
- [x] 컴파일 + 전체 테스트 PASS
- [ ] 수동: GET /admin/users?keyword=홍&status=ACTIVE
- [ ] 수동: PATCH /admin/users/3/suspend {days:7} → status=SUSPENDED 확인
- [ ] 수동: 로그인 → lastLoginAt 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)