### PR TITLE
feat: round 8c — Admin broadcast + EmailSender 확장

### DIFF
--- a/src/main/java/com/sseulang/domain/auth/domain/EmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/EmailSender.java
@@ -10,4 +10,10 @@ public interface EmailSender {
 
     /** 이메일 인증 토큰 발송. URL 은 호출자(EmailVerificationService) 가 token 으로 조립해 전달. */
     void sendVerificationEmail(String toEmail, String verificationUrl);
+
+    /**
+     * 1:1 문의 답변 완료 알림 (round 8c #9). subject/text 모두 호출자 책임 — 본 어댑터는 발송만.
+     * SMTP 미설치 환경에선 LogEmailSender 가 콘솔 출력만 하고 안전 fallback.
+     */
+    void sendInquiryReplyEmail(String toEmail, String subject, String html);
 }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/email/LogEmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/email/LogEmailSender.java
@@ -29,4 +29,9 @@ public class LogEmailSender implements EmailSender {
     public void sendVerificationEmail(String toEmail, String verificationUrl) {
         log.info("[email-verification] to={} url={}", toEmail, verificationUrl);
     }
+
+    @Override
+    public void sendInquiryReplyEmail(String toEmail, String subject, String html) {
+        log.info("[inquiry-reply] to={} subject={} (html len={})", toEmail, subject, html == null ? 0 : html.length());
+    }
 }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSender.java
@@ -41,13 +41,22 @@ public class SmtpEmailSender implements EmailSender {
 
     @Override
     public void sendVerificationEmail(String toEmail, String verificationUrl) {
+        sendHtml(toEmail, SUBJECT, buildHtml(verificationUrl));
+    }
+
+    @Override
+    public void sendInquiryReplyEmail(String toEmail, String subject, String html) {
+        sendHtml(toEmail, subject, html);
+    }
+
+    private void sendHtml(String toEmail, String subject, String html) {
         MimeMessage message = mailSender.createMimeMessage();
         try {
             MimeMessageHelper helper = new MimeMessageHelper(message, false, StandardCharsets.UTF_8.name());
             helper.setFrom(fromAddress);
             helper.setTo(toEmail);
-            helper.setSubject(SUBJECT);
-            helper.setText(buildHtml(verificationUrl), true);
+            helper.setSubject(subject);
+            helper.setText(html, true);
         } catch (MessagingException e) {
             throw new RuntimeException("이메일 메시지 빌드 실패: " + e.getMessage(), e);
         }

--- a/src/main/java/com/sseulang/domain/notification/application/NotificationApplicationService.java
+++ b/src/main/java/com/sseulang/domain/notification/application/NotificationApplicationService.java
@@ -15,10 +15,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class NotificationApplicationService {
 
-    private final NotificationRepository notificationRepository;
+    /** Admin broadcast 청크 크기 — 활성 사용자 id 청크 페이징 + 배치 INSERT 단위. */
+    private static final int BROADCAST_CHUNK_SIZE = 500;
 
-    public NotificationApplicationService(NotificationRepository notificationRepository) {
+    private final NotificationRepository notificationRepository;
+    private final com.sseulang.domain.user.domain.UserRepository userRepository;
+
+    public NotificationApplicationService(
+            NotificationRepository notificationRepository,
+            com.sseulang.domain.user.domain.UserRepository userRepository
+    ) {
         this.notificationRepository = notificationRepository;
+        this.userRepository = userRepository;
     }
 
     /**
@@ -60,5 +68,35 @@ public class NotificationApplicationService {
     /** 본인 unread 알림 모두 read 처리 (atomic UPDATE multi). 처리 건수 반환 — 0 도 정상. */
     public long markAllAsRead(Long userId) {
         return notificationRepository.markAllAsReadByUserId(userId);
+    }
+
+    /**
+     * Admin broadcast — 활성 사용자(blocked/deleted 제외) 전원에게 동일 알림 발송.
+     * 청크 페이징 + Mongo 단위 INSERT 로 OOM 방지. 처리 건수 반환.
+     *
+     * <p>type 은 {@link NotificationType#공지} 고정. linkType=null, linkId=null (특정 자원 아님).</p>
+     */
+    public long broadcast(String title, String content) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("title 은 필수입니다");
+        }
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("content 는 필수입니다");
+        }
+        long total = 0;
+        long afterId = 0;
+        while (true) {
+            java.util.List<Long> chunk = userRepository.findActiveIdsAfter(afterId, BROADCAST_CHUNK_SIZE);
+            if (chunk.isEmpty()) break;
+            for (Long uid : chunk) {
+                notificationRepository.save(
+                        Notification.create(uid, NotificationType.공지, title, content, null, null)
+                );
+            }
+            total += chunk.size();
+            afterId = chunk.get(chunk.size() - 1);
+            if (chunk.size() < BROADCAST_CHUNK_SIZE) break;
+        }
+        return total;
     }
 }

--- a/src/main/java/com/sseulang/domain/notification/presentation/AdminNotificationController.java
+++ b/src/main/java/com/sseulang/domain/notification/presentation/AdminNotificationController.java
@@ -1,0 +1,58 @@
+package com.sseulang.domain.notification.presentation;
+
+import com.sseulang.domain.notification.application.NotificationApplicationService;
+import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 공지 broadcast — 활성 사용자 전원에게 시스템 알림 INSERT.
+ *
+ * <p>SecurityConfig admin chain 으로 ROLE_ADMIN 강제. targetRole 은 현재 ALL 만 — ADMIN/USER 분기는 후속.</p>
+ */
+@Tag(name = "AdminNotification", description = "관리자 — 알림 broadcast")
+@RestController
+@RequestMapping("/api/v1/admin/notifications")
+public class AdminNotificationController {
+
+    private final NotificationApplicationService notificationService;
+
+    public AdminNotificationController(NotificationApplicationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @Operation(summary = "[관리자] 전체 알림 broadcast",
+            description = "활성 사용자(blocked/deleted 제외) 전원에게 동일 알림 발송. type=공지 고정. "
+                    + "처리 건수 반환. targetRole 은 현재 ALL 만 (USER/ADMIN 분기는 후속).")
+    @PostMapping("/broadcast")
+    public ResponseEntity<ApiResponse<BroadcastResponse>> broadcast(@Valid @RequestBody BroadcastRequest request) {
+        long sent = notificationService.broadcast(request.title(), request.content());
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(ApiResponse.ok(new BroadcastResponse(sent)));
+    }
+
+    @Schema(description = "Broadcast 요청. targetRole 은 현재 사용 안 함 (ALL 고정).")
+    public record BroadcastRequest(
+            @Schema(example = "5월 점검 안내", maxLength = 200)
+            @NotBlank @Size(max = 200) String title,
+
+            @Schema(example = "5월 6일 03:00~05:00 결제 일시 중단됩니다.")
+            @NotBlank String content,
+
+            @Schema(description = "현재 무시 (ALL 고정). 향후 USER/ADMIN 등 분기 예정.", nullable = true)
+            String targetRole
+    ) { }
+
+    @Schema(description = "Broadcast 응답 — 발송된 알림 건수.")
+    public record BroadcastResponse(@Schema(example = "1234") long sent) { }
+}

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -75,4 +75,13 @@ public interface UserRepository {
      * 게이트 2 보강 — total - blocked - deleted 의 이중 차감 회피.
      */
     long countActive();
+
+    /**
+     * Admin broadcast 용 — 활성 사용자 id 청크 페이징. blocked/deleted 제외.
+     * 큰 사용자 수에서 OOM 방지를 위해 호출자가 청크 단위로 호출. id ASC 안정 정렬.
+     *
+     * @param afterId 이전 호출의 마지막 id (처음 호출은 0)
+     * @param limit   페이지 크기
+     */
+    java.util.List<Long> findActiveIdsAfter(long afterId, int limit);
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -151,4 +151,8 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
      */
     @Query("SELECT COUNT(u) FROM User u WHERE u.blocked = false AND u.deleted = false")
     long countActive();
+
+    /** Admin broadcast — 활성 사용자 id 만 청크 페이징. id ASC. */
+    @Query("SELECT u.id FROM User u WHERE u.blocked = false AND u.deleted = false AND u.id > :afterId ORDER BY u.id ASC")
+    java.util.List<Long> findActiveIdsAfter(@Param("afterId") long afterId, org.springframework.data.domain.Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -105,4 +105,10 @@ public class UserRepositoryImpl implements UserRepository {
     public long countActive() {
         return jpa.countActive();
     }
+
+    @Override
+    public java.util.List<Long> findActiveIdsAfter(long afterId, int limit) {
+        if (limit <= 0) return java.util.Collections.emptyList();
+        return jpa.findActiveIdsAfter(afterId, org.springframework.data.domain.PageRequest.of(0, limit));
+    }
 }

--- a/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
@@ -49,7 +49,7 @@ class MessageApplicationServiceTest {
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView());
-        NotificationApplicationService notifSvc = new NotificationApplicationService(notifRepo);
+        NotificationApplicationService notifSvc = new NotificationApplicationService(notifRepo, new com.sseulang.domain.user.application.InMemoryFakeUserRepository());
         // 단위 테스트에선 트랜잭션 컨텍스트 X — AFTER_COMMIT listener 직접 호출하는 fake event publisher.
         ChatRealtimeEventListener listener = new ChatRealtimeEventListener(publisher);
         org.springframework.context.ApplicationEventPublisher eventPublisher = event -> {

--- a/src/test/java/com/sseulang/domain/notification/application/NotificationApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/notification/application/NotificationApplicationServiceTest.java
@@ -25,7 +25,7 @@ class NotificationApplicationServiceTest {
     @BeforeEach
     void setUp() {
         repo = new InMemoryFakeNotificationRepository();
-        service = new NotificationApplicationService(repo);
+        service = new NotificationApplicationService(repo, new com.sseulang.domain.user.application.InMemoryFakeUserRepository());
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
+++ b/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
@@ -122,4 +122,15 @@ public class InMemoryFakeUserRepository implements UserRepository {
         // 테스트 fake — 검색·필터 미구현. 기존 findAllForAdmin 으로 대체 위임.
         return findAllForAdmin(pageable);
     }
+
+    @Override
+    public java.util.List<Long> findActiveIdsAfter(long afterId, int limit) {
+        return store.values().stream()
+                .filter(u -> !u.isBlocked() && !u.isDeleted())
+                .map(User::getId)
+                .filter(id -> id > afterId)
+                .sorted()
+                .limit(limit)
+                .toList();
+    }
 }


### PR DESCRIPTION
## Summary
- **P2 #7** \`POST /api/v1/admin/notifications/broadcast\` 신설
- **P3 #9 준비** \`EmailSender.sendInquiryReplyEmail\` 추가 (실제 호출은 PR #76 머지 후)

## Broadcast 동작
- body: \`{title, content, targetRole?}\` (targetRole 무시 — ALL 고정)
- 활성 사용자 (blocked/deleted 제외) 전원에게 \`NotificationType=공지\` INSERT
- 청크 페이징 (500 단위) — OOM 방지
- 응답 202 + \`{sent: N}\`

## EmailSender 확장
- 기존 \`sendVerificationEmail\` + 신규 \`sendInquiryReplyEmail(to, subject, html)\`
- LogEmailSender (개발) / SmtpEmailSender (네이버) 둘 다 구현
- SmtpEmailSender 내부 \`sendHtml\` 헬퍼로 리팩토 (verification 코드 재사용)

## P3 #9 (답변 알림) 후속 작업
PR #76 (고객지원) 머지 후 InquiryApplicationService.adminReply 안에서:
1. \`notificationService.notify(userId, NotificationType.시스템, title, content, "inquiry", inquiryId)\`
2. \`emailSender.sendInquiryReplyEmail(inquiry.email, subject, html)\`
의존 주입만 추가하면 끝.

## Test plan
- [x] 컴파일 + 전체 테스트 BUILD SUCCESSFUL
- [ ] 수동: POST /admin/notifications/broadcast {title, content} → sent count 확인
- [ ] 수동: 사용자 알림 목록에서 broadcast 알림 보임

🤖 Generated with [Claude Code](https://claude.com/claude-code)