### PR TITLE
feat: round 8d — 월별 거래완료 stats endpoint (recharts 친화)

### DIFF
--- a/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
@@ -55,4 +55,10 @@ public class AdminStatsService {
         DeliveryStatsResult deliveries = deliveryService.adminGetStats();
         return new AdminDashboardResult(users, transactions, payments, withdrawals, deliveries);
     }
+
+    /** 월별 거래완료 집계 — recharts 차트용. month ASC, 빈 월은 0 채움. */
+    public java.util.List<com.sseulang.domain.transaction.domain.TransactionMonthlyStat> tradesMonthly(
+            java.time.YearMonth from, java.time.YearMonth to) {
+        return transactionService.adminMonthlyTrades(from, to);
+    }
 }

--- a/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
@@ -27,4 +27,22 @@ public class AdminStatsController {
     public ApiResponse<AdminDashboardResponse> dashboard() {
         return ApiResponse.ok(AdminDashboardResponse.from(statsService.dashboard()));
     }
+
+    @Operation(summary = "월별 거래완료 집계",
+            description = "completed_at 기준. from/to 형식 'YYYY-MM' (양쪽 inclusive). 거래 0건 월은 0 으로 채워져 차트 친화.")
+    @GetMapping("/trades/monthly")
+    public ApiResponse<java.util.List<com.sseulang.domain.stats.presentation.dto.MonthlyTradeStatResponse>> tradesMonthly(
+            @org.springframework.web.bind.annotation.RequestParam("from")
+            @org.springframework.format.annotation.DateTimeFormat(pattern = "yyyy-MM") java.time.YearMonth from,
+            @org.springframework.web.bind.annotation.RequestParam("to")
+            @org.springframework.format.annotation.DateTimeFormat(pattern = "yyyy-MM") java.time.YearMonth to
+    ) {
+        if (from.isAfter(to)) {
+            throw new com.sseulang.global.exception.BusinessException(
+                    com.sseulang.global.exception.ErrorCode.INVALID_REQUEST);
+        }
+        return ApiResponse.ok(statsService.tradesMonthly(from, to).stream()
+                .map(com.sseulang.domain.stats.presentation.dto.MonthlyTradeStatResponse::from)
+                .toList());
+    }
 }

--- a/src/main/java/com/sseulang/domain/stats/presentation/dto/MonthlyTradeStatResponse.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/dto/MonthlyTradeStatResponse.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.stats.presentation.dto;
+
+import com.sseulang.domain.transaction.domain.TransactionMonthlyStat;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 월별 거래완료 집계 응답. recharts 차트 친화 (month ASC, 빈 월은 count=0/amount=0 으로 채워짐).
+ */
+@Schema(description = "월별 거래완료 집계.")
+public record MonthlyTradeStatResponse(
+        @Schema(example = "2026-05") String month,
+        @Schema(example = "42") long count,
+        @Schema(example = "12500000") long amount
+) {
+    public static MonthlyTradeStatResponse from(TransactionMonthlyStat r) {
+        return new MonthlyTradeStatResponse(r.month().toString(), r.count(), r.amount());
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -197,6 +197,22 @@ public class TransactionApplicationService {
     }
 
     /**
+     * 월별 거래완료 집계 (Admin) — completed_at 기준. 거래 0 건 월은 응답에서 0 으로 채워진다.
+     * recharts 친화 — month ASC. (year, month, count, amount).
+     */
+    public java.util.List<com.sseulang.domain.transaction.domain.TransactionMonthlyStat> adminMonthlyTrades(
+            java.time.YearMonth from, java.time.YearMonth to) {
+        java.util.Map<java.time.YearMonth, com.sseulang.domain.transaction.domain.TransactionMonthlyStat> byMonth = new java.util.LinkedHashMap<>();
+        for (java.time.YearMonth m = from; !m.isAfter(to); m = m.plusMonths(1)) {
+            byMonth.put(m, new com.sseulang.domain.transaction.domain.TransactionMonthlyStat(m, 0, 0));
+        }
+        for (var row : transactionRepository.countCompletedMonthly(from, to)) {
+            byMonth.put(row.month(), row);
+        }
+        return new java.util.ArrayList<>(byMonth.values());
+    }
+
+    /**
      * 본인이 reviewer 로 아직 작성하지 않은 거래완료 거래 페이징 (follow-up #56).
      *
      * <p>completedAt 이 7일 이내인 것만 — 작성 가능 기간이 지난 거래는 제외 (가이드 §5.5).

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionMonthlyStat.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionMonthlyStat.java
@@ -1,0 +1,12 @@
+package com.sseulang.domain.transaction.domain;
+
+import java.time.YearMonth;
+
+/**
+ * 월별 거래 집계 결과 — Admin dashboard 차트(recharts)용.
+ *
+ * @param month YYYY-MM 단위 (해당 월에 거래완료된 거래)
+ * @param count 거래완료 건수
+ * @param amount 합계 금액 (KRW)
+ */
+public record TransactionMonthlyStat(YearMonth month, long count, long amount) { }

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -37,6 +37,12 @@ public interface TransactionRepository {
      */
     java.util.Map<Long, Long> countByUserIdsAsParticipant(java.util.Collection<Long> userIds);
 
+    /**
+     * 월별 거래 집계 — completed_at 기준 (status=거래완료 만). [from, to] 월 범위 inclusive.
+     * 결과는 월별 (year, month, count, sumPrice). 거래 0건 월은 응답에 포함되지 않음 (호출자가 0 채움).
+     */
+    List<TransactionMonthlyStat> countCompletedMonthly(java.time.YearMonth from, java.time.YearMonth to);
+
     // ───────── Review pending (follow-up #56) ─────────
 
     /**

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -55,6 +55,32 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
     }
 
     /**
+     * 월별 거래완료 집계 — completed_at YEAR/MONTH GROUP BY. native MySQL.
+     * Result projection: (year, month, count, amount). YearMonth 변환은 호출자.
+     */
+    @Query(value = """
+            SELECT YEAR(completed_at) AS y, MONTH(completed_at) AS m,
+                   COUNT(*) AS cnt, COALESCE(SUM(price), 0) AS amt
+              FROM transactions
+             WHERE status = '거래완료'
+               AND completed_at >= :fromTs
+               AND completed_at <  :toTs
+             GROUP BY YEAR(completed_at), MONTH(completed_at)
+             ORDER BY y ASC, m ASC
+            """, nativeQuery = true)
+    List<MonthlyStatRow> countCompletedMonthlyRaw(
+            @Param("fromTs") java.time.LocalDateTime fromTs,
+            @Param("toTs") java.time.LocalDateTime toTs
+    );
+
+    interface MonthlyStatRow {
+        Integer getY();
+        Integer getM();
+        Long getCnt();
+        Long getAmt();
+    }
+
+    /**
      * Review 작성 대기 거래 — completedAt 하한 + 본인 참여 + 본인이 reviewer 인 review 가 아직 없는 것.
      * Review 와 NOT EXISTS 로 cross-aggregate read (write 가 아니라 도메인 invariant 영향 X).
      */

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -58,6 +58,24 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     }
 
     @Override
+    public List<com.sseulang.domain.transaction.domain.TransactionMonthlyStat> countCompletedMonthly(
+            java.time.YearMonth from, java.time.YearMonth to) {
+        if (from == null || to == null) {
+            throw new IllegalArgumentException("from/to 는 필수입니다");
+        }
+        if (from.isAfter(to)) {
+            throw new IllegalArgumentException("from 은 to 이전이어야 합니다");
+        }
+        java.time.LocalDateTime fromTs = from.atDay(1).atStartOfDay();
+        // toTs 는 (to.다음월 1일 00:00) — exclusive 경계로 to 월 마지막 순간까지 포함.
+        java.time.LocalDateTime toTs = to.plusMonths(1).atDay(1).atStartOfDay();
+        return jpa.countCompletedMonthlyRaw(fromTs, toTs).stream()
+                .map(r -> new com.sseulang.domain.transaction.domain.TransactionMonthlyStat(
+                        java.time.YearMonth.of(r.getY(), r.getM()), r.getCnt(), r.getAmt()))
+                .toList();
+    }
+
+    @Override
     public Page<Transaction> findPendingReviewable(Long userId, LocalDateTime since, Pageable pageable) {
         return jpa.findPendingReviewableJpql(userId, since, pageable);
     }

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -86,6 +86,25 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
     }
 
     @Override
+    public java.util.List<com.sseulang.domain.transaction.domain.TransactionMonthlyStat> countCompletedMonthly(
+            java.time.YearMonth from, java.time.YearMonth to) {
+        Map<java.time.YearMonth, long[]> bucket = new HashMap<>();  // [count, amount]
+        for (Transaction t : store.values()) {
+            if (t.getStatus() != TransactionStatus.거래완료 || t.getCompletedAt() == null) continue;
+            java.time.YearMonth m = java.time.YearMonth.from(t.getCompletedAt());
+            if (m.isBefore(from) || m.isAfter(to)) continue;
+            long[] arr = bucket.computeIfAbsent(m, k -> new long[]{0, 0});
+            arr[0]++;
+            arr[1] += t.getPrice();
+        }
+        return bucket.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> new com.sseulang.domain.transaction.domain.TransactionMonthlyStat(
+                        e.getKey(), e.getValue()[0], e.getValue()[1]))
+                .toList();
+    }
+
+    @Override
     public Page<Transaction> findPendingReviewable(Long userId, LocalDateTime since, Pageable pageable) {
         List<Transaction> filtered = store.values().stream()
                 .filter(t -> t.getStatus() == TransactionStatus.거래완료)


### PR DESCRIPTION
## Summary
P3 #10 — Admin 대시보드 월별 거래 차트 백엔드 데이터 제공.

## API
\`\`\`
GET /api/v1/admin/stats/trades/monthly?from=2026-01&to=2026-05
\`\`\`
- from/to 형식: \`YYYY-MM\` (양쪽 inclusive)
- from > to → 400 INVALID_REQUEST
- ROLE_ADMIN 필수

## 응답 (recharts 친화)
\`\`\`json
[
  { "month": "2026-01", "count": 0, "amount": 0 },
  { "month": "2026-02", "count": 12, "amount": 1500000 },
  { "month": "2026-03", "count": 42, "amount": 12500000 }
]
\`\`\`
- 거래 0건 월도 0 으로 채워서 차트 X축 갭 없음
- month ASC

## 구현
- \`TransactionMonthlyStat\` (year-month, count, amount) record
- \`TransactionJpaRepository.countCompletedMonthlyRaw\` — NATIVE SQL \`GROUP BY YEAR(completed_at), MONTH(completed_at)\`
- \`TransactionApplicationService.adminMonthlyTrades\` — 빈 월 0 채움
- \`AdminStatsService.tradesMonthly\` — orchestration
- \`MonthlyTradeStatResponse\` — month 를 \`YYYY-MM\` String 직렬화

## 명세 vs 본 PR
| 명세 | PR |
|---|---|
| \`GET /trades/monthly?from=&to=\` | ✅ 본 PR |
| \`GET /trades?startDate=&endDate=&type=&status=\` | ❌ Transaction 검색 도메인 — 별도 follow-up (큰 작업) |

## Test plan
- [x] 컴파일 + 전체 테스트 BUILD SUCCESSFUL
- [ ] 수동: GET /admin/stats/trades/monthly?from=2026-01&to=2026-05 → 5개월 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)