### PR TITLE
feat: round 9 — 답변 알림 실호출 + Admin 거래 검색

### DIFF
--- a/src/main/java/com/sseulang/domain/support/application/InquiryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/support/application/InquiryApplicationService.java
@@ -1,5 +1,8 @@
 package com.sseulang.domain.support.application;
 
+import com.sseulang.domain.auth.domain.EmailSender;
+import com.sseulang.domain.notification.application.NotificationApplicationService;
+import com.sseulang.domain.notification.domain.NotificationType;
 import com.sseulang.domain.support.application.dto.InquiryCreateCommand;
 import com.sseulang.domain.support.application.dto.InquiryReplyCommand;
 import com.sseulang.domain.support.application.dto.InquiryResult;
@@ -8,6 +11,7 @@ import com.sseulang.domain.support.domain.InquiryRepository;
 import com.sseulang.domain.support.domain.InquiryStatus;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -27,15 +31,25 @@ import java.time.LocalDateTime;
  * <p>관리자 권한 강제는 SecurityConfig admin chain ({@code hasRole("ADMIN")}). 본 서비스는
  * 사용자 권한 검증만 — 본인 문의가 아니면 {@link ErrorCode#INQUIRY_FORBIDDEN}.</p>
  */
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 public class InquiryApplicationService {
 
     private final InquiryRepository inquiryRepository;
+    private final NotificationApplicationService notificationService;
+    private final EmailSender emailSender;
     private final Clock clock;
 
-    public InquiryApplicationService(InquiryRepository inquiryRepository, Clock clock) {
+    public InquiryApplicationService(
+            InquiryRepository inquiryRepository,
+            NotificationApplicationService notificationService,
+            EmailSender emailSender,
+            Clock clock
+    ) {
         this.inquiryRepository = inquiryRepository;
+        this.notificationService = notificationService;
+        this.emailSender = emailSender;
         this.clock = clock;
     }
 
@@ -90,12 +104,64 @@ public class InquiryApplicationService {
     /**
      * 답변 작성. status null 이면 DONE 으로 자동 — 명세대로.
      * 빈 문자열은 도메인에서 reject.
+     *
+     * <p><b>알림 흐름</b> (round 9):
+     * <ol>
+     *   <li>Notification INSERT — 사용자가 SideDrawer / NotificationPage 에서 즉시 확인</li>
+     *   <li>Email 발송 — best-effort. SMTP 실패해도 트랜잭션 롤백 X (답변 자체는 저장됨).
+     *       예외는 WARN 로그만, 사용자에게 영향 없음.</li>
+     * </ol>
+     * 메일 발송이 트랜잭션 안에 있어 SMTP latency 가 응답 시간에 포함됨 — 5/6 이후 outbox 패턴
+     * 도입 시 비동기로 전환 (현재는 단순화 우선).</p>
      */
     @Transactional
     public void adminReply(Long inquiryId, InquiryReplyCommand cmd) {
         Inquiry inquiry = findOrThrow(inquiryId);
         InquiryStatus next = cmd.status() == null ? InquiryStatus.DONE : cmd.status();
         inquiry.writeAdminReply(cmd.adminReply(), next, LocalDateTime.now(clock));
+
+        // 1) Notification — 푸시 알림 (SideDrawer)
+        notificationService.notify(
+                inquiry.getUserId(),
+                NotificationType.시스템,
+                "문의 답변이 도착했어요",
+                inquiry.getTitle(),
+                "inquiry",
+                inquiry.getId()
+        );
+
+        // 2) Email — best-effort. SMTP 실패해도 답변/알림은 보존.
+        try {
+            emailSender.sendInquiryReplyEmail(
+                    inquiry.getEmail(),
+                    "[쓸랭] 문의 답변이 도착했습니다",
+                    buildReplyEmailHtml(inquiry, cmd.adminReply())
+            );
+        } catch (RuntimeException e) {
+            log.warn("Inquiry reply email 발송 실패 — inquiryId={}, email={}, cause={}",
+                    inquiry.getId(), inquiry.getEmail(), e.getMessage());
+        }
+    }
+
+    private static String buildReplyEmailHtml(Inquiry inquiry, String adminReply) {
+        return """
+                <!doctype html>
+                <html>
+                  <body style="font-family:sans-serif;line-height:1.6;color:#333">
+                    <h2>쓸랭 문의 답변</h2>
+                    <p><b>문의 제목</b><br>%s</p>
+                    <hr>
+                    <p><b>답변</b></p>
+                    <pre style="white-space:pre-wrap;font-family:inherit">%s</pre>
+                    <p style="color:#888;font-size:12px">마이페이지 &gt; 1:1 문의에서도 확인하실 수 있어요.</p>
+                  </body>
+                </html>
+                """.formatted(escapeHtml(inquiry.getTitle()), escapeHtml(adminReply));
+    }
+
+    private static String escapeHtml(String s) {
+        if (s == null) return "";
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
     @Transactional

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -213,6 +213,22 @@ public class TransactionApplicationService {
     }
 
     /**
+     * Admin 거래 검색 (round 9). 모든 필터 nullable, 최신순. cross-aggregate join 부담 회피로
+     * keyword 는 itemId/transactionId 숫자 매칭만 (email/nickname LIKE 는 follow-up).
+     */
+    public Page<TransactionResult> adminSearch(
+            java.time.LocalDateTime startDate,
+            java.time.LocalDateTime endDate,
+            com.sseulang.domain.item.domain.TradeType tradeType,
+            TransactionStatus status,
+            String keyword,
+            Pageable pageable
+    ) {
+        return transactionRepository.adminSearch(startDate, endDate, tradeType, status, keyword, pageable)
+                .map(TransactionResult::from);
+    }
+
+    /**
      * 본인이 reviewer 로 아직 작성하지 않은 거래완료 거래 페이징 (follow-up #56).
      *
      * <p>completedAt 이 7일 이내인 것만 — 작성 가능 기간이 지난 거래는 제외 (가이드 §5.5).

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -43,6 +43,20 @@ public interface TransactionRepository {
      */
     List<TransactionMonthlyStat> countCompletedMonthly(java.time.YearMonth from, java.time.YearMonth to);
 
+    /**
+     * Admin 거래 검색 (round 9). created_at 기준 [start, end] 범위 + tradeType / status 필터 + keyword.
+     * keyword 는 buyer/seller email 또는 nickname LIKE 가 이상적이지만, 현재는 cross-aggregate 부담
+     * 회피 위해 itemId/transactionId 숫자 매칭만 (확장은 follow-up). 모든 필터 nullable. 최신순.
+     */
+    org.springframework.data.domain.Page<Transaction> adminSearch(
+            java.time.LocalDateTime startDate,
+            java.time.LocalDateTime endDate,
+            com.sseulang.domain.item.domain.TradeType tradeType,
+            TransactionStatus status,
+            String keyword,
+            org.springframework.data.domain.Pageable pageable
+    );
+
     // ───────── Review pending (follow-up #56) ─────────
 
     /**

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -33,6 +33,28 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
             """)
     List<TransactionStatusCount> countGroupByStatusJpql();
 
+    /**
+     * Admin 거래 검색 (round 9). created_at [start, end] + tradeType / status / keywordId 필터.
+     * 모두 nullable. keywordId 는 t.id 또는 t.itemId 정확 매칭. 최신순.
+     */
+    @Query("""
+            SELECT t FROM Transaction t
+             WHERE (:start IS NULL OR t.createdAt >= :start)
+               AND (:end   IS NULL OR t.createdAt <= :end)
+               AND (:tradeType IS NULL OR t.tradeType = :tradeType)
+               AND (:status    IS NULL OR t.status    = :status)
+               AND (:keywordId IS NULL OR t.id = :keywordId OR t.itemId = :keywordId)
+             ORDER BY t.id DESC
+            """)
+    Page<Transaction> adminSearchJpql(
+            @Param("start") java.time.LocalDateTime start,
+            @Param("end")   java.time.LocalDateTime end,
+            @Param("tradeType") com.sseulang.domain.item.domain.TradeType tradeType,
+            @Param("status")    TransactionStatus status,
+            @Param("keywordId") Long keywordId,
+            Pageable pageable
+    );
+
     /** Admin 회원 카드용 — sellerId 로 참여한 거래 (sellerId, count). */
     @Query("""
             SELECT t.sellerId AS userId, COUNT(t) AS cnt FROM Transaction t

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -58,6 +58,29 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     }
 
     @Override
+    public Page<Transaction> adminSearch(
+            java.time.LocalDateTime startDate,
+            java.time.LocalDateTime endDate,
+            com.sseulang.domain.item.domain.TradeType tradeType,
+            TransactionStatus status,
+            String keyword,
+            Pageable pageable
+    ) {
+        Long keywordId = parseKeywordId(keyword);
+        return jpa.adminSearchJpql(startDate, endDate, tradeType, status, keywordId, pageable);
+    }
+
+    /** keyword 가 숫자면 long, 아니면 null (LIKE 검색은 미지원, follow-up). */
+    private static Long parseKeywordId(String keyword) {
+        if (keyword == null || keyword.isBlank()) return null;
+        try {
+            return Long.parseLong(keyword.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @Override
     public List<com.sseulang.domain.transaction.domain.TransactionMonthlyStat> countCompletedMonthly(
             java.time.YearMonth from, java.time.YearMonth to) {
         if (from == null || to == null) {

--- a/src/main/java/com/sseulang/domain/transaction/presentation/AdminTransactionController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/AdminTransactionController.java
@@ -1,0 +1,57 @@
+package com.sseulang.domain.transaction.presentation;
+
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.domain.transaction.application.TransactionApplicationService;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+import com.sseulang.domain.transaction.presentation.dto.TransactionResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 거래 검색·관리. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
+ *
+ * <p>round 9 — AdminTransactionListPanel 의 mock 제거용. created_at 기준 [start, end] 범위 +
+ * tradeType / status / keyword 필터. keyword 는 itemId/transactionId 숫자 매칭 (email/nickname
+ * LIKE 는 follow-up). 최신순.</p>
+ */
+@Tag(name = "AdminTransaction", description = "관리자 — 거래 검색/관리")
+@RestController
+@RequestMapping("/api/v1/admin/transactions")
+public class AdminTransactionController {
+
+    private final TransactionApplicationService transactionService;
+
+    public AdminTransactionController(TransactionApplicationService transactionService) {
+        this.transactionService = transactionService;
+    }
+
+    @Operation(summary = "[관리자] 거래 검색·페이징",
+            description = "startDate/endDate (created_at 범위, ISO LocalDateTime). tradeType/status/keyword 모두 선택. "
+                    + "keyword 는 transactionId 또는 itemId 숫자 매칭 (email/nickname LIKE 는 follow-up). 최신순.")
+    @GetMapping
+    public ApiResponse<PageResponse<TransactionResponse>> list(
+            @RequestParam(value = "startDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam(value = "endDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @RequestParam(value = "type", required = false) TradeType tradeType,
+            @RequestParam(value = "status", required = false) TransactionStatus status,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            Pageable pageable
+    ) {
+        return ApiResponse.ok(PageResponse.from(
+                transactionService.adminSearch(startDate, endDate, tradeType, status, keyword, pageable)
+                        .map(TransactionResponse::from)
+        ));
+    }
+}

--- a/src/test/java/com/sseulang/domain/support/application/InquiryApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/support/application/InquiryApplicationServiceTest.java
@@ -33,7 +33,17 @@ class InquiryApplicationServiceTest {
     void setUp() {
         repo = new InMemoryFakeInquiryRepository();
         Clock clock = Clock.fixed(NOW.atZone(KST).toInstant(), KST);
-        service = new InquiryApplicationService(repo, clock);
+        // 테스트는 알림/이메일 사이드 이펙트를 검증하지 않음 — no-op fake 주입.
+        com.sseulang.domain.notification.application.NotificationApplicationService notifSvc =
+                new com.sseulang.domain.notification.application.NotificationApplicationService(
+                        new com.sseulang.domain.notification.application.InMemoryFakeNotificationRepository(),
+                        new com.sseulang.domain.user.application.InMemoryFakeUserRepository()
+                );
+        com.sseulang.domain.auth.domain.EmailSender emailSender = new com.sseulang.domain.auth.domain.EmailSender() {
+            @Override public void sendVerificationEmail(String t, String u) { }
+            @Override public void sendInquiryReplyEmail(String t, String s, String h) { }
+        };
+        service = new InquiryApplicationService(repo, notifSvc, emailSender, clock);
     }
 
     private InquiryCreateCommand cmd() {

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -131,4 +131,31 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
         }
         return result;
     }
+
+    @Override
+    public Page<Transaction> adminSearch(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            com.sseulang.domain.item.domain.TradeType tradeType,
+            TransactionStatus status,
+            String keyword,
+            Pageable pageable
+    ) {
+        Long keywordId = null;
+        if (keyword != null && !keyword.isBlank()) {
+            try { keywordId = Long.parseLong(keyword.trim()); } catch (NumberFormatException ignored) { }
+        }
+        final Long kId = keywordId;
+        List<Transaction> filtered = store.values().stream()
+                .filter(t -> startDate == null || t.getCreatedAt() == null || !t.getCreatedAt().isBefore(startDate))
+                .filter(t -> endDate == null || t.getCreatedAt() == null || !t.getCreatedAt().isAfter(endDate))
+                .filter(t -> tradeType == null || t.getTradeType() == tradeType)
+                .filter(t -> status == null || t.getStatus() == status)
+                .filter(t -> kId == null || kId.equals(t.getId()) || kId.equals(t.getItemId()))
+                .sorted(Comparator.comparingLong(Transaction::getId).reversed())
+                .toList();
+        int start = Math.min((int) pageable.getOffset(), filtered.size());
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
+    }
 }


### PR DESCRIPTION
## Summary
P0 #1 + P0 #2.

### #1 고객지원 답변 알림 실호출
\`InquiryApplicationService.adminReply\` 안에서:
- \`NotificationApplicationService.notify\` (type=시스템, linkType=inquiry, linkId=inquiryId) — SideDrawer 즉시 노출
- \`EmailSender.sendInquiryReplyEmail\` — best-effort. SMTP 실패해도 답변/알림은 보존 (WARN 로그만)
- 답변 작성 + 알림 + 메일이 같은 트랜잭션 — outbox 패턴은 follow-up

### #2 Admin 거래 검색
- \`GET /api/v1/admin/transactions?startDate=&endDate=&type=&status=&keyword=&page=&size=\`
- 모든 필터 nullable, 최신순
- keyword: itemId 또는 transactionId 정확 매칭 (email/nickname LIKE 는 follow-up — cross-aggregate join 부담)

## Test plan
- [x] 컴파일 + 전체 테스트 BUILD SUCCESSFUL
- [ ] 수동: 관리자 답변 → 사용자 SideDrawer 알림 + 메일 수신 확인
- [ ] 수동: GET /admin/transactions?startDate=2026-05-01T00:00:00&type=판매 → 페이지 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)