### PR TITLE
fix: round 9 Codex gate 2 — Critical (SUSPENDED 가드) + Warning 4건

### DIFF
--- a/src/main/java/com/sseulang/domain/auth/application/LocalAuthService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/LocalAuthService.java
@@ -128,7 +128,10 @@ public class LocalAuthService {
         String hashToCompare = (user != null && user.hasPassword()) ? user.getPassword() : dummyPasswordHash;
         boolean passwordOk = passwordEncoder.matches(rawPassword, hashToCompare);
 
-        if (user == null || !user.hasPassword() || user.isBlocked() || user.isDeleted() || !passwordOk) {
+        // SUSPENDED (시한부 정지) 도 LOGIN_FAILED 로 통합 — 정지 사실 leak 방지 + 기존 패스워드로 우회 차단
+        // (Codex round 9 hotfix). isAccessibleAt 은 blocked/deleted/suspended 통합 가드.
+        boolean accessible = user != null && user.isAccessibleAt(java.time.LocalDateTime.now());
+        if (user == null || !user.hasPassword() || !accessible || !passwordOk) {
             throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
         }
         // 휴면 판정 기준 — 응답 status 가 ACTIVE 로 자동 복귀.

--- a/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
@@ -82,7 +82,8 @@ public class OAuthLoginService {
                 info.profileImage()
         );
 
-        if (user.isBlocked() || user.isDeleted()) {
+        // SUSPENDED (시한부 정지) 도 USER_BLOCKED 통합 — Codex round 9 hotfix.
+        if (!user.isAccessibleAt(java.time.LocalDateTime.now())) {
             throw new BusinessException(ErrorCode.USER_BLOCKED);
         }
 

--- a/src/main/java/com/sseulang/domain/auth/application/RefreshTokenRotationService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/RefreshTokenRotationService.java
@@ -27,9 +27,12 @@ import java.time.Duration;
 @Transactional
 public class RefreshTokenRotationService {
 
+    private static final String USER_ROLE = "USER";
+
     private final JwtProvider jwtProvider;
     private final RefreshTokenStore refreshTokenStore;
     private final AccessTokenBlacklist accessTokenBlacklist;
+    private final com.sseulang.domain.user.domain.UserRepository userRepository;
     private final Clock clock;
     private final Duration refreshTokenTtl;
 
@@ -37,12 +40,14 @@ public class RefreshTokenRotationService {
             JwtProvider jwtProvider,
             RefreshTokenStore refreshTokenStore,
             AccessTokenBlacklist accessTokenBlacklist,
+            com.sseulang.domain.user.domain.UserRepository userRepository,
             Clock clock,
             JwtProperties jwtProperties
     ) {
         this.jwtProvider = jwtProvider;
         this.refreshTokenStore = refreshTokenStore;
         this.accessTokenBlacklist = accessTokenBlacklist;
+        this.userRepository = userRepository;
         this.clock = clock;
         this.refreshTokenTtl = Duration.ofSeconds(jwtProperties.refreshTokenValiditySeconds());
     }
@@ -63,6 +68,17 @@ public class RefreshTokenRotationService {
         if (!refreshTokenStore.consume(role, userId, oldJti, claimTv)) {
             refreshTokenStore.revokeAll(role, userId);
             throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
+        }
+
+        // SUSPENDED/blocked/deleted 사용자의 RT 재사용 차단 — Codex round 9 hotfix.
+        // ROLE_USER 만 검사 (admin 은 admins 테이블 + 정지 메커니즘 없음). user 미존재는 무시 —
+        // RT consume 통과한 시점이라 race 외엔 정상 미존재 케이스 없음. accessible=false 일 때만 차단.
+        if (USER_ROLE.equals(role)) {
+            var userOpt = userRepository.findById(userId);
+            if (userOpt.isPresent() && !userOpt.get().isAccessibleAt(java.time.LocalDateTime.now(clock))) {
+                refreshTokenStore.revokeAll(role, userId);
+                throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
+            }
         }
 
         String newAccessToken = jwtProvider.issueAccessToken(userId, role);

--- a/src/main/java/com/sseulang/domain/support/application/InquiryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/support/application/InquiryApplicationService.java
@@ -39,17 +39,20 @@ public class InquiryApplicationService {
     private final InquiryRepository inquiryRepository;
     private final NotificationApplicationService notificationService;
     private final EmailSender emailSender;
+    private final org.springframework.context.ApplicationEventPublisher eventPublisher;
     private final Clock clock;
 
     public InquiryApplicationService(
             InquiryRepository inquiryRepository,
             NotificationApplicationService notificationService,
             EmailSender emailSender,
+            org.springframework.context.ApplicationEventPublisher eventPublisher,
             Clock clock
     ) {
         this.inquiryRepository = inquiryRepository;
         this.notificationService = notificationService;
         this.emailSender = emailSender;
+        this.eventPublisher = eventPublisher;
         this.clock = clock;
     }
 
@@ -102,48 +105,60 @@ public class InquiryApplicationService {
     }
 
     /**
-     * 답변 작성. status null 이면 DONE 으로 자동 — 명세대로.
-     * 빈 문자열은 도메인에서 reject.
+     * 답변 작성. status null 이면 DONE 으로 자동 — 명세대로. status=PENDING 은 거부 (INVALID_STATE).
      *
-     * <p><b>알림 흐름</b> (round 9):
+     * <p><b>알림 흐름</b> (Codex round 9 hotfix):
      * <ol>
-     *   <li>Notification INSERT — 사용자가 SideDrawer / NotificationPage 에서 즉시 확인</li>
-     *   <li>Email 발송 — best-effort. SMTP 실패해도 트랜잭션 롤백 X (답변 자체는 저장됨).
-     *       예외는 WARN 로그만, 사용자에게 영향 없음.</li>
+     *   <li>Inquiry.writeAdminReply — JPA write</li>
+     *   <li>Notification + Email 은 {@code AFTER_COMMIT} 이벤트로 분리 — JPA commit 실패 시 알림/메일도
+     *       함께 롤백 (dangling 차단). Email 은 best-effort (예외는 WARN).</li>
      * </ol>
-     * 메일 발송이 트랜잭션 안에 있어 SMTP latency 가 응답 시간에 포함됨 — 5/6 이후 outbox 패턴
-     * 도입 시 비동기로 전환 (현재는 단순화 우선).</p>
      */
     @Transactional
     public void adminReply(Long inquiryId, InquiryReplyCommand cmd) {
+        if (cmd.status() == InquiryStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INQUIRY_INVALID_STATE);
+        }
         Inquiry inquiry = findOrThrow(inquiryId);
         InquiryStatus next = cmd.status() == null ? InquiryStatus.DONE : cmd.status();
-        inquiry.writeAdminReply(cmd.adminReply(), next, LocalDateTime.now(clock));
+        try {
+            inquiry.writeAdminReply(cmd.adminReply(), next, LocalDateTime.now(clock));
+        } catch (IllegalArgumentException e) {
+            // 도메인 검증 (PENDING 거부 등) 은 비즈니스 예외로 변환 — 500 회귀 차단.
+            throw new BusinessException(ErrorCode.INQUIRY_INVALID_STATE);
+        }
+        // AFTER_COMMIT 이벤트 등록 — 트랜잭션 commit 후 listener 가 알림/메일 발송.
+        eventPublisher.publishEvent(new InquiryRepliedEvent(
+                inquiry.getId(), inquiry.getUserId(), inquiry.getEmail(),
+                inquiry.getTitle(), cmd.adminReply()
+        ));
+    }
 
-        // 1) Notification — 푸시 알림 (SideDrawer)
+    /** Round 9 hotfix — JPA commit 후 알림/메일 발송 (dangling 차단). */
+    @org.springframework.transaction.event.TransactionalEventListener(
+            phase = org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT)
+    public void onInquiryReplied(InquiryRepliedEvent event) {
         notificationService.notify(
-                inquiry.getUserId(),
-                NotificationType.시스템,
-                "문의 답변이 도착했어요",
-                inquiry.getTitle(),
-                "inquiry",
-                inquiry.getId()
+                event.userId(), NotificationType.시스템,
+                "문의 답변이 도착했어요", event.title(),
+                "inquiry", event.inquiryId()
         );
-
-        // 2) Email — best-effort. SMTP 실패해도 답변/알림은 보존.
         try {
             emailSender.sendInquiryReplyEmail(
-                    inquiry.getEmail(),
+                    event.email(),
                     "[쓸랭] 문의 답변이 도착했습니다",
-                    buildReplyEmailHtml(inquiry, cmd.adminReply())
+                    buildReplyEmailHtml(event.title(), event.adminReply())
             );
         } catch (RuntimeException e) {
             log.warn("Inquiry reply email 발송 실패 — inquiryId={}, email={}, cause={}",
-                    inquiry.getId(), inquiry.getEmail(), e.getMessage());
+                    event.inquiryId(), event.email(), e.getMessage());
         }
     }
 
-    private static String buildReplyEmailHtml(Inquiry inquiry, String adminReply) {
+    /** AFTER_COMMIT 이벤트 payload — Inquiry entity 직접 들고가지 않음 (lazy init / 컨텍스트 밖 회귀 차단). */
+    public record InquiryRepliedEvent(Long inquiryId, Long userId, String email, String title, String adminReply) { }
+
+    private static String buildReplyEmailHtml(String title, String adminReply) {
         return """
                 <!doctype html>
                 <html>
@@ -156,7 +171,7 @@ public class InquiryApplicationService {
                     <p style="color:#888;font-size:12px">마이페이지 &gt; 1:1 문의에서도 확인하실 수 있어요.</p>
                   </body>
                 </html>
-                """.formatted(escapeHtml(inquiry.getTitle()), escapeHtml(adminReply));
+                """.formatted(escapeHtml(title), escapeHtml(adminReply));
     }
 
     private static String escapeHtml(String s) {
@@ -167,7 +182,12 @@ public class InquiryApplicationService {
     @Transactional
     public void adminChangeStatus(Long inquiryId, InquiryStatus newStatus) {
         Inquiry inquiry = findOrThrow(inquiryId);
-        inquiry.changeStatus(newStatus);
+        try {
+            inquiry.changeStatus(newStatus);
+        } catch (IllegalArgumentException e) {
+            // 도메인 검증 (역방향 전이 / 답변 없이 DONE 등) 은 비즈니스 예외로 변환 — 500 회귀 차단.
+            throw new BusinessException(ErrorCode.INQUIRY_INVALID_STATE);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/sseulang/domain/support/domain/Inquiry.java
+++ b/src/main/java/com/sseulang/domain/support/domain/Inquiry.java
@@ -128,10 +128,23 @@ public class Inquiry extends BaseEntity {
         this.repliedAt = now;
     }
 
-    /** 답변 없이 status 만 변경 — 보통 PENDING → PROCESSING. */
+    /**
+     * 답변 없이 status 만 변경 — 보통 PENDING → PROCESSING.
+     *
+     * <p>전이 룰 (단방향): {@code PENDING → PROCESSING → DONE}. 역방향 (PROCESSING/DONE → PENDING)
+     * 은 거부 — 상태머신 정합 (Codex round 9 hotfix).</p>
+     * <p>DONE 으로 가려면 admin_reply 가 있어야 함.</p>
+     */
     public void changeStatus(InquiryStatus newStatus) {
         if (newStatus == null) {
             throw new IllegalArgumentException("status 는 필수입니다");
+        }
+        // 역방향 전이 거부 — 정상적인 상태머신은 단방향.
+        if (newStatus == InquiryStatus.PENDING && this.status != InquiryStatus.PENDING) {
+            throw new IllegalArgumentException("PENDING 으로 되돌릴 수 없습니다");
+        }
+        if (newStatus == InquiryStatus.PROCESSING && this.status == InquiryStatus.DONE) {
+            throw new IllegalArgumentException("DONE 에서 PROCESSING 으로 되돌릴 수 없습니다");
         }
         // DONE 으로 가려면 admin_reply 가 있어야 함.
         if (newStatus == InquiryStatus.DONE && (adminReply == null || adminReply.isBlank())) {

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -66,11 +66,17 @@ public class TransactionRepositoryImpl implements TransactionRepository {
             String keyword,
             Pageable pageable
     ) {
+        // keyword 입력이 있으면 숫자만 매칭 — 비숫자 (영문/이메일 등) 는 빈 결과 반환 (Codex round 9 hotfix).
+        // null/blank 는 필터 미적용. NUMBER 매칭만이 현 범위 — LIKE 는 follow-up.
+        boolean hasKeyword = keyword != null && !keyword.isBlank();
         Long keywordId = parseKeywordId(keyword);
+        if (hasKeyword && keywordId == null) {
+            return new org.springframework.data.domain.PageImpl<>(java.util.Collections.emptyList(), pageable, 0);
+        }
         return jpa.adminSearchJpql(startDate, endDate, tradeType, status, keywordId, pageable);
     }
 
-    /** keyword 가 숫자면 long, 아니면 null (LIKE 검색은 미지원, follow-up). */
+    /** keyword 가 숫자면 long, 아니면 null. */
     private static Long parseKeywordId(String keyword) {
         if (keyword == null || keyword.isBlank()) return null;
         try {

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -21,21 +21,25 @@ public class UserApplicationService {
 
     /** 휴면 판정 — 90일 이상 미접속이면 dormant. status derive 와 search 양쪽에서 공유. */
     private static final int DORMANT_THRESHOLD_DAYS = 90;
+    private static final String USER_ROLE = "USER";
 
     private final UserRepository userRepository;
     private final com.sseulang.domain.transaction.domain.TransactionRepository transactionRepository;
     private final com.sseulang.domain.report.domain.UserReportRepository userReportRepository;
+    private final com.sseulang.domain.auth.domain.RefreshTokenStore refreshTokenStore;
     private final java.time.Clock clock;
 
     public UserApplicationService(
             UserRepository userRepository,
             com.sseulang.domain.transaction.domain.TransactionRepository transactionRepository,
             com.sseulang.domain.report.domain.UserReportRepository userReportRepository,
+            com.sseulang.domain.auth.domain.RefreshTokenStore refreshTokenStore,
             java.time.Clock clock
     ) {
         this.userRepository = userRepository;
         this.transactionRepository = transactionRepository;
         this.userReportRepository = userReportRepository;
+        this.refreshTokenStore = refreshTokenStore;
         this.clock = clock;
     }
 
@@ -101,9 +105,15 @@ public class UserApplicationService {
     /**
      * 민감 기능 진입 가드 — 이메일 인증 미완료 시 {@link ErrorCode#AUTH_EMAIL_NOT_VERIFIED} (FORBIDDEN).
      * 거래 시작 / 결제 / 출금 / Item 등록 등 자금·신뢰 영향 흐름의 첫 진입점에서 호출.
+     *
+     * <p>Codex round 9 hotfix — blocked / deleted / suspended 도 함께 차단. 정지된 사용자가
+     * 이미 발급된 AT 로 거래/결제/출금 진입하던 회귀 차단.</p>
      */
     public void requireVerified(Long userId) {
         User user = getById(userId);
+        if (!user.isAccessibleAt(java.time.LocalDateTime.now(clock))) {
+            throw new BusinessException(ErrorCode.USER_BLOCKED);
+        }
         if (!user.isEmailVerified()) {
             throw new BusinessException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
         }
@@ -213,14 +223,21 @@ public class UserApplicationService {
     @Transactional
     public void adminSetBlocked(Long userId, boolean blocked) {
         User u = getById(userId);
-        if (blocked) u.block(); else u.unblock();
+        if (blocked) {
+            u.block();
+            // 즉시 RT 무효화 — 기존 세션이 refresh 로 살아남는 회귀 차단 (Codex round 9 hotfix).
+            refreshTokenStore.revokeAll(USER_ROLE, userId);
+        } else {
+            u.unblock();
+        }
     }
 
-    /** 관리자 시한부 활동정지 — N일 동안. days >= 1. */
+    /** 관리자 시한부 활동정지 — N일 동안. days >= 1. RT 즉시 무효화. */
     @Transactional
     public void adminSuspend(Long userId, int days) {
         User u = getById(userId);
         u.suspend(days, java.time.LocalDateTime.now(clock));
+        refreshTokenStore.revokeAll(USER_ROLE, userId);
     }
 
     /** 관리자 활동정지 즉시 해제. */

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -299,4 +299,12 @@ public class User extends BaseEntity {
         if (isDormantAt(now, dormantThresholdDays)) return UserStatus.DORMANT;
         return UserStatus.ACTIVE;
     }
+
+    /**
+     * 인증/민감 기능 진입 가능한 상태인지. blocked / deleted / suspended (만료 전) 모두 차단.
+     * Codex 게이트 2 (round 9 hotfix) — 정지된 사용자가 기존 AT/RT 로 거래/결제/출금 진입하던 회귀 차단.
+     */
+    public boolean isAccessibleAt(LocalDateTime now) {
+        return !blocked && !deleted && !isSuspendedAt(now);
+    }
 }

--- a/src/test/java/com/sseulang/domain/auth/application/NoOpRefreshTokenStore.java
+++ b/src/test/java/com/sseulang/domain/auth/application/NoOpRefreshTokenStore.java
@@ -1,0 +1,20 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.domain.RefreshTokenStore;
+
+import java.time.Duration;
+
+/**
+ * 단위 테스트용 no-op {@link RefreshTokenStore}.
+ *
+ * <p>RT 의미가 검증 대상이 아닌 service 단위 테스트가 사용 (UserApplicationService.adminSuspend 가
+ * revokeAll 호출하는 케이스 등). RT race / rotation 자체 검증은 {@link InMemoryFakeRefreshTokenStore}
+ * 또는 통합 IT 가 담당.</p>
+ */
+public class NoOpRefreshTokenStore implements RefreshTokenStore {
+    @Override public long currentTokenVersion(String role, Long userId) { return 0; }
+    @Override public void save(String role, Long userId, String jti, Duration ttl) { }
+    @Override public boolean consume(String role, Long userId, String jti, long claimTv) { return true; }
+    @Override public void revoke(String role, Long userId, String jti) { }
+    @Override public void revokeAll(String role, Long userId) { }
+}

--- a/src/test/java/com/sseulang/domain/auth/application/OAuthLoginServiceTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/OAuthLoginServiceTest.java
@@ -79,6 +79,8 @@ class OAuthLoginServiceTest {
         when(u.getId()).thenReturn(id);
         when(u.isBlocked()).thenReturn(blocked);
         when(u.isDeleted()).thenReturn(deleted);
+        // round 9 hotfix — OAuth login 이 isAccessibleAt 으로 통합 가드. mock 기본 false 회피.
+        when(u.isAccessibleAt(any(java.time.LocalDateTime.class))).thenReturn(!blocked && !deleted);
         return u;
     }
 

--- a/src/test/java/com/sseulang/domain/auth/application/RefreshTokenRotationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/RefreshTokenRotationServiceTest.java
@@ -41,7 +41,7 @@ class RefreshTokenRotationServiceTest {
         jwt = new JwtProvider(props, fixedClock);
         store = new InMemoryFakeRefreshTokenStore();
         blacklist = new InMemoryFakeAccessTokenBlacklist();
-        service = new RefreshTokenRotationService(jwt, store, blacklist, fixedClock, props);
+        service = new RefreshTokenRotationService(jwt, store, blacklist, new com.sseulang.domain.user.application.InMemoryFakeUserRepository(), fixedClock, props);
     }
 
     /** login 시점 시뮬레이션: tv 조회 → 토큰 발급 + store 등록. */
@@ -119,7 +119,7 @@ class RefreshTokenRotationServiceTest {
 
         Clock laterClock = Clock.fixed(FIXED_NOW.plusSeconds(RT_VALIDITY + 1), ZoneOffset.UTC);
         JwtProvider laterJwt = new JwtProvider(props, laterClock);
-        RefreshTokenRotationService laterService = new RefreshTokenRotationService(laterJwt, store, blacklist, laterClock, props);
+        RefreshTokenRotationService laterService = new RefreshTokenRotationService(laterJwt, store, blacklist, new com.sseulang.domain.user.application.InMemoryFakeUserRepository(), laterClock, props);
 
         assertThatThrownBy(() -> laterService.rotate(rt))
                 .isInstanceOf(BusinessException.class)
@@ -163,7 +163,7 @@ class RefreshTokenRotationServiceTest {
 
         Clock laterClock = Clock.fixed(FIXED_NOW.plusSeconds(RT_VALIDITY + 1), ZoneOffset.UTC);
         JwtProvider laterJwt = new JwtProvider(props, laterClock);
-        RefreshTokenRotationService laterService = new RefreshTokenRotationService(laterJwt, store, blacklist, laterClock, props);
+        RefreshTokenRotationService laterService = new RefreshTokenRotationService(laterJwt, store, blacklist, new com.sseulang.domain.user.application.InMemoryFakeUserRepository(), laterClock, props);
 
         assertThatCode(() -> laterService.revoke(rt))
                 .doesNotThrowAnyException();
@@ -192,7 +192,7 @@ class RefreshTokenRotationServiceTest {
 
         Clock laterClock = Clock.fixed(FIXED_NOW.plusSeconds(AT_VALIDITY + 1), ZoneOffset.UTC);
         JwtProvider laterJwt = new JwtProvider(props, laterClock);
-        RefreshTokenRotationService laterService = new RefreshTokenRotationService(laterJwt, store, blacklist, laterClock, props);
+        RefreshTokenRotationService laterService = new RefreshTokenRotationService(laterJwt, store, blacklist, new com.sseulang.domain.user.application.InMemoryFakeUserRepository(), laterClock, props);
 
         laterService.logout(at, rt);
 

--- a/src/test/java/com/sseulang/domain/delivery/integration/DeliveryConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/delivery/integration/DeliveryConcurrencyIT.java
@@ -64,6 +64,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         JpaAuditingConfig.class,
         UserRepositoryImpl.class,
         UserApplicationService.class,
+        com.sseulang.domain.auth.application.NoOpRefreshTokenStore.class,
         // UserApplicationService 가 v8b 부터 Transaction/UserReport repo 의존 — slice 에 명시 추가.
         // (Clock 은 SseulangApplication @Bean 이 자동 제공)
         com.sseulang.domain.transaction.infrastructure.persistence.TransactionRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
@@ -43,7 +43,7 @@ class PaymentApplicationServiceTest {
         gateway = new FakePaymentGateway();
         userRepo = new InMemoryFakeUserRepository();
         pointHistoryRepo = new InMemoryFakePointHistoryRepository();
-        userService = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), java.time.Clock.systemDefaultZone());
+        userService = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
         PointApplicationService pointSvc = new PointApplicationService(userService, pointHistoryRepo);
         TossProperties tossProps = new TossProperties(CLIENT_KEY, "test_sk_secret", null, null, null);
         service = new PaymentApplicationService(

--- a/src/test/java/com/sseulang/domain/point/application/PointApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/point/application/PointApplicationServiceTest.java
@@ -35,7 +35,7 @@ class PointApplicationServiceTest {
     void setUp() {
         userRepo = new InMemoryFakeUserRepository();
         historyRepo = new InMemoryFakePointHistoryRepository();
-        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), java.time.Clock.systemDefaultZone());
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
         service = new PointApplicationService(userSvc, historyRepo);
 
         buyerId = userRepo.save(User.createSocialUser(

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -46,7 +46,7 @@ class ReviewApplicationServiceTest {
         userRepo = new InMemoryFakeUserRepository();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), java.time.Clock.systemDefaultZone());
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, new InMemoryFakePointHistoryRepository());
         TransactionApplicationService txSvc = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());

--- a/src/test/java/com/sseulang/domain/support/application/InquiryApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/support/application/InquiryApplicationServiceTest.java
@@ -33,7 +33,6 @@ class InquiryApplicationServiceTest {
     void setUp() {
         repo = new InMemoryFakeInquiryRepository();
         Clock clock = Clock.fixed(NOW.atZone(KST).toInstant(), KST);
-        // 테스트는 알림/이메일 사이드 이펙트를 검증하지 않음 — no-op fake 주입.
         com.sseulang.domain.notification.application.NotificationApplicationService notifSvc =
                 new com.sseulang.domain.notification.application.NotificationApplicationService(
                         new com.sseulang.domain.notification.application.InMemoryFakeNotificationRepository(),
@@ -43,7 +42,9 @@ class InquiryApplicationServiceTest {
             @Override public void sendVerificationEmail(String t, String u) { }
             @Override public void sendInquiryReplyEmail(String t, String s, String h) { }
         };
-        service = new InquiryApplicationService(repo, notifSvc, emailSender, clock);
+        // 단위 테스트용 — AFTER_COMMIT 이벤트는 트랜잭션 밖이라 fire 안 됨. 알림/메일 사이드 이펙트는 별도 IT.
+        org.springframework.context.ApplicationEventPublisher eventPublisher = event -> { };
+        service = new InquiryApplicationService(repo, notifSvc, emailSender, eventPublisher, clock);
     }
 
     private InquiryCreateCommand cmd() {
@@ -127,12 +128,35 @@ class InquiryApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("adminChangeStatus_답변 없이 DONE_도메인 검증 거부 (IllegalArgumentException)")
+    @DisplayName("adminChangeStatus_답변 없이 DONE_INQUIRY_INVALID_STATE (round 9 hotfix)")
     void adminChangeStatus_DONE_답변없음_거부() {
         Long id = service.create(USER, cmd());
 
         assertThatThrownBy(() -> service.adminChangeStatus(id, InquiryStatus.DONE))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INQUIRY_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("adminChangeStatus_역방향 PENDING 으로 되돌리기_INQUIRY_INVALID_STATE (round 9 hotfix)")
+    void adminChangeStatus_역방향_거부() {
+        Long id = service.create(USER, cmd());
+        service.adminChangeStatus(id, InquiryStatus.PROCESSING);
+
+        assertThatThrownBy(() -> service.adminChangeStatus(id, InquiryStatus.PENDING))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INQUIRY_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("adminReply_status=PENDING 명시_INQUIRY_INVALID_STATE (round 9 hotfix)")
+    void adminReply_PENDING_거부() {
+        Long id = service.create(USER, cmd());
+
+        assertThatThrownBy(() -> service.adminReply(id,
+                new com.sseulang.domain.support.application.dto.InquiryReplyCommand("답변", InquiryStatus.PENDING)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INQUIRY_INVALID_STATE);
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -141,9 +141,13 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
             String keyword,
             Pageable pageable
     ) {
+        boolean hasKeyword = keyword != null && !keyword.isBlank();
         Long keywordId = null;
-        if (keyword != null && !keyword.isBlank()) {
+        if (hasKeyword) {
             try { keywordId = Long.parseLong(keyword.trim()); } catch (NumberFormatException ignored) { }
+        }
+        if (hasKeyword && keywordId == null) {
+            return new PageImpl<>(java.util.Collections.emptyList(), pageable, 0);
         }
         final Long kId = keywordId;
         List<Transaction> filtered = store.values().stream()

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -46,7 +46,7 @@ class TransactionApplicationServiceTest {
         userRepo = new InMemoryFakeUserRepository();
         pointHistoryRepo = new InMemoryFakePointHistoryRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), java.time.Clock.systemDefaultZone());
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
         itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, pointHistoryRepo);
         service = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -82,6 +82,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         CategoryApplicationService.class,
         UserRepositoryImpl.class,
         UserApplicationService.class,
+        com.sseulang.domain.auth.application.NoOpRefreshTokenStore.class,
         PointHistoryRepositoryImpl.class,
         PointApplicationService.class,
         TransactionRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -72,6 +72,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         CategoryApplicationService.class,
         UserRepositoryImpl.class,
         UserApplicationService.class,
+        com.sseulang.domain.auth.application.NoOpRefreshTokenStore.class,
         PointHistoryRepositoryImpl.class,
         PointApplicationService.class,
         TransactionRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationServiceTest.java
@@ -40,7 +40,7 @@ class WithdrawalApplicationServiceTest {
         withdrawalRepo = new InMemoryFakeWithdrawalRepository();
         userRepo = new InMemoryFakeUserRepository();
         historyRepo = new InMemoryFakePointHistoryRepository();
-        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), java.time.Clock.systemDefaultZone());
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, historyRepo);
         // self 는 REQUIRES_NEW proxy 용 — 단위 테스트엔 Spring 컨텍스트 없으니 자기 자신을 주입.
         // 단위 테스트의 InMemoryFake 는 deadlock/duplicate 던지지 않으므로 catch 경로 미진입.

--- a/src/test/java/com/sseulang/domain/withdrawal/integration/WithdrawalSettlementIT.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/integration/WithdrawalSettlementIT.java
@@ -57,6 +57,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         JpaAuditingConfig.class,
         UserRepositoryImpl.class,
         UserApplicationService.class,
+        com.sseulang.domain.auth.application.NoOpRefreshTokenStore.class,
         PointHistoryRepositoryImpl.class,
         PointApplicationService.class,
         WithdrawalRepositoryImpl.class,


### PR DESCRIPTION
## Summary
직전 Codex 게이트 2 풀 리뷰 발견 사항 hotfix.

## Critical 1건 ⚠️
**SUSPENDED 가드가 인증 흐름에 연결 안 됨 → 정지된 사용자가 기존 AT/RT 로 거래/결제/출금 계속 가능**

- \`User.isAccessibleAt(now)\` — blocked / deleted / suspended 통합 가드 도메인 메서드 신설
- 4 곳에 가드 연결:
  - \`LocalAuthService.login\` → AUTH_LOGIN_FAILED 통합
  - \`OAuthLoginService.loginWithCode\` → USER_BLOCKED 통합
  - \`RefreshTokenRotationService.rotate\` → ROLE_USER 일 때 검증, false 면 revokeAll + INVALID
  - \`UserApplicationService.requireVerified\` → 거래/결제/출금 진입 차단
- \`adminSetBlocked(true)\` / \`adminSuspend\` → \`refreshTokenStore.revokeAll(USER, userId)\` 즉시 호출

## Warning 4건
1. \`InquiryApplicationService.adminReply\`: \`@TransactionalEventListener(AFTER_COMMIT)\` 분리 — JPA commit 실패 시 알림/메일 dangling 차단
2. \`adminReply\` body \`status=PENDING\` 사전 차단 → INQUIRY_INVALID_STATE (이전 500 → 400)
3. \`adminChangeStatus\` IAE catch → INQUIRY_INVALID_STATE 변환 (500 회귀 차단)
4. \`Inquiry.changeStatus\` 역방향 전이 거부 (PROCESSING/DONE → PENDING, DONE → PROCESSING)
5. \`TransactionRepositoryImpl.adminSearch\` 비숫자 keyword → 빈 결과 (전체 노출 회귀 차단)

## 테스트
- \`NoOpRefreshTokenStore\` 신설 (test 전용)
- 5개 ApplicationService 테스트 + 4개 DataJpaTest IT slice 시그니처 마이그
- \`InquiryApplicationServiceTest\` 보강 (역방향 전이 / status=PENDING / 답변 없이 DONE)
- 전체 BUILD SUCCESSFUL

## Codex 잔여 (의도적 follow-up)
- broadcast 멱등성 + bulk insert
- §3.3 cross-aggregate 의존 리팩토
- 휴면 90일째 boundary 일관성

## Test plan
- [x] 컴파일 + 전체 테스트 PASS
- [ ] 수동: PATCH /admin/users/{id}/suspend → 다음 refresh 시 INVALID
- [ ] 수동: 정지 사용자 login 시도 → AUTH_LOGIN_FAILED
- [ ] 수동: PATCH /admin/inquiries/{id}/reply body {status:"PENDING"} → 400 INQUIRY_INVALID_STATE

🤖 Generated with [Claude Code](https://claude.com/claude-code)