### PR TITLE
feat: round 10 — Admin 거래 검색 keyword email/nickname LIKE (#11)

### DIFF
--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -212,9 +212,19 @@ public class TransactionApplicationService {
         return new java.util.ArrayList<>(byMonth.values());
     }
 
+    /** Admin 거래 keyword LIKE 매칭 시 user IN 절 폭주 방지 — top N user. */
+    private static final int KEYWORD_USER_LIMIT = 200;
+
     /**
-     * Admin 거래 검색 (round 9). 모든 필터 nullable, 최신순. cross-aggregate join 부담 회피로
-     * keyword 는 itemId/transactionId 숫자 매칭만 (email/nickname LIKE 는 follow-up).
+     * Admin 거래 검색 (round 9 + round 10 LIKE).
+     *
+     * <p>keyword 처리 (round 10):
+     * <ul>
+     *   <li>숫자: transactionId 또는 itemId 정확 매칭</li>
+     *   <li>비숫자: UserApplicationService.findUserIdsByKeyword 로 user 매치 (top {@value #KEYWORD_USER_LIMIT}) →
+     *       Transaction.sellerId/buyerId IN. user 매치 0건이면 빈 결과.</li>
+     * </ul>
+     * 모든 필터 nullable, 최신순.</p>
      */
     public Page<TransactionResult> adminSearch(
             java.time.LocalDateTime startDate,
@@ -224,8 +234,18 @@ public class TransactionApplicationService {
             String keyword,
             Pageable pageable
     ) {
-        return transactionRepository.adminSearch(startDate, endDate, tradeType, status, keyword, pageable)
+        java.util.List<Long> matchedUserIds = java.util.Collections.emptyList();
+        if (keyword != null && !keyword.isBlank() && parseLong(keyword) == null) {
+            matchedUserIds = userApplicationService.findUserIdsByKeyword(keyword, KEYWORD_USER_LIMIT);
+        }
+        return transactionRepository.adminSearch(
+                        startDate, endDate, tradeType, status, keyword, matchedUserIds, pageable)
                 .map(TransactionResult::from);
+    }
+
+    private static Long parseLong(String s) {
+        if (s == null || s.isBlank()) return null;
+        try { return Long.parseLong(s.trim()); } catch (NumberFormatException e) { return null; }
     }
 
     /**

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -44,9 +44,17 @@ public interface TransactionRepository {
     List<TransactionMonthlyStat> countCompletedMonthly(java.time.YearMonth from, java.time.YearMonth to);
 
     /**
-     * Admin 거래 검색 (round 9). created_at 기준 [start, end] 범위 + tradeType / status 필터 + keyword.
-     * keyword 는 buyer/seller email 또는 nickname LIKE 가 이상적이지만, 현재는 cross-aggregate 부담
-     * 회피 위해 itemId/transactionId 숫자 매칭만 (확장은 follow-up). 모든 필터 nullable. 최신순.
+     * Admin 거래 검색 (round 9 + round 10 LIKE 보강). created_at [start, end] + tradeType / status + keyword.
+     *
+     * <p>keyword 처리 정책 (호출자 ApplicationService 책임):
+     * <ul>
+     *   <li>숫자 → transactionId 또는 itemId 정확 매칭</li>
+     *   <li>비숫자 → ApplicationService 가 UserApplicationService.findUserIdsByKeyword 로 변환 후
+     *       {@code matchedUserIds} 로 전달 (Transaction.sellerId/buyerId IN). 빈 매치는 빈 결과.</li>
+     * </ul>
+     * 모든 필터 nullable. 최신순.</p>
+     *
+     * @param matchedUserIds 비숫자 keyword 의 user 매치 결과. null 또는 empty 면 user 필터 미적용.
      */
     org.springframework.data.domain.Page<Transaction> adminSearch(
             java.time.LocalDateTime startDate,
@@ -54,6 +62,7 @@ public interface TransactionRepository {
             com.sseulang.domain.item.domain.TradeType tradeType,
             TransactionStatus status,
             String keyword,
+            java.util.Collection<Long> matchedUserIds,
             org.springframework.data.domain.Pageable pageable
     );
 

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -34,8 +34,12 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
     List<TransactionStatusCount> countGroupByStatusJpql();
 
     /**
-     * Admin 거래 검색 (round 9). created_at [start, end] + tradeType / status / keywordId 필터.
-     * 모두 nullable. keywordId 는 t.id 또는 t.itemId 정확 매칭. 최신순.
+     * Admin 거래 검색 (round 9 + round 10). created_at [start, end] + tradeType / status / keywordId / matchedUserIds.
+     * 모두 nullable. 최신순.
+     *
+     * <p>keywordId: t.id 또는 t.itemId 정확 매칭 (숫자 keyword).</p>
+     * <p>matchedUserIds: t.sellerId 또는 t.buyerId 가 IN (cross-aggregate user LIKE 매치 결과).</p>
+     * <p>두 파라미터는 호출자가 mutually exclusive 로 채움 — 동시에 쓰면 OR 로 합쳐짐.</p>
      */
     @Query("""
             SELECT t FROM Transaction t
@@ -43,7 +47,11 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
                AND (:end   IS NULL OR t.createdAt <= :end)
                AND (:tradeType IS NULL OR t.tradeType = :tradeType)
                AND (:status    IS NULL OR t.status    = :status)
-               AND (:keywordId IS NULL OR t.id = :keywordId OR t.itemId = :keywordId)
+               AND (
+                    (:keywordId IS NULL AND :hasUserIds = FALSE)
+                    OR (:keywordId IS NOT NULL AND (t.id = :keywordId OR t.itemId = :keywordId))
+                    OR (:hasUserIds = TRUE AND (t.sellerId IN :userIds OR t.buyerId IN :userIds))
+               )
              ORDER BY t.id DESC
             """)
     Page<Transaction> adminSearchJpql(
@@ -52,6 +60,8 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
             @Param("tradeType") com.sseulang.domain.item.domain.TradeType tradeType,
             @Param("status")    TransactionStatus status,
             @Param("keywordId") Long keywordId,
+            @Param("hasUserIds") boolean hasUserIds,
+            @Param("userIds")    java.util.Collection<Long> userIds,
             Pageable pageable
     );
 

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -64,16 +64,19 @@ public class TransactionRepositoryImpl implements TransactionRepository {
             com.sseulang.domain.item.domain.TradeType tradeType,
             TransactionStatus status,
             String keyword,
+            java.util.Collection<Long> matchedUserIds,
             Pageable pageable
     ) {
-        // keyword 입력이 있으면 숫자만 매칭 — 비숫자 (영문/이메일 등) 는 빈 결과 반환 (Codex round 9 hotfix).
-        // null/blank 는 필터 미적용. NUMBER 매칭만이 현 범위 — LIKE 는 follow-up.
+        // round 10 — keyword 가 숫자면 keywordId 로, 비숫자면 호출자가 미리 LIKE 매치한 userIds 로.
+        // 둘 다 비어있고 keyword 만 있으면 (= 비숫자인데 매치 0건) 빈 결과 즉시 반환.
         boolean hasKeyword = keyword != null && !keyword.isBlank();
         Long keywordId = parseKeywordId(keyword);
-        if (hasKeyword && keywordId == null) {
+        boolean hasUserIds = matchedUserIds != null && !matchedUserIds.isEmpty();
+        if (hasKeyword && keywordId == null && !hasUserIds) {
             return new org.springframework.data.domain.PageImpl<>(java.util.Collections.emptyList(), pageable, 0);
         }
-        return jpa.adminSearchJpql(startDate, endDate, tradeType, status, keywordId, pageable);
+        java.util.Collection<Long> userIdsParam = hasUserIds ? matchedUserIds : java.util.List.of(0L); // dummy IN — JPA 빈 IN 회피
+        return jpa.adminSearchJpql(startDate, endDate, tradeType, status, keywordId, hasUserIds, userIdsParam, pageable);
     }
 
     /** keyword 가 숫자면 long, 아니면 null. */

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -247,6 +247,15 @@ public class UserApplicationService {
         u.unsuspend();
     }
 
+    /**
+     * Admin 거래 검색 (round 10) — keyword 로 매칭되는 user id 리스트.
+     * cross-aggregate keyword (email/nickname LIKE) 매칭 시 호출자가 IN 절로 사용.
+     * limit 으로 IN 절 폭주 방지.
+     */
+    public java.util.List<Long> findUserIdsByKeyword(String keyword, int limit) {
+        return userRepository.findIdsByKeywordLike(keyword, limit);
+    }
+
     /** 로그인 성공 직후 호출 — 마지막 로그인 시각 기록 (휴면 판정 기준). 미존재 userId 무시. */
     @Transactional
     public void recordLogin(Long userId) {

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -84,4 +84,11 @@ public interface UserRepository {
      * @param limit   페이지 크기
      */
     java.util.List<Long> findActiveIdsAfter(long afterId, int limit);
+
+    /**
+     * Admin 거래 검색 (round 10) cross-aggregate keyword 매칭용 — email/nickname LIKE.
+     * 결과 id 만 반환 → 호출자가 IN 절로 사용. limit 으로 IN 절 폭주 방지.
+     * keyword null/blank → 빈 리스트.
+     */
+    java.util.List<Long> findIdsByKeywordLike(String keyword, int limit);
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -155,4 +155,13 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
     /** Admin broadcast — 활성 사용자 id 만 청크 페이징. id ASC. */
     @Query("SELECT u.id FROM User u WHERE u.blocked = false AND u.deleted = false AND u.id > :afterId ORDER BY u.id ASC")
     java.util.List<Long> findActiveIdsAfter(@Param("afterId") long afterId, org.springframework.data.domain.Pageable pageable);
+
+    /** Admin 거래 검색 (round 10) — email/nickname LIKE 매칭 user id. limit 으로 IN 절 폭주 방지. */
+    @Query("""
+            SELECT u.id FROM User u
+             WHERE LOWER(u.email)    LIKE LOWER(CONCAT('%', :kw, '%'))
+                OR LOWER(u.nickname) LIKE LOWER(CONCAT('%', :kw, '%'))
+             ORDER BY u.id ASC
+            """)
+    java.util.List<Long> findIdsByKeywordLike(@Param("kw") String kw, org.springframework.data.domain.Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -111,4 +111,12 @@ public class UserRepositoryImpl implements UserRepository {
         if (limit <= 0) return java.util.Collections.emptyList();
         return jpa.findActiveIdsAfter(afterId, org.springframework.data.domain.PageRequest.of(0, limit));
     }
+
+    @Override
+    public java.util.List<Long> findIdsByKeywordLike(String keyword, int limit) {
+        if (keyword == null || keyword.isBlank() || limit <= 0) {
+            return java.util.Collections.emptyList();
+        }
+        return jpa.findIdsByKeywordLike(keyword.strip(), org.springframework.data.domain.PageRequest.of(0, limit));
+    }
 }

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -139,6 +139,7 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
             com.sseulang.domain.item.domain.TradeType tradeType,
             TransactionStatus status,
             String keyword,
+            java.util.Collection<Long> matchedUserIds,
             Pageable pageable
     ) {
         boolean hasKeyword = keyword != null && !keyword.isBlank();
@@ -146,16 +147,24 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
         if (hasKeyword) {
             try { keywordId = Long.parseLong(keyword.trim()); } catch (NumberFormatException ignored) { }
         }
-        if (hasKeyword && keywordId == null) {
+        boolean hasUserIds = matchedUserIds != null && !matchedUserIds.isEmpty();
+        if (hasKeyword && keywordId == null && !hasUserIds) {
             return new PageImpl<>(java.util.Collections.emptyList(), pageable, 0);
         }
         final Long kId = keywordId;
+        final Set<Long> userIdSet = hasUserIds ? new HashSet<>(matchedUserIds) : Set.of();
         List<Transaction> filtered = store.values().stream()
                 .filter(t -> startDate == null || t.getCreatedAt() == null || !t.getCreatedAt().isBefore(startDate))
                 .filter(t -> endDate == null || t.getCreatedAt() == null || !t.getCreatedAt().isAfter(endDate))
                 .filter(t -> tradeType == null || t.getTradeType() == tradeType)
                 .filter(t -> status == null || t.getStatus() == status)
-                .filter(t -> kId == null || kId.equals(t.getId()) || kId.equals(t.getItemId()))
+                .filter(t -> {
+                    // keyword 가 없으면 패스. 있으면 keywordId 매칭 OR userId IN.
+                    if (kId == null && !hasUserIds) return true;
+                    if (kId != null && (kId.equals(t.getId()) || kId.equals(t.getItemId()))) return true;
+                    if (hasUserIds && (userIdSet.contains(t.getSellerId()) || userIdSet.contains(t.getBuyerId()))) return true;
+                    return false;
+                })
                 .sorted(Comparator.comparingLong(Transaction::getId).reversed())
                 .toList();
         int start = Math.min((int) pageable.getOffset(), filtered.size());

--- a/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
+++ b/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
@@ -133,4 +133,20 @@ public class InMemoryFakeUserRepository implements UserRepository {
                 .limit(limit)
                 .toList();
     }
+
+    @Override
+    public java.util.List<Long> findIdsByKeywordLike(String keyword, int limit) {
+        if (keyword == null || keyword.isBlank() || limit <= 0) return java.util.Collections.emptyList();
+        String kw = keyword.strip().toLowerCase();
+        return store.values().stream()
+                .filter(u -> {
+                    String email = u.getEmail() == null ? "" : u.getEmail().toLowerCase();
+                    String nick  = u.getNickname() == null ? "" : u.getNickname().toLowerCase();
+                    return email.contains(kw) || nick.contains(kw);
+                })
+                .map(User::getId)
+                .sorted()
+                .limit(limit)
+                .toList();
+    }
 }


### PR DESCRIPTION
## Summary
프론트 라운드 9 합의 #11 — Admin 거래 검색에 닉네임/이메일 LIKE 매칭 추가.

## 동작
\`\`\`
GET /api/v1/admin/transactions?keyword=홍길동       # → 닉네임 LIKE 매치
GET /api/v1/admin/transactions?keyword=user@x.com  # → 이메일 LIKE 매치
GET /api/v1/admin/transactions?keyword=12345       # → 기존 transactionId/itemId 정확 매칭
\`\`\`

- 비숫자 keyword → \`UserApplicationService.findUserIdsByKeyword\` 로 매치 (top 200) → \`Transaction.sellerId/buyerId IN\`
- 숫자 keyword → 기존 동작 유지
- user 매치 0건이면 빈 결과 (이전엔 영문 keyword 가 빈 결과 반환)

## CLAUDE.md §3.3 정합
TransactionApplicationService → UserApplicationService → UserRepository 경유 (Transaction 도메인이 UserRepository 직접 호출 X).

## Test plan
- [x] 컴파일 + 전체 테스트 BUILD SUCCESSFUL
- [ ] 수동: \`GET /admin/transactions?keyword=쓸랭\` → 해당 닉네임 user 거래 반환
- [ ] 수동: \`GET /admin/transactions?keyword=alem6516@\` → 해당 email user 거래 반환
- [ ] 수동: \`GET /admin/transactions?keyword=42\` → tx.id=42 또는 itemId=42 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)