### PR TITLE
fix: round 13 — cross-site cookie + Vercel CORS + GCP/DuckDNS 가이드

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -23,15 +23,19 @@ JWT_SECRET=
 
 # =============== Cookie [필수] ===============
 # 운영 도메인. 서브도메인 공유면 .sseulang.com / 단일이면 sseulang.com
+# DuckDNS 같은 무료 sub: sseulang.duckdns.org
 COOKIE_DOMAIN=
+
+# Cross-site 쿠키 정책. 프론트(vercel.app) ↔ 백엔드(duckdns.org) 다른 site 면 None 필수.
+# 같은 eTLD+1 (예: 둘 다 sseulang.com) 으로 합치면 Strict / Lax 로 강화 가능.
+# 옵션: Strict / Lax / None. default None (cross-site 호환).
+COOKIE_SAME_SITE=None
 
 
 # =============== CORS [필수] ===============
 # 콤마 구분. 프론트 운영 도메인 화이트리스트.
-# ⚠️ Vercel 호스팅 변경 (2026-05-05) — 프론트 도메인 확정되면 추가:
-#    예) https://sseulang.vercel.app,https://sseulang-git-{branch}-{team}.vercel.app
-#    Vercel preview 별 도메인까지 허용하려면 패턴 매칭 필요 — 현 구현은 정확 매칭만.
-CORS_ALLOWED_ORIGINS=https://sseulang.com,https://www.sseulang.com
+# 기본은 Vercel 프론트 + 정식 도메인 (있을 때). preview 별 도메인까지 허용하려면 패턴 매칭 (follow-up).
+CORS_ALLOWED_ORIGINS=https://sseulang.vercel.app,https://sseulang.com,https://www.sseulang.com
 
 
 # =============== MySQL [필수] — compose 내부 mysql container ===============

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -102,6 +102,7 @@ services:
       # === 보안 (.env.prod 에서 주입) ===
       JWT_SECRET: ${JWT_SECRET:?required}
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:?required}
+      COOKIE_SAME_SITE: ${COOKIE_SAME_SITE:-None}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:?required}
       # === OAuth ===
       KAKAO_REST_API_KEY: ${KAKAO_REST_API_KEY:?required}

--- a/docs/PROD_DEPLOY.md
+++ b/docs/PROD_DEPLOY.md
@@ -1,35 +1,45 @@
 # 쓸랭 프로덕션 배포 가이드
 
-> Docker Compose 기반. 호스트(EC2)에 nginx 가 80/443 → app:8080 으로 reverse proxy.
-> EC2 + Let's Encrypt 절차는 별도 문서 (`#91 task` 작업 후 추가).
+> Docker Compose 기반. 호스트 (GCP Compute Engine) 에 nginx 가 80/443 → app:8080 으로 reverse proxy.
 
 ---
 
 ## 1. 사전 준비
 
-### 1.1 EC2 호스트
-- Amazon Linux 2023 또는 Ubuntu 22.04+
-- 최소 t3.small (2GB RAM) 권장 — JVM heap + 3개 DB 컨테이너
+### 1.1 호스트 (GCP Compute Engine 기준)
+- e2-medium (2 vCPU / 4GB RAM) — JVM heap + 3개 DB 컨테이너 빠듯하지만 동작
+- Debian 12 / Ubuntu 22.04+
+- 정적 외부 IP 예약 (인스턴스 재시작 시 IP 보존)
+- 디스크 30GB 이상 권장 (10GB 는 Docker image + 로그로 빠르게 참)
+- 방화벽: 80/443/22 만 허용 (GCP Network tags `http-server`, `https-server` 자동 적용)
 - Docker + Docker Compose plugin 설치
   ```bash
-  sudo yum install -y docker
-  sudo systemctl enable --now docker
+  # Debian/Ubuntu
+  curl -fsSL https://get.docker.com | sudo sh
   sudo usermod -aG docker $USER   # 재로그인 필요
   ```
 - nginx 설치 (호스트 패키지 — 컨테이너 외부)
   ```bash
-  sudo yum install -y nginx
+  sudo apt install -y nginx
   ```
+
+### 1.1a 도메인 — DuckDNS (무료) 또는 정식 도메인
+- DuckDNS: https://www.duckdns.org/ 가입 → `sseulang.duckdns.org` 같은 sub 발급 → IP 매핑 → 즉시 사용
+- 정식 도메인: 가비아/Namecheap 구입 후 DNS A 레코드 → 외부 IP
+- ⚠️ Let's Encrypt SSL 은 도메인 필수 (IP 발급 X)
 
 ### 1.2 외부 서비스 키 발급 (.env.prod 채우기 전)
 - **JWT_SECRET**: `openssl rand -hex 64`
 - **카카오**: 콘솔 → 앱 키 → REST API 키
-  - 사이트 도메인 / Redirect URI 등록 (https://sseulang.com 등)
+  - 사이트 도메인: 프론트 도메인 (예: `https://sseulang.vercel.app`)
+  - Redirect URI: 프론트 라우팅 (예: `https://sseulang.vercel.app/auth/oauth2/kakao/callback`)
 - **구글 OAuth**: Google Cloud Console → OAuth 2.0 클라이언트
-  - 승인된 redirect URI: `https://sseulang.com/auth/google/callback`
+  - 승인된 JavaScript 출처: `https://sseulang.vercel.app`
+  - 승인된 redirect URI: `https://sseulang.vercel.app/auth/oauth2/google/callback`
 - **AWS IAM**: S3 PutObject/GetObject/DeleteObject/CopyObject 권한 (특정 버킷 한정)
 - **토스페이먼츠**: 운영 키 (테스트 키 X). webhook secret 도 콘솔에서 발급
-- **SMTP**: Gmail App Password / AWS SES / Naver Works 중 택
+  - webhook URL: `https://{백엔드 도메인}/api/v1/payments/webhook/toss`
+- **SMTP**: Gmail App Password / AWS SES / Naver SMTP 중 택
 
 ---
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -53,7 +53,9 @@ app:
   cookie:
     domain: ${COOKIE_DOMAIN}
     secure: true
-    same-site: Strict
+    # cross-site 쿠키 허용 — 프론트 (vercel.app) 와 백엔드 (duckdns.org 등) 가 다른 site 일 때 None 필수.
+    # 같은 eTLD+1 으로 합쳐지면 Strict / Lax 로 강화. CSRF 방어는 X-XSRF-TOKEN 헤더 + Secure 가 1차.
+    same-site: ${COOKIE_SAME_SITE:None}
   oauth2:
     kakao:
       client-id: ${KAKAO_REST_API_KEY}


### PR DESCRIPTION
## Summary
배포 인프라 결정 반영 — GCP Compute Engine + DuckDNS 도메인 (\`sseulang.duckdns.org\`).

## 변경
### Cross-site 쿠키 허용
- \`application-prod.yml\`: \`cookie.same-site\` 를 \`Strict\` → \`\${COOKIE_SAME_SITE:None}\`
- 이유: 프론트(\`vercel.app\`) ↔ 백엔드(\`duckdns.org\`) 다른 site 면 \`Strict\` 시 쿠키 누락
- 같은 eTLD+1 으로 합쳐지면 환경변수로 다시 \`Strict\` 강화 가능

### CORS
- \`.env.prod.example\` default 에 \`https://sseulang.vercel.app\` 포함

### PROD_DEPLOY.md
- EC2 → GCP Compute Engine (e2-medium / Debian 12 / 정적 IP / 30GB)
- DuckDNS 도메인 옵션
- OAuth/Toss prod 콘솔 등록 URL 패턴

## 영향
- 운영 보안 약화 — \`SameSite=None\` 은 CSRF 방어 1차선 약화. \`Secure=true\` + \`X-XSRF-TOKEN\` 헤더 검증이 2차선 (이미 적용됨).
- Vercel preview 도메인은 별도 follow-up

## Test plan
- [x] 컴파일 SUCCESS
- [ ] prod 부팅 후: 프론트 vercel.app 에서 로그인 → 쿠키 박힘 + Set-Cookie 응답 확인
- [ ] OAuth 카카오/구글 redirect → 쿠키 보존
- [ ] WebSocket handshake 시 쿠키 전달

🤖 Generated with [Claude Code](https://claude.com/claude-code)