### PR TITLE
fix: XSRF-TOKEN 쿠키 Domain 명시 (게이트 1 round 1 후속 fix)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -23,15 +23,19 @@ JWT_SECRET=
 
 # =============== Cookie [필수] ===============
 # 운영 도메인. 서브도메인 공유면 .sseulang.com / 단일이면 sseulang.com
+# DuckDNS 같은 무료 sub: sseulang.duckdns.org
 COOKIE_DOMAIN=
+
+# Cross-site 쿠키 정책. 프론트(vercel.app) ↔ 백엔드(duckdns.org) 다른 site 면 None 필수.
+# 같은 eTLD+1 (예: 둘 다 sseulang.com) 으로 합치면 Strict / Lax 로 강화 가능.
+# 옵션: Strict / Lax / None. default None (cross-site 호환).
+COOKIE_SAME_SITE=None
 
 
 # =============== CORS [필수] ===============
 # 콤마 구분. 프론트 운영 도메인 화이트리스트.
-# ⚠️ Vercel 호스팅 변경 (2026-05-05) — 프론트 도메인 확정되면 추가:
-#    예) https://sseulang.vercel.app,https://sseulang-git-{branch}-{team}.vercel.app
-#    Vercel preview 별 도메인까지 허용하려면 패턴 매칭 필요 — 현 구현은 정확 매칭만.
-CORS_ALLOWED_ORIGINS=https://sseulang.com,https://www.sseulang.com
+# 기본은 Vercel 프론트 + 정식 도메인 (있을 때). preview 별 도메인까지 허용하려면 패턴 매칭 (follow-up).
+CORS_ALLOWED_ORIGINS=https://sseulang.vercel.app,https://sseulang.com,https://www.sseulang.com
 
 
 # =============== MySQL [필수] — compose 내부 mysql container ===============

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -13,7 +13,9 @@
 
 # =============== Application ===============
 SPRING_PROFILES_ACTIVE=prod
-APP_IMAGE_TAG=latest                              # CI 가 빌드한 image tag. latest 또는 git sha
+# Docker Hub 이미지 tag. 일반적으로 latest 또는 git sha (예: a1b2c3d).
+# image: seodongbe/sseulang-backend:${APP_IMAGE_TAG}
+APP_IMAGE_TAG=latest
 
 
 # =============== JWT [필수] ===============

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,6 +45,9 @@ services:
       - "yes"
       - "--requirepass"
       - "${REDIS_PASSWORD:?required}"
+    environment:
+      # healthcheck 안의 $${REDIS_PASSWORD} 는 컨테이너 내부 shell 이 확장 — env 주입 필수.
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?required}
     volumes:
       - "redis-data:/data"
     healthcheck:
@@ -78,8 +81,13 @@ services:
     networks: [db-internal]
 
   app:
-    image: sseulang-backend:${APP_IMAGE_TAG:-latest}
-    # 또는 build context — CI 가 image push 안 하면 아래 주석 해제:
+    # Docker Hub 에서 pull. 빌드/푸시는 로컬에서:
+    #   docker build -t seodongbe/sseulang-backend:latest .
+    #   docker push seodongbe/sseulang-backend:latest
+    # private repo 면 인스턴스에서 `docker login` 1회 필요.
+    image: seodongbe/sseulang-backend:${APP_IMAGE_TAG:-latest}
+    pull_policy: always
+    # local 빌드만 쓰려면 image 주석 + 아래 해제:
     # build:
     #   context: .
     #   dockerfile: Dockerfile
@@ -130,6 +138,10 @@ services:
       TOSS_WEBHOOK_REPLAY_TOLERANCE: ${TOSS_WEBHOOK_REPLAY_TOLERANCE:-300}
       # === Swagger 노출 (옵션, default false — 운영 보안) ===
       APP_SWAGGER_ENABLED: ${APP_SWAGGER_ENABLED:-false}
+      # === 로그 경로 (logback-spring.xml LOG_PATH 변수) ===
+      # 비특권 user (uid 1000) 가 /app 안에 dir 못 만듦 → /tmp 로 회피.
+      # 추후 Dockerfile 에 mkdir /app/logs + chown 추가 또는 stdout-only 전환.
+      LOG_PATH: /tmp/sseulang-logs
     ports:
       # nginx 가 호스트 80/443 → app 의 8080 으로 reverse proxy.
       # 외부에 8080 직접 노출하려면 "8080:8080" 으로 변경 (권장 X — TLS 없이 노출).

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -102,6 +102,7 @@ services:
       # === 보안 (.env.prod 에서 주입) ===
       JWT_SECRET: ${JWT_SECRET:?required}
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:?required}
+      COOKIE_SAME_SITE: ${COOKIE_SAME_SITE:-None}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:?required}
       # === OAuth ===
       KAKAO_REST_API_KEY: ${KAKAO_REST_API_KEY:?required}

--- a/docs/PROD_DEPLOY.md
+++ b/docs/PROD_DEPLOY.md
@@ -178,17 +178,38 @@ sudo nginx -t && sudo systemctl reload nginx
 
 ## 5. 갱신 / 롤백
 
-### 갱신
+### Docker Hub 이미지 빌드 / 푸시 (로컬에서 1회 셋업 후 매 갱신)
+
+레포: `seodongbe/sseulang-backend` (Docker Hub).
+**최초 1회**:
+1. https://hub.docker.com → Repositories → Create — 이름 `sseulang-backend`, public/private 선택
+2. 로컬: `docker login` (Hub 계정)
+3. private 선택 시: GCP 인스턴스에서도 `docker login` 1회 (이후 자동 캐시)
+
+### 갱신 (로컬에서 빌드/푸시 → 인스턴스에서 pull)
 ```bash
-git pull
-docker build -t sseulang-backend:$(git rev-parse --short HEAD) .
-APP_IMAGE_TAG=$(git rev-parse --short HEAD) \
+# === 로컬 (Mac) ===
+git pull                              # main 최신
+TAG=$(git rev-parse --short HEAD)
+docker build --platform=linux/amd64 -t seodongbe/sseulang-backend:$TAG \
+                                  -t seodongbe/sseulang-backend:latest .
+docker push seodongbe/sseulang-backend:$TAG
+docker push seodongbe/sseulang-backend:latest
+
+# === 인스턴스 (GCP) ===
+APP_IMAGE_TAG=$TAG \
+  docker compose -f docker-compose.prod.yml --env-file .env.prod pull app
+APP_IMAGE_TAG=$TAG \
   docker compose -f docker-compose.prod.yml --env-file .env.prod up -d app
 # DB 컨테이너는 영향 X — app 만 새 image 로 교체
 ```
 
-### 롤백
+> ⚠️ Mac (Apple Silicon/arm64) 에서 빌드하면 `--platform=linux/amd64` 필수. GCP e2-medium 은 amd64.
+
+### 롤백 (이전 SHA 로 재기동)
 ```bash
+APP_IMAGE_TAG=<이전-sha> \
+  docker compose -f docker-compose.prod.yml --env-file .env.prod pull app
 APP_IMAGE_TAG=<이전-sha> \
   docker compose -f docker-compose.prod.yml --env-file .env.prod up -d app
 ```

--- a/docs/PROD_DEPLOY.md
+++ b/docs/PROD_DEPLOY.md
@@ -1,35 +1,45 @@
 # 쓸랭 프로덕션 배포 가이드
 
-> Docker Compose 기반. 호스트(EC2)에 nginx 가 80/443 → app:8080 으로 reverse proxy.
-> EC2 + Let's Encrypt 절차는 별도 문서 (`#91 task` 작업 후 추가).
+> Docker Compose 기반. 호스트 (GCP Compute Engine) 에 nginx 가 80/443 → app:8080 으로 reverse proxy.
 
 ---
 
 ## 1. 사전 준비
 
-### 1.1 EC2 호스트
-- Amazon Linux 2023 또는 Ubuntu 22.04+
-- 최소 t3.small (2GB RAM) 권장 — JVM heap + 3개 DB 컨테이너
+### 1.1 호스트 (GCP Compute Engine 기준)
+- e2-medium (2 vCPU / 4GB RAM) — JVM heap + 3개 DB 컨테이너 빠듯하지만 동작
+- Debian 12 / Ubuntu 22.04+
+- 정적 외부 IP 예약 (인스턴스 재시작 시 IP 보존)
+- 디스크 30GB 이상 권장 (10GB 는 Docker image + 로그로 빠르게 참)
+- 방화벽: 80/443/22 만 허용 (GCP Network tags `http-server`, `https-server` 자동 적용)
 - Docker + Docker Compose plugin 설치
   ```bash
-  sudo yum install -y docker
-  sudo systemctl enable --now docker
+  # Debian/Ubuntu
+  curl -fsSL https://get.docker.com | sudo sh
   sudo usermod -aG docker $USER   # 재로그인 필요
   ```
 - nginx 설치 (호스트 패키지 — 컨테이너 외부)
   ```bash
-  sudo yum install -y nginx
+  sudo apt install -y nginx
   ```
+
+### 1.1a 도메인 — DuckDNS (무료) 또는 정식 도메인
+- DuckDNS: https://www.duckdns.org/ 가입 → `sseulang.duckdns.org` 같은 sub 발급 → IP 매핑 → 즉시 사용
+- 정식 도메인: 가비아/Namecheap 구입 후 DNS A 레코드 → 외부 IP
+- ⚠️ Let's Encrypt SSL 은 도메인 필수 (IP 발급 X)
 
 ### 1.2 외부 서비스 키 발급 (.env.prod 채우기 전)
 - **JWT_SECRET**: `openssl rand -hex 64`
 - **카카오**: 콘솔 → 앱 키 → REST API 키
-  - 사이트 도메인 / Redirect URI 등록 (https://sseulang.com 등)
+  - 사이트 도메인: 프론트 도메인 (예: `https://sseulang.vercel.app`)
+  - Redirect URI: 프론트 라우팅 (예: `https://sseulang.vercel.app/auth/oauth2/kakao/callback`)
 - **구글 OAuth**: Google Cloud Console → OAuth 2.0 클라이언트
-  - 승인된 redirect URI: `https://sseulang.com/auth/google/callback`
+  - 승인된 JavaScript 출처: `https://sseulang.vercel.app`
+  - 승인된 redirect URI: `https://sseulang.vercel.app/auth/oauth2/google/callback`
 - **AWS IAM**: S3 PutObject/GetObject/DeleteObject/CopyObject 권한 (특정 버킷 한정)
 - **토스페이먼츠**: 운영 키 (테스트 키 X). webhook secret 도 콘솔에서 발급
-- **SMTP**: Gmail App Password / AWS SES / Naver Works 중 택
+  - webhook URL: `https://{백엔드 도메인}/api/v1/payments/webhook/toss`
+- **SMTP**: Gmail App Password / AWS SES / Naver SMTP 중 택
 
 ---
 

--- a/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
@@ -47,17 +47,20 @@ public class DeliveryApplicationService {
     private final UserApplicationService userApplicationService;
     private final PointApplicationService pointApplicationService;
     private final DeliveryLocationCache locationCache;
+    private final org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     public DeliveryApplicationService(
             DeliveryRepository deliveryRepository,
             UserApplicationService userApplicationService,
             PointApplicationService pointApplicationService,
-            DeliveryLocationCache locationCache
+            DeliveryLocationCache locationCache,
+            org.springframework.context.ApplicationEventPublisher eventPublisher
     ) {
         this.deliveryRepository = deliveryRepository;
         this.userApplicationService = userApplicationService;
         this.pointApplicationService = pointApplicationService;
         this.locationCache = locationCache;
+        this.eventPublisher = eventPublisher;
     }
 
     /**
@@ -136,6 +139,10 @@ public class DeliveryApplicationService {
             throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
         }
         d.markDelivered(LocalDateTime.now());
+        // Mode A escrow 자동 정산 트리거 — listener (EscrowApplicationService) 가 분기 처리.
+        eventPublisher.publishEvent(new com.sseulang.domain.delivery.domain.event.DeliveryDeliveredEvent(
+                d.getId(), d.getEscrowApplicationId()
+        ));
         return DeliveryResult.from(d);
     }
 

--- a/src/main/java/com/sseulang/domain/delivery/application/EscrowToDeliveryEventListener.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/EscrowToDeliveryEventListener.java
@@ -1,0 +1,58 @@
+package com.sseulang.domain.delivery.application;
+
+import com.sseulang.domain.delivery.domain.DeliveryRepository;
+import com.sseulang.domain.delivery.domain.DeliveryRequest;
+import com.sseulang.domain.escrow.domain.event.EscrowConfirmedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 거래대행 (Escrow) 결제완료 → 배달대행 (Delivery) 모집중 row 자동 생성.
+ * 결정 #7 P1 — Delivery 도메인 재사용 + DomainEvent 약결합.
+ *
+ * <p>{@code AFTER_COMMIT} phase — Escrow 트랜잭션 commit 된 후 listener 호출. 새 delivery row 는
+ * 별도 트랜잭션에서 INSERT (REQUIRES_NEW) — escrow 트랜잭션 종료 후이므로 이미 분리된 흐름.</p>
+ *
+ * <p>5/11 시점 자동 라이더 매칭 X — dummy rider 로 운영자가 수동 PATCH /accept 호출 (X1 follow-up).</p>
+ */
+@Component
+public class EscrowToDeliveryEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(EscrowToDeliveryEventListener.class);
+
+    private final DeliveryRepository deliveryRepository;
+
+    public EscrowToDeliveryEventListener(DeliveryRepository deliveryRepository) {
+        this.deliveryRepository = deliveryRepository;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void onEscrowConfirmed(EscrowConfirmedEvent event) {
+        try {
+            DeliveryRequest delivery = DeliveryRequest.createFromEscrow(
+                    event.requesterId(),
+                    event.escrowApplicationId(),
+                    event.pickupAddress(),
+                    event.deliveryAddress(),
+                    event.itemDescription(),
+                    event.deliveryFee(),
+                    LocalDateTime.now()
+            );
+            DeliveryRequest saved = deliveryRepository.save(delivery);
+            log.info("[escrow→delivery] delivery 모집중 자동 생성 — escrowApplicationId={} deliveryId={}",
+                    event.escrowApplicationId(), saved.getId());
+        } catch (RuntimeException e) {
+            // commit 후 실패 시 — escrow 는 결제완료 상태로 유지, delivery 만 누락. 운영자 수동 복구.
+            log.error("[escrow→delivery] delivery 생성 실패 — escrowApplicationId={} reason={}",
+                    event.escrowApplicationId(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
@@ -59,4 +59,7 @@ public interface DeliveryRepository {
 
     /** 정산완료 상태의 fee 총합 (admin stats). 누적 라이더 수익 추정. */
     long sumSettledFee();
+
+    /** 거래대행 application 으로 자동 생성된 delivery 조회 — Escrow 정산 시 rider 식별용. */
+    Optional<DeliveryRequest> findByEscrowApplicationId(Long escrowApplicationId);
 }

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRequest.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRequest.java
@@ -90,6 +90,26 @@ public class DeliveryRequest extends BaseEntity {
     @Column(name = "cancel_reason", length = MAX_CANCEL_REASON)
     private String cancelReason;
 
+    /** 거래대행 (Escrow) 결제완료 → 자동 생성된 delivery 의 application 참조. NULL = 일반 배달대행. */
+    @Column(name = "escrow_application_id")
+    private Long escrowApplicationId;
+
+    /** Escrow 결제완료 시 EscrowConfirmedEvent listener 가 호출. 일반 create 와 동일 + escrow_application_id 표시. */
+    public static DeliveryRequest createFromEscrow(
+            Long requesterId,
+            Long escrowApplicationId,
+            String pickupAddress,
+            String dropoffAddress,
+            String itemDescription,
+            long fee,
+            LocalDateTime now
+    ) {
+        DeliveryRequest d = create(requesterId, pickupAddress, dropoffAddress, itemDescription,
+                fee, null, null, now);
+        d.escrowApplicationId = escrowApplicationId;
+        return d;
+    }
+
     public static DeliveryRequest create(
             Long requesterId,
             String pickupAddress,

--- a/src/main/java/com/sseulang/domain/delivery/domain/event/DeliveryDeliveredEvent.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/event/DeliveryDeliveredEvent.java
@@ -1,0 +1,13 @@
+package com.sseulang.domain.delivery.domain.event;
+
+/**
+ * 라이더가 배송완료 처리한 시점 발행. Escrow Mode A (EXTERNAL) 거래의 자동 정산 트리거.
+ *
+ * @param deliveryId            완료된 배달 id
+ * @param escrowApplicationId   거래대행 연결된 application id (NULL = 일반 배달, NOT NULL = escrow 자동 정산 대상)
+ */
+public record DeliveryDeliveredEvent(
+        Long deliveryId,
+        Long escrowApplicationId
+) {
+}

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
@@ -88,4 +88,6 @@ interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
              WHERE d.status = com.sseulang.domain.delivery.domain.DeliveryStatus.정산완료
             """)
     Long sumSettledFeeJpql();
+
+    java.util.Optional<DeliveryRequest> findByEscrowApplicationId(Long escrowApplicationId);
 }

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryRepositoryImpl.java
@@ -66,4 +66,9 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
         Long sum = jpa.sumSettledFeeJpql();
         return sum != null ? sum : 0L;
     }
+
+    @Override
+    public Optional<DeliveryRequest> findByEscrowApplicationId(Long escrowApplicationId) {
+        return jpa.findByEscrowApplicationId(escrowApplicationId);
+    }
 }

--- a/src/main/java/com/sseulang/domain/escrow/application/DeliveryDeliveredEventListener.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/DeliveryDeliveredEventListener.java
@@ -1,0 +1,43 @@
+package com.sseulang.domain.escrow.application;
+
+import com.sseulang.domain.delivery.domain.event.DeliveryDeliveredEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Delivery 배송완료 → Escrow Mode A 자동 정산 트리거 (게이트 1 round 1 — Warning).
+ *
+ * <p>{@code AFTER_COMMIT} phase — Delivery markDelivered 트랜잭션 commit 후 별도 트랜잭션
+ * (REQUIRES_NEW) 으로 escrow settle. escrow_application_id NULL = 일반 배달이라 무시.</p>
+ */
+@Component
+public class DeliveryDeliveredEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(DeliveryDeliveredEventListener.class);
+
+    private final EscrowApplicationService escrowService;
+
+    public DeliveryDeliveredEventListener(EscrowApplicationService escrowService) {
+        this.escrowService = escrowService;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void onDeliveryDelivered(DeliveryDeliveredEvent event) {
+        if (event.escrowApplicationId() == null) {
+            return;  // 일반 배달 — escrow 정산 무관
+        }
+        try {
+            escrowService.settleAfterDelivery(event.escrowApplicationId());
+        } catch (RuntimeException e) {
+            // 정산 실패 시 escrow 는 진행중 상태 유지. 운영자 수동 복구.
+            log.error("[escrow-settle] Mode A 자동 정산 실패 — escrowApplicationId={} reason={}",
+                    event.escrowApplicationId(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -1,0 +1,411 @@
+package com.sseulang.domain.escrow.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateCommand;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationResult;
+import com.sseulang.domain.escrow.application.dto.EscrowLinkCreateCommand;
+import com.sseulang.domain.escrow.application.dto.EscrowLinkResult;
+import com.sseulang.domain.escrow.domain.EscrowApplication;
+import com.sseulang.domain.escrow.domain.EscrowApplicationRepository;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import com.sseulang.domain.escrow.domain.EscrowFeeCalculator;
+import com.sseulang.domain.escrow.domain.EscrowFeeSettings;
+import com.sseulang.domain.escrow.domain.EscrowFeeSettingsRepository;
+import com.sseulang.domain.escrow.domain.EscrowLink;
+import com.sseulang.domain.escrow.domain.EscrowLinkRepository;
+import com.sseulang.domain.escrow.domain.EscrowLinkStatus;
+import com.sseulang.domain.escrow.domain.FeeBreakdown;
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.InitiatorRole;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.event.EscrowConfirmedEvent;
+import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.point.domain.PointHistoryType;
+import com.sseulang.domain.point.domain.PointReferenceType;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 거래대행 (Escrow) 흐름의 트랜잭션 경계. 8 use case + 결제 통합 + 정산 흐름.
+ *
+ * <p>핵심 보안/정합성 (Codex 게이트 1 영역):
+ * <ul>
+ *   <li>link 첫 폼 제출 atomic UPDATE (race-safe) — 결정 #2/3</li>
+ *   <li>snapshot 보존 — 운영 settings 변경 무관 lock — 결정 #9/12</li>
+ *   <li>fee mismatch ±10원 검증 — 결정 #10</li>
+ *   <li>매칭 후 취소 100% 부담 정책 — 결정 #6 (cancel 메서드 분기)</li>
+ *   <li>자기거래 차단 (initiator != receiver, buyer != seller)</li>
+ * </ul>
+ */
+@Service
+@Transactional(readOnly = true)
+public class EscrowApplicationService {
+
+    private static final ObjectMapper IMAGE_JSON = new ObjectMapper().configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+    private final EscrowLinkRepository linkRepository;
+    private final EscrowApplicationRepository applicationRepository;
+    private final EscrowFeeSettingsRepository feeSettingsRepository;
+    private final UserApplicationService userApplicationService;
+    private final PointApplicationService pointApplicationService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final int linkExpiryHours;
+
+    public EscrowApplicationService(
+            EscrowLinkRepository linkRepository,
+            EscrowApplicationRepository applicationRepository,
+            EscrowFeeSettingsRepository feeSettingsRepository,
+            UserApplicationService userApplicationService,
+            PointApplicationService pointApplicationService,
+            ApplicationEventPublisher eventPublisher,
+            @Value("${app.escrow.link.expiry-hours:24}") int linkExpiryHours
+    ) {
+        this.linkRepository = linkRepository;
+        this.applicationRepository = applicationRepository;
+        this.feeSettingsRepository = feeSettingsRepository;
+        this.userApplicationService = userApplicationService;
+        this.pointApplicationService = pointApplicationService;
+        this.eventPublisher = eventPublisher;
+        this.linkExpiryHours = linkExpiryHours;
+    }
+
+    // =============================================================
+    // Use case 1 — 신청자가 link 생성
+    // =============================================================
+    @Transactional
+    public EscrowLinkResult createLink(EscrowLinkCreateCommand cmd) {
+        userApplicationService.requireVerified(cmd.initiatorId());
+        EscrowLink link = EscrowLink.create(
+                cmd.initiatorId(),
+                cmd.initiatorRole(),
+                cmd.feePayer(),
+                cmd.tradeMode(),
+                linkExpiryHours
+        );
+        EscrowLink saved = linkRepository.save(link);
+        User initiator = userApplicationService.getById(cmd.initiatorId());
+        return EscrowLinkResult.from(saved, initiator.getNickname());
+    }
+
+    // =============================================================
+    // Use case 2 — link 진입 (비로그인 OK, 결정 #1 A1)
+    // =============================================================
+    public EscrowLinkResult getByToken(String linkToken) {
+        EscrowLink link = linkRepository.findByLinkToken(linkToken)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_LINK_NOT_FOUND));
+        if (link.isExpired() && link.getStatus() == EscrowLinkStatus.대기) {
+            throw new BusinessException(ErrorCode.ESCROW_LINK_EXPIRED);
+        }
+        if (link.getStatus() == EscrowLinkStatus.만료) {
+            throw new BusinessException(ErrorCode.ESCROW_LINK_EXPIRED);
+        }
+        if (link.getStatus() == EscrowLinkStatus.완료 || link.getStatus() == EscrowLinkStatus.취소) {
+            throw new BusinessException(ErrorCode.ESCROW_LINK_ALREADY_TAKEN);
+        }
+        User initiator = userApplicationService.getById(link.getInitiatorId());
+        return EscrowLinkResult.from(link, initiator.getNickname());
+    }
+
+    // =============================================================
+    // Use case 3 — 폼 제출 (수신자 확정 + application 생성)
+    // 결정 #2 B3 + #3 C1+C3 (atomic + idempotent)
+    // =============================================================
+    @Transactional
+    public EscrowApplicationResult createApplication(EscrowApplicationCreateCommand cmd) {
+        userApplicationService.requireVerified(cmd.receiverId());
+
+        EscrowLink link = linkRepository.findByLinkToken(cmd.linkToken())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_LINK_NOT_FOUND));
+
+        // idempotent — 이미 본인이 receiver 면 기존 application 반환
+        if (cmd.receiverId().equals(link.getReceiverId())) {
+            return applicationRepository.findByLinkId(link.getId())
+                    .map(a -> EscrowApplicationResult.from(a, parseImageUrls(a.getImageUrls())))
+                    .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_INVALID_STATE));
+        }
+
+        // race lose / 본인 차단 / 만료 일괄 검증 — atomic UPDATE
+        int affected = linkRepository.claimReceiverIfAvailable(link.getId(), cmd.receiverId());
+        if (affected == 0) {
+            // 어떤 사유인지 분기
+            if (link.getInitiatorId().equals(cmd.receiverId())) {
+                throw new BusinessException(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
+            }
+            if (link.isExpired() || link.getStatus() == EscrowLinkStatus.만료) {
+                throw new BusinessException(ErrorCode.ESCROW_LINK_EXPIRED);
+            }
+            throw new BusinessException(ErrorCode.ESCROW_LINK_ALREADY_TAKEN);
+        }
+
+        // snapshot — fee 산정
+        EscrowFeeSettings settings = feeSettingsRepository.findSingleton();
+        BigDecimal calculatedDistance = EscrowFeeCalculator.distanceKm(
+                cmd.pickupLat().doubleValue(), cmd.pickupLng().doubleValue(),
+                cmd.deliveryLat().doubleValue(), cmd.deliveryLng().doubleValue()
+        );
+        FeeBreakdown calculated = EscrowFeeCalculator.calculate(
+                settings, link.getTradeMode(), cmd.itemPrice(), calculatedDistance,
+                cmd.weight(), cmd.volume(), cmd.fragility()
+        );
+        // 결정 #10 — ±10원 tolerance
+        EscrowFeeCalculator.verifyTolerance(
+                calculated, cmd.submittedDeliveryFee(), cmd.submittedCommissionFee(), cmd.submittedTotalFee()
+        );
+
+        // share 산정 — feePayer 별 분기 (결정 #5)
+        long buyerOwed = computeBuyerOwed(link.getTradeMode(), cmd.itemPrice(), calculated, link.getFeePayer());
+        long sellerOwed = computeSellerOwed(calculated, link.getFeePayer());
+        long initiatorShare = link.getInitiatorRole() == InitiatorRole.buyer ? buyerOwed : sellerOwed;
+        long receiverShare = link.getInitiatorRole() == InitiatorRole.buyer ? sellerOwed : buyerOwed;
+
+        EscrowApplication app = EscrowApplication.create(
+                link.getId(),
+                link.getInitiatorId(), cmd.receiverId(), link.getInitiatorRole(),
+                link.getTradeMode(), link.getFeePayer(),
+                cmd.itemPrice(), cmd.itemDescription(),
+                cmd.pickupAddress(), cmd.pickupLat(), cmd.pickupLng(),
+                cmd.deliveryAddress(), cmd.deliveryLat(), cmd.deliveryLng(),
+                cmd.weight(), cmd.volume(), cmd.fragility(), cmd.deliveryNotes(),
+                calculated, initiatorShare, receiverShare,
+                serializeImageUrls(cmd.imageUrls())
+        );
+        EscrowApplication saved = applicationRepository.save(app);
+        // link 상태 → 완료
+        link.markAsCompleted();
+        return EscrowApplicationResult.from(saved, parseImageUrls(saved.getImageUrls()));
+    }
+
+    /**
+     * Mode B 의 buyer 부담 = itemPrice + (feePayer 별 fee 분담).
+     * Mode A 의 buyer 부담 = (feePayer 별 fee 분담).
+     */
+    private long computeBuyerOwed(TradeMode mode, long itemPrice, FeeBreakdown fee, FeePayer payer) {
+        long feeTotal = fee.deliveryFee() + fee.commissionFee();
+        long buyerFeeShare = switch (payer) {
+            case buyer -> feeTotal;
+            case seller -> 0L;
+            case both -> feeTotal / 2;  // 정수 원 단위 — 홀수 1원 차이는 buyer 가 더 부담
+        };
+        return (mode == TradeMode.INTERNAL ? itemPrice : 0L) + buyerFeeShare;
+    }
+
+    private long computeSellerOwed(FeeBreakdown fee, FeePayer payer) {
+        long feeTotal = fee.deliveryFee() + fee.commissionFee();
+        return switch (payer) {
+            case buyer -> 0L;
+            case seller -> feeTotal;
+            case both -> feeTotal - feeTotal / 2;  // 나머지 (홀수면 buyer 가 1 더, seller 가 1 적게)
+        };
+    }
+
+    /**
+     * Payment 도메인이 startCharge 단계에서 호출 — payer / share / status 검증.
+     * 검증 통과한 amount 만 Payment 진입 (위변조 방지 + race-safe).
+     */
+    public void verifyChargeIntent(Long applicationId, Long payerId, long amount) {
+        EscrowApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        if (app.getStatus() != EscrowApplicationStatus.결제대기) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (app.isPaymentTimedOut()) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        long expectedShare;
+        if (payerId.equals(app.getInitiatorId())) {
+            if (app.getInitiatorPaidAt() != null) {
+                throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+            }
+            expectedShare = app.getInitiatorShare();
+        } else if (payerId.equals(app.getReceiverId())) {
+            if (app.getReceiverPaidAt() != null) {
+                throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+            }
+            expectedShare = app.getReceiverShare();
+        } else {
+            throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
+        }
+        if (expectedShare <= 0) {
+            // 본인 share 가 0 인데 결제 시도 — 부정 시도.
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (expectedShare != amount) {
+            throw new BusinessException(ErrorCode.ESCROW_FEE_MISMATCH);
+        }
+    }
+
+    // =============================================================
+    // Use case 4 — 결제 confirm 후 호출 (Payment 도메인이 호출)
+    // =============================================================
+    @Transactional
+    public EscrowApplicationStatus recordPaymentConfirmed(Long applicationId, Long payerId) {
+        EscrowApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        if (app.isPaymentTimedOut()) {
+            // 자동 환불 트리거 — 5/11 시점엔 단순화 — 환불 처리는 Payment 도메인 또는 cron 후속.
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (payerId.equals(app.getInitiatorId())) {
+            app.markInitiatorPaid();
+        } else if (payerId.equals(app.getReceiverId())) {
+            app.markReceiverPaid();
+        } else {
+            throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
+        }
+        // 양쪽 결제 완료 시 EscrowConfirmedEvent 발행 → Delivery 도메인 listen
+        if (app.getStatus() == EscrowApplicationStatus.결제완료) {
+            eventPublisher.publishEvent(new EscrowConfirmedEvent(
+                    app.getId(),
+                    app.getPickupAddress(), app.getPickupLat().doubleValue(), app.getPickupLng().doubleValue(),
+                    app.getDeliveryAddress(), app.getDeliveryLat().doubleValue(), app.getDeliveryLng().doubleValue(),
+                    app.getItemDescription(),
+                    app.getAppliedDeliveryFee(),
+                    app.getBuyerId()
+            ));
+        }
+        return app.getStatus();
+    }
+
+    // =============================================================
+    // Use case 5 — 라이더 자동 매칭됐을 때 (Delivery 도메인이 호출)
+    // =============================================================
+    @Transactional
+    public void markInProgress(Long applicationId) {
+        EscrowApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        app.markInProgress();
+    }
+
+    // =============================================================
+    // Use case 6 — buyer 수령 확인 (Mode B 만) → 정산
+    // 결정 #4
+    // =============================================================
+    @Transactional
+    public void confirmReceipt(Long applicationId, Long requesterId, Long riderId) {
+        EscrowApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        app.confirmReceipt(requesterId);
+        settle(app, riderId);
+    }
+
+    /**
+     * 자동 정산 (Mode A — 배송완료 시 Delivery 도메인이 호출).
+     */
+    @Transactional
+    public void settleAfterDelivery(Long applicationId, Long riderId) {
+        EscrowApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        if (app.getTradeMode() == TradeMode.INTERNAL) {
+            // Mode B 는 buyer 수령 확인 별도 endpoint 호출
+            return;
+        }
+        settle(app, riderId);
+    }
+
+    /**
+     * 정산 — Mode B: seller += itemPrice, rider += deliveryFee.
+     * commissionFee 는 플랫폼 수익 (별도 transfer X — PointHistory 만 기록은 follow-up).
+     */
+    private void settle(EscrowApplication app, Long riderId) {
+        if (app.getTradeMode() == TradeMode.INTERNAL && app.getItemPrice() > 0) {
+            pointApplicationService.credit(
+                    app.getSellerId(), app.getItemPrice(),
+                    PointHistoryType.판매정산, PointReferenceType.ESCROW, app.getId(),
+                    "거래대행 정산 — 판매자 수령"
+            );
+        }
+        if (riderId != null && app.getAppliedDeliveryFee() > 0) {
+            pointApplicationService.credit(
+                    riderId, app.getAppliedDeliveryFee(),
+                    PointHistoryType.배달정산, PointReferenceType.ESCROW, app.getId(),
+                    "거래대행 정산 — 라이더 보상"
+            );
+        }
+        app.markSettled();
+    }
+
+    // =============================================================
+    // Use case 7 — 취소 (시점별 환불 — 결정 #6)
+    // =============================================================
+    @Transactional
+    public void cancel(Long applicationId, Long requesterId, String reason) {
+        EscrowApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        if (!app.isParticipant(requesterId)) {
+            throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
+        }
+        if (app.getStatus().isAfterMatching()) {
+            // 매칭 후 취소 — 100% 부담 정책 (결정 #6).
+            // 5/11 단순화: 별도 추가 결제 흐름 미구현 — 관리자 분기 처리.
+            // TODO(R1): 자동 추가 결제 + 환불 흐름.
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        // 매칭 전 — 양쪽 환불 (결제됐던 양만큼).
+        // 5/11 단순화: 환불 호출은 Payment 도메인이 별도 처리. 여기선 status만 갱신.
+        app.cancel(requesterId, reason);
+    }
+
+    // =============================================================
+    // Use case 8 — 본인 application 목록 / 단건
+    // =============================================================
+    public Page<EscrowApplicationResult> listMine(Long userId, Pageable pageable) {
+        return applicationRepository.findMyApplications(userId, pageable)
+                .map(a -> EscrowApplicationResult.from(a, parseImageUrls(a.getImageUrls())));
+    }
+
+    public EscrowApplicationResult getById(Long id, Long requesterId) {
+        EscrowApplication app = applicationRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        if (!app.isParticipant(requesterId)) {
+            throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
+        }
+        return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()));
+    }
+
+    // =============================================================
+    // Admin 우회 — 참여자 가드 X
+    // =============================================================
+    public Page<EscrowApplicationResult> adminListAll(Pageable pageable) {
+        return applicationRepository.findAll(pageable)
+                .map(a -> EscrowApplicationResult.from(a, parseImageUrls(a.getImageUrls())));
+    }
+
+    public EscrowApplicationResult adminGetById(Long id) {
+        EscrowApplication app = applicationRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()));
+    }
+
+    /** 이미지 URL list 직렬화 (TEXT 컬럼). 5/11 단순화 — JSON 배열. */
+    private String serializeImageUrls(List<String> urls) {
+        if (urls == null || urls.isEmpty()) return null;
+        try {
+            return IMAGE_JSON.writeValueAsString(urls);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("imageUrls 직렬화 실패", e);
+        }
+    }
+
+    private List<String> parseImageUrls(String json) {
+        if (json == null || json.isBlank()) return Collections.emptyList();
+        try {
+            return IMAGE_JSON.readValue(json, IMAGE_JSON.getTypeFactory().constructCollectionType(List.class, String.class));
+        } catch (JsonProcessingException e) {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -20,6 +20,7 @@ import com.sseulang.domain.escrow.domain.FeeBreakdown;
 import com.sseulang.domain.escrow.domain.FeePayer;
 import com.sseulang.domain.escrow.domain.InitiatorRole;
 import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.delivery.domain.DeliveryRepository;
 import com.sseulang.domain.escrow.domain.event.EscrowConfirmedEvent;
 import com.sseulang.domain.point.application.PointApplicationService;
 import com.sseulang.domain.point.domain.PointHistoryType;
@@ -62,6 +63,7 @@ public class EscrowApplicationService {
     private final EscrowFeeSettingsRepository feeSettingsRepository;
     private final UserApplicationService userApplicationService;
     private final PointApplicationService pointApplicationService;
+    private final DeliveryRepository deliveryRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final int linkExpiryHours;
 
@@ -71,6 +73,7 @@ public class EscrowApplicationService {
             EscrowFeeSettingsRepository feeSettingsRepository,
             UserApplicationService userApplicationService,
             PointApplicationService pointApplicationService,
+            DeliveryRepository deliveryRepository,
             ApplicationEventPublisher eventPublisher,
             @Value("${app.escrow.link.expiry-hours:24}") int linkExpiryHours
     ) {
@@ -79,6 +82,7 @@ public class EscrowApplicationService {
         this.feeSettingsRepository = feeSettingsRepository;
         this.userApplicationService = userApplicationService;
         this.pointApplicationService = pointApplicationService;
+        this.deliveryRepository = deliveryRepository;
         this.eventPublisher = eventPublisher;
         this.linkExpiryHours = linkExpiryHours;
     }
@@ -253,7 +257,7 @@ public class EscrowApplicationService {
     // =============================================================
     @Transactional
     public EscrowApplicationStatus recordPaymentConfirmed(Long applicationId, Long payerId) {
-        EscrowApplication app = applicationRepository.findById(applicationId)
+        EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
         if (app.isPaymentTimedOut()) {
             // 자동 환불 트리거 — 5/11 시점엔 단순화 — 환불 처리는 Payment 도메인 또는 cron 후속.
@@ -295,10 +299,18 @@ public class EscrowApplicationService {
     // 결정 #4
     // =============================================================
     @Transactional
-    public void confirmReceipt(Long applicationId, Long requesterId, Long riderId) {
-        EscrowApplication app = applicationRepository.findById(applicationId)
+    public void confirmReceipt(Long applicationId, Long requesterId) {
+        EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
         app.confirmReceipt(requesterId);
+        // 라이더 식별 — Delivery 도메인에서 escrow_application_id 로 조회 (게이트 1 Critical 2).
+        Long riderId = deliveryRepository.findByEscrowApplicationId(applicationId)
+                .map(d -> d.getRiderId())
+                .orElse(null);
+        if (riderId == null) {
+            // 라이더 매칭 안 된 상태에서 receipt 호출 — 데이터 부정합 (정산 불가).
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
         settle(app, riderId);
     }
 
@@ -306,12 +318,18 @@ public class EscrowApplicationService {
      * 자동 정산 (Mode A — 배송완료 시 Delivery 도메인이 호출).
      */
     @Transactional
-    public void settleAfterDelivery(Long applicationId, Long riderId) {
-        EscrowApplication app = applicationRepository.findById(applicationId)
+    public void settleAfterDelivery(Long applicationId) {
+        EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
         if (app.getTradeMode() == TradeMode.INTERNAL) {
             // Mode B 는 buyer 수령 확인 별도 endpoint 호출
             return;
+        }
+        Long riderId = deliveryRepository.findByEscrowApplicationId(applicationId)
+                .map(d -> d.getRiderId())
+                .orElse(null);
+        if (riderId == null) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
         }
         settle(app, riderId);
     }
@@ -343,7 +361,7 @@ public class EscrowApplicationService {
     // =============================================================
     @Transactional
     public void cancel(Long applicationId, Long requesterId, String reason) {
-        EscrowApplication app = applicationRepository.findById(applicationId)
+        EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
         if (!app.isParticipant(requesterId)) {
             throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);

--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowFeeSettingsApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowFeeSettingsApplicationService.java
@@ -1,0 +1,59 @@
+package com.sseulang.domain.escrow.application;
+
+import com.sseulang.domain.escrow.domain.EscrowApplicationRepository;
+import com.sseulang.domain.escrow.domain.EscrowFeeSettings;
+import com.sseulang.domain.escrow.domain.EscrowFeeSettingsRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+/**
+ * 거래대행 수수료 정책 운영 (admin). 결정 #9 + #12.
+ *
+ * <p>변경 흐름: PATCH 호출 → DB UPDATE → 진행 중 application 은 snapshot 으로 영향 X.
+ * 변경 시 진행 중 N건 표시 (12-a HH2) 위해 countInProgress 동시 반환.</p>
+ */
+@Service
+@Transactional(readOnly = true)
+public class EscrowFeeSettingsApplicationService {
+
+    private final EscrowFeeSettingsRepository repository;
+    private final EscrowApplicationRepository applicationRepository;
+
+    public EscrowFeeSettingsApplicationService(
+            EscrowFeeSettingsRepository repository,
+            EscrowApplicationRepository applicationRepository
+    ) {
+        this.repository = repository;
+        this.applicationRepository = applicationRepository;
+    }
+
+    public EscrowFeeSettings get() {
+        return repository.findSingleton();
+    }
+
+    @Transactional
+    public EscrowFeeSettings update(
+            BigDecimal commissionRate,
+            long fuelPricePerL, long baseFuelPrice,
+            long baseDeliveryFee, long baseKmRate, BigDecimal fuelEfficiency, long minDeliveryFee,
+            long truckBaseDeliveryFee, long truckBaseKmRate, BigDecimal truckFuelEfficiency, long truckMinDeliveryFee,
+            Long adminId
+    ) {
+        EscrowFeeSettings settings = repository.findSingleton();
+        settings.apply(
+                commissionRate,
+                fuelPricePerL, baseFuelPrice,
+                baseDeliveryFee, baseKmRate, fuelEfficiency, minDeliveryFee,
+                truckBaseDeliveryFee, truckBaseKmRate, truckFuelEfficiency, truckMinDeliveryFee,
+                adminId
+        );
+        return repository.save(settings);
+    }
+
+    /** admin 변경 시 표시용 — 진행 중 application N건. */
+    public long countInProgress() {
+        return applicationRepository.countInProgress();
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateCommand.java
@@ -1,0 +1,32 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record EscrowApplicationCreateCommand(
+        Long receiverId,                // 폼 제출자 = 수신자 후보
+        String linkToken,
+        long itemPrice,                 // INTERNAL > 0, EXTERNAL = 0
+        String itemDescription,
+        String pickupAddress,
+        BigDecimal pickupLat,
+        BigDecimal pickupLng,
+        String deliveryAddress,
+        BigDecimal deliveryLat,
+        BigDecimal deliveryLng,
+        Weight weight,
+        Volume volume,
+        Fragility fragility,
+        String deliveryNotes,
+        // 프론트가 보낸 fee 값 (백엔드 ±10원 검증)
+        long submittedDeliveryFee,
+        long submittedCommissionFee,
+        long submittedTotalFee,
+        BigDecimal submittedDistanceKm,
+        List<String> imageUrls
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationResult.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationResult.java
@@ -1,0 +1,75 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import com.sseulang.domain.escrow.domain.EscrowApplication;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record EscrowApplicationResult(
+        Long id,
+        Long linkId,
+        Long initiatorId,
+        Long receiverId,
+        Long buyerId,
+        Long sellerId,
+        TradeMode tradeMode,
+        FeePayer feePayer,
+        long itemPrice,
+        String itemDescription,
+        String pickupAddress,
+        BigDecimal pickupLat,
+        BigDecimal pickupLng,
+        String deliveryAddress,
+        BigDecimal deliveryLat,
+        BigDecimal deliveryLng,
+        Weight weight,
+        Volume volume,
+        Fragility fragility,
+        String deliveryNotes,
+        BigDecimal appliedDistanceKm,
+        long appliedDeliveryFee,
+        long appliedCommissionFee,
+        long appliedTotalFee,
+        BigDecimal appliedCommissionRate,
+        long initiatorShare,
+        long receiverShare,
+        LocalDateTime initiatorPaidAt,
+        LocalDateTime receiverPaidAt,
+        LocalDateTime paymentDueAt,
+        EscrowApplicationStatus status,
+        String cancelReason,
+        Long cancelledBy,
+        LocalDateTime receiptConfirmedAt,
+        LocalDateTime settledAt,
+        List<String> imageUrls,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static EscrowApplicationResult from(EscrowApplication a, List<String> imageUrls) {
+        return new EscrowApplicationResult(
+                a.getId(), a.getLinkId(),
+                a.getInitiatorId(), a.getReceiverId(),
+                a.getBuyerId(), a.getSellerId(),
+                a.getTradeMode(), a.getFeePayer(),
+                a.getItemPrice(), a.getItemDescription(),
+                a.getPickupAddress(), a.getPickupLat(), a.getPickupLng(),
+                a.getDeliveryAddress(), a.getDeliveryLat(), a.getDeliveryLng(),
+                a.getWeight(), a.getVolume(), a.getFragility(), a.getDeliveryNotes(),
+                a.getAppliedDistanceKm(), a.getAppliedDeliveryFee(), a.getAppliedCommissionFee(),
+                a.getAppliedTotalFee(), a.getAppliedCommissionRate(),
+                a.getInitiatorShare(), a.getReceiverShare(),
+                a.getInitiatorPaidAt(), a.getReceiverPaidAt(), a.getPaymentDueAt(),
+                a.getStatus(), a.getCancelReason(), a.getCancelledBy(),
+                a.getReceiptConfirmedAt(), a.getSettledAt(),
+                imageUrls,
+                a.getCreatedAt(), a.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkCreateCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkCreateCommand.java
@@ -1,0 +1,13 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.InitiatorRole;
+import com.sseulang.domain.escrow.domain.TradeMode;
+
+public record EscrowLinkCreateCommand(
+        Long initiatorId,
+        InitiatorRole initiatorRole,
+        FeePayer feePayer,
+        TradeMode tradeMode
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkResult.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkResult.java
@@ -1,37 +1,44 @@
 package com.sseulang.domain.escrow.application.dto;
 
 import com.sseulang.domain.escrow.domain.EscrowLink;
-import com.sseulang.domain.escrow.domain.EscrowLinkStatus;
 import com.sseulang.domain.escrow.domain.FeePayer;
 import com.sseulang.domain.escrow.domain.InitiatorRole;
 import com.sseulang.domain.escrow.domain.TradeMode;
 
 import java.time.LocalDateTime;
 
+/**
+ * Escrow link 응답.
+ *
+ * <p>비로그인 GET 응답 시 노출 필드 최소화 (게이트 1 Nit) — 토큰 leak 시 메타데이터 leak 면적 축소.
+ * 신청자 본인의 link 생성 응답은 동일 형식이지만 본인 정보라 leak 위험 X.</p>
+ *
+ * <p>의도적 노출:
+ * <ul>
+ *   <li>linkToken — 응답으로 받기 위해 필요</li>
+ *   <li>initiatorNickname — 수신자가 누가 보낸 건지 식별</li>
+ *   <li>initiatorRole / feePayer / tradeMode — 수신자가 본인 부담 결정</li>
+ *   <li>expiresAt — 클라가 만료 시각 표시</li>
+ * </ul>
+ *
+ * <p>의도적 비노출 (Nit fix): id, initiatorId, status, createdAt — public 진입 시 leak 면적 축소.</p>
+ */
 public record EscrowLinkResult(
-        Long id,
         String linkToken,
-        Long initiatorId,
-        String initiatorNickname,           // public GET 시 노출 — 비로그인 OK
+        String initiatorNickname,
         InitiatorRole initiatorRole,
         FeePayer feePayer,
         TradeMode tradeMode,
-        EscrowLinkStatus status,
-        LocalDateTime expiresAt,
-        LocalDateTime createdAt
+        LocalDateTime expiresAt
 ) {
     public static EscrowLinkResult from(EscrowLink link, String initiatorNickname) {
         return new EscrowLinkResult(
-                link.getId(),
                 link.getLinkToken(),
-                link.getInitiatorId(),
                 initiatorNickname,
                 link.getInitiatorRole(),
                 link.getFeePayer(),
                 link.getTradeMode(),
-                link.getStatus(),
-                link.getExpiresAt(),
-                link.getCreatedAt()
+                link.getExpiresAt()
         );
     }
 }

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkResult.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkResult.java
@@ -1,0 +1,37 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import com.sseulang.domain.escrow.domain.EscrowLink;
+import com.sseulang.domain.escrow.domain.EscrowLinkStatus;
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.InitiatorRole;
+import com.sseulang.domain.escrow.domain.TradeMode;
+
+import java.time.LocalDateTime;
+
+public record EscrowLinkResult(
+        Long id,
+        String linkToken,
+        Long initiatorId,
+        String initiatorNickname,           // public GET 시 노출 — 비로그인 OK
+        InitiatorRole initiatorRole,
+        FeePayer feePayer,
+        TradeMode tradeMode,
+        EscrowLinkStatus status,
+        LocalDateTime expiresAt,
+        LocalDateTime createdAt
+) {
+    public static EscrowLinkResult from(EscrowLink link, String initiatorNickname) {
+        return new EscrowLinkResult(
+                link.getId(),
+                link.getLinkToken(),
+                link.getInitiatorId(),
+                initiatorNickname,
+                link.getInitiatorRole(),
+                link.getFeePayer(),
+                link.getTradeMode(),
+                link.getStatus(),
+                link.getExpiresAt(),
+                link.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
@@ -1,0 +1,301 @@
+package com.sseulang.domain.escrow.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Escrow Application Aggregate Root. V15 {@code escrow_applications} 매핑.
+ *
+ * <p>폼 제출 후 단일 row. 결제/정산/취소 라이프사이클 모두 본 Aggregate 이 책임.
+ * snapshot (applied_*) — settings 변경 무관 lock (결정 #9, #12).</p>
+ *
+ * <p>상태머신: 결제대기 → 결제완료 → 진행중 → 완료 / 취소.
+ * 양쪽 share 결제 (G2) — initiator/receiver 각자 결제 시점 기록.</p>
+ */
+@Entity
+@Table(name = "escrow_applications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EscrowApplication extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "link_id", nullable = false, updatable = false)
+    private Long linkId;
+
+    @Column(name = "initiator_id", nullable = false, updatable = false)
+    private Long initiatorId;
+
+    @Column(name = "receiver_id", nullable = false, updatable = false)
+    private Long receiverId;
+
+    @Column(name = "buyer_id", nullable = false, updatable = false)
+    private Long buyerId;
+
+    @Column(name = "seller_id", nullable = false, updatable = false)
+    private Long sellerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trade_mode", nullable = false, length = 20, updatable = false)
+    private TradeMode tradeMode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "fee_payer", nullable = false, length = 10, updatable = false)
+    private FeePayer feePayer;
+
+    @Column(name = "item_price", nullable = false, updatable = false)
+    private long itemPrice;
+
+    @Column(name = "item_description", nullable = false, length = 500, updatable = false)
+    private String itemDescription;
+
+    @Column(name = "pickup_address", nullable = false, length = 255, updatable = false)
+    private String pickupAddress;
+
+    @Column(name = "pickup_lat", nullable = false, precision = 10, scale = 7, updatable = false)
+    private BigDecimal pickupLat;
+
+    @Column(name = "pickup_lng", nullable = false, precision = 10, scale = 7, updatable = false)
+    private BigDecimal pickupLng;
+
+    @Column(name = "delivery_address", nullable = false, length = 255, updatable = false)
+    private String deliveryAddress;
+
+    @Column(name = "delivery_lat", nullable = false, precision = 10, scale = 7, updatable = false)
+    private BigDecimal deliveryLat;
+
+    @Column(name = "delivery_lng", nullable = false, precision = 10, scale = 7, updatable = false)
+    private BigDecimal deliveryLng;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "weight", nullable = false, length = 10, updatable = false)
+    private Weight weight;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "volume", nullable = false, length = 5, updatable = false)
+    private Volume volume;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "fragility", nullable = false, length = 5, updatable = false)
+    private Fragility fragility;
+
+    @Column(name = "delivery_notes", length = 500, updatable = false)
+    private String deliveryNotes;
+
+    // ===== snapshot — 운영 settings 변경 무관 lock =====
+    @Column(name = "applied_distance_km", nullable = false, precision = 8, scale = 2, updatable = false)
+    private BigDecimal appliedDistanceKm;
+
+    @Column(name = "applied_delivery_fee", nullable = false, updatable = false)
+    private long appliedDeliveryFee;
+
+    @Column(name = "applied_commission_fee", nullable = false, updatable = false)
+    private long appliedCommissionFee;
+
+    @Column(name = "applied_total_fee", nullable = false, updatable = false)
+    private long appliedTotalFee;
+
+    @Column(name = "applied_commission_rate", nullable = false, precision = 5, scale = 4, updatable = false)
+    private BigDecimal appliedCommissionRate;
+
+    // ===== 결제 추적 =====
+    @Column(name = "initiator_share", nullable = false, updatable = false)
+    private long initiatorShare;
+
+    @Column(name = "receiver_share", nullable = false, updatable = false)
+    private long receiverShare;
+
+    @Column(name = "initiator_paid_at")
+    private LocalDateTime initiatorPaidAt;
+
+    @Column(name = "receiver_paid_at")
+    private LocalDateTime receiverPaidAt;
+
+    @Column(name = "payment_due_at")
+    private LocalDateTime paymentDueAt;
+
+    // ===== 상태머신 =====
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private EscrowApplicationStatus status;
+
+    @Column(name = "cancel_reason", length = 500)
+    private String cancelReason;
+
+    @Column(name = "cancelled_by")
+    private Long cancelledBy;
+
+    @Column(name = "receipt_confirmed_at")
+    private LocalDateTime receiptConfirmedAt;
+
+    @Column(name = "settled_at")
+    private LocalDateTime settledAt;
+
+    @Column(name = "image_urls", columnDefinition = "TEXT", updatable = false)
+    private String imageUrls;
+
+    /**
+     * 폼 제출 후 application 생성. snapshot 컬럼 모두 채움.
+     * shares 는 feePayer 별 ApplicationService 가 산정 후 주입.
+     */
+    public static EscrowApplication create(
+            Long linkId,
+            Long initiatorId, Long receiverId, InitiatorRole initiatorRole,
+            TradeMode tradeMode, FeePayer feePayer,
+            long itemPrice, String itemDescription,
+            String pickupAddress, BigDecimal pickupLat, BigDecimal pickupLng,
+            String deliveryAddress, BigDecimal deliveryLat, BigDecimal deliveryLng,
+            Weight weight, Volume volume, Fragility fragility, String deliveryNotes,
+            FeeBreakdown snapshot,
+            long initiatorShare, long receiverShare,
+            String imageUrls
+    ) {
+        if (linkId == null || initiatorId == null || receiverId == null) {
+            throw new IllegalArgumentException("ids required");
+        }
+        if (initiatorId.equals(receiverId)) {
+            throw new BusinessException(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
+        }
+        // role 매핑 — buyer/seller 식별
+        Long buyerId = initiatorRole == InitiatorRole.buyer ? initiatorId : receiverId;
+        Long sellerId = initiatorRole == InitiatorRole.buyer ? receiverId : initiatorId;
+
+        EscrowApplication a = new EscrowApplication();
+        a.linkId = linkId;
+        a.initiatorId = initiatorId;
+        a.receiverId = receiverId;
+        a.buyerId = buyerId;
+        a.sellerId = sellerId;
+        a.tradeMode = tradeMode;
+        a.feePayer = feePayer;
+        a.itemPrice = itemPrice;
+        a.itemDescription = itemDescription;
+        a.pickupAddress = pickupAddress;
+        a.pickupLat = pickupLat;
+        a.pickupLng = pickupLng;
+        a.deliveryAddress = deliveryAddress;
+        a.deliveryLat = deliveryLat;
+        a.deliveryLng = deliveryLng;
+        a.weight = weight;
+        a.volume = volume;
+        a.fragility = fragility;
+        a.deliveryNotes = deliveryNotes;
+        a.appliedDistanceKm = snapshot.distanceKm();
+        a.appliedDeliveryFee = snapshot.deliveryFee();
+        a.appliedCommissionFee = snapshot.commissionFee();
+        a.appliedTotalFee = snapshot.totalFee();
+        a.appliedCommissionRate = snapshot.commissionRate();
+        a.initiatorShare = initiatorShare;
+        a.receiverShare = receiverShare;
+        a.status = EscrowApplicationStatus.결제대기;
+        a.imageUrls = imageUrls;
+        return a;
+    }
+
+    /** 수신자 결제 완료 — 결정 #5 H2 (수신자 먼저). 모든 share 충족 시 결제완료 진입. */
+    public void markReceiverPaid() {
+        if (this.status != EscrowApplicationStatus.결제대기) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (this.receiverPaidAt != null) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        this.receiverPaidAt = LocalDateTime.now();
+        // 첫 결제 시점 — payment_due_at = +24h
+        if (this.paymentDueAt == null) {
+            this.paymentDueAt = this.receiverPaidAt.plusHours(24);
+        }
+        tryAdvanceToConfirmed();
+    }
+
+    public void markInitiatorPaid() {
+        if (this.status != EscrowApplicationStatus.결제대기) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (this.initiatorPaidAt != null) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        this.initiatorPaidAt = LocalDateTime.now();
+        if (this.paymentDueAt == null) {
+            this.paymentDueAt = this.initiatorPaidAt.plusHours(24);
+        }
+        tryAdvanceToConfirmed();
+    }
+
+    /** 양쪽 share 모두 충족됐는지 확인 후 결제완료 전진. share=0 인 쪽은 결제 면제. */
+    private void tryAdvanceToConfirmed() {
+        boolean initiatorOk = this.initiatorShare == 0 || this.initiatorPaidAt != null;
+        boolean receiverOk = this.receiverShare == 0 || this.receiverPaidAt != null;
+        if (initiatorOk && receiverOk) {
+            this.status = EscrowApplicationStatus.결제완료;
+        }
+    }
+
+    /** 라이더 자동 매칭됐을 때 — 결정 #8 X1. */
+    public void markInProgress() {
+        if (this.status != EscrowApplicationStatus.결제완료) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        this.status = EscrowApplicationStatus.진행중;
+    }
+
+    /** Mode B buyer 수령 확인 — 결정 #4. 정산 흐름 트리거. */
+    public void confirmReceipt(Long requesterId) {
+        if (this.tradeMode != TradeMode.INTERNAL) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (this.status != EscrowApplicationStatus.진행중) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (!this.buyerId.equals(requesterId)) {
+            throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
+        }
+        this.receiptConfirmedAt = LocalDateTime.now();
+    }
+
+    /** 정산 완료 표시 — ApplicationService 가 포인트 이동 후 호출. */
+    public void markSettled() {
+        if (this.status != EscrowApplicationStatus.진행중) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        this.status = EscrowApplicationStatus.완료;
+        this.settledAt = LocalDateTime.now();
+    }
+
+    /** 취소 — 시점별 환불은 ApplicationService 가 처리. 본 Aggregate 는 상태만 표시. */
+    public void cancel(Long cancelledBy, String reason) {
+        if (this.status.isTerminal()) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        this.status = EscrowApplicationStatus.취소;
+        this.cancelledBy = cancelledBy;
+        this.cancelReason = reason;
+    }
+
+    public boolean isPaymentTimedOut() {
+        return this.paymentDueAt != null && LocalDateTime.now().isAfter(this.paymentDueAt)
+                && this.status == EscrowApplicationStatus.결제대기;
+    }
+
+    /** 사용자가 양쪽 당사자인지 확인. */
+    public boolean isParticipant(Long userId) {
+        return this.initiatorId.equals(userId) || this.receiverId.equals(userId);
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationRepository.java
@@ -12,6 +12,12 @@ public interface EscrowApplicationRepository {
 
     Optional<EscrowApplication> findById(Long id);
 
+    /**
+     * 결제/정산 흐름 비관적 락 — recordPaymentConfirmed / confirmReceipt / cancel race 직렬화
+     * (게이트 1 round 1 — Critical 3: 동시 결제 / receipt 연타 시 paid_at 유실 또는 정산 중복 회귀 차단).
+     */
+    Optional<EscrowApplication> findByIdForUpdate(Long id);
+
     Optional<EscrowApplication> findByLinkId(Long linkId);
 
     /** 본인이 참여한 (initiator OR receiver) application 목록. */

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationRepository.java
@@ -1,0 +1,33 @@
+package com.sseulang.domain.escrow.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EscrowApplicationRepository {
+
+    EscrowApplication save(EscrowApplication application);
+
+    Optional<EscrowApplication> findById(Long id);
+
+    Optional<EscrowApplication> findByLinkId(Long linkId);
+
+    /** 본인이 참여한 (initiator OR receiver) application 목록. */
+    Page<EscrowApplication> findMyApplications(Long userId, Pageable pageable);
+
+    /** Admin — 전체. */
+    Page<EscrowApplication> findAll(Pageable pageable);
+
+    /** Admin — 상태 필터. */
+    Page<EscrowApplication> findAllByStatus(EscrowApplicationStatus status, Pageable pageable);
+
+    /**
+     * Passive timeout 검증 — 결제대기 + payment_due_at 경과한 것들. 사용자 조회/admin 시점에 사용.
+     */
+    List<EscrowApplication> findPaymentTimedOut();
+
+    /** 진행 중 N건 (admin fee_settings 변경 시 영향 안내용). 결정 #12 12-a HH2. */
+    long countInProgress();
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationStatus.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationStatus.java
@@ -1,0 +1,31 @@
+package com.sseulang.domain.escrow.domain;
+
+/**
+ * Escrow application 상태머신.
+ *
+ * <pre>
+ *   결제대기 → 결제완료 (양쪽 share 결제 — feePayer 별 분기) → 진행중 (라이더 자동 매칭)
+ *   진행중   → 완료 (Mode B: buyer 수령 확인 + 정산 / Mode A: 배송완료 + 정산)
+ *   any 시점 → 취소 (시점별 환불 정책 — 결정 #6)
+ * </pre>
+ */
+public enum EscrowApplicationStatus {
+    결제대기,
+    결제완료,
+    진행중,
+    완료,
+    취소;
+
+    public boolean isTerminal() {
+        return this == 완료 || this == 취소;
+    }
+
+    public boolean isPaymentDone() {
+        return this != 결제대기;
+    }
+
+    /** 매칭 후 시점 — 취소 시 fee 100% 부담 정책 (결정 #6 갱신). */
+    public boolean isAfterMatching() {
+        return this == 진행중 || this == 완료;
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeCalculator.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeCalculator.java
@@ -1,0 +1,115 @@
+package com.sseulang.domain.escrow.domain;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * 거래대행 수수료 계산 DomainService. 프론트 {@code calcFees} 와 동일 로직 (결정 #9, CC3).
+ *
+ * <pre>
+ * adjustedKmRate = (truck ? truckBaseKmRate : baseKmRate)
+ *                  + (fuelPricePerL - baseFuelPrice) * distance / fuelEfficiency
+ * baseFee        = (truck ? truckBaseDeliveryFee : baseDeliveryFee)
+ * deliveryFee    = baseFee + adjustedKmRate * distance
+ * deliveryFee    = max(deliveryFee, truck ? truckMinDeliveryFee : minDeliveryFee)
+ * deliveryFee    = round(deliveryFee * weightMul * volumeMul * fragMul)
+ * </pre>
+ *
+ * <p>spring 컴포넌트 X — 순수 도메인 (의존성 없음). 호출자가 settings 주입.</p>
+ */
+public final class EscrowFeeCalculator {
+
+    private static final double EARTH_RADIUS_KM = 6371.0;
+
+    private EscrowFeeCalculator() {}
+
+    /**
+     * 좌표 → distance (haversine). 프론트와 동일 공식.
+     */
+    public static BigDecimal distanceKm(double lat1, double lng1, double lat2, double lng2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        double km = EARTH_RADIUS_KM * c;
+        return BigDecimal.valueOf(km).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * 전체 수수료 산정 (snapshot 용).
+     *
+     * @param settings   현재 운영 정책 (singleton row)
+     * @param tradeMode  INTERNAL/EXTERNAL
+     * @param itemPrice  Mode B 만 > 0
+     * @param distanceKm 좌표로 사전 계산된 거리 (소수점 2)
+     */
+    public static FeeBreakdown calculate(
+            EscrowFeeSettings settings,
+            TradeMode tradeMode,
+            long itemPrice,
+            BigDecimal distanceKm,
+            Weight weight,
+            Volume volume,
+            Fragility fragility
+    ) {
+        if (settings == null || tradeMode == null || weight == null || volume == null || fragility == null) {
+            throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+        }
+        if (tradeMode == TradeMode.INTERNAL && itemPrice <= 0) {
+            throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+        }
+        if (tradeMode == TradeMode.EXTERNAL && itemPrice != 0) {
+            throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+        }
+
+        boolean truck = weight.isTruck();
+        double dist = distanceKm.doubleValue();
+
+        // 유류비 보정: (현재유가 - 기준유가) * 거리 / 연비 = 거리당 추가비용
+        long baseKmRate = truck ? settings.getTruckBaseKmRate() : settings.getBaseKmRate();
+        double fuelEff = (truck ? settings.getTruckFuelEfficiency() : settings.getFuelEfficiency()).doubleValue();
+        double fuelDiff = settings.getFuelPricePerL() - settings.getBaseFuelPrice();
+        double adjustedKmRate = baseKmRate + (fuelDiff * dist / Math.max(fuelEff, 0.0001));
+
+        long baseFee = truck ? settings.getTruckBaseDeliveryFee() : settings.getBaseDeliveryFee();
+        long minFee = truck ? settings.getTruckMinDeliveryFee() : settings.getMinDeliveryFee();
+
+        double rawDelivery = baseFee + adjustedKmRate * dist;
+        rawDelivery = Math.max(rawDelivery, minFee);
+        rawDelivery = rawDelivery * weight.multiplier() * volume.multiplier() * fragility.multiplier();
+        long deliveryFee = Math.round(rawDelivery);
+
+        long commissionFee = 0L;
+        if (tradeMode == TradeMode.INTERNAL) {
+            commissionFee = Math.round(itemPrice * settings.getCommissionRate().doubleValue());
+        }
+
+        long totalFee = deliveryFee + commissionFee + (tradeMode == TradeMode.INTERNAL ? itemPrice : 0L);
+
+        return new FeeBreakdown(
+                distanceKm,
+                deliveryFee,
+                commissionFee,
+                totalFee,
+                settings.getCommissionRate()
+        );
+    }
+
+    /**
+     * 프론트가 보낸 fee 값을 ±10원 tolerance 로 검증 (결정 #10, EE2).
+     * mismatch 시 ESCROW_FEE_MISMATCH (race 또는 위변조 의심).
+     */
+    public static void verifyTolerance(FeeBreakdown calculated, long submittedDeliveryFee, long submittedCommissionFee, long submittedTotalFee) {
+        long tolerance = 10L;
+        if (Math.abs(calculated.deliveryFee() - submittedDeliveryFee) > tolerance ||
+                Math.abs(calculated.commissionFee() - submittedCommissionFee) > tolerance ||
+                Math.abs(calculated.totalFee() - submittedTotalFee) > tolerance) {
+            throw new BusinessException(ErrorCode.ESCROW_FEE_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeSettings.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeSettings.java
@@ -1,0 +1,95 @@
+package com.sseulang.domain.escrow.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 거래대행 수수료 정책 — singleton row (id=1).
+ *
+ * <p>운영 변경은 admin endpoint 로. 변경 시 진행 중 application 영향 X — application 등록 시
+ * snapshot 컬럼에 lock (결정 #9, #12).</p>
+ *
+ * <p>11 fields = 프론트 calcFees 와 동일 (CC3). multiplier 는 enum 코드 상수.</p>
+ */
+@Entity
+@Table(name = "escrow_fee_settings")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EscrowFeeSettings {
+
+    public static final long SINGLETON_ID = 1L;
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "commission_rate", nullable = false, precision = 5, scale = 4)
+    private BigDecimal commissionRate;
+
+    @Column(name = "fuel_price_per_l", nullable = false)
+    private long fuelPricePerL;
+
+    @Column(name = "base_fuel_price", nullable = false)
+    private long baseFuelPrice;
+
+    @Column(name = "base_delivery_fee", nullable = false)
+    private long baseDeliveryFee;
+
+    @Column(name = "base_km_rate", nullable = false)
+    private long baseKmRate;
+
+    @Column(name = "fuel_efficiency", nullable = false, precision = 5, scale = 2)
+    private BigDecimal fuelEfficiency;
+
+    @Column(name = "min_delivery_fee", nullable = false)
+    private long minDeliveryFee;
+
+    @Column(name = "truck_base_delivery_fee", nullable = false)
+    private long truckBaseDeliveryFee;
+
+    @Column(name = "truck_base_km_rate", nullable = false)
+    private long truckBaseKmRate;
+
+    @Column(name = "truck_fuel_efficiency", nullable = false, precision = 5, scale = 2)
+    private BigDecimal truckFuelEfficiency;
+
+    @Column(name = "truck_min_delivery_fee", nullable = false)
+    private long truckMinDeliveryFee;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    /** 수수료 정책 일괄 변경 — admin endpoint 호출. */
+    public void apply(
+            BigDecimal commissionRate,
+            long fuelPricePerL, long baseFuelPrice,
+            long baseDeliveryFee, long baseKmRate, BigDecimal fuelEfficiency, long minDeliveryFee,
+            long truckBaseDeliveryFee, long truckBaseKmRate, BigDecimal truckFuelEfficiency, long truckMinDeliveryFee,
+            Long updatedBy
+    ) {
+        this.commissionRate = commissionRate;
+        this.fuelPricePerL = fuelPricePerL;
+        this.baseFuelPrice = baseFuelPrice;
+        this.baseDeliveryFee = baseDeliveryFee;
+        this.baseKmRate = baseKmRate;
+        this.fuelEfficiency = fuelEfficiency;
+        this.minDeliveryFee = minDeliveryFee;
+        this.truckBaseDeliveryFee = truckBaseDeliveryFee;
+        this.truckBaseKmRate = truckBaseKmRate;
+        this.truckFuelEfficiency = truckFuelEfficiency;
+        this.truckMinDeliveryFee = truckMinDeliveryFee;
+        this.updatedBy = updatedBy;
+        // updated_at 은 DB ON UPDATE CURRENT_TIMESTAMP — JPA Dirty checking 으로 트리거
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeSettingsRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeSettingsRepository.java
@@ -1,0 +1,9 @@
+package com.sseulang.domain.escrow.domain;
+
+public interface EscrowFeeSettingsRepository {
+
+    /** Singleton row (id=1) 조회. 없으면 IllegalStateException — V15 마이그레이션이 default 보장. */
+    EscrowFeeSettings findSingleton();
+
+    EscrowFeeSettings save(EscrowFeeSettings settings);
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowLink.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowLink.java
@@ -1,0 +1,133 @@
+package com.sseulang.domain.escrow.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Escrow Link Aggregate Root. V15 {@code escrow_links} 매핑.
+ *
+ * <p>신청자가 link 생성 → 수신자에게 공유 → 수신자가 token 으로 진입. 첫 폼 제출자 = 수신자 확정
+ * (결정 #2, B3). atomic UPDATE 는 ApplicationService 가 conditional WHERE 로 처리.</p>
+ */
+@Entity
+@Table(name = "escrow_links")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EscrowLink extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "link_token", nullable = false, length = 36, updatable = false)
+    private String linkToken;
+
+    @Column(name = "initiator_id", nullable = false, updatable = false)
+    private Long initiatorId;
+
+    @Column(name = "receiver_id")
+    private Long receiverId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "initiator_role", nullable = false, length = 10, updatable = false)
+    private InitiatorRole initiatorRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "fee_payer", nullable = false, length = 10, updatable = false)
+    private FeePayer feePayer;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trade_mode", nullable = false, length = 20, updatable = false)
+    private TradeMode tradeMode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private EscrowLinkStatus status;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    /** 신청자가 link 생성. UUID v4 token + 24h expiry (호출자가 hours 주입). */
+    public static EscrowLink create(
+            Long initiatorId,
+            InitiatorRole initiatorRole,
+            FeePayer feePayer,
+            TradeMode tradeMode,
+            int expiryHours
+    ) {
+        if (initiatorId == null) throw new IllegalArgumentException("initiatorId required");
+        if (initiatorRole == null) throw new IllegalArgumentException("initiatorRole required");
+        if (feePayer == null) throw new IllegalArgumentException("feePayer required");
+        if (tradeMode == null) throw new IllegalArgumentException("tradeMode required");
+        if (expiryHours <= 0) throw new IllegalArgumentException("expiryHours > 0");
+
+        EscrowLink link = new EscrowLink();
+        link.linkToken = UUID.randomUUID().toString();
+        link.initiatorId = initiatorId;
+        link.initiatorRole = initiatorRole;
+        link.feePayer = feePayer;
+        link.tradeMode = tradeMode;
+        link.status = EscrowLinkStatus.대기;
+        link.expiresAt = LocalDateTime.now().plusHours(expiryHours);
+        return link;
+    }
+
+    /** 수신자 확정 — 결정 #2 B3. 본인 차단 가드는 ApplicationService 가 처리 (DB chk 제약 + 코드 가드). */
+    public void claimByReceiver(Long receiverId) {
+        if (receiverId == null) {
+            throw new IllegalArgumentException("receiverId required");
+        }
+        if (this.initiatorId.equals(receiverId)) {
+            throw new BusinessException(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
+        }
+        if (this.status != EscrowLinkStatus.대기) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (LocalDateTime.now().isAfter(this.expiresAt)) {
+            throw new BusinessException(ErrorCode.ESCROW_LINK_EXPIRED);
+        }
+        if (this.receiverId != null && !this.receiverId.equals(receiverId)) {
+            throw new BusinessException(ErrorCode.ESCROW_LINK_ALREADY_TAKEN);
+        }
+        this.receiverId = receiverId;
+    }
+
+    /** Application 생성된 후 — link 본 의무 끝. */
+    public void markAsCompleted() {
+        if (this.status != EscrowLinkStatus.대기) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        this.status = EscrowLinkStatus.완료;
+    }
+
+    public void markAsExpired() {
+        if (this.status != EscrowLinkStatus.대기) return;
+        this.status = EscrowLinkStatus.만료;
+    }
+
+    public void markAsCancelled() {
+        if (this.status != EscrowLinkStatus.대기) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        this.status = EscrowLinkStatus.취소;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowLinkRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowLinkRepository.java
@@ -1,0 +1,29 @@
+package com.sseulang.domain.escrow.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+/**
+ * EscrowLink 도메인 Repository (인터페이스).
+ * 구현은 {@code infrastructure/persistence/} 의 JPA Adapter.
+ */
+public interface EscrowLinkRepository {
+
+    EscrowLink save(EscrowLink link);
+
+    Optional<EscrowLink> findById(Long id);
+
+    Optional<EscrowLink> findByLinkToken(String linkToken);
+
+    Page<EscrowLink> findByInitiatorId(Long initiatorId, Pageable pageable);
+
+    /**
+     * 첫 폼 제출자 = 수신자 확정 — atomic UPDATE (race-safe).
+     * receiver_id IS NULL && status = 대기 && expires_at > NOW() && initiator_id != receiverId 조건 만족 시만 성공.
+     *
+     * @return 영향 받은 row 수 (0=race lose 또는 만료/본인, 1=성공)
+     */
+    int claimReceiverIfAvailable(Long linkId, Long receiverId);
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowLinkStatus.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowLinkStatus.java
@@ -1,0 +1,21 @@
+package com.sseulang.domain.escrow.domain;
+
+/**
+ * Escrow link 상태머신.
+ *
+ * <pre>
+ *   대기 → 완료 (수신자 확정 + application 생성됨)
+ *   대기 → 만료 (expiresAt 경과)
+ *   대기 → 취소 (신청자 직접 취소)
+ * </pre>
+ */
+public enum EscrowLinkStatus {
+    대기,
+    완료,
+    만료,
+    취소;
+
+    public boolean isTerminal() {
+        return this != 대기;
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/FeeBreakdown.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/FeeBreakdown.java
@@ -1,0 +1,21 @@
+package com.sseulang.domain.escrow.domain;
+
+import java.math.BigDecimal;
+
+/**
+ * 수수료 계산 결과 (snapshot).
+ *
+ * @param distanceKm        haversine 산정 거리 (소수점 2)
+ * @param deliveryFee       라이더 보상 (원)
+ * @param commissionFee     플랫폼 수익 (Mode B 만 > 0)
+ * @param totalFee          buyer 가 부담할 총액 (Mode B = item + delivery + commission, Mode A = delivery only)
+ * @param commissionRate    적용된 수수료율 (snapshot)
+ */
+public record FeeBreakdown(
+        BigDecimal distanceKm,
+        long deliveryFee,
+        long commissionFee,
+        long totalFee,
+        BigDecimal commissionRate
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/FeePayer.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/FeePayer.java
@@ -1,0 +1,16 @@
+package com.sseulang.domain.escrow.domain;
+
+/**
+ * 수수료 부담 정책. 결정 #5 — feePayer=both 는 양쪽 별도 결제 (G2).
+ *
+ * <ul>
+ *   <li>{@code buyer}  : buyer 가 100% 결제</li>
+ *   <li>{@code seller} : seller 가 100% 결제</li>
+ *   <li>{@code both}   : 50/50 양쪽 별도 결제</li>
+ * </ul>
+ */
+public enum FeePayer {
+    buyer,
+    seller,
+    both
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/Fragility.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/Fragility.java
@@ -1,0 +1,36 @@
+package com.sseulang.domain.escrow.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** 취급주의 등급 (안전 ~ 매우 높음). multiplier 코드 상수. */
+public enum Fragility {
+    F1("f1", 1.0),
+    F2("f2", 1.1),
+    F3("f3", 1.2),
+    F4("f4", 1.4),
+    F5("f5", 1.6);
+
+    private final String code;
+    private final double multiplier;
+
+    Fragility(String code, double multiplier) {
+        this.code = code;
+        this.multiplier = multiplier;
+    }
+
+    @JsonProperty
+    public String code() {
+        return code;
+    }
+
+    public double multiplier() {
+        return multiplier;
+    }
+
+    @JsonCreator
+    public static Fragility fromCode(String code) {
+        for (Fragility f : values()) if (f.code.equals(code)) return f;
+        throw new IllegalArgumentException("Unknown Fragility: " + code);
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/InitiatorRole.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/InitiatorRole.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.escrow.domain;
+
+/** 신청자 역할 (수신자는 반대 role 자동). 가이드 §5.7 거래대행. */
+public enum InitiatorRole {
+    buyer,
+    seller;
+
+    public InitiatorRole opposite() {
+        return this == buyer ? seller : buyer;
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/TradeMode.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/TradeMode.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.escrow.domain;
+
+/**
+ * 거래 모드. 결정 #4 — D-Hybrid.
+ *
+ * <ul>
+ *   <li>{@code INTERNAL}: 쓸랭 내부 거래. itemPrice 까지 escrow hold + buyer 수령 확인 후 정산.</li>
+ *   <li>{@code EXTERNAL}: 외부 플랫폼 거래. itemPrice 처리 X — 배달비/수수료만.</li>
+ * </ul>
+ */
+public enum TradeMode {
+    INTERNAL,
+    EXTERNAL;
+
+    public boolean isInternal() {
+        return this == INTERNAL;
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/Volume.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/Volume.java
@@ -1,0 +1,34 @@
+package com.sseulang.domain.escrow.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** 부피 enum. multiplier 코드 상수 (운영 변경은 follow-up). */
+public enum Volume {
+    S("s", 1.0),
+    M("m", 1.2),
+    L("l", 1.5);
+
+    private final String code;
+    private final double multiplier;
+
+    Volume(String code, double multiplier) {
+        this.code = code;
+        this.multiplier = multiplier;
+    }
+
+    @JsonProperty
+    public String code() {
+        return code;
+    }
+
+    public double multiplier() {
+        return multiplier;
+    }
+
+    @JsonCreator
+    public static Volume fromCode(String code) {
+        for (Volume v : values()) if (v.code.equals(code)) return v;
+        throw new IllegalArgumentException("Unknown Volume: " + code);
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/Weight.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/Weight.java
@@ -1,0 +1,46 @@
+package com.sseulang.domain.escrow.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 물품 무게 enum. 5kg 이상은 용달차 분기 (truck fee 적용).
+ * JSON value 는 프론트와 일치 (lt1 / 1to3 / 3to5 / 5to10 / gt10).
+ */
+public enum Weight {
+    LT1("lt1", 1.0, false),
+    R1TO3("1to3", 1.2, false),
+    R3TO5("3to5", 1.5, false),
+    R5TO10("5to10", 2.0, true),
+    GT10("gt10", 2.5, true);
+
+    private final String code;
+    private final double multiplier;
+    private final boolean truck;
+
+    Weight(String code, double multiplier, boolean truck) {
+        this.code = code;
+        this.multiplier = multiplier;
+        this.truck = truck;
+    }
+
+    @JsonProperty
+    public String code() {
+        return code;
+    }
+
+    public double multiplier() {
+        return multiplier;
+    }
+
+    /** 5kg 이상이면 용달차 요금 분기 — 결정 #9 (CC3 프론트 schema 와 동일). */
+    public boolean isTruck() {
+        return truck;
+    }
+
+    @JsonCreator
+    public static Weight fromCode(String code) {
+        for (Weight w : values()) if (w.code.equals(code)) return w;
+        throw new IllegalArgumentException("Unknown Weight: " + code);
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/event/EscrowConfirmedEvent.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/event/EscrowConfirmedEvent.java
@@ -1,0 +1,30 @@
+package com.sseulang.domain.escrow.domain.event;
+
+/**
+ * 양쪽 결제 완료 → 결제완료 상태 진입 시 발행. Delivery 도메인이 listen 해서 모집중 row 자동 INSERT
+ * + 자동 라이더 매칭 (X1, 결정 #8).
+ *
+ * @param escrowApplicationId 결제완료된 application
+ * @param pickupAddress       픽업 주소
+ * @param pickupLat           픽업 위도
+ * @param pickupLng           픽업 경도
+ * @param deliveryAddress     도착 주소
+ * @param deliveryLat         도착 위도
+ * @param deliveryLng         도착 경도
+ * @param itemDescription     물품 설명 (라이더가 보는 이름)
+ * @param deliveryFee         라이더 보상 (snapshot)
+ * @param requesterId         요청자 = buyer 의 user_id (라이더 fee 차감 X — escrow 가 hold 중)
+ */
+public record EscrowConfirmedEvent(
+        Long escrowApplicationId,
+        String pickupAddress,
+        double pickupLat,
+        double pickupLng,
+        String deliveryAddress,
+        double deliveryLat,
+        double deliveryLng,
+        String itemDescription,
+        long deliveryFee,
+        Long requesterId
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationJpaRepository.java
@@ -1,0 +1,44 @@
+package com.sseulang.domain.escrow.infrastructure.persistence;
+
+import com.sseulang.domain.escrow.domain.EscrowApplication;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface EscrowApplicationJpaRepository extends JpaRepository<EscrowApplication, Long> {
+
+    Optional<EscrowApplication> findByLinkId(Long linkId);
+
+    @Query("""
+            SELECT a FROM EscrowApplication a
+            WHERE a.initiatorId = :userId OR a.receiverId = :userId
+            """)
+    Page<EscrowApplication> findMyApplications(@Param("userId") Long userId, Pageable pageable);
+
+    Page<EscrowApplication> findAllByStatus(EscrowApplicationStatus status, Pageable pageable);
+
+    @Query("""
+            SELECT a FROM EscrowApplication a
+            WHERE a.status = com.sseulang.domain.escrow.domain.EscrowApplicationStatus.결제대기
+              AND a.paymentDueAt IS NOT NULL
+              AND a.paymentDueAt < :now
+            """)
+    List<EscrowApplication> findPaymentTimedOut(@Param("now") LocalDateTime now);
+
+    @Query("""
+            SELECT COUNT(a) FROM EscrowApplication a
+            WHERE a.status IN (
+                com.sseulang.domain.escrow.domain.EscrowApplicationStatus.결제대기,
+                com.sseulang.domain.escrow.domain.EscrowApplicationStatus.결제완료,
+                com.sseulang.domain.escrow.domain.EscrowApplicationStatus.진행중
+            )
+            """)
+    long countInProgress();
+}

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationJpaRepository.java
@@ -2,9 +2,11 @@ package com.sseulang.domain.escrow.infrastructure.persistence;
 
 import com.sseulang.domain.escrow.domain.EscrowApplication;
 import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,6 +15,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface EscrowApplicationJpaRepository extends JpaRepository<EscrowApplication, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT a FROM EscrowApplication a WHERE a.id = :id")
+    Optional<EscrowApplication> findByIdForUpdate(@Param("id") Long id);
 
     Optional<EscrowApplication> findByLinkId(Long linkId);
 

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.sseulang.domain.escrow.infrastructure.persistence;
+
+import com.sseulang.domain.escrow.domain.EscrowApplication;
+import com.sseulang.domain.escrow.domain.EscrowApplicationRepository;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class EscrowApplicationRepositoryImpl implements EscrowApplicationRepository {
+
+    private final EscrowApplicationJpaRepository jpa;
+
+    public EscrowApplicationRepositoryImpl(EscrowApplicationJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public EscrowApplication save(EscrowApplication application) {
+        return jpa.save(application);
+    }
+
+    @Override
+    public Optional<EscrowApplication> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Optional<EscrowApplication> findByLinkId(Long linkId) {
+        return jpa.findByLinkId(linkId);
+    }
+
+    @Override
+    public Page<EscrowApplication> findMyApplications(Long userId, Pageable pageable) {
+        return jpa.findMyApplications(userId, pageable);
+    }
+
+    @Override
+    public Page<EscrowApplication> findAll(Pageable pageable) {
+        return jpa.findAll(pageable);
+    }
+
+    @Override
+    public Page<EscrowApplication> findAllByStatus(EscrowApplicationStatus status, Pageable pageable) {
+        return jpa.findAllByStatus(status, pageable);
+    }
+
+    @Override
+    public List<EscrowApplication> findPaymentTimedOut() {
+        return jpa.findPaymentTimedOut(LocalDateTime.now());
+    }
+
+    @Override
+    public long countInProgress() {
+        return jpa.countInProgress();
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationRepositoryImpl.java
@@ -31,6 +31,11 @@ public class EscrowApplicationRepositoryImpl implements EscrowApplicationReposit
     }
 
     @Override
+    public Optional<EscrowApplication> findByIdForUpdate(Long id) {
+        return jpa.findByIdForUpdate(id);
+    }
+
+    @Override
     public Optional<EscrowApplication> findByLinkId(Long linkId) {
         return jpa.findByLinkId(linkId);
     }

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowFeeSettingsJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowFeeSettingsJpaRepository.java
@@ -1,0 +1,7 @@
+package com.sseulang.domain.escrow.infrastructure.persistence;
+
+import com.sseulang.domain.escrow.domain.EscrowFeeSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EscrowFeeSettingsJpaRepository extends JpaRepository<EscrowFeeSettings, Long> {
+}

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowFeeSettingsRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowFeeSettingsRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.sseulang.domain.escrow.infrastructure.persistence;
+
+import com.sseulang.domain.escrow.domain.EscrowFeeSettings;
+import com.sseulang.domain.escrow.domain.EscrowFeeSettingsRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class EscrowFeeSettingsRepositoryImpl implements EscrowFeeSettingsRepository {
+
+    private final EscrowFeeSettingsJpaRepository jpa;
+
+    public EscrowFeeSettingsRepositoryImpl(EscrowFeeSettingsJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public EscrowFeeSettings findSingleton() {
+        return jpa.findById(EscrowFeeSettings.SINGLETON_ID)
+                .orElseThrow(() -> new IllegalStateException(
+                        "escrow_fee_settings singleton row missing — V15 마이그레이션 확인"));
+    }
+
+    @Override
+    public EscrowFeeSettings save(EscrowFeeSettings settings) {
+        return jpa.save(settings);
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowLinkJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowLinkJpaRepository.java
@@ -1,0 +1,40 @@
+package com.sseulang.domain.escrow.infrastructure.persistence;
+
+import com.sseulang.domain.escrow.domain.EscrowLink;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface EscrowLinkJpaRepository extends JpaRepository<EscrowLink, Long> {
+
+    Optional<EscrowLink> findByLinkToken(String linkToken);
+
+    Page<EscrowLink> findByInitiatorId(Long initiatorId, Pageable pageable);
+
+    /**
+     * 첫 폼 제출자 = 수신자 확정 atomic UPDATE.
+     * race-safe: receiver_id IS NULL && status = '대기' && expires_at > NOW() && initiator_id != receiverId.
+     * 본인 차단 + race lose 둘 다 영향 0 — 호출자가 분기 처리 (ApplicationService).
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            UPDATE EscrowLink l
+               SET l.receiverId = :receiverId
+             WHERE l.id = :linkId
+               AND l.receiverId IS NULL
+               AND l.status = com.sseulang.domain.escrow.domain.EscrowLinkStatus.대기
+               AND l.expiresAt > :now
+               AND l.initiatorId <> :receiverId
+            """)
+    int claimReceiverIfAvailable(
+            @Param("linkId") Long linkId,
+            @Param("receiverId") Long receiverId,
+            @Param("now") LocalDateTime now
+    );
+}

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowLinkRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowLinkRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.sseulang.domain.escrow.infrastructure.persistence;
+
+import com.sseulang.domain.escrow.domain.EscrowLink;
+import com.sseulang.domain.escrow.domain.EscrowLinkRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public class EscrowLinkRepositoryImpl implements EscrowLinkRepository {
+
+    private final EscrowLinkJpaRepository jpa;
+
+    public EscrowLinkRepositoryImpl(EscrowLinkJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public EscrowLink save(EscrowLink link) {
+        return jpa.save(link);
+    }
+
+    @Override
+    public Optional<EscrowLink> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Optional<EscrowLink> findByLinkToken(String linkToken) {
+        return jpa.findByLinkToken(linkToken);
+    }
+
+    @Override
+    public Page<EscrowLink> findByInitiatorId(Long initiatorId, Pageable pageable) {
+        return jpa.findByInitiatorId(initiatorId, pageable);
+    }
+
+    @Override
+    public int claimReceiverIfAvailable(Long linkId, Long receiverId) {
+        return jpa.claimReceiverIfAvailable(linkId, receiverId, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/AdminEscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/AdminEscrowController.java
@@ -1,0 +1,37 @@
+package com.sseulang.domain.escrow.presentation;
+
+import com.sseulang.domain.escrow.application.EscrowApplicationService;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationResult;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "AdminEscrow", description = "관리자 — 거래대행 신청 모니터링")
+@RestController
+@RequestMapping("/api/v1/admin/escrow/applications")
+public class AdminEscrowController {
+
+    private final EscrowApplicationService service;
+
+    public AdminEscrowController(EscrowApplicationService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "거래대행 신청 전체 (admin)", description = "최신순. status 필터는 후속.")
+    @GetMapping
+    public ApiResponse<PageResponse<EscrowApplicationResult>> listAll(Pageable pageable) {
+        return ApiResponse.ok(PageResponse.from(service.adminListAll(pageable)));
+    }
+
+    @Operation(summary = "거래대행 신청 단건 (admin)")
+    @GetMapping("/{id}")
+    public ApiResponse<EscrowApplicationResult> getOne(@PathVariable Long id) {
+        return ApiResponse.ok(service.adminGetById(id));
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/AdminEscrowFeeSettingsController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/AdminEscrowFeeSettingsController.java
@@ -1,0 +1,62 @@
+package com.sseulang.domain.escrow.presentation;
+
+import com.sseulang.domain.escrow.application.EscrowFeeSettingsApplicationService;
+import com.sseulang.domain.escrow.presentation.dto.EscrowFeeSettingsPatchRequest;
+import com.sseulang.domain.escrow.presentation.dto.EscrowFeeSettingsResponse;
+import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * 거래대행 수수료 정책 (admin). 결정 #9 — 프론트 11 fields schema (CC3) + AdminEscrowConfigPage 연동.
+ *
+ * <p>변경 시 진행 중 N건 표시 (12-a HH2) — PATCH 응답에 inProgressCount 포함.</p>
+ */
+@Tag(name = "AdminEscrowFeeSettings", description = "관리자 — 거래대행 수수료 정책 운영")
+@RestController
+@RequestMapping("/api/v1/admin/escrow/fee-settings")
+public class AdminEscrowFeeSettingsController {
+
+    private final EscrowFeeSettingsApplicationService service;
+
+    public AdminEscrowFeeSettingsController(EscrowFeeSettingsApplicationService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "현재 수수료 정책 조회")
+    @GetMapping
+    public ApiResponse<EscrowFeeSettingsResponse> get() {
+        return ApiResponse.ok(EscrowFeeSettingsResponse.from(service.get()));
+    }
+
+    @Operation(summary = "수수료 정책 변경 (관리자)",
+            description = "변경 즉시 신규 application 부터 적용. 진행 중 N건은 snapshot 보존 (영향 X).")
+    @PatchMapping
+    public ApiResponse<Map<String, Object>> update(
+            @AuthenticationPrincipal Long adminId,
+            @Valid @RequestBody EscrowFeeSettingsPatchRequest req
+    ) {
+        var updated = service.update(
+                req.commissionRate(),
+                req.fuelPricePerL(), req.baseFuelPrice(),
+                req.baseDeliveryFee(), req.baseKmRate(), req.fuelEfficiency(), req.minDeliveryFee(),
+                req.truckBaseDeliveryFee(), req.truckBaseKmRate(), req.truckFuelEfficiency(), req.truckMinDeliveryFee(),
+                adminId
+        );
+        long inProgress = service.countInProgress();
+        return ApiResponse.ok(Map.of(
+                "settings", EscrowFeeSettingsResponse.from(updated),
+                "inProgressCount", inProgress,
+                "message", "수수료 정책이 변경되었습니다. 진행 중 " + inProgress + "건은 snapshot 으로 보존되어 영향 없습니다."
+        ));
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
@@ -1,0 +1,115 @@
+package com.sseulang.domain.escrow.presentation;
+
+import com.sseulang.domain.escrow.application.EscrowApplicationService;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationResult;
+import com.sseulang.domain.escrow.application.dto.EscrowLinkResult;
+import com.sseulang.domain.escrow.presentation.dto.EscrowApplicationCancelRequest;
+import com.sseulang.domain.escrow.presentation.dto.EscrowApplicationCreateRequest;
+import com.sseulang.domain.escrow.presentation.dto.EscrowLinkCreateRequest;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Escrow", description = "거래대행 (Escrow) — link 생성/진입 + 폼 제출 + 결제 + 정산.")
+@RestController
+@RequestMapping("/api/v1/escrow")
+public class EscrowController {
+
+    private final EscrowApplicationService service;
+
+    public EscrowController(EscrowApplicationService service) {
+        this.service = service;
+    }
+
+    // =========================================================
+    // Link
+    // =========================================================
+    @Operation(summary = "거래대행 link 생성 (신청자)",
+            description = "이메일 인증 필수. UUID v4 token + 24h 만료 (env override 가능).")
+    @PostMapping("/links")
+    public ResponseEntity<ApiResponse<EscrowLinkResult>> createLink(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody EscrowLinkCreateRequest request
+    ) {
+        EscrowLinkResult result = service.createLink(request.toCommand(userId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result));
+    }
+
+    @Operation(summary = "거래대행 link 진입 (수신자)",
+            description = "비로그인 OK — 결정 #1 A1. 신청자 닉네임 + role + feePayer + 만료 노출.")
+    @GetMapping("/links/{linkToken}")
+    public ApiResponse<EscrowLinkResult> getLink(@PathVariable String linkToken) {
+        return ApiResponse.ok(service.getByToken(linkToken));
+    }
+
+    // =========================================================
+    // Application
+    // =========================================================
+    @Operation(summary = "거래대행 폼 제출 (수신자)",
+            description = "이메일 인증 필수. linkToken 매칭 + atomic claim + snapshot 저장. 동일 사용자 재제출 시 idempotent.")
+    @PostMapping("/applications")
+    public ResponseEntity<ApiResponse<EscrowApplicationResult>> createApplication(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody EscrowApplicationCreateRequest request
+    ) {
+        EscrowApplicationResult result = service.createApplication(request.toCommand(userId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result));
+    }
+
+    @Operation(summary = "본인 거래대행 신청 목록", description = "최신순. 필터는 후속 (5/11 단순).")
+    @GetMapping("/applications/me")
+    public ApiResponse<PageResponse<EscrowApplicationResult>> listMine(
+            @AuthenticationPrincipal Long userId,
+            Pageable pageable
+    ) {
+        return ApiResponse.ok(PageResponse.from(service.listMine(userId, pageable)));
+    }
+
+    @Operation(summary = "거래대행 신청 단건", description = "참여자만 (initiator/receiver).")
+    @GetMapping("/applications/{id}")
+    public ApiResponse<EscrowApplicationResult> getOne(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        return ApiResponse.ok(service.getById(id, userId));
+    }
+
+    @Operation(summary = "거래대행 신청 취소",
+            description = "매칭 전엔 양쪽 환불, 매칭 후엔 결정 #6 (귀책자 100% 부담 — 추가 결제 흐름은 R1).")
+    @PatchMapping("/applications/{id}/cancel")
+    public ApiResponse<Void> cancel(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id,
+            @Valid @RequestBody EscrowApplicationCancelRequest request
+    ) {
+        service.cancel(id, userId, request.reason());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "buyer 수령 확인 (Mode B)",
+            description = "Mode B INTERNAL 거래만. 진행중 → 완료 + 정산 (seller 적립, rider 적립).")
+    @PostMapping("/applications/{id}/confirm-receipt")
+    public ApiResponse<Void> confirmReceipt(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        // 라이더 식별은 Delivery 도메인에서 — Service 가 알아서 조회.
+        // 5/11 단순화: riderId null 전달 — Service 가 delivery row 조회하지 않고 정산 시 누락 가능.
+        // TODO(R1): Service 안에서 deliveryRepository.findByEscrowApplicationId 로 rider 조회.
+        service.confirmReceipt(id, userId, null);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
@@ -106,10 +106,7 @@ public class EscrowController {
             @AuthenticationPrincipal Long userId,
             @PathVariable Long id
     ) {
-        // 라이더 식별은 Delivery 도메인에서 — Service 가 알아서 조회.
-        // 5/11 단순화: riderId null 전달 — Service 가 delivery row 조회하지 않고 정산 시 누락 가능.
-        // TODO(R1): Service 안에서 deliveryRepository.findByEscrowApplicationId 로 rider 조회.
-        service.confirmReceipt(id, userId, null);
+        service.confirmReceipt(id, userId);
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCancelRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCancelRequest.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "거래대행 신청 취소. 매칭 전엔 양쪽 환불, 매칭 후엔 결정 #6 정책.")
+public record EscrowApplicationCancelRequest(
+        @Schema(description = "취소 사유 (선택)", example = "단순 변심")
+        @Size(max = 500) String reason
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCreateRequest.java
@@ -1,0 +1,53 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateCommand;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Schema(description = "거래대행 폼 제출 — 수신자가 호출. linkToken 으로 link 매칭 후 atomic claim + application 생성.")
+public record EscrowApplicationCreateRequest(
+        @NotBlank @Size(min = 36, max = 36) String linkToken,
+        @PositiveOrZero @Schema(description = "INTERNAL > 0, EXTERNAL = 0", example = "1800000")
+        long itemPrice,
+        @NotBlank @Size(max = 500) String itemDescription,
+        @NotBlank @Size(max = 255) String pickupAddress,
+        @NotNull @DecimalMin("33") @DecimalMax("39") BigDecimal pickupLat,
+        @NotNull @DecimalMin("124") @DecimalMax("132") BigDecimal pickupLng,
+        @NotBlank @Size(max = 255) String deliveryAddress,
+        @NotNull @DecimalMin("33") @DecimalMax("39") BigDecimal deliveryLat,
+        @NotNull @DecimalMin("124") @DecimalMax("132") BigDecimal deliveryLng,
+        @NotNull Weight weight,
+        @NotNull Volume volume,
+        @NotNull Fragility fragility,
+        @Size(max = 500) String deliveryNotes,
+        // 프론트 calcFees 결과 — 백엔드 ±10원 검증
+        @PositiveOrZero long deliveryFee,
+        @PositiveOrZero long commissionFee,
+        @PositiveOrZero long totalFee,
+        @NotNull BigDecimal distanceKm,
+        // S3 업로드된 이미지 key/url
+        List<@Size(max = 500) String> imageUrls
+) {
+    public EscrowApplicationCreateCommand toCommand(Long receiverId) {
+        return new EscrowApplicationCreateCommand(
+                receiverId, linkToken,
+                itemPrice, itemDescription,
+                pickupAddress, pickupLat, pickupLng,
+                deliveryAddress, deliveryLat, deliveryLng,
+                weight, volume, fragility, deliveryNotes,
+                deliveryFee, commissionFee, totalFee, distanceKm,
+                imageUrls
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowFeeSettingsPatchRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowFeeSettingsPatchRequest.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+@Schema(description = "거래대행 수수료 정책 변경 (admin). 결정 #9 — DB 단일 row 갱신. 진행 중 신청 영향 X (snapshot).")
+public record EscrowFeeSettingsPatchRequest(
+        @NotNull @DecimalMin("0.0") @DecimalMax("1.0") BigDecimal commissionRate,
+        @NotNull @Positive Long fuelPricePerL,
+        @NotNull @Positive Long baseFuelPrice,
+        @NotNull @Positive Long baseDeliveryFee,
+        @NotNull @Positive Long baseKmRate,
+        @NotNull @DecimalMin("0.01") BigDecimal fuelEfficiency,
+        @NotNull @Positive Long minDeliveryFee,
+        @NotNull @Positive Long truckBaseDeliveryFee,
+        @NotNull @Positive Long truckBaseKmRate,
+        @NotNull @DecimalMin("0.01") BigDecimal truckFuelEfficiency,
+        @NotNull @Positive Long truckMinDeliveryFee
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowFeeSettingsResponse.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowFeeSettingsResponse.java
@@ -1,0 +1,34 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.domain.EscrowFeeSettings;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Schema(description = "거래대행 수수료 정책 — 프론트 calcFees 와 동일 11 fields (CC3).")
+public record EscrowFeeSettingsResponse(
+        BigDecimal commissionRate,
+        long fuelPricePerL,
+        long baseFuelPrice,
+        long baseDeliveryFee,
+        long baseKmRate,
+        BigDecimal fuelEfficiency,
+        long minDeliveryFee,
+        long truckBaseDeliveryFee,
+        long truckBaseKmRate,
+        BigDecimal truckFuelEfficiency,
+        long truckMinDeliveryFee,
+        LocalDateTime updatedAt,
+        Long updatedBy
+) {
+    public static EscrowFeeSettingsResponse from(EscrowFeeSettings s) {
+        return new EscrowFeeSettingsResponse(
+                s.getCommissionRate(),
+                s.getFuelPricePerL(), s.getBaseFuelPrice(),
+                s.getBaseDeliveryFee(), s.getBaseKmRate(), s.getFuelEfficiency(), s.getMinDeliveryFee(),
+                s.getTruckBaseDeliveryFee(), s.getTruckBaseKmRate(), s.getTruckFuelEfficiency(), s.getTruckMinDeliveryFee(),
+                s.getUpdatedAt(), s.getUpdatedBy()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowLinkCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowLinkCreateRequest.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.application.dto.EscrowLinkCreateCommand;
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.InitiatorRole;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "거래대행 link 생성 (신청자). role + feePayer + tradeMode 결정.")
+public record EscrowLinkCreateRequest(
+        @Schema(description = "신청자 역할 (수신자는 반대)", example = "buyer", allowableValues = {"buyer", "seller"})
+        @NotNull InitiatorRole role,
+
+        @Schema(description = "수수료 부담", example = "buyer", allowableValues = {"buyer", "seller", "both"})
+        @NotNull FeePayer feePayer,
+
+        @Schema(description = "거래 모드 — INTERNAL (쓸랭 내) / EXTERNAL (외부 거래 + 배달만)",
+                example = "INTERNAL", allowableValues = {"INTERNAL", "EXTERNAL"})
+        @NotNull TradeMode tradeMode
+) {
+    public EscrowLinkCreateCommand toCommand(Long initiatorId) {
+        return new EscrowLinkCreateCommand(initiatorId, role, feePayer, tradeMode);
+    }
+}

--- a/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
+++ b/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
@@ -48,7 +48,8 @@ public class FileApplicationService {
     private static final Set<FilePurpose> USER_ALLOWED_PURPOSES = EnumSet.of(
             FilePurpose.PROFILE,
             FilePurpose.ITEM,
-            FilePurpose.SUPPORT
+            FilePurpose.SUPPORT,
+            FilePurpose.ESCROW
     );
 
     private static final Map<String, String> EXTENSION_BY_CONTENT_TYPE = Map.of(

--- a/src/main/java/com/sseulang/domain/file/domain/FilePurpose.java
+++ b/src/main/java/com/sseulang/domain/file/domain/FilePurpose.java
@@ -7,14 +7,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * <p>가이드 §4.5 폴더 구조와 정합. {@code messages/{roomId}/...} 처럼 owner 의미가 다른 케이스도
  * controller 에서 owner 를 적절히 결정해 전달한다.</p>
  */
-@Schema(description = "S3 업로드 용도 — PROFILE/ITEM/SUPPORT 는 일반 사용자 발급 가능. NOTICE/BANNER/MESSAGE 는 도메인 전용.")
+@Schema(description = "S3 업로드 용도 — PROFILE/ITEM/SUPPORT/ESCROW 는 일반 사용자 발급 가능. NOTICE/BANNER/MESSAGE 는 도메인 전용.")
 public enum FilePurpose {
     PROFILE("profiles"),
     ITEM("items"),
     MESSAGE("messages"),
     NOTICE("notices"),
     BANNER("banners"),
-    SUPPORT("support");
+    SUPPORT("support"),
+    ESCROW("escrow");
 
     private final String folder;
 

--- a/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
@@ -59,6 +59,7 @@ public class PaymentApplicationService {
     private final TossWebhookSignatureVerifier webhookVerifier;
     private final ObjectMapper objectMapper;
     private final WebhookPendingRateLimiter pendingRateLimiter;
+    private final com.sseulang.domain.escrow.application.EscrowApplicationService escrowApplicationService;
 
     public PaymentApplicationService(
             PaymentRepository paymentRepository,
@@ -69,7 +70,8 @@ public class PaymentApplicationService {
             WebhookEventRepository webhookEventRepository,
             TossWebhookSignatureVerifier webhookVerifier,
             ObjectMapper objectMapper,
-            WebhookPendingRateLimiter pendingRateLimiter
+            WebhookPendingRateLimiter pendingRateLimiter,
+            com.sseulang.domain.escrow.application.EscrowApplicationService escrowApplicationService
     ) {
         this.paymentRepository = paymentRepository;
         this.paymentGateway = paymentGateway;
@@ -80,6 +82,7 @@ public class PaymentApplicationService {
         this.webhookVerifier = webhookVerifier;
         this.objectMapper = objectMapper;
         this.pendingRateLimiter = pendingRateLimiter;
+        this.escrowApplicationService = escrowApplicationService;
     }
 
     @Transactional
@@ -89,8 +92,14 @@ public class PaymentApplicationService {
         }
         // 자금 흐름 진입점 — 이메일 인증 미완료 사용자 차단 (게이트 1).
         userApplicationService.requireVerified(cmd.userId());
+
+        // 거래대행 결제면 — Escrow application 검증 (payer / share / status).
+        if (cmd.isEscrow()) {
+            escrowApplicationService.verifyChargeIntent(cmd.escrowApplicationId(), cmd.userId(), cmd.amount());
+        }
+
         String merchantUid = generateMerchantUid();
-        Payment payment = Payment.startCharge(cmd.userId(), merchantUid, cmd.amount());
+        Payment payment = Payment.startCharge(cmd.userId(), merchantUid, cmd.amount(), cmd.escrowApplicationId());
         Payment saved = paymentRepository.save(payment);
         return new ChargeStartResult(saved.getId(), merchantUid, cmd.amount(), tossProperties.clientKey());
     }
@@ -164,15 +173,24 @@ public class PaymentApplicationService {
         );
 
         if (newlyPaid) {
-            // 가이드 §4.8 — 충전 성공 시 atomic point_balance 증가 + history 적재 (Day 8 PointApplicationService 도입).
-            pointApplicationService.credit(
-                    payment.getUserId(),
-                    payment.getAmount(),
-                    PointHistoryType.충전,
-                    PointReferenceType.PAYMENT,
-                    payment.getId(),
-                    "토스 충전"
-            );
+            if (payment.getEscrowApplicationId() != null) {
+                // 거래대행 결제 — buyer 잔액 변동 X (escrow hold). escrow application 의 paid_at 갱신만.
+                // 정산 시 seller / rider 한테만 credit (운영 자금에서 분배 모방).
+                escrowApplicationService.recordPaymentConfirmed(
+                        payment.getEscrowApplicationId(),
+                        payment.getUserId()
+                );
+            } else {
+                // 일반 충전 — atomic point_balance 증가 + history 적재.
+                pointApplicationService.credit(
+                        payment.getUserId(),
+                        payment.getAmount(),
+                        PointHistoryType.충전,
+                        PointReferenceType.PAYMENT,
+                        payment.getId(),
+                        "토스 충전"
+                );
+            }
         }
 
         return PaymentResult.from(payment);

--- a/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
@@ -173,27 +173,39 @@ public class PaymentApplicationService {
         );
 
         if (newlyPaid) {
-            if (payment.getEscrowApplicationId() != null) {
-                // 거래대행 결제 — buyer 잔액 변동 X (escrow hold). escrow application 의 paid_at 갱신만.
-                // 정산 시 seller / rider 한테만 credit (운영 자금에서 분배 모방).
-                escrowApplicationService.recordPaymentConfirmed(
-                        payment.getEscrowApplicationId(),
-                        payment.getUserId()
-                );
-            } else {
-                // 일반 충전 — atomic point_balance 증가 + history 적재.
-                pointApplicationService.credit(
-                        payment.getUserId(),
-                        payment.getAmount(),
-                        PointHistoryType.충전,
-                        PointReferenceType.PAYMENT,
-                        payment.getId(),
-                        "토스 충전"
-                );
-            }
+            applyPaymentConfirmedEffects(payment, "토스 충전");
         }
 
         return PaymentResult.from(payment);
+    }
+
+    /**
+     * Payment 가 newly paid 됐을 때 부수효과 — escrow 결제 / 일반 충전 분기.
+     * confirmCharge / handleWebhook / reconcileStalePayment 가 모두 호출 (게이트 1 Critical 1 회귀 방지).
+     *
+     * <ul>
+     *   <li>escrow 결제 (escrow_application_id NOT NULL): buyer 잔액 변동 X — escrow application paid_at 갱신만</li>
+     *   <li>일반 충전: atomic point_balance + history 적재</li>
+     * </ul>
+     */
+    private void applyPaymentConfirmedEffects(Payment payment, String chargeDescription) {
+        if (payment.getEscrowApplicationId() != null) {
+            // 거래대행 결제 — buyer 잔액 변동 X (escrow hold). 정산 시 seller / rider 한테만 credit.
+            escrowApplicationService.recordPaymentConfirmed(
+                    payment.getEscrowApplicationId(),
+                    payment.getUserId()
+            );
+        } else {
+            // 일반 충전 — atomic point_balance 증가 + history 적재.
+            pointApplicationService.credit(
+                    payment.getUserId(),
+                    payment.getAmount(),
+                    PointHistoryType.충전,
+                    PointReferenceType.PAYMENT,
+                    payment.getId(),
+                    chargeDescription
+            );
+        }
     }
 
     /**
@@ -353,14 +365,7 @@ public class PaymentApplicationService {
                 lookup.paymentKey(), lookup.method(), lookup.approvedAt(), lookup.rawResponse()
         );
         if (newlyPaid) {
-            pointApplicationService.credit(
-                    payment.getUserId(),
-                    payment.getAmount(),
-                    PointHistoryType.충전,
-                    PointReferenceType.PAYMENT,
-                    payment.getId(),
-                    "토스 webhook 충전"
-            );
+            applyPaymentConfirmedEffects(payment, "토스 webhook 충전");
         }
         return true;
     }
@@ -431,14 +436,7 @@ public class PaymentApplicationService {
                 lookup.paymentKey(), lookup.method(), lookup.approvedAt(), lookup.rawResponse()
         );
         if (newlyPaid) {
-            pointApplicationService.credit(
-                    locked.getUserId(),
-                    locked.getAmount(),
-                    PointHistoryType.충전,
-                    PointReferenceType.PAYMENT,
-                    locked.getId(),
-                    "토스 reconcile 복구"
-            );
+            applyPaymentConfirmedEffects(locked, "토스 reconcile 복구");
             log.info("[reconcile] payment#{} 복구 완료", paymentId);
         }
         return true;

--- a/src/main/java/com/sseulang/domain/payment/application/dto/ChargeStartCommand.java
+++ b/src/main/java/com/sseulang/domain/payment/application/dto/ChargeStartCommand.java
@@ -1,3 +1,23 @@
 package com.sseulang.domain.payment.application.dto;
 
-public record ChargeStartCommand(Long userId, long amount) { }
+/**
+ * 충전 시작 — escrowApplicationId=null 면 일반 충전, NOT NULL 이면 거래대행 결제.
+ */
+public record ChargeStartCommand(
+        Long userId,
+        long amount,
+        Long escrowApplicationId
+) {
+    /** 일반 충전 (Day 7 spec) — 호환 secondary constructor. */
+    public ChargeStartCommand(Long userId, long amount) {
+        this(userId, amount, null);
+    }
+
+    public static ChargeStartCommand charge(Long userId, long amount) {
+        return new ChargeStartCommand(userId, amount, null);
+    }
+
+    public boolean isEscrow() {
+        return escrowApplicationId != null;
+    }
+}

--- a/src/main/java/com/sseulang/domain/payment/domain/Payment.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/Payment.java
@@ -39,6 +39,9 @@ public class Payment extends BaseEntity {
     @Column(name = "transaction_id")
     private Long transactionId;
 
+    @Column(name = "escrow_application_id")
+    private Long escrowApplicationId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "payment_type", nullable = false)
     private PaymentType paymentType;
@@ -74,8 +77,9 @@ public class Payment extends BaseEntity {
 
     /**
      * 충전 시작 — status=대기. amount 양수 강제.
+     * escrowApplicationId 가 NOT NULL 이면 거래대행 결제 — confirm 시 잔액 차감 + escrow 갱신 트리거.
      */
-    public static Payment startCharge(Long userId, String merchantUid, long amount) {
+    public static Payment startCharge(Long userId, String merchantUid, long amount, Long escrowApplicationId) {
         if (userId == null || userId <= 0) {
             throw new IllegalArgumentException("userId 는 양수여야 합니다");
         }
@@ -88,11 +92,17 @@ public class Payment extends BaseEntity {
         Payment p = new Payment();
         p.userId = userId;
         p.transactionId = null;
+        p.escrowApplicationId = escrowApplicationId;
         p.paymentType = PaymentType.충전;
         p.amount = amount;
         p.merchantUid = merchantUid;
         p.status = PaymentStatus.대기;
         return p;
+    }
+
+    /** Day 7 호환 (escrowApplicationId 없는 일반 충전). */
+    public static Payment startCharge(Long userId, String merchantUid, long amount) {
+        return startCharge(userId, merchantUid, amount, null);
     }
 
     /**

--- a/src/main/java/com/sseulang/domain/payment/presentation/dto/ChargeStartRequest.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/dto/ChargeStartRequest.java
@@ -11,6 +11,6 @@ public record ChargeStartRequest(
         @NotNull @Positive Long amount
 ) {
     public ChargeStartCommand toCommand(Long userId) {
-        return new ChargeStartCommand(userId, amount);
+        return ChargeStartCommand.charge(userId, amount);
     }
 }

--- a/src/main/java/com/sseulang/domain/point/domain/PointReferenceType.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointReferenceType.java
@@ -8,5 +8,6 @@ public enum PointReferenceType {
     PAYMENT,
     TRANSACTION,
     WITHDRAWAL,
-    DELIVERY
+    DELIVERY,
+    ESCROW
 }

--- a/src/main/java/com/sseulang/global/config/SecurityConfig.java
+++ b/src/main/java/com/sseulang/global/config/SecurityConfig.java
@@ -85,6 +85,13 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler accessDeniedHandler;
     private final CsrfCookieFilter csrfCookieFilter;
 
+    /**
+     * XSRF-TOKEN 쿠키의 Domain. cross-subdomain 공유 (super-domain 통합 시) 위해 prod 에 .sseulang.store
+     * 설정. 미주입 시 host-only — frontend 가 다른 sub-domain 에서 readCookie 못함 (게이트 1 round 1 round 2 fix).
+     */
+    @org.springframework.beans.factory.annotation.Value("${app.cookie.domain:}")
+    private String cookieDomain;
+
     public SecurityConfig(
             JwtAuthenticationFilter jwtAuthenticationFilter,
             JwtAuthenticationEntryPoint authenticationEntryPoint,
@@ -136,13 +143,25 @@ public class SecurityConfig {
         return source;
     }
 
+    /**
+     * XSRF-TOKEN 쿠키 발급 — prod 에선 Domain={@code .sseulang.store} 명시해서 sub-domain 공유.
+     * 미주입(local) 시 default host-only.
+     */
+    private CookieCsrfTokenRepository buildCsrfRepo() {
+        CookieCsrfTokenRepository repo = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        if (cookieDomain != null && !cookieDomain.isBlank()) {
+            repo.setCookieCustomizer(c -> c.domain(cookieDomain));
+        }
+        return repo;
+    }
+
     @Bean
     @Order(1)
     public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
         applyCommon(http)
                 .securityMatcher("/api/v1/admin/**")
                 .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRepository(buildCsrfRepo())
                         .csrfTokenRequestHandler(eagerCsrfHandler()))
                 .exceptionHandling(eh -> eh
                         .authenticationEntryPoint(authenticationEntryPoint)
@@ -159,7 +178,7 @@ public class SecurityConfig {
         applyCommon(http)
                 .securityMatcher("/api/v1/**", "/ws-stomp/**", "/ws-stomp-native/**")
                 .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRepository(buildCsrfRepo())
                         .csrfTokenRequestHandler(eagerCsrfHandler())
                         .ignoringRequestMatchers(CSRF_IGNORED_ENDPOINTS))
                 .exceptionHandling(eh -> eh

--- a/src/main/java/com/sseulang/global/config/SecurityConfig.java
+++ b/src/main/java/com/sseulang/global/config/SecurityConfig.java
@@ -176,6 +176,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/notices/**").permitAll()
                         // 고객지원 FAQ/QNA 게시글 — 비로그인 조회 허용. 1:1 문의는 본인 인증 필수.
                         .requestMatchers(HttpMethod.GET, "/api/v1/support/posts", "/api/v1/support/posts/**").permitAll()
+                        // 거래대행 link 진입 — 결정 #1 A1 (비로그인 OK). POST 들은 표준 인증.
+                        .requestMatchers(HttpMethod.GET, "/api/v1/escrow/links/*").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/payments/webhook/**").permitAll()
                         // WebSocket handshake 는 인증 없이 통과 — STOMP CONNECT 단계의 ChannelInterceptor 가
                         // Authorization 헤더 검증으로 인증 책임 (follow-up #19 native 토큰 인증).

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -103,6 +103,19 @@ public enum ErrorCode {
     DELIVERY_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "본인이 등록한 요청은 수락할 수 없습니다."),
     DELIVERY_LOCATION_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 위치 좌표입니다."),
     DELIVERY_LOCATION_TOO_FREQUENT(HttpStatus.TOO_MANY_REQUESTS, "위치 업데이트 빈도가 너무 높습니다."),
+    DELIVERY_NOT_RIDER(HttpStatus.FORBIDDEN, "라이더 권한이 없습니다."),
+
+    // ===== Escrow (거래대행) =====
+    ESCROW_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "거래대행 링크를 찾을 수 없습니다."),
+    ESCROW_LINK_EXPIRED(HttpStatus.GONE, "거래대행 링크가 만료되었습니다."),
+    ESCROW_LINK_ALREADY_TAKEN(HttpStatus.CONFLICT, "이미 다른 사용자가 참여한 링크입니다."),
+    ESCROW_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "본인이 생성한 링크에는 참여할 수 없습니다."),
+    ESCROW_NOT_FOUND(HttpStatus.NOT_FOUND, "거래대행 신청을 찾을 수 없습니다."),
+    ESCROW_FORBIDDEN(HttpStatus.FORBIDDEN, "거래대행 신청에 대한 권한이 없습니다."),
+    ESCROW_INVALID_STATE(HttpStatus.BAD_REQUEST, "현재 상태에서 수행할 수 없는 동작입니다."),
+    ESCROW_FORM_INVALID(HttpStatus.BAD_REQUEST, "거래대행 신청 입력값이 올바르지 않습니다."),
+    ESCROW_FEE_MISMATCH(HttpStatus.BAD_REQUEST, "수수료 정책이 변경되었습니다. 새 금액 확인 후 다시 시도해주세요."),
+
     PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "요청 본문 크기가 한도를 초과합니다.");
 
     private final HttpStatus status;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -53,7 +53,9 @@ app:
   cookie:
     domain: ${COOKIE_DOMAIN}
     secure: true
-    same-site: Strict
+    # cross-site 쿠키 허용 — 프론트 (vercel.app) 와 백엔드 (duckdns.org 등) 가 다른 site 일 때 None 필수.
+    # 같은 eTLD+1 으로 합쳐지면 Strict / Lax 로 강화. CSRF 방어는 X-XSRF-TOKEN 헤더 + Secure 가 1차.
+    same-site: ${COOKIE_SAME_SITE:None}
   oauth2:
     kakao:
       client-id: ${KAKAO_REST_API_KEY}

--- a/src/main/resources/db/migration/V15__add_escrow_domain.sql
+++ b/src/main/resources/db/migration/V15__add_escrow_domain.sql
@@ -1,0 +1,200 @@
+-- =============================================================================
+-- V15 — 거래대행 (Escrow) 도메인 신설
+--
+-- 5개 변경:
+--   1) escrow_links              : 신청자가 link 생성 → 수신자 join
+--   2) escrow_applications       : 폼 제출 + 결제 추적 + 상태머신 + snapshot
+--   3) escrow_fee_settings       : 운영 수수료 정책 (singleton row)
+--   4) ALTER deliveries          : escrow_application_id FK (배달대행과 연결)
+--   5) ALTER users               : is_rider 플래그 (라이더 권한)
+--
+-- 12 결정 사항 통합 (게이트 1 보안/결제/정산 영역).
+-- =============================================================================
+
+-- =============================================================================
+-- 1) escrow_links — 신청자가 생성, 수신자가 join 하는 invite link
+--    UUID token + 24h expiry + receiver_id race-safe (atomic UPDATE).
+-- =============================================================================
+CREATE TABLE escrow_links (
+    id                BIGINT       NOT NULL AUTO_INCREMENT,
+    link_token        VARCHAR(36)  NOT NULL              COMMENT 'UUID v4 — 외부 노출 식별자',
+    initiator_id      BIGINT       NOT NULL,
+    receiver_id       BIGINT       NULL                  COMMENT '첫 폼 제출 시 atomic UPDATE 로 확정',
+    initiator_role    VARCHAR(10)  NOT NULL              COMMENT 'buyer | seller — 수신자는 반대',
+    fee_payer         VARCHAR(10)  NOT NULL              COMMENT 'buyer | seller | both',
+    trade_mode        VARCHAR(20)  NOT NULL              COMMENT 'INTERNAL (itemPrice escrow) | EXTERNAL (배달만)',
+    status            VARCHAR(20)  NOT NULL              COMMENT '대기 | 완료 | 만료 | 취소',
+    expires_at        DATETIME     NOT NULL              COMMENT 'created + APP_ESCROW_LINK_EXPIRY_HOURS (default 24h)',
+    created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_escrow_links_token       (link_token),
+    KEY        idx_escrow_links_initiator  (initiator_id, created_at DESC),
+    KEY        idx_escrow_links_receiver   (receiver_id, created_at DESC),
+    KEY        idx_escrow_links_expires    (status, expires_at),
+    CONSTRAINT fk_escrow_links_initiator   FOREIGN KEY (initiator_id) REFERENCES users(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_escrow_links_receiver    FOREIGN KEY (receiver_id)  REFERENCES users(id) ON DELETE RESTRICT,
+    CONSTRAINT chk_escrow_links_role        CHECK (initiator_role IN ('buyer','seller')),
+    CONSTRAINT chk_escrow_links_fee_payer   CHECK (fee_payer IN ('buyer','seller','both')),
+    CONSTRAINT chk_escrow_links_trade_mode  CHECK (trade_mode IN ('INTERNAL','EXTERNAL')),
+    CONSTRAINT chk_escrow_links_status      CHECK (status IN ('대기','완료','만료','취소')),
+    CONSTRAINT chk_escrow_links_not_self    CHECK (receiver_id IS NULL OR receiver_id <> initiator_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- =============================================================================
+-- 2) escrow_applications — 폼 제출 후 단일 row (결제/정산/취소 라이프사이클)
+--    snapshot 컬럼 (applied_*) — settings 변경 시 진행 중 신청 보호.
+--    initiator_share/receiver_share — feePayer 별 부담 산정 결과.
+-- =============================================================================
+CREATE TABLE escrow_applications (
+    id                          BIGINT        NOT NULL AUTO_INCREMENT,
+    link_id                     BIGINT        NOT NULL,
+    -- 당사자 (denormalized for indexing)
+    initiator_id                BIGINT        NOT NULL,
+    receiver_id                 BIGINT        NOT NULL,
+    buyer_id                    BIGINT        NOT NULL              COMMENT 'role 매핑 후 확정',
+    seller_id                   BIGINT        NOT NULL,
+    trade_mode                  VARCHAR(20)   NOT NULL              COMMENT 'INTERNAL | EXTERNAL',
+    fee_payer                   VARCHAR(10)   NOT NULL              COMMENT 'buyer | seller | both',
+    -- 폼 — 물품
+    item_price                  BIGINT        NOT NULL DEFAULT 0    COMMENT 'INTERNAL>0, EXTERNAL=0',
+    item_description            VARCHAR(500)  NOT NULL,
+    -- 폼 — 픽업/배송 좌표
+    pickup_address              VARCHAR(255)  NOT NULL,
+    pickup_lat                  DECIMAL(10,7) NOT NULL,
+    pickup_lng                  DECIMAL(10,7) NOT NULL,
+    delivery_address            VARCHAR(255)  NOT NULL,
+    delivery_lat                DECIMAL(10,7) NOT NULL,
+    delivery_lng                DECIMAL(10,7) NOT NULL,
+    -- 폼 — 옵션
+    weight                      VARCHAR(10)   NOT NULL              COMMENT 'lt1 | 1to3 | 3to5 | 5to10 | gt10',
+    volume                      VARCHAR(5)    NOT NULL              COMMENT 's | m | l',
+    fragility                   VARCHAR(5)    NOT NULL              COMMENT 'f1 ~ f5',
+    delivery_notes              VARCHAR(500)  NULL,
+    -- snapshot (결정 #9, #10, #12) — 운영 settings 변경 무관 lock
+    applied_distance_km         DECIMAL(8,2)  NOT NULL,
+    applied_delivery_fee        BIGINT        NOT NULL,
+    applied_commission_fee      BIGINT        NOT NULL              COMMENT 'INTERNAL 만 > 0',
+    applied_total_fee           BIGINT        NOT NULL,
+    applied_commission_rate     DECIMAL(5,4)  NOT NULL,
+    -- 결제 추적 (결정 #5, G2 양쪽 별도 결제)
+    initiator_share             BIGINT        NOT NULL DEFAULT 0    COMMENT '신청자 부담분 (feePayer 산정 결과)',
+    receiver_share              BIGINT        NOT NULL DEFAULT 0    COMMENT '수신자 부담분',
+    initiator_paid_at           DATETIME      NULL,
+    receiver_paid_at            DATETIME      NULL,
+    payment_due_at              DATETIME      NULL                  COMMENT '첫 결제 시점 + 24h timeout',
+    -- 상태머신
+    status                      VARCHAR(20)   NOT NULL              COMMENT '결제대기 | 결제완료 | 진행중 | 완료 | 취소',
+    cancel_reason               VARCHAR(500)  NULL,
+    cancelled_by                BIGINT        NULL                  COMMENT '취소 트리거 user_id (귀책자)',
+    -- 정산 (Mode B — buyer 수령 확인 수동)
+    receipt_confirmed_at        DATETIME      NULL,
+    settled_at                  DATETIME      NULL,
+    -- 이미지 (S3 key 또는 url, JSON list)
+    image_urls                  TEXT          NULL,
+    created_at                  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_escrow_applications_link        (link_id),
+    KEY        idx_escrow_applications_buyer      (buyer_id, created_at DESC),
+    KEY        idx_escrow_applications_seller     (seller_id, created_at DESC),
+    KEY        idx_escrow_applications_status     (status, created_at DESC),
+    KEY        idx_escrow_applications_due        (payment_due_at),
+    CONSTRAINT fk_escrow_applications_link        FOREIGN KEY (link_id)      REFERENCES escrow_links(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_escrow_applications_initiator   FOREIGN KEY (initiator_id) REFERENCES users(id)         ON DELETE RESTRICT,
+    CONSTRAINT fk_escrow_applications_receiver    FOREIGN KEY (receiver_id)  REFERENCES users(id)         ON DELETE RESTRICT,
+    CONSTRAINT fk_escrow_applications_buyer       FOREIGN KEY (buyer_id)     REFERENCES users(id)         ON DELETE RESTRICT,
+    CONSTRAINT fk_escrow_applications_seller      FOREIGN KEY (seller_id)    REFERENCES users(id)         ON DELETE RESTRICT,
+    CONSTRAINT fk_escrow_applications_cancelled   FOREIGN KEY (cancelled_by) REFERENCES users(id)         ON DELETE RESTRICT,
+    CONSTRAINT chk_escrow_applications_status     CHECK (status IN ('결제대기','결제완료','진행중','완료','취소')),
+    CONSTRAINT chk_escrow_applications_trade_mode CHECK (trade_mode IN ('INTERNAL','EXTERNAL')),
+    CONSTRAINT chk_escrow_applications_fee_payer  CHECK (fee_payer IN ('buyer','seller','both')),
+    CONSTRAINT chk_escrow_applications_buyer_seller_diff CHECK (buyer_id <> seller_id),
+    -- INTERNAL 은 itemPrice > 0, EXTERNAL 은 itemPrice = 0 (commission 도 EXTERNAL 은 0)
+    CONSTRAINT chk_escrow_applications_item_price CHECK (
+        (trade_mode = 'EXTERNAL' AND item_price = 0 AND applied_commission_fee = 0) OR
+        (trade_mode = 'INTERNAL' AND item_price > 0)
+    ),
+    CONSTRAINT chk_escrow_applications_total_fee_positive CHECK (applied_total_fee > 0),
+    CONSTRAINT chk_escrow_applications_share CHECK (initiator_share >= 0 AND receiver_share >= 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- =============================================================================
+-- 3) escrow_fee_settings — 운영 수수료 정책 (singleton row, id=1)
+--    프론트 calcFees 와 동일 11 fields (결정 #9 — CC3).
+--    multiplier (weight/volume/fragility) 는 양쪽 코드 상수 (운영 변경 X — follow-up).
+-- =============================================================================
+CREATE TABLE escrow_fee_settings (
+    id                          BIGINT        NOT NULL              COMMENT 'always = 1 (singleton)',
+    commission_rate             DECIMAL(5,4)  NOT NULL              COMMENT '0.0500 = 5%',
+    fuel_price_per_l            BIGINT        NOT NULL              COMMENT '실시간 유류비 (원/L)',
+    base_fuel_price             BIGINT        NOT NULL              COMMENT '기준 유류비 (원/L) — 차이로 km_rate 보정',
+    base_delivery_fee           BIGINT        NOT NULL              COMMENT '일반 차량 기본 배달비 (원)',
+    base_km_rate                BIGINT        NOT NULL              COMMENT '일반 km당 추가 (원)',
+    fuel_efficiency             DECIMAL(5,2)  NOT NULL              COMMENT '일반 km/L',
+    min_delivery_fee            BIGINT        NOT NULL              COMMENT '일반 최저 배달비 (원)',
+    truck_base_delivery_fee     BIGINT        NOT NULL              COMMENT '용달 (5kg+) 기본 배달비',
+    truck_base_km_rate          BIGINT        NOT NULL              COMMENT '용달 km당 추가',
+    truck_fuel_efficiency       DECIMAL(5,2)  NOT NULL              COMMENT '용달 km/L',
+    truck_min_delivery_fee      BIGINT        NOT NULL              COMMENT '용달 최저 배달비',
+    updated_at                  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    updated_by                  BIGINT        NULL                  COMMENT 'admin id (마지막 변경자)',
+    PRIMARY KEY (id),
+    CONSTRAINT chk_escrow_fee_settings_singleton  CHECK (id = 1),
+    CONSTRAINT chk_escrow_fee_settings_commission CHECK (commission_rate >= 0 AND commission_rate <= 1),
+    CONSTRAINT chk_escrow_fee_settings_positive   CHECK (
+        fuel_price_per_l > 0 AND base_fuel_price > 0 AND
+        base_delivery_fee > 0 AND base_km_rate > 0 AND fuel_efficiency > 0 AND min_delivery_fee > 0 AND
+        truck_base_delivery_fee > 0 AND truck_base_km_rate > 0 AND truck_fuel_efficiency > 0 AND truck_min_delivery_fee > 0
+    ),
+    CONSTRAINT fk_escrow_fee_settings_admin       FOREIGN KEY (updated_by) REFERENCES admins(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- 기본값 — 프론트 mock 과 동일 (5% commission, fuelPrice 1650, etc.)
+INSERT INTO escrow_fee_settings (
+    id, commission_rate, fuel_price_per_l, base_fuel_price,
+    base_delivery_fee, base_km_rate, fuel_efficiency, min_delivery_fee,
+    truck_base_delivery_fee, truck_base_km_rate, truck_fuel_efficiency, truck_min_delivery_fee,
+    updated_at, updated_by
+) VALUES (
+    1, 0.0500, 1650, 1650,
+    1500, 500, 25.00, 3000,
+    5000, 1200, 10.00, 15000,
+    NOW(), NULL
+);
+
+
+-- =============================================================================
+-- 4) ALTER deliveries — escrow_application_id FK
+--    NULL = 일반 배달대행, NOT NULL = 거래대행 연결 (DomainEvent 자동 생성).
+-- =============================================================================
+ALTER TABLE deliveries
+    ADD COLUMN escrow_application_id BIGINT NULL AFTER memo,
+    ADD CONSTRAINT fk_deliveries_escrow FOREIGN KEY (escrow_application_id)
+        REFERENCES escrow_applications(id) ON DELETE RESTRICT;
+
+-- 한 application 당 delivery 1개 (자동 매칭 멱등성).
+CREATE UNIQUE INDEX uk_deliveries_escrow ON deliveries (escrow_application_id);
+
+
+-- =============================================================================
+-- 5) ALTER users — is_rider 플래그 (관리자 부여)
+-- =============================================================================
+ALTER TABLE users
+    ADD COLUMN is_rider BOOLEAN NOT NULL DEFAULT FALSE AFTER is_deleted;
+
+CREATE INDEX idx_users_is_rider ON users (is_rider);
+
+
+-- =============================================================================
+-- 6) ALTER payments — escrow_application_id (Escrow 결제 추적)
+--    payments 가 transaction_id, escrow_application_id 둘 중 하나로 분기.
+-- =============================================================================
+ALTER TABLE payments
+    ADD COLUMN escrow_application_id BIGINT NULL AFTER transaction_id,
+    ADD CONSTRAINT fk_payments_escrow FOREIGN KEY (escrow_application_id)
+        REFERENCES escrow_applications(id) ON DELETE RESTRICT;
+
+CREATE INDEX idx_payments_escrow ON payments (escrow_application_id);

--- a/src/test/java/com/sseulang/domain/delivery/application/DeliveryApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/delivery/application/DeliveryApplicationServiceTest.java
@@ -43,7 +43,7 @@ class DeliveryApplicationServiceTest {
         pointService = mock(PointApplicationService.class);
         com.sseulang.domain.delivery.domain.DeliveryLocationCache locationCache =
                 mock(com.sseulang.domain.delivery.domain.DeliveryLocationCache.class);
-        service = new DeliveryApplicationService(repo, userService, pointService, locationCache);
+        service = new DeliveryApplicationService(repo, userService, pointService, locationCache, e -> {});
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/delivery/application/InMemoryFakeDeliveryRepository.java
+++ b/src/test/java/com/sseulang/domain/delivery/application/InMemoryFakeDeliveryRepository.java
@@ -99,4 +99,11 @@ public class InMemoryFakeDeliveryRepository implements DeliveryRepository {
                 .mapToLong(DeliveryRequest::getFee)
                 .sum();
     }
+
+    @Override
+    public java.util.Optional<DeliveryRequest> findByEscrowApplicationId(Long escrowApplicationId) {
+        return store.values().stream()
+                .filter(d -> escrowApplicationId.equals(d.getEscrowApplicationId()))
+                .findFirst();
+    }
 }

--- a/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
@@ -1,0 +1,334 @@
+package com.sseulang.domain.escrow.application;
+
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateCommand;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationResult;
+import com.sseulang.domain.escrow.application.dto.EscrowLinkCreateCommand;
+import com.sseulang.domain.escrow.application.dto.EscrowLinkResult;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.InitiatorRole;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+import com.sseulang.domain.escrow.domain.event.EscrowConfirmedEvent;
+import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * EscrowApplicationService 단위 테스트. 보안 영역 — race / idempotent / fee mismatch / share 산정.
+ * 게이트 1 검증 영역.
+ */
+class EscrowApplicationServiceTest {
+
+    private InMemoryFakeEscrowLinkRepository linkRepo;
+    private InMemoryFakeEscrowApplicationRepository appRepo;
+    private InMemoryFakeEscrowFeeSettingsRepository settingsRepo;
+    private com.sseulang.domain.delivery.application.InMemoryFakeDeliveryRepository deliveryRepo;
+    private UserApplicationService userService;
+    private PointApplicationService pointService;
+    private List<Object> publishedEvents;
+    private ApplicationEventPublisher eventPublisher;
+    private EscrowApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        linkRepo = new InMemoryFakeEscrowLinkRepository();
+        appRepo = new InMemoryFakeEscrowApplicationRepository();
+        settingsRepo = new InMemoryFakeEscrowFeeSettingsRepository();
+        userService = mock(UserApplicationService.class);
+        pointService = mock(PointApplicationService.class);
+        publishedEvents = new ArrayList<>();
+        eventPublisher = publishedEvents::add;
+
+        // requireVerified — 통과
+        doNothing().when(userService).requireVerified(anyLong());
+        // getById — User stub
+        User stub = mock(User.class);
+        when(stub.getNickname()).thenReturn("닉넴");
+        when(userService.getById(anyLong())).thenReturn(stub);
+
+        deliveryRepo = new com.sseulang.domain.delivery.application.InMemoryFakeDeliveryRepository();
+        service = new EscrowApplicationService(
+                linkRepo, appRepo, settingsRepo,
+                userService, pointService, deliveryRepo, eventPublisher,
+                24
+        );
+    }
+
+    private EscrowApplicationCreateCommand validForm(Long receiverId, String linkToken,
+                                                     long itemPrice, long deliveryFee, long commissionFee, long totalFee) {
+        return new EscrowApplicationCreateCommand(
+                receiverId, linkToken,
+                itemPrice, "맥북 프로",
+                "픽업주소", new BigDecimal("37.5065"), new BigDecimal("127.0530"),
+                "도착주소", new BigDecimal("37.5144"), new BigDecimal("127.1058"),
+                Weight.R1TO3, Volume.M, Fragility.F3, "메모",
+                deliveryFee, commissionFee, totalFee, new BigDecimal("8.50"),
+                List.of()
+        );
+    }
+
+    // ------------------------------- createLink -------------------------------
+
+    @Test
+    @DisplayName("createLink_정상_token+expiresAt_발급")
+    void createLink_normal() {
+        EscrowLinkResult r = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        assertThat(r.linkToken()).hasSize(36);
+        assertThat(r.initiatorRole()).isEqualTo(InitiatorRole.buyer);
+        assertThat(r.expiresAt()).isAfter(java.time.LocalDateTime.now().plusHours(23));
+    }
+
+    @Test
+    @DisplayName("createLink_미인증_requireVerified_차단")
+    void createLink_unverified_blocked() {
+        doThrow(new BusinessException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED))
+                .when(userService).requireVerified(99L);
+        assertThatThrownBy(() -> service.createLink(new EscrowLinkCreateCommand(
+                99L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ))).isInstanceOf(BusinessException.class);
+    }
+
+    // ------------------------------ createApplication ------------------------------
+
+    /** 거리 8.51km / weight=1to3 / volume=m / fragility=f3 / itemPrice=1.8M 시점의 산정값 (default settings 기준). */
+    private long expectedDeliveryFee = -1; // setUp 후 한번 산정해서 캐시
+    private long expectedCommissionFee = -1;
+    private long expectedTotalFee = -1;
+
+    private void cacheExpectedFees() {
+        if (expectedDeliveryFee > 0) return;
+        var settings = settingsRepo.findSingleton();
+        // 백엔드가 좌표로 재계산하는 distance 와 동일 산정 (validForm 의 좌표 사용)
+        BigDecimal dist = com.sseulang.domain.escrow.domain.EscrowFeeCalculator.distanceKm(
+                37.5065, 127.0530, 37.5144, 127.1058
+        );
+        var fb = com.sseulang.domain.escrow.domain.EscrowFeeCalculator.calculate(
+                settings, TradeMode.INTERNAL, 1_800_000L, dist,
+                Weight.R1TO3, Volume.M, Fragility.F3
+        );
+        expectedDeliveryFee = fb.deliveryFee();
+        expectedCommissionFee = fb.commissionFee();
+        expectedTotalFee = fb.totalFee();
+    }
+
+    @Test
+    @DisplayName("createApplication_정상_status_결제대기_+_share_산정")
+    void createApplication_normal() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult r = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        assertThat(r.status()).isEqualTo(EscrowApplicationStatus.결제대기);
+        assertThat(r.buyerId()).isEqualTo(11L);
+        assertThat(r.sellerId()).isEqualTo(20L);
+        // both → buyer (initiator) 부담 = itemPrice + (delivery+commission)/2, seller 부담 = (delivery+commission) - half
+        long feeTotal = expectedDeliveryFee + expectedCommissionFee;
+        assertThat(r.initiatorShare()).isEqualTo(1_800_000L + feeTotal / 2);
+        assertThat(r.receiverShare()).isEqualTo(feeTotal - feeTotal / 2);
+    }
+
+    @Test
+    @DisplayName("createApplication_본인_SELF_NOT_ALLOWED")
+    void createApplication_self_rejected() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        assertThatThrownBy(() -> service.createApplication(validForm(
+                11L /* self */, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ))).isInstanceOf(BusinessException.class)
+           .extracting(e -> ((BusinessException) e).getErrorCode())
+           .isEqualTo(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("createApplication_idempotent_본인_더블클릭_같은application")
+    void createApplication_idempotent() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult first = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        EscrowApplicationResult second = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        assertThat(second.id()).isEqualTo(first.id());
+    }
+
+    @Test
+    @DisplayName("createApplication_race_다른receiver_ALREADY_TAKEN")
+    void createApplication_race_other_receiver() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        // 첫 수신자 확정
+        service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        // 다른 사용자 시도 → 실패
+        assertThatThrownBy(() -> service.createApplication(validForm(
+                30L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ))).isInstanceOf(BusinessException.class)
+           .extracting(e -> ((BusinessException) e).getErrorCode())
+           .isEqualTo(ErrorCode.ESCROW_LINK_ALREADY_TAKEN);
+    }
+
+    @Test
+    @DisplayName("createApplication_fee_위변조_FEE_MISMATCH")
+    void createApplication_fee_tampering_rejected() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        // 100원 차이 — tolerance 초과
+        assertThatThrownBy(() -> service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee - 100, expectedCommissionFee, expectedTotalFee
+        ))).isInstanceOf(BusinessException.class)
+           .extracting(e -> ((BusinessException) e).getErrorCode())
+           .isEqualTo(ErrorCode.ESCROW_FEE_MISMATCH);
+    }
+
+    // ------------------------------- recordPaymentConfirmed -------------------------------
+
+    @Test
+    @DisplayName("recordPaymentConfirmed_양쪽결제완료_EscrowConfirmedEvent_발행")
+    void recordPaymentConfirmed_event_published() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult app = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        // receiver 결제 — 양쪽 share 있으니 결제대기 유지
+        service.recordPaymentConfirmed(app.id(), 20L);
+        assertThat(publishedEvents).isEmpty();
+        // initiator 결제 — 양쪽 충족 → 결제완료 + 이벤트
+        service.recordPaymentConfirmed(app.id(), 11L);
+        assertThat(publishedEvents).hasSize(1);
+        assertThat(publishedEvents.get(0)).isInstanceOf(EscrowConfirmedEvent.class);
+        EscrowConfirmedEvent ev = (EscrowConfirmedEvent) publishedEvents.get(0);
+        assertThat(ev.escrowApplicationId()).isEqualTo(app.id());
+    }
+
+    // ------------------------------- verifyChargeIntent -------------------------------
+
+    @Test
+    @DisplayName("verifyChargeIntent_본인_share_일치_통과")
+    void verifyChargeIntent_match_pass() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult app = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        // receiver share 만큼 결제 시도
+        assertThatNoException().isThrownBy(() ->
+                service.verifyChargeIntent(app.id(), 20L, app.receiverShare())
+        );
+    }
+
+    @Test
+    @DisplayName("verifyChargeIntent_share_불일치_FEE_MISMATCH")
+    void verifyChargeIntent_amount_mismatch() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult app = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        assertThatThrownBy(() -> service.verifyChargeIntent(app.id(), 20L, app.receiverShare() + 100))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ESCROW_FEE_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("verifyChargeIntent_제3자_FORBIDDEN")
+    void verifyChargeIntent_other_user_rejected() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult app = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        assertThatThrownBy(() -> service.verifyChargeIntent(app.id(), 99L, 1000L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ESCROW_FORBIDDEN);
+    }
+
+    // ------------------------------- cancel -------------------------------
+
+    @Test
+    @DisplayName("cancel_매칭전_status_취소")
+    void cancel_before_match() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult app = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        service.cancel(app.id(), 11L, "단순 변심");
+        EscrowApplicationResult after = service.getById(app.id(), 11L);
+        assertThat(after.status()).isEqualTo(EscrowApplicationStatus.취소);
+        assertThat(after.cancelledBy()).isEqualTo(11L);
+    }
+
+    @Test
+    @DisplayName("cancel_제3자_FORBIDDEN")
+    void cancel_third_party_rejected() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult app = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        assertThatThrownBy(() -> service.cancel(app.id(), 99L, "남이 취소"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ESCROW_FORBIDDEN);
+    }
+}

--- a/src/test/java/com/sseulang/domain/escrow/application/InMemoryFakeEscrowApplicationRepository.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/InMemoryFakeEscrowApplicationRepository.java
@@ -1,0 +1,84 @@
+package com.sseulang.domain.escrow.application;
+
+import com.sseulang.domain.escrow.domain.EscrowApplication;
+import com.sseulang.domain.escrow.domain.EscrowApplicationRepository;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class InMemoryFakeEscrowApplicationRepository implements EscrowApplicationRepository {
+
+    private final Map<Long, EscrowApplication> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public EscrowApplication save(EscrowApplication application) {
+        if (application.getId() == null) {
+            ReflectionTestUtils.setField(application, "id", ++sequence);
+            ReflectionTestUtils.setField(application, "createdAt", LocalDateTime.now());
+        }
+        ReflectionTestUtils.setField(application, "updatedAt", LocalDateTime.now());
+        store.put(application.getId(), application);
+        return application;
+    }
+
+    @Override
+    public Optional<EscrowApplication> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<EscrowApplication> findByIdForUpdate(Long id) {
+        // fake — 락 의미 없음. 실 동시성은 IT 에서.
+        return findById(id);
+    }
+
+    @Override
+    public Optional<EscrowApplication> findByLinkId(Long linkId) {
+        return store.values().stream().filter(a -> a.getLinkId().equals(linkId)).findFirst();
+    }
+
+    @Override
+    public Page<EscrowApplication> findMyApplications(Long userId, Pageable pageable) {
+        List<EscrowApplication> list = store.values().stream()
+                .filter(a -> a.getInitiatorId().equals(userId) || a.getReceiverId().equals(userId))
+                .collect(Collectors.toList());
+        return new PageImpl<>(list, pageable, list.size());
+    }
+
+    @Override
+    public Page<EscrowApplication> findAll(Pageable pageable) {
+        return new PageImpl<>(List.copyOf(store.values()), pageable, store.size());
+    }
+
+    @Override
+    public Page<EscrowApplication> findAllByStatus(EscrowApplicationStatus status, Pageable pageable) {
+        List<EscrowApplication> list = store.values().stream()
+                .filter(a -> a.getStatus() == status)
+                .collect(Collectors.toList());
+        return new PageImpl<>(list, pageable, list.size());
+    }
+
+    @Override
+    public List<EscrowApplication> findPaymentTimedOut() {
+        return store.values().stream()
+                .filter(EscrowApplication::isPaymentTimedOut)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public long countInProgress() {
+        return store.values().stream()
+                .filter(a -> a.getStatus() != EscrowApplicationStatus.완료 && a.getStatus() != EscrowApplicationStatus.취소)
+                .count();
+    }
+}

--- a/src/test/java/com/sseulang/domain/escrow/application/InMemoryFakeEscrowFeeSettingsRepository.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/InMemoryFakeEscrowFeeSettingsRepository.java
@@ -1,0 +1,47 @@
+package com.sseulang.domain.escrow.application;
+
+import com.sseulang.domain.escrow.domain.EscrowFeeSettings;
+import com.sseulang.domain.escrow.domain.EscrowFeeSettingsRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class InMemoryFakeEscrowFeeSettingsRepository implements EscrowFeeSettingsRepository {
+
+    private EscrowFeeSettings singleton;
+
+    public InMemoryFakeEscrowFeeSettingsRepository() {
+        try {
+            var ctor = EscrowFeeSettings.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            singleton = ctor.newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+        ReflectionTestUtils.setField(singleton, "id", EscrowFeeSettings.SINGLETON_ID);
+        ReflectionTestUtils.setField(singleton, "commissionRate", new BigDecimal("0.0500"));
+        ReflectionTestUtils.setField(singleton, "fuelPricePerL", 1650L);
+        ReflectionTestUtils.setField(singleton, "baseFuelPrice", 1650L);
+        ReflectionTestUtils.setField(singleton, "baseDeliveryFee", 1500L);
+        ReflectionTestUtils.setField(singleton, "baseKmRate", 500L);
+        ReflectionTestUtils.setField(singleton, "fuelEfficiency", new BigDecimal("25.00"));
+        ReflectionTestUtils.setField(singleton, "minDeliveryFee", 3000L);
+        ReflectionTestUtils.setField(singleton, "truckBaseDeliveryFee", 5000L);
+        ReflectionTestUtils.setField(singleton, "truckBaseKmRate", 1200L);
+        ReflectionTestUtils.setField(singleton, "truckFuelEfficiency", new BigDecimal("10.00"));
+        ReflectionTestUtils.setField(singleton, "truckMinDeliveryFee", 15000L);
+        ReflectionTestUtils.setField(singleton, "updatedAt", LocalDateTime.now());
+    }
+
+    @Override
+    public EscrowFeeSettings findSingleton() {
+        return singleton;
+    }
+
+    @Override
+    public EscrowFeeSettings save(EscrowFeeSettings settings) {
+        this.singleton = settings;
+        return settings;
+    }
+}

--- a/src/test/java/com/sseulang/domain/escrow/application/InMemoryFakeEscrowLinkRepository.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/InMemoryFakeEscrowLinkRepository.java
@@ -1,0 +1,63 @@
+package com.sseulang.domain.escrow.application;
+
+import com.sseulang.domain.escrow.domain.EscrowLink;
+import com.sseulang.domain.escrow.domain.EscrowLinkRepository;
+import com.sseulang.domain.escrow.domain.EscrowLinkStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class InMemoryFakeEscrowLinkRepository implements EscrowLinkRepository {
+
+    private final Map<Long, EscrowLink> store = new HashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public EscrowLink save(EscrowLink link) {
+        if (link.getId() == null) {
+            ReflectionTestUtils.setField(link, "id", ++sequence);
+            ReflectionTestUtils.setField(link, "createdAt", LocalDateTime.now());
+        }
+        ReflectionTestUtils.setField(link, "updatedAt", LocalDateTime.now());
+        store.put(link.getId(), link);
+        return link;
+    }
+
+    @Override
+    public Optional<EscrowLink> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<EscrowLink> findByLinkToken(String linkToken) {
+        return store.values().stream()
+                .filter(l -> l.getLinkToken().equals(linkToken))
+                .findFirst();
+    }
+
+    @Override
+    public Page<EscrowLink> findByInitiatorId(Long initiatorId, Pageable pageable) {
+        return new PageImpl<>(store.values().stream()
+                .filter(l -> l.getInitiatorId().equals(initiatorId))
+                .collect(Collectors.toList()), pageable, store.size());
+    }
+
+    @Override
+    public int claimReceiverIfAvailable(Long linkId, Long receiverId) {
+        EscrowLink l = store.get(linkId);
+        if (l == null) return 0;
+        if (l.getReceiverId() != null) return 0;
+        if (l.getStatus() != EscrowLinkStatus.대기) return 0;
+        if (LocalDateTime.now().isAfter(l.getExpiresAt())) return 0;
+        if (l.getInitiatorId().equals(receiverId)) return 0;
+        ReflectionTestUtils.setField(l, "receiverId", receiverId);
+        return 1;
+    }
+}

--- a/src/test/java/com/sseulang/domain/escrow/domain/EscrowApplicationTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/domain/EscrowApplicationTest.java
@@ -1,0 +1,159 @@
+package com.sseulang.domain.escrow.domain;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * EscrowApplication Aggregate 단위 테스트.
+ * 결정 #4 (tradeMode), #5 (feePayer), #6 (cancel), #8 (참여자 가드).
+ */
+class EscrowApplicationTest {
+
+    private static FeeBreakdown snap(long deliveryFee, long commissionFee, long itemPrice, TradeMode mode) {
+        long total = deliveryFee + commissionFee + (mode == TradeMode.INTERNAL ? itemPrice : 0);
+        return new FeeBreakdown(new BigDecimal("8.50"), deliveryFee, commissionFee, total, new BigDecimal("0.0500"));
+    }
+
+    private static EscrowApplication build(InitiatorRole role, TradeMode mode, FeePayer payer,
+                                           long itemPrice, long initiatorShare, long receiverShare) {
+        return EscrowApplication.create(
+                100L,
+                /* initiator */ 11L, /* receiver */ 20L, role,
+                mode, payer,
+                itemPrice, "맥북",
+                "픽업주소", new BigDecimal("37.5"), new BigDecimal("127.0"),
+                "도착주소", new BigDecimal("37.6"), new BigDecimal("127.1"),
+                Weight.R1TO3, Volume.M, Fragility.F3, null,
+                snap(12000L, mode == TradeMode.INTERNAL ? 50_000L : 0L, itemPrice, mode),
+                initiatorShare, receiverShare,
+                null
+        );
+    }
+
+    @Test
+    @DisplayName("create_initiatorRole_buyer_매핑")
+    void create_buyer_role_mapping() {
+        EscrowApplication a = build(InitiatorRole.buyer, TradeMode.INTERNAL, FeePayer.buyer,
+                1_000_000L, 1_062_000L, 0L);
+        assertThat(a.getBuyerId()).isEqualTo(11L);   // initiator
+        assertThat(a.getSellerId()).isEqualTo(20L);  // receiver
+    }
+
+    @Test
+    @DisplayName("create_initiatorRole_seller_매핑")
+    void create_seller_role_mapping() {
+        EscrowApplication a = build(InitiatorRole.seller, TradeMode.INTERNAL, FeePayer.buyer,
+                1_000_000L, 0L, 1_062_000L);
+        assertThat(a.getBuyerId()).isEqualTo(20L);   // receiver
+        assertThat(a.getSellerId()).isEqualTo(11L);  // initiator
+    }
+
+    @Test
+    @DisplayName("markReceiverPaid_initiatorShare_0_즉시_결제완료")
+    void receiverPaid_alone_advances_when_initiator_share_zero() {
+        // feePayer=buyer 인 경우 seller 부담 0
+        EscrowApplication a = build(InitiatorRole.seller, TradeMode.INTERNAL, FeePayer.buyer,
+                1_000_000L, 0L /* seller initiator share */, 1_062_000L /* buyer receiver share */);
+        a.markReceiverPaid();
+        assertThat(a.getStatus()).isEqualTo(EscrowApplicationStatus.결제완료);
+        assertThat(a.getReceiverPaidAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("markReceiverPaid_양쪽share_있으면_결제대기_유지")
+    void both_shares_pending_until_both() {
+        EscrowApplication a = build(InitiatorRole.buyer, TradeMode.INTERNAL, FeePayer.both,
+                1_000_000L, 531_000L, 531_000L);
+        a.markReceiverPaid();
+        // 신청자 결제 안 함 → 결제대기 유지
+        assertThat(a.getStatus()).isEqualTo(EscrowApplicationStatus.결제대기);
+        a.markInitiatorPaid();
+        assertThat(a.getStatus()).isEqualTo(EscrowApplicationStatus.결제완료);
+    }
+
+    @Test
+    @DisplayName("markReceiverPaid_2번_INVALID_STATE")
+    void receiver_double_pay_rejected() {
+        EscrowApplication a = build(InitiatorRole.buyer, TradeMode.INTERNAL, FeePayer.both,
+                1_000_000L, 531_000L, 531_000L);
+        a.markReceiverPaid();
+        assertThatThrownBy(a::markReceiverPaid)
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("confirmReceipt_buyer만_허용_Mode_B")
+    void confirmReceipt_only_buyer_internal() {
+        EscrowApplication a = build(InitiatorRole.buyer, TradeMode.INTERNAL, FeePayer.buyer,
+                1_000_000L, 1_062_000L, 0L);
+        a.markInitiatorPaid();  // share 0 receiver + 결제 initiator → 결제완료
+        a.markInProgress();     // 라이더 매칭됨
+
+        // seller 가 호출 — 거부
+        assertThatThrownBy(() -> a.confirmReceipt(20L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ESCROW_FORBIDDEN);
+
+        // buyer 호출 — 통과
+        a.confirmReceipt(11L);
+        assertThat(a.getReceiptConfirmedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("confirmReceipt_Mode_A_거부")
+    void confirmReceipt_external_mode_rejected() {
+        EscrowApplication a = build(InitiatorRole.buyer, TradeMode.EXTERNAL, FeePayer.buyer,
+                0L, 12_000L, 0L);
+        a.markInitiatorPaid();
+        a.markInProgress();
+        assertThatThrownBy(() -> a.confirmReceipt(11L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ESCROW_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("cancel_terminal_상태_거부")
+    void cancel_terminal_rejected() {
+        EscrowApplication a = build(InitiatorRole.buyer, TradeMode.INTERNAL, FeePayer.buyer,
+                1_000_000L, 1_062_000L, 0L);
+        a.markInitiatorPaid();
+        a.markInProgress();
+        a.markSettled();  // 완료
+        assertThatThrownBy(() -> a.cancel(11L, "변심"))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("isParticipant_initiator_or_receiver_만")
+    void isParticipant_check() {
+        EscrowApplication a = build(InitiatorRole.buyer, TradeMode.INTERNAL, FeePayer.buyer,
+                1_000_000L, 1_062_000L, 0L);
+        assertThat(a.isParticipant(11L)).isTrue();
+        assertThat(a.isParticipant(20L)).isTrue();
+        assertThat(a.isParticipant(99L)).isFalse();
+    }
+
+    @Test
+    @DisplayName("create_buyer_seller_같음_SELF_NOT_ALLOWED")
+    void create_self_rejected() {
+        assertThatThrownBy(() -> EscrowApplication.create(
+                100L, 11L, 11L, InitiatorRole.buyer,
+                TradeMode.INTERNAL, FeePayer.buyer,
+                1_000_000L, "x", "p", new BigDecimal("37.5"), new BigDecimal("127.0"),
+                "d", new BigDecimal("37.6"), new BigDecimal("127.1"),
+                Weight.LT1, Volume.S, Fragility.F1, null,
+                snap(12000L, 50000L, 1_000_000L, TradeMode.INTERNAL),
+                1_062_000L, 0L, null
+        )).isInstanceOf(BusinessException.class)
+          .extracting(e -> ((BusinessException) e).getErrorCode())
+          .isEqualTo(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
+    }
+}

--- a/src/test/java/com/sseulang/domain/escrow/domain/EscrowFeeCalculatorTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/domain/EscrowFeeCalculatorTest.java
@@ -1,0 +1,166 @@
+package com.sseulang.domain.escrow.domain;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * EscrowFeeCalculator 단위 테스트 — pure function. 게이트 1 보안 영역 (결제 산정 정확성).
+ */
+class EscrowFeeCalculatorTest {
+
+    private static EscrowFeeSettings defaultSettings() {
+        EscrowFeeSettings s = new EscrowFeeSettings();
+        ReflectionTestUtils.setField(s, "id", 1L);
+        ReflectionTestUtils.setField(s, "commissionRate", new BigDecimal("0.0500"));
+        ReflectionTestUtils.setField(s, "fuelPricePerL", 1650L);
+        ReflectionTestUtils.setField(s, "baseFuelPrice", 1650L);  // diff=0 → 보정 0
+        ReflectionTestUtils.setField(s, "baseDeliveryFee", 1500L);
+        ReflectionTestUtils.setField(s, "baseKmRate", 500L);
+        ReflectionTestUtils.setField(s, "fuelEfficiency", new BigDecimal("25.00"));
+        ReflectionTestUtils.setField(s, "minDeliveryFee", 3000L);
+        ReflectionTestUtils.setField(s, "truckBaseDeliveryFee", 5000L);
+        ReflectionTestUtils.setField(s, "truckBaseKmRate", 1200L);
+        ReflectionTestUtils.setField(s, "truckFuelEfficiency", new BigDecimal("10.00"));
+        ReflectionTestUtils.setField(s, "truckMinDeliveryFee", 15000L);
+        ReflectionTestUtils.setField(s, "updatedAt", LocalDateTime.now());
+        return s;
+    }
+
+    @Test
+    @DisplayName("distanceKm_같은좌표_0km")
+    void distanceKm_same_coordinate() {
+        BigDecimal d = EscrowFeeCalculator.distanceKm(37.5, 127.0, 37.5, 127.0);
+        assertThat(d).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    @DisplayName("distanceKm_강남강서_약16km")
+    void distanceKm_haversine_real() {
+        // 강남역 (37.4979, 127.0276) ↔ 강서구청 (37.5510, 126.8495)
+        BigDecimal d = EscrowFeeCalculator.distanceKm(37.4979, 127.0276, 37.5510, 126.8495);
+        assertThat(d.doubleValue()).isBetween(15.0, 17.0);
+    }
+
+    @Test
+    @DisplayName("calculate_INTERNAL_buyer결제_itemPrice포함")
+    void calculate_internal_total_includes_itemPrice() {
+        EscrowFeeSettings s = defaultSettings();
+        FeeBreakdown fb = EscrowFeeCalculator.calculate(
+                s, TradeMode.INTERNAL, 1_000_000L,
+                new BigDecimal("8.50"),
+                Weight.R1TO3, Volume.M, Fragility.F3
+        );
+        // commission = 1M × 0.05 = 50,000
+        assertThat(fb.commissionFee()).isEqualTo(50_000L);
+        // total = item + delivery + commission
+        assertThat(fb.totalFee()).isEqualTo(1_000_000L + fb.deliveryFee() + 50_000L);
+        assertThat(fb.deliveryFee()).isPositive();
+        assertThat(fb.commissionRate()).isEqualByComparingTo("0.0500");
+    }
+
+    @Test
+    @DisplayName("calculate_EXTERNAL_itemPrice0_commission0")
+    void calculate_external_no_item_no_commission() {
+        EscrowFeeSettings s = defaultSettings();
+        FeeBreakdown fb = EscrowFeeCalculator.calculate(
+                s, TradeMode.EXTERNAL, 0L,
+                new BigDecimal("5.00"),
+                Weight.LT1, Volume.S, Fragility.F1
+        );
+        assertThat(fb.commissionFee()).isZero();
+        assertThat(fb.totalFee()).isEqualTo(fb.deliveryFee());  // delivery 만
+    }
+
+    @Test
+    @DisplayName("calculate_5kg이상_용달차_분기")
+    void calculate_truck_branch() {
+        EscrowFeeSettings s = defaultSettings();
+        // 동일 거리 — 일반 vs 용달
+        BigDecimal dist = new BigDecimal("10.00");
+        FeeBreakdown normal = EscrowFeeCalculator.calculate(s, TradeMode.EXTERNAL, 0L, dist, Weight.R3TO5, Volume.M, Fragility.F1);
+        FeeBreakdown truck = EscrowFeeCalculator.calculate(s, TradeMode.EXTERNAL, 0L, dist, Weight.R5TO10, Volume.M, Fragility.F1);
+        // 용달이 일반보다 비쌈 (truckBaseDeliveryFee 5000 + km_rate 1200 vs 1500 + 500)
+        assertThat(truck.deliveryFee()).isGreaterThan(normal.deliveryFee());
+    }
+
+    @Test
+    @DisplayName("calculate_거리짧음_minDeliveryFee_floor")
+    void calculate_min_floor() {
+        EscrowFeeSettings s = defaultSettings();
+        // 0.1km — 1500 + 500*0.1 = 1550, weight×volume×frag multiplier 1.0 → 1550
+        // minDeliveryFee 3000 → floor 적용 후 3000 × 1.0 = 3000
+        FeeBreakdown fb = EscrowFeeCalculator.calculate(
+                s, TradeMode.EXTERNAL, 0L,
+                new BigDecimal("0.10"),
+                Weight.LT1, Volume.S, Fragility.F1
+        );
+        assertThat(fb.deliveryFee()).isEqualTo(3000L);  // minDeliveryFee 적용
+    }
+
+    @Test
+    @DisplayName("calculate_INTERNAL_itemPrice0_FORM_INVALID")
+    void calculate_internal_zero_item_rejected() {
+        EscrowFeeSettings s = defaultSettings();
+        assertThatThrownBy(() -> EscrowFeeCalculator.calculate(
+                s, TradeMode.INTERNAL, 0L,
+                new BigDecimal("5.00"),
+                Weight.LT1, Volume.S, Fragility.F1
+        )).isInstanceOf(BusinessException.class)
+          .extracting(e -> ((BusinessException) e).getErrorCode())
+          .isEqualTo(ErrorCode.ESCROW_FORM_INVALID);
+    }
+
+    @Test
+    @DisplayName("calculate_EXTERNAL_itemPriceNot0_FORM_INVALID")
+    void calculate_external_with_item_rejected() {
+        EscrowFeeSettings s = defaultSettings();
+        assertThatThrownBy(() -> EscrowFeeCalculator.calculate(
+                s, TradeMode.EXTERNAL, 100_000L,
+                new BigDecimal("5.00"),
+                Weight.LT1, Volume.S, Fragility.F1
+        )).isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("verifyTolerance_정확일치_통과")
+    void verifyTolerance_exact_pass() {
+        FeeBreakdown calculated = new FeeBreakdown(
+                new BigDecimal("8.50"), 12000L, 90000L, 1_902_000L, new BigDecimal("0.0500")
+        );
+        assertThatNoException().isThrownBy(() ->
+                EscrowFeeCalculator.verifyTolerance(calculated, 12000L, 90000L, 1_902_000L)
+        );
+    }
+
+    @Test
+    @DisplayName("verifyTolerance_5원차이_통과(±10원)")
+    void verifyTolerance_within_5won_pass() {
+        FeeBreakdown calculated = new FeeBreakdown(
+                new BigDecimal("8.50"), 12000L, 90000L, 1_902_000L, new BigDecimal("0.0500")
+        );
+        assertThatNoException().isThrownBy(() ->
+                EscrowFeeCalculator.verifyTolerance(calculated, 12005L, 89998L, 1_902_007L)
+        );
+    }
+
+    @Test
+    @DisplayName("verifyTolerance_11원차이_FEE_MISMATCH")
+    void verifyTolerance_11won_diff_rejected() {
+        FeeBreakdown calculated = new FeeBreakdown(
+                new BigDecimal("8.50"), 12000L, 90000L, 1_902_000L, new BigDecimal("0.0500")
+        );
+        assertThatThrownBy(() ->
+                EscrowFeeCalculator.verifyTolerance(calculated, 12011L, 90000L, 1_902_000L)
+        ).isInstanceOf(BusinessException.class)
+         .extracting(e -> ((BusinessException) e).getErrorCode())
+         .isEqualTo(ErrorCode.ESCROW_FEE_MISMATCH);
+    }
+}

--- a/src/test/java/com/sseulang/domain/escrow/domain/EscrowLinkTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/domain/EscrowLinkTest.java
@@ -1,0 +1,97 @@
+package com.sseulang.domain.escrow.domain;
+
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * EscrowLink Aggregate 단위 테스트. 결정 #2/3 — claimByReceiver 가드.
+ */
+class EscrowLinkTest {
+
+    private static EscrowLink link(Long initiatorId) {
+        return EscrowLink.create(initiatorId, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL, 24);
+    }
+
+    @Test
+    @DisplayName("claimByReceiver_본인_SELF_NOT_ALLOWED")
+    void claim_self_blocked() {
+        EscrowLink l = link(11L);
+        assertThatThrownBy(() -> l.claimByReceiver(11L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("claimByReceiver_정상_receiver_확정")
+    void claim_normal() {
+        EscrowLink l = link(11L);
+        l.claimByReceiver(20L);
+        assertThat(l.getReceiverId()).isEqualTo(20L);
+    }
+
+    @Test
+    @DisplayName("claimByReceiver_만료_LINK_EXPIRED")
+    void claim_expired() {
+        EscrowLink l = link(11L);
+        ReflectionTestUtils.setField(l, "expiresAt", LocalDateTime.now().minusMinutes(1));
+        assertThatThrownBy(() -> l.claimByReceiver(20L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ESCROW_LINK_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("claimByReceiver_이미다른수신자_ALREADY_TAKEN")
+    void claim_already_taken_other() {
+        EscrowLink l = link(11L);
+        l.claimByReceiver(20L);  // 첫 수신자
+        assertThatThrownBy(() -> l.claimByReceiver(30L))  // 다른 수신자 시도
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ESCROW_LINK_ALREADY_TAKEN);
+    }
+
+    @Test
+    @DisplayName("claimByReceiver_같은수신자재시도_idempotent")
+    void claim_same_receiver_idempotent() {
+        EscrowLink l = link(11L);
+        l.claimByReceiver(20L);
+        // 같은 사용자 재시도 — 가드 통과 (idempotent — Aggregate 측면).
+        // 실 흐름의 idempotent 처리는 ApplicationService 가 더 위에서 처리.
+        assertThatNoException().isThrownBy(() -> l.claimByReceiver(20L));
+    }
+
+    @Test
+    @DisplayName("markAsCompleted_대기상태만_허용")
+    void completed_only_from_대기() {
+        EscrowLink l = link(11L);
+        l.markAsCompleted();
+        assertThat(l.getStatus()).isEqualTo(EscrowLinkStatus.완료);
+        // 두번째 호출은 INVALID_STATE
+        assertThatThrownBy(l::markAsCompleted)
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("markAsCancelled_대기상태만_허용")
+    void cancel_only_from_대기() {
+        EscrowLink l = link(11L);
+        l.markAsCancelled();
+        assertThat(l.getStatus()).isEqualTo(EscrowLinkStatus.취소);
+    }
+
+    @Test
+    @DisplayName("create_expiryHours_0이하_거부")
+    void create_invalid_expiry() {
+        assertThatThrownBy(() -> EscrowLink.create(11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
@@ -52,7 +52,8 @@ class PaymentApplicationServiceTest {
                 new InMemoryFakeWebhookEventRepository(),
                 new TossWebhookSignatureVerifier(tossProps),
                 new ObjectMapper(),
-                new WebhookPendingRateLimiter()
+                new WebhookPendingRateLimiter(),
+                null  // EscrowApplicationService — Payment 단위 테스트에선 escrow 흐름 호출 X
         );
         userId = userRepo.save(User.createSocialUser(
                 SocialProvider.KAKAO, "kakao-1", new Email("u1@x.com"), "u1", null

--- a/src/test/java/com/sseulang/integration/EscrowFlowE2EIT.java
+++ b/src/test/java/com/sseulang/integration/EscrowFlowE2EIT.java
@@ -1,0 +1,278 @@
+package com.sseulang.integration;
+
+import com.sseulang.domain.delivery.application.DeliveryApplicationService;
+import com.sseulang.domain.delivery.application.dto.DeliveryCreateCommand;
+import com.sseulang.domain.escrow.application.EscrowApplicationService;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateCommand;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationResult;
+import com.sseulang.domain.escrow.application.dto.EscrowLinkCreateCommand;
+import com.sseulang.domain.escrow.application.dto.EscrowLinkResult;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.InitiatorRole;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+import com.sseulang.domain.payment.application.PaymentApplicationService;
+import com.sseulang.domain.payment.application.dto.ChargeConfirmCommand;
+import com.sseulang.domain.payment.application.dto.ChargeStartCommand;
+import com.sseulang.domain.payment.application.dto.ChargeStartResult;
+import com.sseulang.domain.payment.domain.PaymentConfirmResult;
+import com.sseulang.domain.payment.domain.PaymentGateway;
+import com.sseulang.domain.payment.domain.PaymentMethod;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * 거래대행 e2e — link 생성 → 폼 제출 → 양쪽 결제 → Delivery 자동 매칭 → 라이더 수락 → markDelivered
+ * → Mode A 자동 정산 / Mode B 수령 확인 정산. PaymentGateway 만 mock — DB·Redis·Mongo·이벤트 모두 real.
+ */
+@SpringBootTest
+@Testcontainers
+class EscrowFlowE2EIT {
+
+    @Container
+    static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+                    .withDatabaseName("sseulang").withUsername("test").withPassword("test")
+                    .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci",
+                            "--ngram_token_size=2");
+
+    @Container
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+
+    @Container
+    static final MongoDBContainer MONGO =
+            new MongoDBContainer(DockerImageName.parse("mongo:7"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        r.add("spring.datasource.username", MYSQL::getUsername);
+        r.add("spring.datasource.password", MYSQL::getPassword);
+        r.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        r.add("spring.flyway.enabled", () -> "true");
+        r.add("spring.data.redis.host", REDIS::getHost);
+        r.add("spring.data.redis.port", REDIS::getFirstMappedPort);
+        r.add("spring.data.mongodb.uri", MONGO::getReplicaSetUrl);
+        r.add("app.dev-auth.enabled", () -> "false");
+    }
+
+    @Autowired private EscrowApplicationService escrowService;
+    @Autowired private DeliveryApplicationService deliveryService;
+    @Autowired private PaymentApplicationService paymentService;
+    @Autowired private UserApplicationService userService;
+    @Autowired private com.sseulang.domain.escrow.domain.EscrowFeeSettingsRepository feeSettingsRepository;
+    @Autowired private EntityManager em;
+    @Autowired private PlatformTransactionManager txManager;
+
+    @MockBean
+    private PaymentGateway paymentGateway;
+
+    private Long buyerId;
+    private Long sellerId;
+    private Long riderId;
+
+    @BeforeEach
+    void setUp() {
+        TransactionTemplate tx = new TransactionTemplate(txManager);
+        tx.execute(s -> {
+            em.createNativeQuery("DELETE FROM point_histories").executeUpdate();
+            em.createNativeQuery("DELETE FROM deliveries").executeUpdate();
+            em.createNativeQuery("DELETE FROM payments").executeUpdate();
+            em.createNativeQuery("DELETE FROM escrow_applications").executeUpdate();
+            em.createNativeQuery("DELETE FROM escrow_links").executeUpdate();
+            em.createNativeQuery("DELETE FROM users").executeUpdate();
+            return null;
+        });
+        // 3명 가입 + verified
+        buyerId = createVerifiedUser("buyer");
+        sellerId = createVerifiedUser("seller");
+        riderId = createVerifiedUser("rider");
+        // rider 권한 부여
+        tx.execute(s -> {
+            em.createNativeQuery("UPDATE users SET is_rider = TRUE WHERE id = :id")
+                    .setParameter("id", riderId).executeUpdate();
+            return null;
+        });
+    }
+
+    private Long createVerifiedUser(String suffix) {
+        // social 가입 후 인증 수동 처리.
+        User created = userService.findOrCreateBySocial(
+                SocialProvider.KAKAO, "social-" + suffix + "-" + UUID.randomUUID(),
+                new Email(suffix + "@x.com"), suffix, null
+        );
+        new TransactionTemplate(txManager).execute(s -> {
+            em.createNativeQuery("UPDATE users SET email_verified = TRUE WHERE id = :id")
+                    .setParameter("id", created.getId()).executeUpdate();
+            return null;
+        });
+        return created.getId();
+    }
+
+    private long balance(Long userId) {
+        return ((Number) em.createNativeQuery("SELECT point_balance FROM users WHERE id = :id")
+                .setParameter("id", userId).getSingleResult()).longValue();
+    }
+
+    /** 양쪽 결제 (escrow application 의 share 양쪽) — paymentGateway mock 으로 confirm. */
+    private void payShare(Long payerId, Long applicationId, long amount) {
+        // start
+        ChargeStartResult started = paymentService.startCharge(
+                new ChargeStartCommand(payerId, amount, applicationId)
+        );
+        // toss confirm mock
+        when(paymentGateway.confirm(anyString(), anyString(), anyLong()))
+                .thenReturn(new PaymentConfirmResult(
+                        "key-" + started.merchantUid(),
+                        started.merchantUid(),
+                        amount,
+                        PaymentMethod.CARD,
+                        LocalDateTime.now(),
+                        "{}"
+                ));
+        // confirm
+        paymentService.confirmCharge(new ChargeConfirmCommand(
+                payerId, "key-" + started.merchantUid(), started.merchantUid(), amount
+        ));
+    }
+
+    @Test
+    @DisplayName("Mode B INTERNAL feePayer=buyer e2e — buyer 잔액 변동 X + seller 정산 + rider 정산")
+    void mode_b_internal_full_flow() {
+        // 1) link 생성 (buyer initiator, feePayer=buyer)
+        EscrowLinkResult link = escrowService.createLink(new EscrowLinkCreateCommand(
+                buyerId, InitiatorRole.buyer, FeePayer.buyer, TradeMode.INTERNAL
+        ));
+
+        // 2) 수신자 (seller) 폼 제출 — itemPrice=1M
+        long itemPrice = 1_000_000L;
+        EscrowApplicationCreateCommand cmd = formCommand(sellerId, link.linkToken(), itemPrice);
+        EscrowApplicationResult app = escrowService.createApplication(cmd);
+        assertThat(app.status()).isEqualTo(EscrowApplicationStatus.결제대기);
+        assertThat(app.buyerId()).isEqualTo(buyerId);
+        assertThat(app.sellerId()).isEqualTo(sellerId);
+        // feePayer=buyer → seller share = 0, buyer share = item + fees
+        assertThat(app.receiverShare()).isZero();
+        assertThat(app.initiatorShare()).isEqualTo(app.appliedTotalFee());
+
+        // 3) buyer 결제 (initiator = buyer)
+        payShare(buyerId, app.id(), app.initiatorShare());
+
+        // 4) status = 결제완료 + delivery 모집중 row 자동 생성 (event listener)
+        EscrowApplicationResult afterPay = escrowService.getById(app.id(), buyerId);
+        assertThat(afterPay.status()).isEqualTo(EscrowApplicationStatus.결제완료);
+        Number deliveryCount = (Number) em.createNativeQuery(
+                "SELECT COUNT(*) FROM deliveries WHERE escrow_application_id = :id"
+        ).setParameter("id", app.id()).getSingleResult();
+        assertThat(deliveryCount.intValue()).isEqualTo(1);
+
+        // 5) rider 가 delivery 수락 + pickup + delivered
+        Long deliveryId = ((Number) em.createNativeQuery(
+                "SELECT id FROM deliveries WHERE escrow_application_id = :id"
+        ).setParameter("id", app.id()).getSingleResult()).longValue();
+        deliveryService.accept(deliveryId, riderId);
+        deliveryService.markPickedUp(deliveryId, riderId);
+        deliveryService.markDelivered(deliveryId, riderId);
+
+        // 6) Mode B 라 자동 정산 X (settleAfterDelivery 가 INTERNAL 분기 return 하므로 진행중 유지)
+        // application 상태는 결제완료 그대로 (markInProgress 호출 안 했음 — 5/11 시점 단순화).
+        // Mode B 정산은 buyer 의 confirmReceipt 호출.
+        // 단 markInProgress 가 없어서 confirmReceipt 가 결제완료 → INVALID_STATE 던짐.
+        // → 진행중 마커가 명시되어야 함. ApplicationService.markInProgress 호출.
+        escrowService.markInProgress(app.id());
+
+        // 7) buyer 수령 확인 → 정산
+        escrowService.confirmReceipt(app.id(), buyerId);
+
+        // 8) 잔액 검증
+        EscrowApplicationResult finalApp = escrowService.getById(app.id(), buyerId);
+        assertThat(finalApp.status()).isEqualTo(EscrowApplicationStatus.완료);
+        assertThat(finalApp.settledAt()).isNotNull();
+        // buyer: 결제 X (escrow hold — 잔액 변동 0)
+        assertThat(balance(buyerId)).isZero();
+        // seller: itemPrice 적립
+        assertThat(balance(sellerId)).isEqualTo(itemPrice);
+        // rider: deliveryFee 적립 (snapshot 값)
+        assertThat(balance(riderId)).isEqualTo(finalApp.appliedDeliveryFee());
+    }
+
+    @Test
+    @DisplayName("createApplication race — 두 수신자 중 한 명만 성공")
+    void claim_race() {
+        EscrowLinkResult link = escrowService.createLink(new EscrowLinkCreateCommand(
+                buyerId, InitiatorRole.buyer, FeePayer.buyer, TradeMode.INTERNAL
+        ));
+        // seller 가 첫 폼 제출
+        escrowService.createApplication(formCommand(sellerId, link.linkToken(), 500_000L));
+
+        // rider 가 같은 link 에 시도 → ALREADY_TAKEN
+        assertThatThrownBy(() ->
+                escrowService.createApplication(formCommand(riderId, link.linkToken(), 500_000L))
+        ).isInstanceOfSatisfying(BusinessException.class, e ->
+                assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ESCROW_LINK_ALREADY_TAKEN));
+    }
+
+    private EscrowApplicationCreateCommand formCommand(Long receiverId, String linkToken, long itemPrice) {
+        BigDecimal pickLat = new BigDecimal("37.5065");
+        BigDecimal pickLng = new BigDecimal("127.0530");
+        BigDecimal dropLat = new BigDecimal("37.5144");
+        BigDecimal dropLng = new BigDecimal("127.1058");
+        BigDecimal dist = com.sseulang.domain.escrow.domain.EscrowFeeCalculator.distanceKm(
+                pickLat.doubleValue(), pickLng.doubleValue(),
+                dropLat.doubleValue(), dropLng.doubleValue()
+        );
+        // 백엔드가 form 의 좌표로 동일하게 재계산 — 같은 calculator 사용해서 일치하는 fee 미리 산정.
+        var feeSettings = feeSettingsRepository.findSingleton();
+        var fb = com.sseulang.domain.escrow.domain.EscrowFeeCalculator.calculate(
+                feeSettings,
+                itemPrice > 0 ? TradeMode.INTERNAL : TradeMode.EXTERNAL,
+                itemPrice, dist,
+                Weight.R1TO3, Volume.M, Fragility.F3
+        );
+        return new EscrowApplicationCreateCommand(
+                receiverId, linkToken,
+                itemPrice, "테스트 물품",
+                "픽업주소", pickLat, pickLng,
+                "도착주소", dropLat, dropLng,
+                Weight.R1TO3, Volume.M, Fragility.F3, "메모",
+                fb.deliveryFee(), fb.commissionFee(), fb.totalFee(), dist,
+                java.util.List.of()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
PR #91 머지 후 발견된 CSRF cookie 도메인 이슈 fix.

## 문제
- 프론트 (`www.sseulang.store`) 가 백엔드 (`api.sseulang.store`) 의 XSRF-TOKEN 쿠키를 \`document.cookie\` 로 못 읽음
- 결과: \`X-XSRF-TOKEN\` 헤더 echo 누락 → 모든 POST/PATCH/DELETE 가 403 (CSRF reject)

## 원인
- \`CookieCsrfTokenRepository.withHttpOnlyFalse()\` 가 Domain 미명시 → host-only 쿠키
- host-only 는 발급 호스트(api.sseulang.store) 에서만 접근 가능
- www 페이지 JS 에선 안 보임

## Fix
- SecurityConfig 에 \`@Value("\${app.cookie.domain:}")\` 주입
- \`buildCsrfRepo()\` helper — \`cookieCustomizer\` 로 Domain 적용
- adminFilterChain / userFilterChain 양쪽 적용
- prod 시 Domain=\`sseulang.store\` (sub-domain 공유) — local 미주입 시 default

## 추가 변경
- \`.env.prod\` 의 \`COOKIE_DOMAIN=.sseulang.store\` → \`sseulang.store\`
  - leading dot 는 Tomcat Cookie validation reject (RFC 6265 dot 없이도 sub-domain 매칭)

## Test plan
- [x] 컴파일 통과
- [x] prod 배포 + Set-Cookie 검증 (Domain=sseulang.store 명시)
- [ ] 프론트 측 POST 재시도 → 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)