### PR TITLE
feat: 라운드 11 — 거래 escrow hold + 양쪽 확인 정책 (게이트 1+2 통과)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -138,6 +138,8 @@ services:
       TOSS_WEBHOOK_REPLAY_TOLERANCE: ${TOSS_WEBHOOK_REPLAY_TOLERANCE:-300}
       # !!! dev/QA 한정 !!! true 면 토스 confirm 검증 우회. 운영 진입 시 false 복귀 (보안).
       TOSS_SKIP_VERIFY: ${TOSS_SKIP_VERIFY:-false}
+      # OAuth 로그인 시 ROLE_ADMIN JWT 발급 email 화이트리스트 (콤마구분). 빈 값이면 모두 USER.
+      ADMIN_USER_EMAILS: ${ADMIN_USER_EMAILS:-}
       # === Swagger 노출 (옵션, default false — 운영 보안) ===
       APP_SWAGGER_ENABLED: ${APP_SWAGGER_ENABLED:-false}
       # === 로그 경로 (logback-spring.xml LOG_PATH 변수) ===

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -136,6 +136,8 @@ services:
       APP_EMAIL_VERIFICATION_URL_BASE: ${APP_EMAIL_VERIFICATION_URL_BASE:-}
       # === 토스 webhook replay 허용 (옵션) ===
       TOSS_WEBHOOK_REPLAY_TOLERANCE: ${TOSS_WEBHOOK_REPLAY_TOLERANCE:-300}
+      # !!! dev/QA 한정 !!! true 면 토스 confirm 검증 우회. 운영 진입 시 false 복귀 (보안).
+      TOSS_SKIP_VERIFY: ${TOSS_SKIP_VERIFY:-false}
       # === Swagger 노출 (옵션, default false — 운영 보안) ===
       APP_SWAGGER_ENABLED: ${APP_SWAGGER_ENABLED:-false}
       # === 로그 경로 (logback-spring.xml LOG_PATH 변수) ===

--- a/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
@@ -13,29 +13,44 @@ import com.sseulang.global.exception.ExternalApiException;
 import com.sseulang.global.security.JwtProperties;
 import com.sseulang.global.security.JwtProvider;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
  * 소셜 로그인 흐름 — provider 검증 → user 조회/생성 → JWT 발급 + RT 저장.
  *
- * <p>본 PR 범위에선 role 은 항상 "USER" (일반 사용자). 관리자는 별도 admins 테이블로 관리.</p>
- */
-/**
- * 클래스 단위 {@code @Transactional} 의도적으로 미적용 — 가이드 §3.10 "외부 API 호출은 트랜잭션
+ * <p>기본 role 은 "USER". 별도로 {@code app.admin.user-emails} 화이트리스트에 매치되는 email 의
+ * OAuth user 는 role="ADMIN" 으로 JWT 발급 — 본인 SSO 로 admin 페이지 접근 가능. admin 페이지의
+ * 별도 username/password 로그인 ({@code admins} 테이블) 흐름과 병존.</p>
+ *
+ * <p><b>권한 회수 운영 절차 (게이트 1 W-1)</b>: allowlist 에서 email 제거만으로는 이미 발급된
+ * AT(30분) / RT(7일) 가 즉시 무효화되지 않는다 — 발급 시점 기준이라 그 후 refresh 도 ADMIN role 로
+ * rotate 된다. 운영자가 즉시 권한 회수가 필요하면:
+ * <ol>
+ *   <li>{@code ADMIN_USER_EMAILS} 환경변수에서 해당 email 제거 + 재배포 (이후 신규 로그인은 USER)</li>
+ *   <li>{@code RefreshTokenStore.revokeAll("ADMIN", userId)} 호출 — RT 무효화 (Redis tv INCR)</li>
+ *   <li>해당 사용자에게 강제 logout 안내 — AT 30분 만료까지는 잔존</li>
+ * </ol>
+ * R1 follow-up: 운영자 일괄 revoke endpoint (admin 측에서 호출) 추가 검토.</p>
+ *
+ * <p>클래스 단위 {@code @Transactional} 의도적으로 미적용 — 가이드 §3.10 "외부 API 호출은 트랜잭션
  * 밖에서". UserApplicationService 가 자체 트랜잭션을 가지며, RefreshTokenStore.save 는 Redis 라
- * JPA 트랜잭션 밖. AT 발급은 stateless.
+ * JPA 트랜잭션 밖. AT 발급은 stateless.</p>
  */
 @Slf4j
 @Service
 public class OAuthLoginService {
 
     private static final String DEFAULT_ROLE = "USER";
+    private static final String ADMIN_ROLE = "ADMIN";
 
     private final Map<SocialProvider, OAuthProvider> providersByType;
     private final UserApplicationService userService;
@@ -43,12 +58,19 @@ public class OAuthLoginService {
     private final RefreshTokenStore refreshTokenStore;
     private final Duration refreshTokenTtl;
 
+    /**
+     * 본인 OAuth 로그인 시 ROLE_ADMIN JWT 를 발급할 email 화이트리스트 (lowercase 정규화).
+     * 빈 set 이면 모두 USER 로 발급. {@code app.admin.user-emails} (콤마구분) 에서 주입.
+     */
+    private final Set<String> adminUserEmails;
+
     public OAuthLoginService(
             List<OAuthProvider> providers,
             UserApplicationService userService,
             JwtProvider jwtProvider,
             RefreshTokenStore refreshTokenStore,
-            JwtProperties jwtProperties
+            JwtProperties jwtProperties,
+            @Value("${app.admin.user-emails:}") String adminUserEmailsRaw
     ) {
         this.providersByType = providers.stream()
                 .collect(Collectors.toMap(OAuthProvider::supports, Function.identity()));
@@ -56,6 +78,20 @@ public class OAuthLoginService {
         this.jwtProvider = jwtProvider;
         this.refreshTokenStore = refreshTokenStore;
         this.refreshTokenTtl = Duration.ofSeconds(jwtProperties.refreshTokenValiditySeconds());
+        this.adminUserEmails = parseAdminEmails(adminUserEmailsRaw);
+        if (!adminUserEmails.isEmpty()) {
+            log.warn("[admin-oauth] OAuth role=ADMIN 발급 대상 email {}건 활성 — app.admin.user-emails. "
+                    + "운영 진입 전 의도된 대상인지 점검.", adminUserEmails.size());
+        }
+    }
+
+    private static Set<String> parseAdminEmails(String raw) {
+        if (raw == null || raw.isBlank()) return Set.of();
+        return Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(s -> s.toLowerCase(java.util.Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     public TokenPair loginWithCode(SocialProvider provider, String code, String redirectUri) {
@@ -90,13 +126,27 @@ public class OAuthLoginService {
         // 휴면 판정 기준 — 응답 status 가 ACTIVE 로 자동 복귀.
         userService.recordLogin(user.getId());
 
-        String at = jwtProvider.issueAccessToken(user.getId(), DEFAULT_ROLE);
+        // role 결정 — email allowlist 매치 시 ADMIN, 아니면 기본 USER.
+        // RefreshTokenStore 의 (role,userId) 격리 — 같은 userId 가 USER/ADMIN 양쪽 RT 보유 가능하지만
+        // 일반적으로 마지막 로그인 흐름의 role 만 사용 (logout-rotate 가 cleanup).
+        String role = isAdminEmail(user.getEmail()) ? ADMIN_ROLE : DEFAULT_ROLE;
+        if (ADMIN_ROLE.equals(role)) {
+            log.warn("[admin-oauth][PROMOTE] OAuth user.id={} email={} → role=ADMIN JWT 발급",
+                    user.getId(), user.getEmail());
+        }
+
+        String at = jwtProvider.issueAccessToken(user.getId(), role);
         // tv: store 의 현재 버전을 RT claim 에 박는다. 이후 revokeAll → INCR 시 본 RT 는 mismatch 로 거부됨.
-        long tv = refreshTokenStore.currentTokenVersion(DEFAULT_ROLE, user.getId());
-        String rt = jwtProvider.issueRefreshToken(user.getId(), DEFAULT_ROLE, tv);
+        long tv = refreshTokenStore.currentTokenVersion(role, user.getId());
+        String rt = jwtProvider.issueRefreshToken(user.getId(), role, tv);
         String rtJti = jwtProvider.parse(rt).jti();
-        refreshTokenStore.save(DEFAULT_ROLE, user.getId(), rtJti, refreshTokenTtl);
+        refreshTokenStore.save(role, user.getId(), rtJti, refreshTokenTtl);
 
         return new TokenPair(at, rt);
+    }
+
+    private boolean isAdminEmail(String email) {
+        if (email == null || adminUserEmails.isEmpty()) return false;
+        return adminUserEmails.contains(email.toLowerCase(java.util.Locale.ROOT));
     }
 }

--- a/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
@@ -81,8 +81,9 @@ public class AuthController {
     private ResponseEntity<ApiResponse<MeResponse>> setAuthCookiesWithMe(TokenPair pair) {
         ResponseCookie at = cookieUtil.accessTokenCookie(pair.accessToken());
         ResponseCookie rt = cookieUtil.refreshTokenCookie(pair.refreshToken());
-        Long userId = jwtProvider.parse(pair.accessToken()).userId();
-        MeResponse me = MeResponse.from(userService.getById(userId));
+        // JWT role claim 그대로 응답에 노출 — 프론트가 ADMIN/USER 분기 (마이페이지 → 관리 페이지 redirect 등).
+        var claims = jwtProvider.parse(pair.accessToken());
+        MeResponse me = MeResponse.from(userService.getById(claims.userId()), claims.role());
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, at.toString())
                 .header(HttpHeaders.SET_COOKIE, rt.toString())

--- a/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
@@ -85,6 +85,18 @@ public class PaymentApplicationService {
         this.escrowApplicationService = escrowApplicationService;
     }
 
+    /**
+     * 부팅 시점 skipVerify 활성 경고. dev/QA 환경에서 토스 시크릿 키 미발급 상태로 결제 흐름 검증할 때만 사용.
+     * 운영 진입 시 반드시 false 로 복귀해야 함.
+     */
+    @jakarta.annotation.PostConstruct
+    void warnIfSkipVerifyEnabled() {
+        if (Boolean.TRUE.equals(tossProperties.skipVerify())) {
+            log.warn("[!!! SKIP-VERIFY ACTIVE !!!] app.toss.skip-verify=true — 토스 confirm 검증 우회 모드 활성. "
+                    + "dev/QA 한정. 운영 진입 전 반드시 false 로 복귀 (TOSS_SKIP_VERIFY 환경변수 또는 application yml).");
+        }
+    }
+
     @Transactional
     public ChargeStartResult startCharge(ChargeStartCommand cmd) {
         if (cmd.amount() <= 0) {
@@ -131,6 +143,23 @@ public class PaymentApplicationService {
 
         // 멱등 — 이미 완료된 결제는 토스 호출 없이 그대로 반환.
         if (payment.getStatus().isPaid()) {
+            return PaymentResult.from(payment);
+        }
+
+        // skip-verify 모드 (dev/QA 한정) — 토스 시크릿 키 없는 환경에서 confirm 흐름 검증용.
+        // 1차 verifyAmount 가드는 통과한 상태 → 클라이언트 amount 그대로 신뢰. 운영 절대 사용 X (부팅 WARN 참고).
+        if (Boolean.TRUE.equals(tossProperties.skipVerify())) {
+            log.warn("[toss-confirm][SKIP-VERIFY] 토스 검증 우회 — paymentId={} merchantUid={} amount={} requesterId={}",
+                    payment.getId(), payment.getMerchantUid(), cmd.amount(), cmd.requesterId());
+            boolean newlyPaidSkip = payment.markAsPaid(
+                    "skip-" + cmd.paymentKey(),
+                    com.sseulang.domain.payment.domain.PaymentMethod.CARD,
+                    LocalDateTime.now(),
+                    "{\"skipped\":true,\"reason\":\"app.toss.skip-verify=true\"}"
+            );
+            if (newlyPaidSkip) {
+                applyPaymentConfirmedEffects(payment, "토스 충전 (skip-verify, dev 전용)");
+            }
             return PaymentResult.from(payment);
         }
 

--- a/src/main/java/com/sseulang/domain/point/application/PointApplicationService.java
+++ b/src/main/java/com/sseulang/domain/point/application/PointApplicationService.java
@@ -210,4 +210,105 @@ public class PointApplicationService {
         return pointHistoryRepository.findByUserIdAndType(userId, type, pageable)
                 .map(PointHistoryResult::from);
     }
+
+    // ───────── 라운드 11 — 거래 escrow hold 흐름 (가이드 §5.1) ─────────
+
+    /**
+     * 거래 예약 시 buyer hold — point_balance 차감 + point_hold 적립을 단일 atomic UPDATE.
+     * 거래보관 history 1건 적재 (balance_after = 차감 후 잔액).
+     *
+     * <p>잔액 부족 시 UserApplicationService 가 INSUFFICIENT_POINT throw → 트랜잭션 롤백
+     * (history 미적재).</p>
+     */
+    @Transactional
+    public void escrowHold(Long buyerId, long amount, Long transactionId, String description) {
+        if (buyerId == null || buyerId <= 0) {
+            throw new IllegalArgumentException("buyerId 는 양수여야 합니다");
+        }
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        if (transactionId == null || transactionId <= 0) {
+            throw new IllegalArgumentException("transactionId 는 양수여야 합니다");
+        }
+        userApplicationService.holdForEscrow(buyerId, amount);
+        long balanceAfter = readBalance(buyerId);
+        pointHistoryRepository.save(PointHistory.recordDebit(
+                buyerId, PointHistoryType.거래보관, amount, balanceAfter,
+                PointReferenceType.TRANSACTION, transactionId, description, LocalDateTime.now()
+        ));
+    }
+
+    /**
+     * 거래완료 (인수확인) 시 정산 — buyer hold 해제 + seller balance 적립을 한 트랜잭션.
+     *
+     * <p>가이드 §5.3 deadlock 방지: 두 user 의 잔액 변동 순서를 userId 오름차순으로 강제.
+     * buyer 의 hold 해제는 잔액 변화 X 라 history 미적재 (Aggregate 정책 — V16/PointHistoryType 주석 동기).
+     * seller 는 판매정산 history 1건 적재.</p>
+     *
+     * <p>buyer hold 부족 시 UserApplicationService 가 TRANSACTION_HOLD_FAILED throw — 운영 이상,
+     * seller 선행 적립도 롤백.</p>
+     */
+    @Transactional
+    public void escrowRelease(
+            Long buyerId,
+            Long sellerId,
+            long amount,
+            Long transactionId,
+            String description
+    ) {
+        if (buyerId == null || sellerId == null) {
+            throw new IllegalArgumentException("buyerId / sellerId 는 필수입니다");
+        }
+        if (buyerId.equals(sellerId)) {
+            throw new IllegalArgumentException("buyer 와 seller 는 같을 수 없습니다");
+        }
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        if (transactionId == null || transactionId <= 0) {
+            throw new IllegalArgumentException("transactionId 는 양수여야 합니다");
+        }
+        if (buyerId < sellerId) {
+            userApplicationService.releaseHold(buyerId, amount);
+            creditSellerSettlement(sellerId, amount, transactionId, description);
+        } else {
+            creditSellerSettlement(sellerId, amount, transactionId, description);
+            userApplicationService.releaseHold(buyerId, amount);
+        }
+    }
+
+    /**
+     * 거래 취소 시 buyer 환불 — point_hold 차감 + point_balance 적립을 단일 atomic UPDATE.
+     * 거래환불 history 1건 적재 (balance_after = 적립 후 잔액). seller 잔액 변동 X (정산 전이라).
+     *
+     * <p>buyer hold 부족 시 UserApplicationService 가 TRANSACTION_HOLD_FAILED throw → 운영 이상.</p>
+     */
+    @Transactional
+    public void escrowRefund(Long buyerId, long amount, Long transactionId, String description) {
+        if (buyerId == null || buyerId <= 0) {
+            throw new IllegalArgumentException("buyerId 는 양수여야 합니다");
+        }
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        if (transactionId == null || transactionId <= 0) {
+            throw new IllegalArgumentException("transactionId 는 양수여야 합니다");
+        }
+        userApplicationService.refundHold(buyerId, amount);
+        long balanceAfter = readBalance(buyerId);
+        pointHistoryRepository.save(PointHistory.recordCredit(
+                buyerId, PointHistoryType.거래환불, amount, balanceAfter,
+                PointReferenceType.TRANSACTION, transactionId, description, LocalDateTime.now()
+        ));
+    }
+
+    private void creditSellerSettlement(Long sellerId, long amount, Long transactionId, String description) {
+        userApplicationService.creditPoint(sellerId, amount);
+        long balanceAfter = readBalance(sellerId);
+        pointHistoryRepository.save(PointHistory.recordCredit(
+                sellerId, PointHistoryType.판매정산, amount, balanceAfter,
+                PointReferenceType.TRANSACTION, transactionId, description, LocalDateTime.now()
+        ));
+    }
 }

--- a/src/main/java/com/sseulang/domain/point/domain/PointHistory.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointHistory.java
@@ -142,8 +142,10 @@ public class PointHistory {
         if (type != PointHistoryType.충전
                 && type != PointHistoryType.판매정산
                 && type != PointHistoryType.환불
-                && type != PointHistoryType.배달정산) {
-            throw new IllegalArgumentException("recordCredit 은 충전 / 판매정산 / 환불 / 배달정산 type 만 허용: " + type);
+                && type != PointHistoryType.배달정산
+                && type != PointHistoryType.거래환불) {
+            throw new IllegalArgumentException(
+                    "recordCredit 은 충전 / 판매정산 / 환불 / 배달정산 / 거래환불 type 만 허용: " + type);
         }
     }
 
@@ -151,8 +153,10 @@ public class PointHistory {
         if (type != PointHistoryType.결제
                 && type != PointHistoryType.출금
                 && type != PointHistoryType.환불
-                && type != PointHistoryType.배달결제) {
-            throw new IllegalArgumentException("recordDebit 은 결제 / 출금 / 환불 / 배달결제 type 만 허용: " + type);
+                && type != PointHistoryType.배달결제
+                && type != PointHistoryType.거래보관) {
+            throw new IllegalArgumentException(
+                    "recordDebit 은 결제 / 출금 / 환불 / 배달결제 / 거래보관 type 만 허용: " + type);
         }
     }
 }

--- a/src/main/java/com/sseulang/domain/point/domain/PointHistoryType.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointHistoryType.java
@@ -5,13 +5,18 @@ package com.sseulang.domain.point.domain;
  *
  * <ul>
  *   <li>{@link #충전} — 토스 결제로 잔액 증가 (Day 7)</li>
- *   <li>{@link #결제} — 거래 결제 시 구매자 잔액 차감 (Day 8)</li>
- *   <li>{@link #판매정산} — 거래 결제 시 판매자 잔액 적립 (Day 8)</li>
+ *   <li>{@link #결제} — 거래 결제 시 구매자 잔액 차감 (Day 8 — 즉시 정산 정책. 라운드 11 부터는 사용 X)</li>
+ *   <li>{@link #판매정산} — 거래 정산 시 판매자 잔액 적립 (Day 8 / 라운드 11 인수확인)</li>
  *   <li>{@link #출금} — 출금 신청 시 잔액 차감 (Day 8)</li>
- *   <li>{@link #환불} — 거래 취소 시 양쪽 잔액 원복 (Day 8)</li>
+ *   <li>{@link #환불} — Day 8 거래 취소 시 양쪽 잔액 원복 (라운드 11 부터는 거래환불로 분리)</li>
  *   <li>{@link #배달결제} — 배달 정산 시 요청자 잔액 차감 (Day 9)</li>
  *   <li>{@link #배달정산} — 배달 정산 시 라이더 잔액 적립 (Day 9)</li>
+ *   <li>{@link #거래보관} — 라운드 11 예약 시 buyer balance↓ + hold↑ (escrow hold). 프론트 라벨 "거래 #N 보관".</li>
+ *   <li>{@link #거래환불} — 라운드 11 거래 취소 시 buyer balance↑ + hold↓. 프론트 라벨 "거래 #N 취소 환불".</li>
  * </ul>
+ *
+ * <p>라운드 11 인수확인 시 buyer 의 hold 해제는 잔액 변화 X 이므로 history 미적재 (Aggregate 정책 — V16 주석 동기).
+ * seller 의 정산 적립은 기존 {@link #판매정산} 활용, 프론트 라벨 "거래 #N 정산 수령".</p>
  */
 public enum PointHistoryType {
     충전,
@@ -20,5 +25,7 @@ public enum PointHistoryType {
     출금,
     환불,
     배달결제,
-    배달정산
+    배달정산,
+    거래보관,
+    거래환불
 }

--- a/src/main/java/com/sseulang/domain/point/presentation/PointController.java
+++ b/src/main/java/com/sseulang/domain/point/presentation/PointController.java
@@ -2,7 +2,9 @@ package com.sseulang.domain.point.presentation;
 
 import com.sseulang.domain.point.application.PointApplicationService;
 import com.sseulang.domain.point.domain.PointHistoryType;
+import com.sseulang.domain.point.presentation.dto.PointBalanceResponse;
 import com.sseulang.domain.point.presentation.dto.PointHistoryResponse;
+import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.global.common.ApiResponse;
 import com.sseulang.global.common.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,10 +19,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 본인 포인트 관련 endpoint. 잔액은 {@code GET /api/v1/users/me} 의 {@code pointBalance} 로 노출되므로
- * 별도 balance endpoint 는 두지 않음. 본 컨트롤러는 history 페이징만.
+ * 본인 포인트 관련 endpoint. 라운드 11: 잔액 페이지 3분할 표시용 balance endpoint 추가
+ * (사용 가능 / 거래 보관 / 합산). 헤더/카드 용도는 GET /users/me 의 pointBalance + pointHold 활용.
  */
-@Tag(name = "Point", description = "본인 포인트 히스토리 페이징")
+@Tag(name = "Point", description = "본인 포인트 잔액 / 히스토리")
 @RestController
 @RequestMapping("/api/v1/users/me/point")
 public class PointController {
@@ -28,14 +30,28 @@ public class PointController {
     private static final int MAX_PAGE_SIZE = 100;
 
     private final PointApplicationService pointService;
+    private final UserApplicationService userApplicationService;
 
-    public PointController(PointApplicationService pointService) {
+    public PointController(
+            PointApplicationService pointService,
+            UserApplicationService userApplicationService
+    ) {
         this.pointService = pointService;
+        this.userApplicationService = userApplicationService;
+    }
+
+    @Operation(summary = "본인 포인트 잔액 (라운드 11)",
+            description = "사용 가능(balance) / 거래 보관(holdAmount) / 합산(totalBalance) 3분할. "
+                    + "두 컬럼을 단일 SELECT 로 읽어 동시 reserve/cancel/refund 사이의 합산 어긋남 방지 (게이트 1 W-1).")
+    @GetMapping
+    public ApiResponse<PointBalanceResponse> getMyBalance(@AuthenticationPrincipal Long userId) {
+        var snapshot = userApplicationService.getPointSnapshot(userId);
+        return ApiResponse.ok(PointBalanceResponse.of(snapshot.balance(), snapshot.hold()));
     }
 
     @Operation(summary = "본인 포인트 히스토리 페이징",
-            description = "잔액 변동 내역 (충전/결제/판매정산/출금/환불/배달결제/배달정산). type 미지정 시 전체. "
-                    + "정렬: createdAt DESC. 잔액 자체는 GET /users/me 의 pointBalance 사용.")
+            description = "잔액 변동 내역 (충전/결제/판매정산/출금/환불/배달결제/배달정산/거래보관/거래환불). "
+                    + "type 미지정 시 전체. 정렬: createdAt DESC. 잔액 자체는 GET /api/v1/users/me/point 또는 GET /users/me 사용.")
     @GetMapping("/history")
     public ApiResponse<PageResponse<PointHistoryResponse>> getMyHistory(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/sseulang/domain/point/presentation/dto/PointBalanceResponse.java
+++ b/src/main/java/com/sseulang/domain/point/presentation/dto/PointBalanceResponse.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.point.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 본인 포인트 잔액 응답 — 라운드 11 (B-1 A안 합의). 잔액 페이지에서 3분할 표시:
+ * "{balance}P 사용 가능 · {holdAmount}P 거래 보관 중 · 총 {totalBalance}P".
+ */
+@Schema(description = "본인 포인트 잔액 — 사용 가능 / 거래 보관 / 합산 3분할.")
+public record PointBalanceResponse(
+        @Schema(example = "50000", description = "즉시 사용 가능 (point_balance)") long balance,
+        @Schema(example = "10000", description = "진행 중 거래에 hold 된 금액 (point_hold)") long holdAmount,
+        @Schema(example = "60000", description = "balance + holdAmount") long totalBalance
+) {
+    public static PointBalanceResponse of(long balance, long holdAmount) {
+        return new PointBalanceResponse(balance, holdAmount, balance + holdAmount);
+    }
+}

--- a/src/main/java/com/sseulang/domain/point/presentation/dto/PointHistoryResponse.java
+++ b/src/main/java/com/sseulang/domain/point/presentation/dto/PointHistoryResponse.java
@@ -10,10 +10,10 @@ import java.time.LocalDateTime;
 @Schema(description = "포인트 히스토리 row — 마이페이지 잔액 변동 내역. amount 는 부호 포함 (+ 적립, - 차감).")
 public record PointHistoryResponse(
         @Schema(example = "200") Long id,
-        @Schema(description = "변동 타입 — 충전/결제/판매정산/출금/환불/배달결제/배달정산") PointHistoryType type,
+        @Schema(description = "변동 타입 — 충전/결제/판매정산/출금/환불/배달결제/배달정산/거래보관/거래환불 (라운드 11)") PointHistoryType type,
         @Schema(example = "50000", description = "+ 적립 / - 차감 부호 포함") long amount,
         @Schema(example = "80000", description = "변동 직후 잔액 스냅샷") long balanceAfter,
-        @Schema(description = "참조 도메인 — PAYMENT/TRANSACTION/WITHDRAWAL/DELIVERY/REFUND") PointReferenceType referenceType,
+        @Schema(description = "참조 도메인 — PAYMENT/TRANSACTION/WITHDRAWAL/DELIVERY/ESCROW") PointReferenceType referenceType,
         @Schema(example = "78", description = "참조 도메인 row id (예 paymentId, transactionId)") Long referenceId,
         @Schema(example = "토스 충전") String description,
         LocalDateTime createdAt

--- a/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
+++ b/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
@@ -76,6 +76,11 @@ public class UserReportApplicationService {
         return findOrThrow(reportId);
     }
 
+    /** 차트 dashboard summary — 처리 대기 (접수 + 처리중) 신고 수. */
+    public long countPending() {
+        return repository.countPending();
+    }
+
     private UserReport findOrThrow(Long reportId) {
         return repository.findById(reportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REPORT_NOT_FOUND));

--- a/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
+++ b/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
@@ -19,4 +19,7 @@ public interface UserReportRepository {
      * 빈 입력은 빈 맵. 단일 GROUP BY 쿼리 — N+1 회피.
      */
     java.util.Map<Long, Long> countByTargetUserIds(java.util.Collection<Long> targetUserIds);
+
+    /** 차트 dashboard summary — 처리 대기 신고 수 (status IN (접수, 처리중)). */
+    long countPending();
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
@@ -29,4 +29,8 @@ interface UserReportJpaRepository extends JpaRepository<UserReport, Long> {
         Long getUserId();
         Long getCnt();
     }
+
+    /** 차트 dashboard summary — 처리 대기 (접수 또는 처리중) 신고 수. */
+    @Query("SELECT COUNT(r) FROM UserReport r WHERE r.status IN (com.sseulang.domain.report.domain.ReportStatus.접수, com.sseulang.domain.report.domain.ReportStatus.처리중)")
+    long countPending();
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
@@ -44,4 +44,9 @@ public class UserReportRepositoryImpl implements UserReportRepository {
         }
         return result;
     }
+
+    @Override
+    public long countPending() {
+        return jpa.countPending();
+    }
 }

--- a/src/main/java/com/sseulang/domain/stats/application/AdminDashboardChartsResult.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminDashboardChartsResult.java
@@ -1,0 +1,44 @@
+package com.sseulang.domain.stats.application;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 관리자 대시보드 차트 데이터 — recharts 친화 (date ASC, 빈 일자 0 채움).
+ *
+ * <p>프론트 합의 (옵션 A'):
+ * <ul>
+ *   <li>summary: 카드 4종 + 비교값</li>
+ *   <li>signupTrend: 일자별 가입자 (AreaChart)</li>
+ *   <li>tradeByType: TradeType 별 (BarChart) — 한국어 enum</li>
+ *   <li>tradeByStatus: 진행중/완료/취소 3분류 (PieChart) — 라운드 11 5단계 그룹핑</li>
+ * </ul>
+ */
+public record AdminDashboardChartsResult(
+        Summary summary,
+        List<DailyCount> signupTrend,
+        List<TradeTypeCount> tradeByType,
+        List<StatusGroupCount> tradeByStatus
+) {
+    public record Summary(
+            UsersSummary users,
+            TodaySignupsSummary todaySignups,
+            MonthTradesSummary monthTrades,
+            long pendingReports
+    ) { }
+
+    public record UsersSummary(long total, long monthDelta) { }
+
+    public record TodaySignupsSummary(long count, long yesterdayDelta) { }
+
+    /** prevMonthRate: 전월 대비 증감률. 전월 0이면 null. */
+    public record MonthTradesSummary(long count, Double prevMonthRate) { }
+
+    public record DailyCount(LocalDate date, long count) { }
+
+    /** tradeType: 한국어 enum (판매/대여/나눔). */
+    public record TradeTypeCount(String type, long count) { }
+
+    /** group: 진행중/완료/취소. */
+    public record StatusGroupCount(String status, long count) { }
+}

--- a/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
@@ -10,8 +10,23 @@ import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.domain.user.application.dto.UserStatsResult;
 import com.sseulang.domain.withdrawal.application.WithdrawalApplicationService;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
+import com.sseulang.domain.report.application.UserReportApplicationService;
+import com.sseulang.domain.transaction.domain.TransactionStatus;
+import com.sseulang.domain.transaction.domain.TransactionStatusCount;
+import com.sseulang.domain.transaction.domain.TransactionRepository;
+import com.sseulang.domain.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * 관리자 dashboard 통계 — 4개 도메인 ApplicationService 를 호출하여 단순 조립.
@@ -32,19 +47,25 @@ public class AdminStatsService {
     private final PaymentApplicationService paymentService;
     private final WithdrawalApplicationService withdrawalService;
     private final DeliveryApplicationService deliveryService;
+    private final UserReportApplicationService userReportService;
+    private final Clock clock;
 
     public AdminStatsService(
             UserApplicationService userService,
             TransactionApplicationService transactionService,
             PaymentApplicationService paymentService,
             WithdrawalApplicationService withdrawalService,
-            DeliveryApplicationService deliveryService
+            DeliveryApplicationService deliveryService,
+            UserReportApplicationService userReportService,
+            Clock clock
     ) {
         this.userService = userService;
         this.transactionService = transactionService;
         this.paymentService = paymentService;
         this.withdrawalService = withdrawalService;
         this.deliveryService = deliveryService;
+        this.userReportService = userReportService;
+        this.clock = clock;
     }
 
     public AdminDashboardResult dashboard() {
@@ -60,5 +81,106 @@ public class AdminStatsService {
     public java.util.List<com.sseulang.domain.transaction.domain.TransactionMonthlyStat> tradesMonthly(
             java.time.YearMonth from, java.time.YearMonth to) {
         return transactionService.adminMonthlyTrades(from, to);
+    }
+
+    /**
+     * 차트 dashboard — summary 카드 + signupTrend + tradeByType + tradeByStatus 한 번에.
+     * 기간 [startDate 00:00, endDate 23:59:59.999) — endDate 도 inclusive day.
+     * default (양쪽 null): 최근 14일 (today-13 ~ today).
+     */
+    public AdminDashboardChartsResult dashboardCharts(LocalDate startDate, LocalDate endDate) {
+        LocalDate today = LocalDate.now(clock);
+        LocalDate end = (endDate != null) ? endDate : today;
+        LocalDate start = (startDate != null) ? startDate : end.minusDays(13);
+        if (start.isAfter(end)) {
+            throw new IllegalArgumentException("startDate 가 endDate 보다 미래일 수 없습니다");
+        }
+
+        LocalDateTime fromTs = start.atStartOfDay();
+        LocalDateTime toExclusive = end.plusDays(1).atStartOfDay();
+
+        return new AdminDashboardChartsResult(
+                buildSummary(today),
+                buildSignupTrend(start, end, fromTs, toExclusive),
+                buildTradeByType(fromTs, toExclusive),
+                buildTradeByStatus(fromTs, toExclusive)
+        );
+    }
+
+    private AdminDashboardChartsResult.Summary buildSummary(LocalDate today) {
+        // users
+        long totalUsers = userService.adminGetStats().total();
+        LocalDateTime monthStart = today.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime tomorrow = today.plusDays(1).atStartOfDay();
+        long monthDelta = userService.countSignupsBetween(monthStart, tomorrow);
+
+        // today signups
+        LocalDateTime todayStart = today.atStartOfDay();
+        long todayCount = userService.countSignupsBetween(todayStart, tomorrow);
+        long yesterdayCount = userService.countSignupsBetween(today.minusDays(1).atStartOfDay(), todayStart);
+        long yesterdayDelta = todayCount - yesterdayCount;
+
+        // month trades — TransactionMonthlyStat 활용 (status=거래완료, completed_at 기준)
+        YearMonth thisMonth = YearMonth.from(today);
+        YearMonth prevMonth = thisMonth.minusMonths(1);
+        var monthly = transactionService.adminMonthlyTrades(prevMonth, thisMonth);
+        long thisMonthTrades = monthly.stream().filter(m -> m.month().equals(thisMonth)).mapToLong(m -> m.count()).sum();
+        long prevMonthTrades = monthly.stream().filter(m -> m.month().equals(prevMonth)).mapToLong(m -> m.count()).sum();
+        Double prevMonthRate = prevMonthTrades == 0
+                ? null
+                : (thisMonthTrades - prevMonthTrades) / (double) prevMonthTrades;
+
+        // pending reports
+        long pendingReports = userReportService.countPending();
+
+        return new AdminDashboardChartsResult.Summary(
+                new AdminDashboardChartsResult.UsersSummary(totalUsers, monthDelta),
+                new AdminDashboardChartsResult.TodaySignupsSummary(todayCount, yesterdayDelta),
+                new AdminDashboardChartsResult.MonthTradesSummary(thisMonthTrades, prevMonthRate),
+                pendingReports
+        );
+    }
+
+    private List<AdminDashboardChartsResult.DailyCount> buildSignupTrend(
+            LocalDate start, LocalDate end, LocalDateTime fromTs, LocalDateTime toExclusive) {
+        var raw = userService.findDailySignups(fromTs, toExclusive);
+        Map<LocalDate, Long> rawMap = new TreeMap<>();
+        for (var r : raw) rawMap.put(r.date(), r.count());
+        List<AdminDashboardChartsResult.DailyCount> filled = new ArrayList<>();
+        for (LocalDate d = start; !d.isAfter(end); d = d.plusDays(1)) {
+            filled.add(new AdminDashboardChartsResult.DailyCount(d, rawMap.getOrDefault(d, 0L)));
+        }
+        return filled;
+    }
+
+    private List<AdminDashboardChartsResult.TradeTypeCount> buildTradeByType(
+            LocalDateTime fromTs, LocalDateTime toExclusive) {
+        var raw = transactionService.countByTradeTypeBetween(fromTs, toExclusive);
+        // 한국어 enum 이름 그대로 (판매/대여/나눔). 빈 type 은 0 채움 — TradeType 모든 값 포함.
+        Map<com.sseulang.domain.item.domain.TradeType, Long> rawMap = new EnumMap<>(com.sseulang.domain.item.domain.TradeType.class);
+        for (var r : raw) rawMap.put(r.tradeType(), r.count());
+        List<AdminDashboardChartsResult.TradeTypeCount> result = new ArrayList<>();
+        for (var t : com.sseulang.domain.item.domain.TradeType.values()) {
+            result.add(new AdminDashboardChartsResult.TradeTypeCount(t.name(), rawMap.getOrDefault(t, 0L)));
+        }
+        return result;
+    }
+
+    private List<AdminDashboardChartsResult.StatusGroupCount> buildTradeByStatus(
+            LocalDateTime fromTs, LocalDateTime toExclusive) {
+        var raw = transactionService.countByStatusBetween(fromTs, toExclusive);
+        long inProgress = 0, completed = 0, canceled = 0;
+        for (TransactionStatusCount r : raw) {
+            switch (r.status()) {
+                case 채팅중, 예약, 인계완료 -> inProgress += r.count();
+                case 거래완료 -> completed += r.count();
+                case 취소 -> canceled += r.count();
+            }
+        }
+        return List.of(
+                new AdminDashboardChartsResult.StatusGroupCount("진행중", inProgress),
+                new AdminDashboardChartsResult.StatusGroupCount("완료", completed),
+                new AdminDashboardChartsResult.StatusGroupCount("취소", canceled)
+        );
     }
 }

--- a/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
@@ -45,4 +45,22 @@ public class AdminStatsController {
                 .map(com.sseulang.domain.stats.presentation.dto.MonthlyTradeStatResponse::from)
                 .toList());
     }
+
+    @Operation(summary = "차트 dashboard (recharts 친화)",
+            description = "카드 4종 + signupTrend(AreaChart) + tradeByType(BarChart) + tradeByStatus(PieChart). "
+                    + "기간 [startDate 00:00, endDate 23:59:59.999) — endDate inclusive. "
+                    + "default (양쪽 미지정): 최근 14일 (today-13 ~ today).")
+    @GetMapping("/dashboard/charts")
+    public ApiResponse<com.sseulang.domain.stats.presentation.dto.AdminDashboardChartsResponse> dashboardCharts(
+            @org.springframework.web.bind.annotation.RequestParam(name = "startDate", required = false)
+            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
+            java.time.LocalDate startDate,
+            @org.springframework.web.bind.annotation.RequestParam(name = "endDate", required = false)
+            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
+            java.time.LocalDate endDate
+    ) {
+        return ApiResponse.ok(com.sseulang.domain.stats.presentation.dto.AdminDashboardChartsResponse.from(
+                statsService.dashboardCharts(startDate, endDate)
+        ));
+    }
 }

--- a/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardChartsResponse.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardChartsResponse.java
@@ -1,0 +1,68 @@
+package com.sseulang.domain.stats.presentation.dto;
+
+import com.sseulang.domain.stats.application.AdminDashboardChartsResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Schema(description = "관리자 차트 dashboard — 카드 4종 + 차트 3종 (signupTrend / tradeByType / tradeByStatus).")
+public record AdminDashboardChartsResponse(
+        Summary summary,
+        List<DailyCount> signupTrend,
+        List<TradeTypeCount> tradeByType,
+        List<StatusGroupCount> tradeByStatus
+) {
+    public static AdminDashboardChartsResponse from(AdminDashboardChartsResult r) {
+        return new AdminDashboardChartsResponse(
+                Summary.from(r.summary()),
+                r.signupTrend().stream().map(s -> new DailyCount(s.date(), s.count())).toList(),
+                r.tradeByType().stream().map(t -> new TradeTypeCount(t.type(), t.count())).toList(),
+                r.tradeByStatus().stream().map(s -> new StatusGroupCount(s.status(), s.count())).toList()
+        );
+    }
+
+    @Schema(description = "요약 카드 4종 + 비교값.")
+    public record Summary(
+            UsersSummary users,
+            TodaySignupsSummary todaySignups,
+            MonthTradesSummary monthTrades,
+            @Schema(example = "7") long pendingReports
+    ) {
+        static Summary from(AdminDashboardChartsResult.Summary s) {
+            return new Summary(
+                    new UsersSummary(s.users().total(), s.users().monthDelta()),
+                    new TodaySignupsSummary(s.todaySignups().count(), s.todaySignups().yesterdayDelta()),
+                    new MonthTradesSummary(s.monthTrades().count(), s.monthTrades().prevMonthRate()),
+                    s.pendingReports()
+            );
+        }
+    }
+
+    public record UsersSummary(
+            @Schema(example = "1284") long total,
+            @Schema(example = "89", description = "이번 달(1일~today) 신규 가입자 수") long monthDelta
+    ) { }
+
+    public record TodaySignupsSummary(
+            @Schema(example = "15") long count,
+            @Schema(example = "3", description = "오늘 - 어제. 음수 가능") long yesterdayDelta
+    ) { }
+
+    public record MonthTradesSummary(
+            @Schema(example = "316", description = "이번 달 거래완료 수 (completed_at 기준)") long count,
+            @Schema(example = "0.12", description = "(이번달-전월)/전월. 전월 0이면 null", nullable = true) Double prevMonthRate
+    ) { }
+
+    public record DailyCount(@Schema(example = "2026-04-23") LocalDate date, @Schema(example = "5") long count) { }
+
+    public record TradeTypeCount(
+            @Schema(example = "판매", description = "TradeType — 한국어 enum (판매/대여/나눔)") String type,
+            @Schema(example = "120") long count
+    ) { }
+
+    public record StatusGroupCount(
+            @Schema(example = "진행중", description = "그룹: 진행중/완료/취소 (라운드 11 5단계 → 3 그룹핑)") String status,
+            @Schema(example = "56") long count
+    ) { }
+}

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -273,6 +273,18 @@ public class TransactionApplicationService {
         return new ReviewableTransactionResult(tx.getId(), requesterId, revieweeId, tx.getCompletedAt());
     }
 
+    /** 차트 dashboard — 기간 [from, to) tradeType 별 카운트 (created_at 기준). */
+    public java.util.List<com.sseulang.domain.transaction.domain.TransactionRepository.TradeTypeCount>
+            countByTradeTypeBetween(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return transactionRepository.countByTradeTypeBetween(from, to);
+    }
+
+    /** 차트 dashboard — 기간 [from, to) status 별 카운트 (라운드 11 5단계, created_at 기준). */
+    public java.util.List<TransactionStatusCount> countByStatusBetween(
+            java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return transactionRepository.countByStatusBetween(from, to);
+    }
+
     /**
      * 관리자 거래 통계 — total + status 별 카운트. byStatus 는 enum 모든 값 포함 (없는 status 는 0L).
      * 단일 GROUP BY 쿼리 — N+1 없음.

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -3,7 +3,6 @@ package com.sseulang.domain.transaction.application;
 import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.domain.item.application.dto.ItemForTransactionResult;
 import com.sseulang.domain.point.application.PointApplicationService;
-import com.sseulang.domain.point.domain.PointReferenceType;
 import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.domain.transaction.application.dto.PendingReviewableResult;
 import com.sseulang.domain.transaction.application.dto.ReviewableTransactionResult;
@@ -15,8 +14,13 @@ import com.sseulang.domain.transaction.domain.Transaction;
 import com.sseulang.domain.transaction.domain.TransactionRepository;
 import com.sseulang.domain.transaction.domain.TransactionStatus;
 import com.sseulang.domain.transaction.domain.TransactionStatusCount;
+import com.sseulang.domain.transaction.domain.event.TransactionCanceledEvent;
+import com.sseulang.domain.transaction.domain.event.TransactionHandoverConfirmedEvent;
+import com.sseulang.domain.transaction.domain.event.TransactionReceiveConfirmedEvent;
+import com.sseulang.domain.transaction.domain.event.TransactionReservedEvent;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -49,6 +53,7 @@ public class TransactionApplicationService {
     private final ItemApplicationService itemApplicationService;
     private final PointApplicationService pointApplicationService;
     private final UserApplicationService userApplicationService;
+    private final ApplicationEventPublisher eventPublisher;
     private final java.time.Clock clock;
 
     public TransactionApplicationService(
@@ -56,12 +61,14 @@ public class TransactionApplicationService {
             ItemApplicationService itemApplicationService,
             PointApplicationService pointApplicationService,
             UserApplicationService userApplicationService,
+            ApplicationEventPublisher eventPublisher,
             java.time.Clock clock
     ) {
         this.transactionRepository = transactionRepository;
         this.itemApplicationService = itemApplicationService;
         this.pointApplicationService = pointApplicationService;
         this.userApplicationService = userApplicationService;
+        this.eventPublisher = eventPublisher;
         this.clock = clock;
     }
 
@@ -86,6 +93,23 @@ public class TransactionApplicationService {
         return transactionRepository.save(tx).getId();
     }
 
+    /**
+     * 거래 예약 — seller 가 호출. 라운드 11 흐름:
+     * <ol>
+     *   <li>Transaction 비관적 락 (findByIdForUpdate)</li>
+     *   <li>seller 권한 가드 (TRANSACTION_FORBIDDEN)</li>
+     *   <li>Item 락 + markItemAsReserved (락 순서 Transaction → Item — deadlock 회피)</li>
+     *   <li>Transaction.markAsReserved(now, price) — escrowHoldAmount 동기 set</li>
+     *   <li>price &gt; 0 이면 PointApplicationService.escrowHold — buyer point_balance↓ + point_hold↑
+     *       + 거래보관 history. 잔액 부족 시 INSUFFICIENT_POINT 트랜잭션 롤백 (Item/Tx 도 원복).</li>
+     * </ol>
+     *
+     * <p>락 순서: Transaction → Item → User(buyer). 다른 거래의 reserve 와는 Item 락이, 같은 buyer 의
+     * 다른 거래 reserve 동시 시도는 buyer 행 락이 직렬화. 두 거래 모두 잔액 충분이면 차례로 통과,
+     * 한 쪽만 충분이면 다른 쪽은 INSUFFICIENT_POINT.</p>
+     *
+     * <p>나눔 거래 (price=0) 는 escrowHold 호출 X — escrowHoldAmount 도 0.</p>
+     */
     @Transactional
     public void reserve(Long transactionId, Long requesterId) {
         Transaction tx = findOrThrowForUpdate(transactionId);
@@ -94,43 +118,99 @@ public class TransactionApplicationService {
         }
         // Item 락 + 상태 전이 — 락 순서 Transaction → Item 고정 (deadlock 회피)
         itemApplicationService.markItemAsReserved(tx.getItemId());
-        tx.markAsReserved(LocalDateTime.now(clock));
+        LocalDateTime now = LocalDateTime.now(clock);
+        long holdAmount = tx.getPrice();
+        tx.markAsReserved(now, holdAmount);
+        if (holdAmount > 0) {
+            pointApplicationService.escrowHold(
+                    tx.getBuyerId(),
+                    holdAmount,
+                    tx.getId(),
+                    "거래 #" + tx.getId() + " 보관"
+            );
+        }
+        eventPublisher.publishEvent(new TransactionReservedEvent(
+                tx.getId(), tx.getBuyerId(), tx.getSellerId(), tx.getPrice()));
     }
 
     /**
-     * 거래 완료 — Day 8 활성화. 흐름:
-     * <ol>
-     *   <li>Transaction 비관적 락 → seller 권한 검증 + 상태 검증 (예약 상태에서만 완료 가능)</li>
-     *   <li>Item 락 → markAsSold (락 순서 Transaction → Item 고정, deadlock 방지)</li>
-     *   <li>PointApplicationService.transfer — buyer 차감 → seller 적립 (id-asc 락 순서, 가이드 §5.3) + history 두 건 적재</li>
-     *   <li>Transaction.markAsCompleted</li>
-     * </ol>
+     * 라운드 11 — seller 인계확인. 예약 → 인계완료 전이.
      *
-     * <p>buyer 잔액 부족 → INSUFFICIENT_POINT 트랜잭션 롤백 → seller 의 선행 적립도 함께 원복 (정합성 보장).</p>
-     * <p>현재 PR 범위는 price 정산만. 대여 보증금 처리는 가이드 §4.13 — 관리자 수동 (Day 9 영역).</p>
+     * <ul>
+     *   <li>seller 가 아니면 TRANSACTION_HANDOVER_NOT_ALLOWED</li>
+     *   <li>이미 인계완료 상태이면 멱등 (no-op) — PATCH 재시도 시 사용자 혼란 방지</li>
+     *   <li>그 외 status (채팅중/거래완료/취소) 에서 호출 시 TRANSACTION_INVALID_STATE</li>
+     * </ul>
+     *
+     * <p>buyer 잔액/hold 변동 X — 단순 status 전이. Item 도 변동 X (markAsSold 는 markReceived 시점).</p>
      */
     @Transactional
-    public void complete(Long transactionId, Long requesterId) {
+    public void markHandover(Long transactionId, Long requesterId) {
         Transaction tx = findOrThrowForUpdate(transactionId);
         if (!tx.isSeller(requesterId)) {
-            throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
+            throw new BusinessException(ErrorCode.TRANSACTION_HANDOVER_NOT_ALLOWED);
         }
-        // Item 락 + 상태 전이 — 락 순서 Transaction → Item 고정 (deadlock 회피, reserve/cancel 와 동일)
-        itemApplicationService.markItemAsSold(tx.getItemId());
-        // 포인트 정산 — price > 0 인 거래만 (나눔 거래는 0 일 수 있음, 가이드 §4.11)
-        if (tx.getPrice() > 0) {
-            pointApplicationService.transfer(
-                    tx.getBuyerId(),
-                    tx.getSellerId(),
-                    tx.getPrice(),
-                    PointReferenceType.TRANSACTION,
-                    tx.getId(),
-                    "거래 결제: tx#" + tx.getId()
-            );
+        if (tx.getStatus() == TransactionStatus.인계완료) {
+            return;  // 멱등 — 이미 인계완료
         }
-        tx.markAsCompleted(LocalDateTime.now(clock));
+        tx.markHandover(LocalDateTime.now(clock));
+        eventPublisher.publishEvent(new TransactionHandoverConfirmedEvent(tx.getId(), tx.getBuyerId()));
     }
 
+    /**
+     * 라운드 11 — buyer 인수확인. 인계완료 → 거래완료 자동 전이 + 정산.
+     *
+     * <ol>
+     *   <li>Transaction 락 + buyer 권한 가드 (TRANSACTION_RECEIVE_NOT_ALLOWED)</li>
+     *   <li>이미 거래완료 상태이면 멱등 (no-op)</li>
+     *   <li>Item 락 + markItemAsSold (락 순서 Transaction → Item — reserve 와 동일)</li>
+     *   <li>escrowHoldAmount &gt; 0 이면 PointApplicationService.escrowRelease — buyer hold↓ + seller balance↑
+     *       (id-asc 락 순서, 가이드 §5.3) + 판매정산 history 1건</li>
+     *   <li>Transaction.markReceived — status=거래완료, receiveConfirmedAt + completedAt 동기 set</li>
+     * </ol>
+     *
+     * <p>buyer hold 부족 (운영 이상) → TRANSACTION_HOLD_FAILED. 트랜잭션 롤백으로 Item / Tx / 잔액
+     * 모두 원복. 나눔 거래 (escrowHoldAmount=0) 는 escrowRelease skip.</p>
+     */
+    @Transactional
+    public void markReceived(Long transactionId, Long requesterId) {
+        Transaction tx = findOrThrowForUpdate(transactionId);
+        if (!tx.isBuyer(requesterId)) {
+            throw new BusinessException(ErrorCode.TRANSACTION_RECEIVE_NOT_ALLOWED);
+        }
+        if (tx.getStatus() == TransactionStatus.거래완료) {
+            return;  // 멱등 — 이미 거래완료
+        }
+        // Item 락 + markAsSold (락 순서 Transaction → Item)
+        itemApplicationService.markItemAsSold(tx.getItemId());
+        long settleAmount = tx.getEscrowHoldAmount();
+        if (settleAmount > 0) {
+            pointApplicationService.escrowRelease(
+                    tx.getBuyerId(),
+                    tx.getSellerId(),
+                    settleAmount,
+                    tx.getId(),
+                    "거래 #" + tx.getId() + " 정산 수령"
+            );
+        }
+        tx.markReceived(LocalDateTime.now(clock));
+        eventPublisher.publishEvent(new TransactionReceiveConfirmedEvent(
+                tx.getId(), tx.getSellerId(), settleAmount));
+    }
+
+    /**
+     * 거래 취소 — 양쪽 참여자 누구나 호출. 라운드 11 단계별 환불:
+     *
+     * <ul>
+     *   <li>채팅중 단계: hold 없음 → 단순 status 전이만</li>
+     *   <li>예약 단계: Item 판매중 복원 + escrowRefund (buyer hold↓, balance↑) + 거래환불 history</li>
+     *   <li>인계완료 / 거래완료 / 취소 단계: Transaction.cancel 의 canCancel() 가드가 거부 (TRANSACTION_INVALID_STATE).
+     *       라운드 11 합의 (B-3) — 인계 후 환불은 R2 분쟁 endpoint 영역</li>
+     * </ul>
+     *
+     * <p>예약 단계 환불 시 락 순서: Transaction → Item → User(buyer). reserve 와 동일 순서라 deadlock 회피.
+     * 호출 시점에 escrowHoldAmount 를 미리 캡처 — tx.cancel() 후에도 컬럼은 유지되지만 명확성을 위해.</p>
+     */
     @Transactional
     public void cancel(Long transactionId, Long requesterId, String reason) {
         Transaction tx = findOrThrowForUpdate(transactionId);
@@ -138,11 +218,25 @@ public class TransactionApplicationService {
             throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
         }
         boolean wasReserved = tx.getStatus() == TransactionStatus.예약;
+        long holdAmount = tx.getEscrowHoldAmount();
+        // canCancel() 가드 — 인계완료 이후 status 는 TRANSACTION_INVALID_STATE
         tx.cancel(LocalDateTime.now(clock), reason);
         if (wasReserved) {
             // 예약 상태였던 거래만 Item 을 판매중으로 복원 (가이드 §5.2 채팅 재활성화)
             itemApplicationService.restoreItemFromReserved(tx.getItemId());
+            if (holdAmount > 0) {
+                // 라운드 11 — buyer escrow 환불 (hold↓, balance↑) + 거래환불 history.
+                // hold 부족 (운영 이상) → TRANSACTION_HOLD_FAILED 트랜잭션 롤백 (Item/Tx 도 원복).
+                pointApplicationService.escrowRefund(
+                        tx.getBuyerId(),
+                        holdAmount,
+                        tx.getId(),
+                        "거래 #" + tx.getId() + " 취소 환불"
+                );
+            }
         }
+        eventPublisher.publishEvent(new TransactionCanceledEvent(
+                tx.getId(), tx.getBuyerId(), tx.getSellerId(), requesterId));
     }
 
     public TransactionResult getById(Long id, Long requesterId) {

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionNotificationListener.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionNotificationListener.java
@@ -1,0 +1,128 @@
+package com.sseulang.domain.transaction.application;
+
+import com.sseulang.domain.notification.application.NotificationApplicationService;
+import com.sseulang.domain.notification.domain.NotificationType;
+import com.sseulang.domain.transaction.domain.event.TransactionCanceledEvent;
+import com.sseulang.domain.transaction.domain.event.TransactionHandoverConfirmedEvent;
+import com.sseulang.domain.transaction.domain.event.TransactionReceiveConfirmedEvent;
+import com.sseulang.domain.transaction.domain.event.TransactionReservedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 라운드 11 — 거래 단계별 알림 발송. {@code AFTER_COMMIT} phase: TransactionApplicationService 의
+ * 트랜잭션 커밋 후 실행 (롤백 시 X). linkType="TRANSACTION" + linkId=거래ID — 프론트가 클릭 시
+ * /trades/{id} 이동 (B-4 합의).
+ *
+ * <p><b>예외 격리</b> (게이트 2 W-1): 각 listener 는 {@code REQUIRES_NEW} 별도 트랜잭션 + try/catch.
+ * Mongo 저장 실패가 호출자(HTTP request 처리 스레드) 로 전파되어 거래 응답이 500 으로 끝나는 회귀 방지.
+ * 알림 발송 실패는 ERROR 로깅으로만 기록 — 운영 모니터링이 처리.</p>
+ */
+@Component
+public class TransactionNotificationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(TransactionNotificationListener.class);
+
+    private static final String LINK_TYPE = "TRANSACTION";
+
+    private final NotificationApplicationService notificationService;
+
+    public TransactionNotificationListener(NotificationApplicationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    /** 예약됨 → buyer 에게. */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void onReserved(TransactionReservedEvent e) {
+        try {
+            notificationService.notify(
+                    e.buyerId(),
+                    NotificationType.거래,
+                    "거래가 예약되었습니다",
+                    "거래 #" + e.transactionId() + " 가 예약되었습니다.",
+                    LINK_TYPE,
+                    e.transactionId()
+            );
+        } catch (RuntimeException ex) {
+            log.error("[tx-notify] reserved 알림 발송 실패 — txId={} buyerId={}", e.transactionId(), e.buyerId(), ex);
+        }
+    }
+
+    /** 인계확인됨 → buyer 에게 인수확인 부탁. */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void onHandoverConfirmed(TransactionHandoverConfirmedEvent e) {
+        try {
+            notificationService.notify(
+                    e.buyerId(),
+                    NotificationType.거래,
+                    "판매자가 인계를 확인했습니다",
+                    "거래 #" + e.transactionId() + " — 인수 확인을 부탁드립니다.",
+                    LINK_TYPE,
+                    e.transactionId()
+            );
+        } catch (RuntimeException ex) {
+            log.error("[tx-notify] handover 알림 발송 실패 — txId={} buyerId={}", e.transactionId(), e.buyerId(), ex);
+        }
+    }
+
+    /** 인수확인됨 / 거래완료 → seller 에게 정산 완료 (+N,000P 표시). */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void onReceiveConfirmed(TransactionReceiveConfirmedEvent e) {
+        try {
+            String body;
+            if (e.settleAmount() > 0) {
+                body = "거래 #" + e.transactionId() + " 정산 완료 (+" + formatKrw(e.settleAmount()) + "P)";
+            } else {
+                body = "거래 #" + e.transactionId() + " 가 완료되었습니다.";  // 나눔 거래
+            }
+            notificationService.notify(
+                    e.sellerId(),
+                    NotificationType.거래,
+                    "거래 정산이 완료되었습니다",
+                    body,
+                    LINK_TYPE,
+                    e.transactionId()
+            );
+        } catch (RuntimeException ex) {
+            log.error("[tx-notify] receive 알림 발송 실패 — txId={} sellerId={}", e.transactionId(), e.sellerId(), ex);
+        }
+    }
+
+    /** 거래취소됨 → 양쪽 참여자에게. */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void onCanceled(TransactionCanceledEvent e) {
+        String body = "거래 #" + e.transactionId() + " 가 취소되었습니다.";
+        // 두 발송을 한 트랜잭션 안에서 — 한 쪽 실패해도 try/catch 격리.
+        try {
+            notificationService.notify(
+                    e.buyerId(), NotificationType.거래,
+                    "거래가 취소되었습니다", body, LINK_TYPE, e.transactionId()
+            );
+        } catch (RuntimeException ex) {
+            log.error("[tx-notify] canceled buyer 알림 발송 실패 — txId={} buyerId={}", e.transactionId(), e.buyerId(), ex);
+        }
+        if (!e.buyerId().equals(e.sellerId())) {
+            try {
+                notificationService.notify(
+                        e.sellerId(), NotificationType.거래,
+                        "거래가 취소되었습니다", body, LINK_TYPE, e.transactionId()
+                );
+            } catch (RuntimeException ex) {
+                log.error("[tx-notify] canceled seller 알림 발송 실패 — txId={} sellerId={}", e.transactionId(), e.sellerId(), ex);
+            }
+        }
+    }
+
+    private static String formatKrw(long amount) {
+        return String.format("%,d", amount);
+    }
+}

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionResult.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionResult.java
@@ -18,9 +18,12 @@ public record TransactionResult(
         LocalDateTime rentalEnd,
         TransactionStatus status,
         LocalDateTime reservedAt,
+        LocalDateTime handoverConfirmedAt,
+        LocalDateTime receiveConfirmedAt,
         LocalDateTime completedAt,
         LocalDateTime canceledAt,
         String cancelReason,
+        long escrowHoldAmount,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -29,8 +32,12 @@ public record TransactionResult(
                 t.getId(), t.getItemId(), t.getSellerId(), t.getBuyerId(),
                 t.getTradeType(), t.getPrice(), t.getDeposit(),
                 t.getRentalStart(), t.getRentalEnd(),
-                t.getStatus(), t.getReservedAt(), t.getCompletedAt(), t.getCanceledAt(),
+                t.getStatus(),
+                t.getReservedAt(),
+                t.getHandoverConfirmedAt(), t.getReceiveConfirmedAt(),
+                t.getCompletedAt(), t.getCanceledAt(),
                 t.getCancelReason(),
+                t.getEscrowHoldAmount(),
                 t.getCreatedAt(), t.getUpdatedAt()
         );
     }

--- a/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
@@ -69,6 +69,20 @@ public class Transaction extends BaseEntity {
     @Column(name = "reserved_at")
     private LocalDateTime reservedAt;
 
+    /**
+     * 라운드 11 — seller 인계확인 시각 (V16). 예약 → 인계완료 전이 시점.
+     * 본 필드 set 만으로는 의미 없음 — markHandover 가 status 함께 전이.
+     */
+    @Column(name = "handover_confirmed_at")
+    private LocalDateTime handoverConfirmedAt;
+
+    /**
+     * 라운드 11 — buyer 인수확인 시각 (V16). 인계완료 → 거래완료 전이 시점 + 정산 트리거.
+     * 본 필드 set 만으로는 의미 없음 — markReceived 가 status 함께 전이 + completedAt 동기 set.
+     */
+    @Column(name = "receive_confirmed_at")
+    private LocalDateTime receiveConfirmedAt;
+
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
 
@@ -77,6 +91,14 @@ public class Transaction extends BaseEntity {
 
     @Column(name = "cancel_reason", length = 255)
     private String cancelReason;
+
+    /**
+     * 라운드 11 — 예약 시 buyer point_balance 에서 본 컬럼으로 hold 한 금액 (V16). 일반적으로 price 와
+     * 동일하지만, 환불/감사 추적용으로 명시 컬럼화. 채팅중/예약 외 단계에서 cancel 시 환불 금액 결정 키.
+     * 나눔 거래 (price=0) 또는 옛 정책 거래는 0.
+     */
+    @Column(name = "escrow_hold_amount", nullable = false)
+    private long escrowHoldAmount;
 
     public static Transaction create(
             Long itemId,
@@ -121,21 +143,58 @@ public class Transaction extends BaseEntity {
         return t;
     }
 
+    /**
+     * 나눔 거래용 (price=0, hold 0) — 가이드 §4.11. 라운드 11 일반 판매/대여는
+     * {@link #markAsReserved(LocalDateTime, long)} 으로 hold 금액 명시.
+     */
     public void markAsReserved(LocalDateTime now) {
+        markAsReserved(now, 0L);
+    }
+
+    /**
+     * 라운드 11 예약 — status=예약 + reservedAt + escrowHoldAmount 동기 set. ApplicationService 가
+     * 같은 트랜잭션 안에서 PointApplicationService.escrowHold 호출 (buyer balance↓, hold↑).
+     *
+     * @param holdAmount 0 (나눔/옛) 또는 양수 (price 와 동일). 음수는 IllegalArgumentException.
+     */
+    public void markAsReserved(LocalDateTime now, long holdAmount) {
         if (!status.canReserve()) {
             throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
         }
+        if (holdAmount < 0) {
+            throw new IllegalArgumentException("holdAmount 는 0 이상이어야 합니다");
+        }
         this.status = TransactionStatus.예약;
         this.reservedAt = now;
+        this.escrowHoldAmount = holdAmount;
     }
 
-    public void markAsCompleted(LocalDateTime now) {
-        if (!status.canComplete()) {
+    /**
+     * 라운드 11 — seller 인계확인. 예약 → 인계완료 전이. ApplicationService 가 권한 가드 (seller 만)
+     * 후 호출. 잘못된 status 에서 호출 시 TRANSACTION_INVALID_STATE.
+     */
+    public void markHandover(LocalDateTime now) {
+        if (!status.canHandover()) {
+            throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
+        }
+        this.status = TransactionStatus.인계완료;
+        this.handoverConfirmedAt = now;
+    }
+
+    /**
+     * 라운드 11 — buyer 인수확인. 인계완료 → 거래완료 자동 전이 + completedAt 동기 set.
+     * ApplicationService 가 같은 트랜잭션 안에서 PointApplicationService.escrowRelease (정산) 호출.
+     * receiveConfirmedAt 과 completedAt 은 같은 시각 (자동 전이 의미).
+     */
+    public void markReceived(LocalDateTime now) {
+        if (!status.canReceive()) {
             throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
         }
         this.status = TransactionStatus.거래완료;
+        this.receiveConfirmedAt = now;
         this.completedAt = now;
     }
+
 
     public void cancel(LocalDateTime now, String reason) {
         if (!status.canCancel()) {

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -32,6 +32,21 @@ public interface TransactionRepository {
     List<TransactionStatusCount> countGroupByStatus();
 
     /**
+     * 차트 dashboard — 기간 안 (created_at &gt;= from AND created_at &lt; to) tradeType 별 거래 카운트.
+     * to 는 exclusive. 빈 type 은 결과에 미포함 (호출자가 0 채움).
+     */
+    List<TradeTypeCount> countByTradeTypeBetween(LocalDateTime from, LocalDateTime to);
+
+    /**
+     * 차트 dashboard — 기간 안 status 별 거래 카운트. 라운드 11 의 5단계 status 그대로 반환.
+     * 그룹핑 (진행중/완료/취소) 은 ApplicationService 가 변환.
+     */
+    List<TransactionStatusCount> countByStatusBetween(LocalDateTime from, LocalDateTime to);
+
+    /** 차트용 — (tradeType, count) record. */
+    record TradeTypeCount(com.sseulang.domain.item.domain.TradeType tradeType, long count) { }
+
+    /**
      * Admin 회원 카드용 — userId 가 buyer 또는 seller 로 참여한 transaction 의 (userId → count) 맵.
      * 빈 입력은 빈 맵. 단일 GROUP BY 쿼리 — N+1 회피.
      */

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatus.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatus.java
@@ -2,13 +2,17 @@ package com.sseulang.domain.transaction.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 /**
- * 거래 상태. DB ENUM('채팅중','예약','거래완료','취소') 1:1 매핑.
- * 가이드 §5.1: {@code 채팅중 → 예약 → 거래완료} (또는 {@code 취소}).
+ * 거래 상태. DB ENUM('채팅중','예약','인계완료','거래완료','취소') 1:1 매핑 (V16 라운드 11).
+ * 가이드 §5.1: {@code 채팅중 → 예약 → 인계완료 → 거래완료} (또는 {@code 취소}).
+ *
+ * <p>라운드 11 흐름: 예약 시 buyer escrow hold, 인계확인(seller) → 인계완료, 인수확인(buyer) → 거래완료
+ * 자동 전이 + 정산 (buyer hold 해제 + seller credit). 인계완료 이후 단순 취소 차단 — R2 분쟁 흐름.</p>
  */
-@Schema(description = "거래 상태 머신. 채팅중→예약→거래완료 (또는 취소).")
+@Schema(description = "거래 상태 머신. 채팅중→예약→인계완료→거래완료 (또는 취소).")
 public enum TransactionStatus {
     채팅중,
     예약,
+    인계완료,
     거래완료,
     취소;
 
@@ -20,10 +24,19 @@ public enum TransactionStatus {
         return this == 채팅중;
     }
 
-    public boolean canComplete() {
+    /** seller 인계확인 — 예약 상태에서만 가능. */
+    public boolean canHandover() {
         return this == 예약;
     }
 
+    /** buyer 인수확인 — 인계완료 상태에서만 가능 (자동으로 거래완료 전이 + 정산). */
+    public boolean canReceive() {
+        return this == 인계완료;
+    }
+
+    /**
+     * 라운드 11 합의 (B-3): 채팅중 / 예약 단계만 단순 취소 가능. 인계완료 이후엔 차단 — R2 분쟁 endpoint 영역.
+     */
     public boolean canCancel() {
         return this == 채팅중 || this == 예약;
     }

--- a/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionCanceledEvent.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionCanceledEvent.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.transaction.domain.event;
+
+/**
+ * 거래 취소 시점 — 양쪽 참여자 알림용 (라운드 11). canceledByUserId 는 취소를 누른 사용자 (buyer 또는 seller).
+ */
+public record TransactionCanceledEvent(
+        Long transactionId,
+        Long buyerId,
+        Long sellerId,
+        Long canceledByUserId
+) { }

--- a/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionHandoverConfirmedEvent.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionHandoverConfirmedEvent.java
@@ -1,0 +1,9 @@
+package com.sseulang.domain.transaction.domain.event;
+
+/**
+ * seller 인계확인 시점 — buyer 에게 인수확인 부탁 알림용 (라운드 11).
+ */
+public record TransactionHandoverConfirmedEvent(
+        Long transactionId,
+        Long buyerId
+) { }

--- a/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionReceiveConfirmedEvent.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionReceiveConfirmedEvent.java
@@ -1,0 +1,10 @@
+package com.sseulang.domain.transaction.domain.event;
+
+/**
+ * buyer 인수확인 시점 — seller 에게 정산 완료 알림용 (라운드 11). settleAmount 는 seller 에게 적립된 금액.
+ */
+public record TransactionReceiveConfirmedEvent(
+        Long transactionId,
+        Long sellerId,
+        long settleAmount
+) { }

--- a/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionReservedEvent.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionReservedEvent.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.transaction.domain.event;
+
+/**
+ * 거래 예약 시점 — buyer 알림용 (라운드 11). reserve 트랜잭션 commit 후 listener 가 처리.
+ */
+public record TransactionReservedEvent(
+        Long transactionId,
+        Long buyerId,
+        Long sellerId,
+        long price
+) { }

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -33,6 +33,26 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
             """)
     List<TransactionStatusCount> countGroupByStatusJpql();
 
+    /** 차트 dashboard — 기간 [from, to) tradeType 별 카운트. created_at 기준. */
+    @Query("""
+            SELECT new com.sseulang.domain.transaction.domain.TransactionRepository$TradeTypeCount(t.tradeType, COUNT(t))
+              FROM Transaction t
+             WHERE t.createdAt >= :from AND t.createdAt < :to
+             GROUP BY t.tradeType
+            """)
+    List<com.sseulang.domain.transaction.domain.TransactionRepository.TradeTypeCount> countByTradeTypeBetweenJpql(
+            @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
+    /** 차트 dashboard — 기간 [from, to) status 별 카운트. created_at 기준. */
+    @Query("""
+            SELECT new com.sseulang.domain.transaction.domain.TransactionStatusCount(t.status, COUNT(t))
+              FROM Transaction t
+             WHERE t.createdAt >= :from AND t.createdAt < :to
+             GROUP BY t.status
+            """)
+    List<TransactionStatusCount> countByStatusBetweenJpql(
+            @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
     /**
      * Admin 거래 검색 (round 9 + round 10). created_at [start, end] + tradeType / status / keywordId / matchedUserIds.
      * 모두 nullable. 최신순.

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -43,6 +43,17 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     }
 
     @Override
+    public List<com.sseulang.domain.transaction.domain.TransactionRepository.TradeTypeCount>
+            countByTradeTypeBetween(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return jpa.countByTradeTypeBetweenJpql(from, to);
+    }
+
+    @Override
+    public List<TransactionStatusCount> countByStatusBetween(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return jpa.countByStatusBetweenJpql(from, to);
+    }
+
+    @Override
     public java.util.Map<Long, Long> countByUserIdsAsParticipant(java.util.Collection<Long> userIds) {
         if (userIds == null || userIds.isEmpty()) {
             return java.util.Collections.emptyMap();

--- a/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
@@ -22,7 +22,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Transaction", description = "거래 — 채팅중→예약→거래완료 (또는 취소). 정산은 거래완료 시점에 buyer→seller 포인트 이동.")
+@Tag(name = "Transaction", description = "거래 — 채팅중→예약→인계완료→거래완료 (또는 취소). "
+        + "라운드 11 escrow hold: 예약 시 buyer 잔액 hold, 인수확인 시 seller 정산.")
 @RestController
 @RequestMapping("/api/v1/transactions")
 public class TransactionController {
@@ -56,17 +57,18 @@ public class TransactionController {
     }
 
     /**
-     * 거래 상태 전이. action 별 분기:
+     * 거래 상태 전이. action 별 분기 (라운드 11):
      * <ul>
-     *   <li>{@code 예약}: seller 만 호출 가능. Item 비관적 락 + markAsReserved.</li>
-     *   <li>{@code 거래완료}: seller 만. (포인트 이동은 Day 8)</li>
-     *   <li>{@code 취소}: 양쪽 참여자. 예약 상태였다면 Item 판매중으로 복원.</li>
+     *   <li>{@code 예약}: seller. Item 비관적 락 + buyer escrow hold (잔액 부족 시 INSUFFICIENT_POINT).</li>
+     *   <li>{@code 인계확인}: seller. 예약 → 인계완료. 잔액 변동 X. 멱등.</li>
+     *   <li>{@code 인수확인}: buyer. 인계완료 → 거래완료 자동 전이 + 정산 (buyer hold 해제 + seller credit). 멱등.</li>
+     *   <li>{@code 취소}: 양쪽 참여자. 채팅중/예약 단계만 (인계완료 이후 차단 — R2 분쟁). 예약 단계 취소 시 Item 복원 + escrowRefund.</li>
      * </ul>
-     * action={@code 채팅중} 은 거부 — 채팅중은 create 시점에만 부여되는 초기 상태.
      */
-    @Operation(summary = "거래 상태 전이 (예약 / 거래완료 / 취소)",
-            description = "action 분기 — 예약: seller, 거래완료: seller(잔액 부족 시 INSUFFICIENT_POINT), 취소: 양쪽. "
-                    + "예약→취소 시 Item 판매중으로 복원. 동시 reserve 는 한 건만 성공(409 TRANSACTION_RESERVED_BY_OTHER).")
+    @Operation(summary = "거래 상태 전이 (예약 / 인계확인 / 인수확인 / 취소)",
+            description = "action 분기 — 예약: seller(잔액 부족 시 INSUFFICIENT_POINT), 인계확인: seller, "
+                    + "인수확인: buyer(자동 거래완료 + 정산), 취소: 양쪽(채팅중/예약 단계만). "
+                    + "동시 reserve 는 한 건만 성공(409 TRANSACTION_RESERVED_BY_OTHER).")
     @PatchMapping("/{id}")
     public ApiResponse<Void> patch(
             @AuthenticationPrincipal Long requesterId,
@@ -75,8 +77,10 @@ public class TransactionController {
     ) {
         if (request.isReserve()) {
             transactionService.reserve(id, requesterId);
-        } else if (request.isComplete()) {
-            transactionService.complete(id, requesterId);
+        } else if (request.isHandover()) {
+            transactionService.markHandover(id, requesterId);
+        } else if (request.isReceive()) {
+            transactionService.markReceived(id, requesterId);
         } else if (request.isCancel()) {
             transactionService.cancel(id, requesterId, request.cancelReason());
         } else {

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchAction.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchAction.java
@@ -1,0 +1,15 @@
+package com.sseulang.domain.transaction.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * PATCH /transactions/{id} body 의 action 값. 라운드 11 합의 (B-2).
+ * 사용자 의도 표현 — TransactionStatus enum 과 별도로 둔다 (예: 인계확인 → 인계완료 status 전이).
+ */
+@Schema(description = "거래 상태 전이 액션. 예약(seller) / 인계확인(seller) / 인수확인(buyer) / 취소(양쪽).")
+public enum TransactionPatchAction {
+    예약,
+    인계확인,
+    인수확인,
+    취소
+}

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchRequest.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchRequest.java
@@ -1,32 +1,35 @@
 package com.sseulang.domain.transaction.presentation.dto;
 
-import com.sseulang.domain.transaction.domain.TransactionStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 /**
- * 거래 상태 전이 요청. {@code action} 으로 의도된 상태(예약/거래완료/취소) 명시.
- * cancelReason 은 action=취소 일 때만 의미. 다른 action 일 때 null/무시.
+ * 거래 상태 전이 요청. 라운드 11 — action enum 은 사용자 의도 표현
+ * (예약 / 인계확인 / 인수확인 / 취소). cancelReason 은 action=취소 일 때만 의미.
  */
-@Schema(description = "거래 상태 전이. action 별 권한: 예약/거래완료=seller, 취소=양쪽 참여자.")
+@Schema(description = "거래 상태 전이. action 별 권한: 예약/인계확인=seller, 인수확인=buyer, 취소=양쪽 참여자.")
 public record TransactionPatchRequest(
-        @Schema(description = "전이할 상태", example = "예약",
-                allowableValues = {"예약", "거래완료", "취소"})
-        @NotNull TransactionStatus action,
+        @Schema(description = "전이 액션", example = "예약",
+                allowableValues = {"예약", "인계확인", "인수확인", "취소"})
+        @NotNull TransactionPatchAction action,
 
         @Schema(description = "취소 사유 (action=취소 전용)", example = "구매자 변심", nullable = true, maxLength = 255)
         @Size(max = 255) String cancelReason
 ) {
     public boolean isReserve() {
-        return action == TransactionStatus.예약;
+        return action == TransactionPatchAction.예약;
     }
 
-    public boolean isComplete() {
-        return action == TransactionStatus.거래완료;
+    public boolean isHandover() {
+        return action == TransactionPatchAction.인계확인;
+    }
+
+    public boolean isReceive() {
+        return action == TransactionPatchAction.인수확인;
     }
 
     public boolean isCancel() {
-        return action == TransactionStatus.취소;
+        return action == TransactionPatchAction.취소;
     }
 }

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionResponse.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionResponse.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(description = "거래 — 채팅중→예약→거래완료 상태 머신. 정산은 거래완료 시 buyer 차감/seller 적립.")
+@Schema(description = "거래 — 채팅중→예약→인계완료→거래완료 (라운드 11). 정산은 인수확인 시점에 buyer hold 해제 + seller 적립.")
 public record TransactionResponse(
         @Schema(example = "12") Long id,
         @Schema(example = "42") Long itemId,
@@ -20,9 +20,14 @@ public record TransactionResponse(
         LocalDateTime rentalEnd,
         TransactionStatus status,
         LocalDateTime reservedAt,
+        @Schema(description = "seller 인계확인 시각 (라운드 11)") LocalDateTime handoverConfirmedAt,
+        @Schema(description = "buyer 인수확인 시각 (라운드 11)") LocalDateTime receiveConfirmedAt,
         LocalDateTime completedAt,
         LocalDateTime canceledAt,
         @Schema(example = "구매자 변심") String cancelReason,
+        @Schema(example = "1200000",
+                description = "예약 시 buyer point_balance 에서 hold 한 금액 (라운드 11). 0 = 나눔 또는 옛 거래.")
+        long escrowHoldAmount,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -31,8 +36,12 @@ public record TransactionResponse(
                 r.id(), r.itemId(), r.sellerId(), r.buyerId(),
                 r.tradeType(), r.price(), r.deposit(),
                 r.rentalStart(), r.rentalEnd(),
-                r.status(), r.reservedAt(), r.completedAt(), r.canceledAt(),
+                r.status(),
+                r.reservedAt(),
+                r.handoverConfirmedAt(), r.receiveConfirmedAt(),
+                r.completedAt(), r.canceledAt(),
                 r.cancelReason(),
+                r.escrowHoldAmount(),
                 r.createdAt(), r.updatedAt()
         );
     }

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -221,6 +221,17 @@ public class UserApplicationService {
         }
     }
 
+    /** 차트 dashboard — 기간 [from, to) 가입자 수. */
+    public long countSignupsBetween(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return userRepository.countSignupsBetween(from, to);
+    }
+
+    /** 차트 dashboard — 일자별 가입자 수 (빈 일은 미포함, 호출자가 0 채움). */
+    public java.util.List<UserRepository.DailyCount> findDailySignups(
+            java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return userRepository.findDailySignups(from, to);
+    }
+
     /** point_hold 단건 scalar 조회 (UI/통계용 + history balance_after 보강용). */
     public long getPointHold(Long userId) {
         Long hold = userRepository.findPointHold(userId);

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -176,6 +176,70 @@ public class UserApplicationService {
     }
 
     /**
+     * 가이드 §5.1 거래 hold (라운드 11) — buyer point_balance 차감 + point_hold 적립을 단일 atomic UPDATE.
+     * 잔액 부족 시 INSUFFICIENT_POINT (음수 방지 가드). amount 양수 강제.
+     * Transaction 도메인은 Point 도메인을 통해 호출, 본 메서드는 UserRepository 위임 단일 진입점.
+     */
+    @Transactional
+    public void holdForEscrow(Long userId, long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        int affected = userRepository.holdForEscrow(userId, amount);
+        if (affected != 1) {
+            throw new BusinessException(ErrorCode.INSUFFICIENT_POINT);
+        }
+    }
+
+    /**
+     * 거래완료 정산 — buyer point_hold 만 차감 (seller credit 은 creditPoint 별도 호출).
+     * affected=0 = hold 잔액 부족 (운영 이상 — 가드 회귀) → TRANSACTION_HOLD_FAILED.
+     */
+    @Transactional
+    public void releaseHold(Long userId, long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        int affected = userRepository.releaseHold(userId, amount);
+        if (affected != 1) {
+            throw new BusinessException(ErrorCode.TRANSACTION_HOLD_FAILED);
+        }
+    }
+
+    /**
+     * 거래 취소 환불 — buyer point_hold 차감 + point_balance 적립을 단일 atomic UPDATE.
+     * affected=0 = hold 잔액 부족 (운영 이상 — 가드 회귀) → TRANSACTION_HOLD_FAILED.
+     */
+    @Transactional
+    public void refundHold(Long userId, long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        int affected = userRepository.refundHold(userId, amount);
+        if (affected != 1) {
+            throw new BusinessException(ErrorCode.TRANSACTION_HOLD_FAILED);
+        }
+    }
+
+    /** point_hold 단건 scalar 조회 (UI/통계용 + history balance_after 보강용). */
+    public long getPointHold(Long userId) {
+        Long hold = userRepository.findPointHold(userId);
+        if (hold == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        return hold;
+    }
+
+    /**
+     * 잔액 + hold 단일 SELECT 스냅샷 — 잔액 페이지 3분할 표시 응답의 race-safe 일관성.
+     * balance / hold 분리 read 시 동시 reserve/cancel/refund 사이에 끼어 합산이 어긋날 수 있어 통합 (게이트 1 W-1).
+     */
+    public com.sseulang.domain.user.domain.UserRepository.PointSnapshot getPointSnapshot(Long userId) {
+        return userRepository.findPointSnapshot(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
      * 관리자 회원 목록 — created_at DESC 페이징. 차단/삭제 상태 모두 포함.
      */
     public Page<User> adminFindAll(Pageable pageable) {

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -118,6 +118,23 @@ public class User extends BaseEntity {
     private long pointBalance;
 
     /**
+     * 거래 보관 잔액 (escrow hold) — 가이드 §5.1 라운드 11. 예약 시 buyer point_balance 에서
+     * 차감해 본 컬럼에 적립. 거래완료(인수확인) 시 hold 해제 + seller credit, 취소 시 buyer 환불.
+     *
+     * <p>point_balance 와 분리한 이유 (라운드 11 합의 B-3 A안):
+     * <ul>
+     *   <li>잔액 표시 — 즉시 사용 가능(balance) vs 거래 보관(hold) 3분할 UI</li>
+     *   <li>가이드 §5.3 원자 연산 — 단일 SQL UPDATE 로 두 컬럼 동시 변경, race-safe</li>
+     *   <li>잔액 부족 가드 — WHERE point_balance &gt;= :amount 가 hold 무관하게 깔끔</li>
+     * </ul>
+     *
+     * <p>본 필드 setter 없음 — UserRepository.holdForEscrow / releaseHold / refundHold
+     * atomic 메서드만이 갱신. CHECK point_hold &gt;= 0 (V16).</p>
+     */
+    @Column(name = "point_hold", nullable = false)
+    private long pointHold;
+
+    /**
      * JPA optimistic lock — V7 마이그레이션. LOCAL takeover 처럼 read-modify-write 흐름에서 두
      * 트랜잭션이 같은 user 를 동시 변경하면 OptimisticLockException 으로 한 쪽이 실패한다 (게이트 1).
      * 단순 atomic UPDATE (point_balance 등) 는 본 컬럼을 갱신하지 않는다 — JPA dirty-check 시점에만 동작.

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -59,6 +59,38 @@ public interface UserRepository {
      */
     Long findPointBalance(Long userId);
 
+    /**
+     * 가이드 §5.1 거래 hold (라운드 11) — point_balance 에서 amount 차감 + point_hold 에 적립.
+     * 단일 원자 UPDATE 로 두 컬럼 동시 변경 → race-safe + buyer 잔액 부족 가드 (WHERE point_balance >= :amount).
+     * 영향 행 0 = 잔액 부족, 1 = 정상.
+     */
+    int holdForEscrow(Long userId, long amount);
+
+    /**
+     * 거래완료 정산 — buyer point_hold 만 차감 (seller credit 은 creditPointBalance 별도 호출).
+     * 단일 원자 UPDATE. point_hold &lt; amount 이면 affected=0 (가드 회귀 시 호출자 fail-fast).
+     */
+    int releaseHold(Long userId, long amount);
+
+    /**
+     * 거래 취소 환불 — point_hold 에서 차감 + point_balance 로 적립.
+     * 단일 원자 UPDATE 로 두 컬럼 동시 변경. point_hold &lt; amount 이면 affected=0.
+     */
+    int refundHold(Long userId, long amount);
+
+    /**
+     * point_hold scalar 조회. atomic UPDATE 직후 history balance_after 적재용 (영속성 컨텍스트 stale 우회).
+     */
+    Long findPointHold(Long userId);
+
+    /**
+     * (point_balance, point_hold) 단일 SELECT 스냅샷. 잔액 표시 응답 (3분할) 의 race-safe 일관성 보장 —
+     * 두 컬럼을 분리 read 하면 동시 reserve/cancel/refund 사이에 끼어 합산이 어긋날 수 있음 (게이트 1 W-1).
+     */
+    java.util.Optional<PointSnapshot> findPointSnapshot(Long userId);
+
+    record PointSnapshot(long balance, long hold) { }
+
     // ───────── 관리자 통계 ─────────
 
     /** 전체 사용자 수 (차단/삭제 포함). */

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -109,6 +109,21 @@ public interface UserRepository {
     long countActive();
 
     /**
+     * 차트 dashboard — 기간 안 (created_at &gt;= from AND created_at &lt; to) 가입자 수.
+     * to 는 exclusive. summary.users.monthDelta / todaySignups.* 등 기간 합산용.
+     */
+    long countSignupsBetween(java.time.LocalDateTime from, java.time.LocalDateTime to);
+
+    /**
+     * 차트 dashboard — 일자별 가입자 수. 빈 일은 결과에 미포함 (호출자가 0으로 채움).
+     * created_at DATE GROUP BY, ASC.
+     */
+    java.util.List<DailyCount> findDailySignups(java.time.LocalDateTime from, java.time.LocalDateTime to);
+
+    /** {@code (date, count)} record — 일자별 차트 데이터용. */
+    record DailyCount(java.time.LocalDate date, long count) { }
+
+    /**
      * Admin broadcast 용 — 활성 사용자 id 청크 페이징. blocked/deleted 제외.
      * 큰 사용자 수에서 OOM 방지를 위해 호출자가 청크 단위로 호출. id ASC 안정 정렬.
      *

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -203,6 +203,30 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
     @Query("SELECT COUNT(u) FROM User u WHERE u.blocked = true")
     long countBlocked();
 
+    @Query("SELECT COUNT(u) FROM User u WHERE u.createdAt >= :from AND u.createdAt < :to")
+    long countSignupsBetween(@Param("from") java.time.LocalDateTime from, @Param("to") java.time.LocalDateTime to);
+
+    /**
+     * 일자별 가입자 — DATE(created_at) GROUP BY. native query (JPQL DATE 함수 호환성 회피).
+     * 결과 row: (date, count). 빈 일자는 결과에 미포함 (호출자가 fill).
+     */
+    @Query(value = """
+            SELECT DATE(u.created_at) AS d, COUNT(*) AS c
+              FROM users u
+             WHERE u.created_at >= :from AND u.created_at < :to
+             GROUP BY DATE(u.created_at)
+             ORDER BY d ASC
+            """, nativeQuery = true)
+    java.util.List<DailySignupRow> findDailySignupsRaw(
+            @Param("from") java.time.LocalDateTime from,
+            @Param("to") java.time.LocalDateTime to);
+
+    /** native projection — UserRepository.DailyCount 으로 매핑. */
+    interface DailySignupRow {
+        java.sql.Date getD();
+        long getC();
+    }
+
     @Query("SELECT COUNT(u) FROM User u WHERE u.deleted = true")
     long countDeleted();
 

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -58,6 +58,67 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
     @Query("SELECT u.pointBalance FROM User u WHERE u.id = :userId")
     Long findPointBalanceById(@Param("userId") Long userId);
 
+    /**
+     * 가이드 §5.1 거래 hold (라운드 11) — point_balance 차감 + point_hold 적립을 단일 원자 UPDATE.
+     * 잔액 부족 시 affected=0 (WHERE point_balance >= :amount 가드 — 음수 방지).
+     * 동시 hold race 안전 (행 락 직렬화 + 단일 SQL).
+     *
+     * <p><b>@Version 정책</b>: 본 메서드 + creditPointBalance / deductPointBalance / releaseHold /
+     * refundHold / recordReviewFor 는 모두 가이드 §5.3 패턴 (원자 SQL 로 직접 컬럼 변경) — JPA dirty-check
+     * 경로를 우회하므로 {@code @Version} 을 의도적으로 갱신하지 않는다. race-safety 는 SQL 자체의
+     * 행 락 + WHERE 가드가 보장. 단, 같은 트랜잭션 안에서 다른 managed write (profile / block / suspend
+     * 등 entity dirty-check 경로) 와 섞이면 별도 optimistic-lock 방어가 필요 — Day 5 takeover 패턴 참고.</p>
+     */
+    @Modifying
+    @Query("""
+            UPDATE User u
+               SET u.pointBalance = u.pointBalance - :amount,
+                   u.pointHold    = u.pointHold + :amount
+             WHERE u.id = :userId
+               AND u.pointBalance >= :amount
+            """)
+    int holdForEscrow(@Param("userId") Long userId, @Param("amount") long amount);
+
+    /**
+     * 거래완료 정산 — buyer point_hold 만 차감. seller credit 은 별도 호출 (양 사용자 id-asc 락 순서).
+     * point_hold &lt; amount 면 affected=0 — 호출자가 fail-fast.
+     */
+    @Modifying
+    @Query("UPDATE User u SET u.pointHold = u.pointHold - :amount WHERE u.id = :userId AND u.pointHold >= :amount")
+    int releaseHold(@Param("userId") Long userId, @Param("amount") long amount);
+
+    /**
+     * 거래 취소 환불 — point_hold 차감 + point_balance 적립을 단일 원자 UPDATE.
+     * point_hold &lt; amount 면 affected=0.
+     */
+    @Modifying
+    @Query("""
+            UPDATE User u
+               SET u.pointBalance = u.pointBalance + :amount,
+                   u.pointHold    = u.pointHold - :amount
+             WHERE u.id = :userId
+               AND u.pointHold >= :amount
+            """)
+    int refundHold(@Param("userId") Long userId, @Param("amount") long amount);
+
+    /** point_hold scalar 조회. atomic UPDATE 직후 history balance_after 적재용. */
+    @Query("SELECT u.pointHold FROM User u WHERE u.id = :userId")
+    Long findPointHoldById(@Param("userId") Long userId);
+
+    /**
+     * 잔액 + hold 단일 SELECT 스냅샷 — 게이트 1 W-1 보강 (race-safe 일관성).
+     * native projection 으로 영속성 컨텍스트 stale 우회.
+     */
+    @Query(value = "SELECT point_balance AS balance, point_hold AS hold FROM users WHERE id = :userId",
+           nativeQuery = true)
+    java.util.Optional<PointSnapshotRow> findPointSnapshotById(@Param("userId") Long userId);
+
+    /** native projection — UserRepository.PointSnapshot 으로 매핑 (Spring Data 인터페이스 projection). */
+    interface PointSnapshotRow {
+        long getBalance();
+        long getHold();
+    }
+
     Page<User> findAllByOrderByIdDesc(Pageable pageable);
 
     /**

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -133,6 +133,18 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public long countSignupsBetween(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return jpa.countSignupsBetween(from, to);
+    }
+
+    @Override
+    public java.util.List<DailyCount> findDailySignups(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return jpa.findDailySignupsRaw(from, to).stream()
+                .map(r -> new DailyCount(r.getD().toLocalDate(), r.getC()))
+                .toList();
+    }
+
+    @Override
     public java.util.List<Long> findActiveIdsAfter(long afterId, int limit) {
         if (limit <= 0) return java.util.Collections.emptyList();
         return jpa.findActiveIdsAfter(afterId, org.springframework.data.domain.PageRequest.of(0, limit));

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -87,6 +87,32 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public int holdForEscrow(Long userId, long amount) {
+        return jpa.holdForEscrow(userId, amount);
+    }
+
+    @Override
+    public int releaseHold(Long userId, long amount) {
+        return jpa.releaseHold(userId, amount);
+    }
+
+    @Override
+    public int refundHold(Long userId, long amount) {
+        return jpa.refundHold(userId, amount);
+    }
+
+    @Override
+    public Long findPointHold(Long userId) {
+        return jpa.findPointHoldById(userId);
+    }
+
+    @Override
+    public Optional<PointSnapshot> findPointSnapshot(Long userId) {
+        return jpa.findPointSnapshotById(userId)
+                .map(row -> new PointSnapshot(row.getBalance(), row.getHold()));
+    }
+
+    @Override
     public long countAll() {
         return jpa.count();
     }

--- a/src/main/java/com/sseulang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/UserController.java
@@ -8,6 +8,8 @@ import com.sseulang.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,10 +30,13 @@ public class UserController {
     }
 
     @Operation(summary = "본인 정보 조회",
-            description = "AT 쿠키 기반 인증된 사용자 정보. 로그인 후 페이지 새로고침 시 store 재초기화에 사용.")
+            description = "AT 쿠키 기반 인증된 사용자 정보. 응답 role 필드로 ADMIN 여부 판별 가능 — 프론트 마이페이지 → 관리 페이지 redirect 분기.")
     @GetMapping("/me")
-    public ApiResponse<MeResponse> getMe(@AuthenticationPrincipal Long userId) {
-        return ApiResponse.ok(MeResponse.from(userService.getById(userId)));
+    public ApiResponse<MeResponse> getMe(
+            @AuthenticationPrincipal Long userId,
+            Authentication auth
+    ) {
+        return ApiResponse.ok(MeResponse.from(userService.getById(userId), roleFrom(auth)));
     }
 
     @Operation(summary = "다른 사용자 공개 프로필 조회",
@@ -49,10 +54,23 @@ public class UserController {
     @PatchMapping("/me")
     public ApiResponse<MeResponse> updateMe(
             @AuthenticationPrincipal Long userId,
+            Authentication auth,
             @Valid @RequestBody UserUpdateRequest request
     ) {
         return ApiResponse.ok(MeResponse.from(
-                userService.updateProfile(userId, request.profileImage(), request.nickname())
+                userService.updateProfile(userId, request.profileImage(), request.nickname()),
+                roleFrom(auth)
         ));
+    }
+
+    /** Spring Security Authentication 의 GrantedAuthority 에서 ROLE_ prefix 제거한 role 문자열. */
+    private static String roleFrom(Authentication auth) {
+        if (auth == null) return "USER";
+        return auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(a -> a != null && a.startsWith("ROLE_"))
+                .findFirst()
+                .map(a -> a.substring("ROLE_".length()))
+                .orElse("USER");
     }
 }

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/MeResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/MeResponse.java
@@ -20,7 +20,8 @@ public record MeResponse(
         @Schema(description = "프로필 이미지 URL (없으면 null)") String profileImage,
         @Schema(description = "LOCAL / KAKAO / GOOGLE") SocialProvider socialProvider,
         @Schema(example = "true", description = "이메일 인증 여부 — false 면 자금/거래 API 가 403") boolean emailVerified,
-        @Schema(example = "50000", description = "포인트 잔액 (KRW)") long pointBalance,
+        @Schema(example = "50000", description = "즉시 사용 가능 포인트 (KRW). 라운드 11 부터 거래 hold 분 제외.") long pointBalance,
+        @Schema(example = "10000", description = "거래 hold 잔액 (라운드 11). 헤더/카드에 작은 텍스트 안내용.") long pointHold,
         @Schema(example = "4.7", description = "리뷰 평균. 리뷰 0건이면 null") BigDecimal trustScore,
         @Schema(example = "12") int reviewCount
 ) {
@@ -33,6 +34,7 @@ public record MeResponse(
                 u.getSocialProvider(),
                 u.isEmailVerified(),
                 u.getPointBalance(),
+                u.getPointHold(),
                 u.getTrustScore(),
                 u.getReviewCount()
         );

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/MeResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/MeResponse.java
@@ -23,9 +23,17 @@ public record MeResponse(
         @Schema(example = "50000", description = "즉시 사용 가능 포인트 (KRW). 라운드 11 부터 거래 hold 분 제외.") long pointBalance,
         @Schema(example = "10000", description = "거래 hold 잔액 (라운드 11). 헤더/카드에 작은 텍스트 안내용.") long pointHold,
         @Schema(example = "4.7", description = "리뷰 평균. 리뷰 0건이면 null") BigDecimal trustScore,
-        @Schema(example = "12") int reviewCount
+        @Schema(example = "12") int reviewCount,
+        @Schema(example = "USER",
+                description = "현재 세션의 권한 — \"USER\" 또는 \"ADMIN\". 프론트가 마이페이지 → 관리 페이지 redirect 분기 결정용. "
+                        + "JWT role claim 그대로 노출.",
+                allowableValues = {"USER", "ADMIN"})
+        String role
 ) {
-    public static MeResponse from(User u) {
+    /**
+     * @param role 현재 세션의 role ("USER" / "ADMIN"). 호출자가 Authentication 또는 JwtClaims 에서 추출해 전달.
+     */
+    public static MeResponse from(User u, String role) {
         return new MeResponse(
                 u.getId(),
                 u.getEmail(),
@@ -36,7 +44,8 @@ public record MeResponse(
                 u.getPointBalance(),
                 u.getPointHold(),
                 u.getTrustScore(),
-                u.getReviewCount()
+                u.getReviewCount(),
+                (role == null || role.isBlank()) ? "USER" : role
         );
     }
 }

--- a/src/main/java/com/sseulang/global/config/SecurityConfig.java
+++ b/src/main/java/com/sseulang/global/config/SecurityConfig.java
@@ -85,6 +85,13 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler accessDeniedHandler;
     private final CsrfCookieFilter csrfCookieFilter;
 
+    /**
+     * XSRF-TOKEN 쿠키의 Domain. cross-subdomain 공유 (super-domain 통합 시) 위해 prod 에 .sseulang.store
+     * 설정. 미주입 시 host-only — frontend 가 다른 sub-domain 에서 readCookie 못함 (게이트 1 round 1 round 2 fix).
+     */
+    @org.springframework.beans.factory.annotation.Value("${app.cookie.domain:}")
+    private String cookieDomain;
+
     public SecurityConfig(
             JwtAuthenticationFilter jwtAuthenticationFilter,
             JwtAuthenticationEntryPoint authenticationEntryPoint,
@@ -136,13 +143,25 @@ public class SecurityConfig {
         return source;
     }
 
+    /**
+     * XSRF-TOKEN 쿠키 발급 — prod 에선 Domain={@code .sseulang.store} 명시해서 sub-domain 공유.
+     * 미주입(local) 시 default host-only.
+     */
+    private CookieCsrfTokenRepository buildCsrfRepo() {
+        CookieCsrfTokenRepository repo = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        if (cookieDomain != null && !cookieDomain.isBlank()) {
+            repo.setCookieCustomizer(c -> c.domain(cookieDomain));
+        }
+        return repo;
+    }
+
     @Bean
     @Order(1)
     public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
         applyCommon(http)
                 .securityMatcher("/api/v1/admin/**")
                 .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRepository(buildCsrfRepo())
                         .csrfTokenRequestHandler(eagerCsrfHandler()))
                 .exceptionHandling(eh -> eh
                         .authenticationEntryPoint(authenticationEntryPoint)
@@ -159,7 +178,7 @@ public class SecurityConfig {
         applyCommon(http)
                 .securityMatcher("/api/v1/**", "/ws-stomp/**", "/ws-stomp-native/**")
                 .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRepository(buildCsrfRepo())
                         .csrfTokenRequestHandler(eagerCsrfHandler())
                         .ignoringRequestMatchers(CSRF_IGNORED_ENDPOINTS))
                 .exceptionHandling(eh -> eh

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -50,7 +50,9 @@ public enum ErrorCode {
     TRANSACTION_INVALID_STATE(HttpStatus.BAD_REQUEST, "현재 상태에서 수행할 수 없는 동작입니다."),
     TRANSACTION_RESERVED_BY_OTHER(HttpStatus.CONFLICT, "이미 다른 사용자와 예약된 거래입니다."),
     TRANSACTION_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "본인의 물품으로는 거래를 시작할 수 없습니다."),
-    TRANSACTION_COMPLETION_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "거래 완료 처리는 결제·포인트 도메인 합류 후 활성화됩니다."),
+    TRANSACTION_HANDOVER_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "인계 확인은 판매자만 수행할 수 있습니다."),
+    TRANSACTION_RECEIVE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "인수 확인은 구매자만 수행할 수 있습니다."),
+    TRANSACTION_HOLD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "거래 보관 잔액 처리에 실패했습니다."),
 
     // 결제 / 포인트
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/sseulang/global/infra/payment/TossProperties.java
+++ b/src/main/java/com/sseulang/global/infra/payment/TossProperties.java
@@ -19,10 +19,21 @@ public record TossProperties(
          * Webhook timestamp 의 허용 시간차 (초). 초과 시 replay 로 간주해 거부.
          * 기본 300 = 5분. 0 또는 음수면 timestamp 검증 비활성.
          */
-        Long webhookReplayToleranceSeconds
+        Long webhookReplayToleranceSeconds,
+        /**
+         * confirm 단의 토스 lookup 검증 우회 플래그.
+         *
+         * <p><b>운영 절대 사용 X</b> — 토스 시크릿 키 미발급 환경 (dev/QA) 에서 결제 흐름만 검증할 때 사용.
+         * true 면 confirmCharge 가 토스 API 를 호출하지 않고 클라이언트 amount 그대로 markAsPaid + 잔액 적립.
+         * 1차 amount 위변조 가드 (clientAmount == storedAmount) 는 그대로 유지.</p>
+         *
+         * <p>활성 시 부팅 로그에 WARN 1회 + confirm 호출마다 WARN 로그 출력 — 운영자가 켜진 상태를 즉시 인지.</p>
+         */
+        Boolean skipVerify
 ) {
     public TossProperties {
         baseUrl = (baseUrl == null || baseUrl.isBlank()) ? "https://api.tosspayments.com" : baseUrl;
         webhookReplayToleranceSeconds = (webhookReplayToleranceSeconds == null) ? 300L : webhookReplayToleranceSeconds;
+        skipVerify = (skipVerify != null) && skipVerify;
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -80,6 +80,8 @@ app:
     client-key: ${TOSS_CLIENT_KEY:}
     secret-key: ${TOSS_SECRET_KEY:}
     base-url: https://api.tosspayments.com
+    # dev/QA 한정 — 토스 시크릿 키 미발급 환경에서 confirm 검증 우회.
+    skip-verify: ${TOSS_SKIP_VERIFY:false}
   cors:
     allowed-origins:
       - http://localhost:3000

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -77,6 +77,9 @@ app:
     # Webhook 검증 — 토스 콘솔에서 webhook secret 발급 후 주입. 미주입 시 시그니처 검증 비활성 (위험).
     webhook-secret: ${TOSS_WEBHOOK_SECRET:}
     webhook-replay-tolerance-seconds: ${TOSS_WEBHOOK_REPLAY_TOLERANCE:300}
+    # !!! 운영 절대 false 유지 !!! — confirm 단의 토스 lookup 검증 우회. dev/QA 환경에서 시크릿 키
+    # 미발급 상태로 결제 흐름 검증용. 활성 시 부팅 WARN + confirm 호출마다 WARN.
+    skip-verify: ${TOSS_SKIP_VERIFY:false}
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
   email:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -80,6 +80,10 @@ app:
     # !!! 운영 절대 false 유지 !!! — confirm 단의 토스 lookup 검증 우회. dev/QA 환경에서 시크릿 키
     # 미발급 상태로 결제 흐름 검증용. 활성 시 부팅 WARN + confirm 호출마다 WARN.
     skip-verify: ${TOSS_SKIP_VERIFY:false}
+  admin:
+    # OAuth 로그인 시 role=ADMIN JWT 를 발급할 email 화이트리스트 (콤마구분, lowercase 비교).
+    # 빈 값이면 모두 USER. 활성 시 부팅 WARN + 로그인마다 WARN.
+    user-emails: ${ADMIN_USER_EMAILS:}
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
   email:

--- a/src/main/resources/db/migration/V16__add_transaction_escrow_hold.sql
+++ b/src/main/resources/db/migration/V16__add_transaction_escrow_hold.sql
@@ -1,0 +1,49 @@
+-- V16: Transaction escrow hold 정책 적용 (라운드 11)
+--
+-- 변경 요약 — 가이드 §5.1 거래 상태 머신 + §5.3 동시성 정합:
+--   1) transactions.status enum 에 '인계완료' 추가 (예약 / 거래완료 사이)
+--   2) transactions: handover_confirmed_at / receive_confirmed_at / escrow_hold_amount 컬럼 추가
+--   3) users: point_hold 컬럼 추가 (거래 보관 중 잔액, point_balance 와 분리)
+--
+-- 기존 row 호환:
+--   - 진행 중 status='예약' row 는 escrow_hold_amount default 0 — 옛 정책 그대로 종결
+--   - 새 거래만 hold 흐름 진입 (TransactionApplicationService 가 0 → price 로 set)
+--   - users.point_hold default 0 — 기존 row 영향 없음
+--
+-- ENUM ordinal: 기존 '거래완료' / '취소' row 는 이름 기반 매칭으로 안전.
+--
+-- !! prod 호환성 (게이트 2 W-2) !!
+--   본 스크립트는 transactions / users / point_histories 3 테이블에 MODIFY COLUMN ENUM
+--   (전체 테이블 재빌드) 을 포함한다. MySQL 8 InnoDB 기본 정책으로:
+--   - 50만+ row 시 metadata lock 시간 + 디스크 재빌드 시간이 길어진다 (수십 초~수 분).
+--   - 5/11 신규 운영 진입 시점에는 row 적어 영향 X — 본 마이그레이션 그대로 적용.
+--   - row 100만+ 단계 진입 후엔 INPLACE / pt-online-schema-change 등 분리 마이그레이션 검토 필요.
+--   R1 follow-up issue 등록 예정 (별도 마이그레이션 분할 가이드).
+
+-- 1. transactions.status enum 확장 — '인계완료' 를 '예약' 과 '거래완료' 사이에 배치
+ALTER TABLE transactions
+    MODIFY COLUMN status ENUM('채팅중','예약','인계완료','거래완료','취소') NOT NULL DEFAULT '채팅중';
+
+-- 2. 인계/인수 확인 시각 + escrow hold 금액
+ALTER TABLE transactions
+    ADD COLUMN handover_confirmed_at DATETIME NULL AFTER reserved_at,
+    ADD COLUMN receive_confirmed_at  DATETIME NULL AFTER handover_confirmed_at,
+    ADD COLUMN escrow_hold_amount    BIGINT NOT NULL DEFAULT 0 AFTER cancel_reason,
+    ADD CONSTRAINT chk_transactions_escrow_hold_nonneg CHECK (escrow_hold_amount >= 0);
+
+-- 3. users.point_hold — 거래 보관 잔액 (point_balance 와 분리, race-safe 원자 UPDATE)
+ALTER TABLE users
+    ADD COLUMN point_hold BIGINT NOT NULL DEFAULT 0 AFTER point_balance,
+    ADD CONSTRAINT chk_users_point_hold_nonneg CHECK (point_hold >= 0);
+
+-- 4. point_histories.point_type ENUM 확장 — 거래 hold 흐름 history 적재용
+--    프론트 라벨 합의 (라운드 11 B-2):
+--      거래보관 → "거래 #N 보관"        (예약 시 buyer balance -, hold +)
+--      거래환불 → "거래 #N 취소 환불"   (취소 시 buyer balance +, hold -)
+--    seller 정산은 기존 '판매정산' 활용 → "거래 #N 정산 수령"
+--    buyer 의 hold 해제(인수확인)는 잔액 변화 X 라 history 미적재 (Aggregate 정책).
+ALTER TABLE point_histories
+    MODIFY COLUMN point_type ENUM(
+        '충전','결제','판매정산','출금','환불','배달결제','배달정산',
+        '거래보관','거래환불'
+    ) NOT NULL;

--- a/src/test/java/com/sseulang/domain/auth/application/OAuthLoginServiceTest.java
+++ b/src/test/java/com/sseulang/domain/auth/application/OAuthLoginServiceTest.java
@@ -70,7 +70,8 @@ class OAuthLoginServiceTest {
                 userService,
                 jwtProvider,
                 store,
-                props
+                props,
+                ""  // adminUserEmailsRaw — empty (모두 USER role)
         );
     }
 
@@ -194,5 +195,76 @@ class OAuthLoginServiceTest {
         assertThat(store.contains("USER", USER_ID, j2)).isTrue();
 
         verify(userService, times(2)).findOrCreateBySocial(any(), any(), any(), any(), any());
+    }
+
+    // ───────── admin email allowlist (ROLE_ADMIN JWT 발급) ─────────
+
+    @Test
+    @DisplayName("login admin allowlist 매치_role=ADMIN JWT 발급 + RT store(ADMIN, userId)")
+    void login_admin_allowlist_매치() {
+        OAuthLoginService adminService = adminAllowlistService("admin@example.com,Other@Example.COM");
+
+        OAuthUserInfo info = new OAuthUserInfo(
+                SocialProvider.GOOGLE, "google-admin",
+                new Email("Admin@Example.com"),  // 대소문자 다름 — lowercase 비교
+                "관리자", "https://img/a.png");
+        when(googleProvider.exchangeCodeAndFetch("T", "http://cb")).thenReturn(info);
+        User u = userWithIdAndEmail(USER_ID, "Admin@Example.com");
+        when(userService.findOrCreateBySocial(any(), any(), any(), any(), any())).thenReturn(u);
+
+        TokenPair pair = adminService.loginWithCode(SocialProvider.GOOGLE, "T", "http://cb");
+
+        assertThat(jwtProvider.parse(pair.accessToken()).role()).isEqualTo("ADMIN");
+        String rtJti = jwtProvider.parse(pair.refreshToken()).jti();
+        assertThat(store.contains("ADMIN", USER_ID, rtJti)).isTrue();
+        assertThat(store.contains("USER", USER_ID, rtJti)).isFalse();
+    }
+
+    @Test
+    @DisplayName("login_allowlist 비매치 email_role=USER 유지 (기본 흐름)")
+    void login_admin_allowlist_비매치() {
+        OAuthLoginService adminService = adminAllowlistService("admin@example.com");
+
+        OAuthUserInfo info = new OAuthUserInfo(
+                SocialProvider.GOOGLE, "google-other",
+                new Email("other@example.com"),
+                "일반", null);
+        when(googleProvider.exchangeCodeAndFetch("T", "http://cb")).thenReturn(info);
+        User u = userWithIdAndEmail(USER_ID, "other@example.com");
+        when(userService.findOrCreateBySocial(any(), any(), any(), any(), any())).thenReturn(u);
+
+        TokenPair pair = adminService.loginWithCode(SocialProvider.GOOGLE, "T", "http://cb");
+
+        assertThat(jwtProvider.parse(pair.accessToken()).role()).isEqualTo("USER");
+    }
+
+    @Test
+    @DisplayName("login_allowlist empty (default)_role=USER 유지")
+    void login_admin_allowlist_empty() {
+        // 기본 service 는 setUp 에서 빈 allowlist — 모두 USER
+        when(kakaoProvider.exchangeCodeAndFetch("T", "http://cb")).thenReturn(INFO);
+        User u = userWithIdAndEmail(USER_ID, "user@kakao.com");
+        when(userService.findOrCreateBySocial(any(), any(), any(), any(), any())).thenReturn(u);
+
+        TokenPair pair = service.loginWithCode(SocialProvider.KAKAO, "T", "http://cb");
+
+        assertThat(jwtProvider.parse(pair.accessToken()).role()).isEqualTo("USER");
+    }
+
+    private OAuthLoginService adminAllowlistService(String adminEmailsCsv) {
+        JwtProperties props = new JwtProperties(SECRET, AT_VALIDITY, RT_VALIDITY);
+        return new OAuthLoginService(
+                List.of(kakaoProvider, googleProvider),
+                userService, jwtProvider, store, props,
+                adminEmailsCsv
+        );
+    }
+
+    private User userWithIdAndEmail(Long id, String email) {
+        User u = mock(User.class);
+        when(u.getId()).thenReturn(id);
+        when(u.isAccessibleAt(any(java.time.LocalDateTime.class))).thenReturn(true);
+        when(u.getEmail()).thenReturn(email);
+        return u;
     }
 }

--- a/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
@@ -45,7 +45,7 @@ class PaymentApplicationServiceTest {
         pointHistoryRepo = new InMemoryFakePointHistoryRepository();
         userService = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
         PointApplicationService pointSvc = new PointApplicationService(userService, pointHistoryRepo);
-        TossProperties tossProps = new TossProperties(CLIENT_KEY, "test_sk_secret", null, null, null);
+        TossProperties tossProps = new TossProperties(CLIENT_KEY, "test_sk_secret", null, null, null, null);
         service = new PaymentApplicationService(
                 paymentRepo, gateway, pointSvc, userService,
                 tossProps,

--- a/src/test/java/com/sseulang/domain/payment/infrastructure/toss/TossPaymentGatewayTest.java
+++ b/src/test/java/com/sseulang/domain/payment/infrastructure/toss/TossPaymentGatewayTest.java
@@ -27,7 +27,7 @@ class TossPaymentGatewayTest {
         gateway = new TossPaymentGateway(
                 RestClient.builder(),
                 new ObjectMapper(),
-                new TossProperties("ck", "sk", "https://api.tosspayments.com", null, null)
+                new TossProperties("ck", "sk", "https://api.tosspayments.com", null, null, null)
         );
     }
 

--- a/src/test/java/com/sseulang/domain/report/application/InMemoryFakeUserReportRepository.java
+++ b/src/test/java/com/sseulang/domain/report/application/InMemoryFakeUserReportRepository.java
@@ -56,4 +56,11 @@ public class InMemoryFakeUserReportRepository implements UserReportRepository {
         }
         return result;
     }
+
+    @Override
+    public long countPending() {
+        return store.values().stream()
+                .filter(r -> r.getStatus() == ReportStatus.접수 || r.getStatus() == ReportStatus.처리중)
+                .count();
+    }
 }

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -49,7 +49,10 @@ class ReviewApplicationServiceTest {
         UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, new InMemoryFakePointHistoryRepository());
-        TransactionApplicationService txSvc = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());
+        TransactionApplicationService txSvc = new TransactionApplicationService(
+                txRepo, itemSvc, pointSvc, userSvc,
+                (org.springframework.context.ApplicationEventPublisher) event -> {},
+                java.time.Clock.systemDefaultZone());
         service = new ReviewApplicationService(reviewRepo, txSvc, userSvc);
 
         Item item = itemRepo.save(Item.create(

--- a/src/test/java/com/sseulang/domain/stats/application/AdminStatsServiceTest.java
+++ b/src/test/java/com/sseulang/domain/stats/application/AdminStatsServiceTest.java
@@ -42,7 +42,11 @@ class AdminStatsServiceTest {
         paymentService = mock(PaymentApplicationService.class);
         withdrawalService = mock(WithdrawalApplicationService.class);
         deliveryService = mock(DeliveryApplicationService.class);
-        statsService = new AdminStatsService(userService, transactionService, paymentService, withdrawalService, deliveryService);
+        var userReportService = mock(com.sseulang.domain.report.application.UserReportApplicationService.class);
+        statsService = new AdminStatsService(
+                userService, transactionService, paymentService, withdrawalService, deliveryService,
+                userReportService,
+                java.time.Clock.systemDefaultZone());
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -54,6 +54,31 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
                 .toList();
     }
 
+    @Override
+    public List<com.sseulang.domain.transaction.domain.TransactionRepository.TradeTypeCount>
+            countByTradeTypeBetween(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return store.values().stream()
+                .filter(t -> withinRange(t.getCreatedAt(), from, to))
+                .collect(Collectors.groupingBy(Transaction::getTradeType, Collectors.counting()))
+                .entrySet().stream()
+                .map(e -> new com.sseulang.domain.transaction.domain.TransactionRepository.TradeTypeCount(e.getKey(), e.getValue()))
+                .toList();
+    }
+
+    @Override
+    public List<TransactionStatusCount> countByStatusBetween(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return store.values().stream()
+                .filter(t -> withinRange(t.getCreatedAt(), from, to))
+                .collect(Collectors.groupingBy(Transaction::getStatus, Collectors.counting()))
+                .entrySet().stream()
+                .map(e -> new TransactionStatusCount(e.getKey(), e.getValue()))
+                .toList();
+    }
+
+    private static boolean withinRange(java.time.LocalDateTime when, java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return when != null && !when.isBefore(from) && when.isBefore(to);
+    }
+
     /**
      * 단위 테스트용 — Review 도메인을 cross-aggregate 로 알 수 없으므로 외부에서 (txId, reviewerId) pair 를
      * 주입받아 NOT EXISTS 시뮬레이션. 비어 있으면 모든 거래완료 거래가 pending 으로 반환됨.

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -14,6 +14,7 @@ import com.sseulang.domain.item.domain.ItemStatus;
 import com.sseulang.domain.item.domain.TradeType;
 import com.sseulang.domain.point.application.InMemoryFakePointHistoryRepository;
 import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.point.domain.PointHistoryType;
 import com.sseulang.domain.transaction.application.dto.TransactionCreateCommand;
 import com.sseulang.domain.transaction.application.dto.TransactionResult;
 import com.sseulang.domain.transaction.domain.TransactionStatus;
@@ -22,6 +23,9 @@ import com.sseulang.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,6 +36,7 @@ class TransactionApplicationServiceTest {
     private InMemoryFakeItemRepository itemRepo;
     private InMemoryFakeUserRepository userRepo;
     private InMemoryFakePointHistoryRepository pointHistoryRepo;
+    private List<Object> publishedEvents;
     private ItemApplicationService itemSvc;
     private TransactionApplicationService service;
     private Long itemId;
@@ -45,11 +50,22 @@ class TransactionApplicationServiceTest {
         itemRepo = new InMemoryFakeItemRepository();
         userRepo = new InMemoryFakeUserRepository();
         pointHistoryRepo = new InMemoryFakePointHistoryRepository();
+        publishedEvents = new ArrayList<>();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
-        itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
+        UserApplicationService userSvc = new UserApplicationService(
+                userRepo,
+                new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(),
+                new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(),
+                new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(),
+                java.time.Clock.systemDefaultZone());
+        itemSvc = new ItemApplicationService(
+                itemRepo, catSvc, userSvc,
+                new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(),
+                new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, pointHistoryRepo);
-        service = new TransactionApplicationService(txRepo, itemSvc, pointSvc, userSvc, java.time.Clock.systemDefaultZone());
+        org.springframework.context.ApplicationEventPublisher publisher = publishedEvents::add;
+        service = new TransactionApplicationService(
+                txRepo, itemSvc, pointSvc, userSvc, publisher, java.time.Clock.systemDefaultZone());
 
         SELLER = userRepo.save(User.createSocialUser(
                 SocialProvider.KAKAO, "k-seller", new Email("seller@x.com"), "seller", null
@@ -67,6 +83,8 @@ class TransactionApplicationServiceTest {
         itemId = item.getId();
     }
 
+    // ───────── create ─────────
+
     @Test
     @DisplayName("create 정상_status=채팅중")
     void create_정상() {
@@ -78,6 +96,7 @@ class TransactionApplicationServiceTest {
         assertThat(r.buyerId()).isEqualTo(BUYER);
         assertThat(r.status()).isEqualTo(TransactionStatus.채팅중);
         assertThat(r.price()).isEqualTo(50_000L);
+        assertThat(r.escrowHoldAmount()).isZero();  // 라운드 11 — hold 는 reserve 시점부터
     }
 
     @Test
@@ -114,15 +133,38 @@ class TransactionApplicationServiceTest {
                 .isEqualTo(ErrorCode.ITEM_NOT_FOUND);
     }
 
+    // ───────── reserve (hold 흐름) ─────────
+
     @Test
-    @DisplayName("reserve seller 정상_Transaction.예약 + Item.예약")
-    void reserve_정상() {
+    @DisplayName("reserve 정상_buyer balance↓ + hold↑ + escrowHoldAmount + 거래보관 history + ReservedEvent")
+    void reserve_정상_hold() {
         Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        userRepo.creditPointBalance(BUYER, 50_000L);  // 잔액 충전
 
         service.reserve(txId, SELLER);
 
-        assertThat(service.getById(txId, SELLER).status()).isEqualTo(TransactionStatus.예약);
+        TransactionResult r = service.getById(txId, SELLER);
+        assertThat(r.status()).isEqualTo(TransactionStatus.예약);
+        assertThat(r.escrowHoldAmount()).isEqualTo(50_000L);
         assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.예약);
+        assertThat(userRepo.findPointBalance(BUYER)).isZero();
+        assertThat(userRepo.findPointHold(BUYER)).isEqualTo(50_000L);
+        assertThat(pointHistoryRepo.size()).isEqualTo(1);  // 거래보관 1건
+        assertThat(publishedEvents)
+                .hasSize(1)
+                .first().isInstanceOf(com.sseulang.domain.transaction.domain.event.TransactionReservedEvent.class);
+    }
+
+    @Test
+    @DisplayName("reserve 잔액 부족_INSUFFICIENT_POINT")
+    void reserve_잔액부족_거부() {
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        userRepo.creditPointBalance(BUYER, 10_000L);  // 부족
+
+        assertThatThrownBy(() -> service.reserve(txId, SELLER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INSUFFICIENT_POINT);
     }
 
     @Test
@@ -154,79 +196,126 @@ class TransactionApplicationServiceTest {
                 SocialProvider.KAKAO, "k-buyer2-" + System.nanoTime(),
                 new Email("buyer2-" + System.nanoTime() + "@x.com"), "buyer2", null
         )).getId();
+        userRepo.creditPointBalance(BUYER, 50_000L);
+        userRepo.creditPointBalance(buyer2, 50_000L);
         Long tx1 = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
         Long tx2 = service.create(new TransactionCreateCommand(itemId, buyer2, null, null));
 
-        // 첫 reserve 성공
         service.reserve(tx1, SELLER);
 
-        // 두 번째 reserve 는 Item.status=예약 으로 인해 거부
         assertThatThrownBy(() -> service.reserve(tx2, SELLER))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.TRANSACTION_RESERVED_BY_OTHER);
     }
 
-    @Test
-    @DisplayName("complete 정상_seller 호출_Item.판매완료 + 포인트 정산 + history 두 건")
-    void complete_정상() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
-        service.reserve(txId, SELLER);
-        userRepo.creditPointBalance(BUYER, 50_000L);  // buyer 잔액 충전
+    // ───────── markHandover (라운드 11) ─────────
 
-        service.complete(txId, SELLER);
+    @Test
+    @DisplayName("markHandover seller 정상_status=인계완료 + HandoverEvent")
+    void handover_정상() {
+        Long txId = reservedTxByBuyer();
+
+        service.markHandover(txId, SELLER);
 
         TransactionResult r = service.getById(txId, SELLER);
+        assertThat(r.status()).isEqualTo(TransactionStatus.인계완료);
+        assertThat(r.handoverConfirmedAt()).isNotNull();
+        assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.예약);  // 아직 sold X
+        assertThat(userRepo.findPointBalance(BUYER)).isZero();  // hold 유지
+        assertThat(userRepo.findPointHold(BUYER)).isEqualTo(50_000L);
+        assertThat(eventTypes()).contains("TransactionHandoverConfirmedEvent");
+    }
+
+    @Test
+    @DisplayName("markHandover buyer 호출_TRANSACTION_HANDOVER_NOT_ALLOWED")
+    void handover_buyer_거부() {
+        Long txId = reservedTxByBuyer();
+
+        assertThatThrownBy(() -> service.markHandover(txId, BUYER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_HANDOVER_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("markHandover 멱등_이미 인계완료면 no-op")
+    void handover_멱등() {
+        Long txId = reservedTxByBuyer();
+        service.markHandover(txId, SELLER);
+        int eventsBefore = publishedEvents.size();
+
+        service.markHandover(txId, SELLER);  // 두 번째 — no-op
+
+        assertThat(service.getById(txId, SELLER).status()).isEqualTo(TransactionStatus.인계완료);
+        assertThat(publishedEvents).hasSize(eventsBefore);  // 추가 발행 X
+    }
+
+    // ───────── markReceived (라운드 11) ─────────
+
+    @Test
+    @DisplayName("markReceived buyer 정상_정산_buyer hold↓ + seller balance↑ + 판매정산 history + ReceiveEvent")
+    void receive_정상() {
+        Long txId = reservedTxByBuyer();
+        service.markHandover(txId, SELLER);
+
+        service.markReceived(txId, BUYER);
+
+        TransactionResult r = service.getById(txId, BUYER);
         assertThat(r.status()).isEqualTo(TransactionStatus.거래완료);
+        assertThat(r.receiveConfirmedAt()).isNotNull();
+        assertThat(r.completedAt()).isEqualTo(r.receiveConfirmedAt());
         assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.거래완료);
         assertThat(userRepo.findPointBalance(BUYER)).isZero();
+        assertThat(userRepo.findPointHold(BUYER)).isZero();  // 해제됨
         assertThat(userRepo.findPointBalance(SELLER)).isEqualTo(50_000L);
+        // history: 거래보관(buyer, reserve) + 판매정산(seller, receive) = 2건
         assertThat(pointHistoryRepo.size()).isEqualTo(2);
+        assertThat(eventTypes()).contains("TransactionReceiveConfirmedEvent");
     }
 
     @Test
-    @DisplayName("complete buyer 호출_TRANSACTION_FORBIDDEN")
-    void complete_buyer_금지() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
-        service.reserve(txId, SELLER);
-        userRepo.creditPointBalance(BUYER, 50_000L);
+    @DisplayName("markReceived seller 호출_TRANSACTION_RECEIVE_NOT_ALLOWED")
+    void receive_seller_거부() {
+        Long txId = reservedTxByBuyer();
+        service.markHandover(txId, SELLER);
 
-        assertThatThrownBy(() -> service.complete(txId, BUYER))
+        assertThatThrownBy(() -> service.markReceived(txId, SELLER))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.TRANSACTION_FORBIDDEN);
-        assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.예약);
-        assertThat(userRepo.findPointBalance(BUYER)).isEqualTo(50_000L);  // 차감 X
+                .isEqualTo(ErrorCode.TRANSACTION_RECEIVE_NOT_ALLOWED);
     }
 
     @Test
-    @DisplayName("complete buyer 잔액 부족_INSUFFICIENT_POINT_seller 적립도 롤백")
-    void complete_buyer_잔액부족() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
-        service.reserve(txId, SELLER);
-        userRepo.creditPointBalance(BUYER, 10_000L);  // 부족
+    @DisplayName("markReceived 인계 전_TRANSACTION_INVALID_STATE")
+    void receive_인계전_거부() {
+        Long txId = reservedTxByBuyer();
 
-        assertThatThrownBy(() -> service.complete(txId, SELLER))
+        assertThatThrownBy(() -> service.markReceived(txId, BUYER))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.INSUFFICIENT_POINT);
-
-        // 트랜잭션 롤백 — fake 는 롤백 시뮬 못 하지만 잔액/Item/Tx 상태로 상위 흐름 검증
-        // (실제 prod 트랜잭션 IT 는 후속 #23)
+                .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
     }
 
     @Test
-    @DisplayName("complete 채팅중 상태_TRANSACTION_INVALID_STATE")
-    void complete_채팅중_거부() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
-        userRepo.creditPointBalance(BUYER, 50_000L);
+    @DisplayName("markReceived 멱등_이미 거래완료면 no-op (재호출 시 더블 정산 X)")
+    void receive_멱등() {
+        Long txId = reservedTxByBuyer();
+        service.markHandover(txId, SELLER);
+        service.markReceived(txId, BUYER);
+        long sellerBalance = userRepo.findPointBalance(SELLER);
+        int historyBefore = pointHistoryRepo.size();
 
-        assertThatThrownBy(() -> service.complete(txId, SELLER))
-                .isInstanceOf(BusinessException.class);
+        service.markReceived(txId, BUYER);  // 멱등
+
+        assertThat(userRepo.findPointBalance(SELLER)).isEqualTo(sellerBalance);
+        assertThat(pointHistoryRepo.size()).isEqualTo(historyBefore);
     }
 
+    // ───────── cancel 단계별 환불 (라운드 11) ─────────
+
     @Test
-    @DisplayName("cancel 채팅중 buyer_정상_Item 변경 없음")
+    @DisplayName("cancel 채팅중 buyer_정상_Item 변경 없음 + 잔액 변동 없음")
     void cancel_채팅중() {
         Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
 
@@ -234,18 +323,39 @@ class TransactionApplicationServiceTest {
 
         assertThat(service.getById(txId, BUYER).status()).isEqualTo(TransactionStatus.취소);
         assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.판매중);
+        assertThat(userRepo.findPointBalance(BUYER)).isZero();
+        assertThat(userRepo.findPointHold(BUYER)).isZero();
     }
 
     @Test
-    @DisplayName("cancel 예약 상태_Item.판매중 으로 복원")
-    void cancel_예약_복원() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
-        service.reserve(txId, SELLER);
+    @DisplayName("cancel 예약 상태_Item 복원 + buyer hold 환불 + 거래환불 history + CancelEvent")
+    void cancel_예약_환불() {
+        Long txId = reservedTxByBuyer();
+        int historyBefore = pointHistoryRepo.size();
 
         service.cancel(txId, SELLER, "물건 파손");
 
         assertThat(service.getById(txId, SELLER).status()).isEqualTo(TransactionStatus.취소);
         assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.판매중);
+        assertThat(userRepo.findPointBalance(BUYER)).isEqualTo(50_000L);  // 환불
+        assertThat(userRepo.findPointHold(BUYER)).isZero();
+        assertThat(pointHistoryRepo.size()).isEqualTo(historyBefore + 1);
+        assertThat(pointHistoryRepo.findByUserIdOrderByCreatedAtDesc(BUYER))
+                .extracting("pointType")
+                .contains(PointHistoryType.거래보관, PointHistoryType.거래환불);
+        assertThat(eventTypes()).contains("TransactionCanceledEvent");
+    }
+
+    @Test
+    @DisplayName("cancel 인계완료 이후_TRANSACTION_INVALID_STATE (R2 분쟁 영역)")
+    void cancel_인계완료_거부() {
+        Long txId = reservedTxByBuyer();
+        service.markHandover(txId, SELLER);
+
+        assertThatThrownBy(() -> service.cancel(txId, SELLER, "사후 취소"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
     }
 
     @Test
@@ -271,20 +381,37 @@ class TransactionApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("cancel 후 다른 buyer 가 같은 Item 으로 거래 시작 가능")
+    @DisplayName("cancel 후 다른 buyer 가 같은 Item 으로 거래 시작 가능 + hold 환불 받음")
     void cancel_후_새_거래() {
         Long buyer2 = userRepo.save(User.createSocialUser(
                 SocialProvider.KAKAO, "k-buyer2-" + System.nanoTime(),
                 new Email("buyer2-" + System.nanoTime() + "@x.com"), "buyer2", null
         )).getId();
+        userRepo.creditPointBalance(BUYER, 50_000L);
+        userRepo.creditPointBalance(buyer2, 50_000L);
+
         Long tx1 = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
         service.reserve(tx1, SELLER);
         service.cancel(tx1, SELLER, "재예약 가능");
+        assertThat(userRepo.findPointBalance(BUYER)).isEqualTo(50_000L);  // 환불 OK
 
-        // Item 이 판매중으로 복원 → 새 거래 시작 OK
         Long tx2 = service.create(new TransactionCreateCommand(itemId, buyer2, null, null));
         service.reserve(tx2, SELLER);
 
         assertThat(service.getById(tx2, SELLER).status()).isEqualTo(TransactionStatus.예약);
+    }
+
+    // ───────── helpers ─────────
+
+    /** buyer 충전 + 거래 생성 + reserve 까지 진행한 trasaction id 반환. */
+    private Long reservedTxByBuyer() {
+        userRepo.creditPointBalance(BUYER, 50_000L);
+        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        service.reserve(txId, SELLER);
+        return txId;
+    }
+
+    private List<String> eventTypes() {
+        return publishedEvents.stream().map(e -> e.getClass().getSimpleName()).toList();
     }
 }

--- a/src/test/java/com/sseulang/domain/transaction/domain/TransactionTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/domain/TransactionTest.java
@@ -17,21 +17,27 @@ class TransactionTest {
     private static final Long SELLER = 100L;
     private static final Long BUYER = 200L;
     private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 1, 12, 0);
+    private static final long PRICE = 50_000L;
+
+    // ───────── create ─────────
 
     @Test
     @DisplayName("create 판매_정상_status=채팅중, deposit/rental null")
     void create_판매_정상() {
-        Transaction t = Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, 50_000L, null, null, null);
+        Transaction t = Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, PRICE, null, null, null);
 
         assertThat(t.getItemId()).isEqualTo(ITEM);
         assertThat(t.getSellerId()).isEqualTo(SELLER);
         assertThat(t.getBuyerId()).isEqualTo(BUYER);
         assertThat(t.getTradeType()).isEqualTo(TradeType.판매);
-        assertThat(t.getPrice()).isEqualTo(50_000L);
+        assertThat(t.getPrice()).isEqualTo(PRICE);
         assertThat(t.getStatus()).isEqualTo(TransactionStatus.채팅중);
         assertThat(t.getReservedAt()).isNull();
+        assertThat(t.getHandoverConfirmedAt()).isNull();
+        assertThat(t.getReceiveConfirmedAt()).isNull();
         assertThat(t.getCompletedAt()).isNull();
         assertThat(t.getCanceledAt()).isNull();
+        assertThat(t.getEscrowHoldAmount()).isZero();
     }
 
     @Test
@@ -98,45 +104,123 @@ class TransactionTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    // ───────── markAsReserved ─────────
+
     @Test
-    @DisplayName("markAsReserved 정상_status=예약 + reservedAt")
-    void reserve_정상() {
+    @DisplayName("markAsReserved(now) 나눔용_holdAmount=0")
+    void reserve_old_signature_나눔() {
         Transaction t = sale();
         t.markAsReserved(NOW);
+
         assertThat(t.getStatus()).isEqualTo(TransactionStatus.예약);
         assertThat(t.getReservedAt()).isEqualTo(NOW);
+        assertThat(t.getEscrowHoldAmount()).isZero();
+    }
+
+    @Test
+    @DisplayName("markAsReserved(now, holdAmount) 정상_escrowHoldAmount 동기 set (라운드 11)")
+    void reserve_hold_정상() {
+        Transaction t = sale();
+        t.markAsReserved(NOW, PRICE);
+
+        assertThat(t.getStatus()).isEqualTo(TransactionStatus.예약);
+        assertThat(t.getReservedAt()).isEqualTo(NOW);
+        assertThat(t.getEscrowHoldAmount()).isEqualTo(PRICE);
+    }
+
+    @Test
+    @DisplayName("markAsReserved 음수 holdAmount_거부")
+    void reserve_음수_hold_거부() {
+        Transaction t = sale();
+        assertThatThrownBy(() -> t.markAsReserved(NOW, -1L))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     @DisplayName("markAsReserved 채팅중 외_TRANSACTION_INVALID_STATE")
     void reserve_상태_위반() {
         Transaction t = sale();
-        t.markAsReserved(NOW);
-        assertThatThrownBy(() -> t.markAsReserved(NOW))
+        t.markAsReserved(NOW, PRICE);
+        assertThatThrownBy(() -> t.markAsReserved(NOW, PRICE))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
+    }
+
+    // ───────── markHandover (라운드 11) ─────────
+
+    @Test
+    @DisplayName("markHandover 정상_예약→인계완료 + handoverConfirmedAt")
+    void handover_정상() {
+        Transaction t = sale();
+        t.markAsReserved(NOW, PRICE);
+        t.markHandover(NOW.plusHours(1));
+
+        assertThat(t.getStatus()).isEqualTo(TransactionStatus.인계완료);
+        assertThat(t.getHandoverConfirmedAt()).isEqualTo(NOW.plusHours(1));
+        assertThat(t.getReceiveConfirmedAt()).isNull();
+        assertThat(t.getCompletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("markHandover 채팅중에서 직행_TRANSACTION_INVALID_STATE")
+    void handover_채팅중_거부() {
+        Transaction t = sale();
+        assertThatThrownBy(() -> t.markHandover(NOW))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
     }
 
     @Test
-    @DisplayName("markAsCompleted 정상_예약→거래완료")
-    void complete_정상() {
+    @DisplayName("markHandover 인계완료 후 재호출_TRANSACTION_INVALID_STATE (Aggregate 가드 — 멱등은 ApplicationService 책임)")
+    void handover_재호출_거부() {
         Transaction t = sale();
-        t.markAsReserved(NOW);
-        t.markAsCompleted(NOW.plusHours(1));
+        t.markAsReserved(NOW, PRICE);
+        t.markHandover(NOW.plusHours(1));
+        assertThatThrownBy(() -> t.markHandover(NOW.plusHours(2)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
+    }
+
+    // ───────── markReceived (라운드 11) ─────────
+
+    @Test
+    @DisplayName("markReceived 정상_인계완료→거래완료 + receiveConfirmedAt + completedAt 동기")
+    void receive_정상() {
+        Transaction t = sale();
+        t.markAsReserved(NOW, PRICE);
+        t.markHandover(NOW.plusHours(1));
+        t.markReceived(NOW.plusHours(2));
+
         assertThat(t.getStatus()).isEqualTo(TransactionStatus.거래완료);
-        assertThat(t.getCompletedAt()).isEqualTo(NOW.plusHours(1));
+        assertThat(t.getReceiveConfirmedAt()).isEqualTo(NOW.plusHours(2));
+        assertThat(t.getCompletedAt()).isEqualTo(NOW.plusHours(2));
     }
 
     @Test
-    @DisplayName("markAsCompleted 채팅중에서 직행_거부")
-    void complete_채팅중에서_거부() {
+    @DisplayName("markReceived 예약 상태에서_TRANSACTION_INVALID_STATE (인계완료 거쳐야 함)")
+    void receive_예약에서_거부() {
         Transaction t = sale();
-        assertThatThrownBy(() -> t.markAsCompleted(NOW))
+        t.markAsReserved(NOW, PRICE);
+        assertThatThrownBy(() -> t.markReceived(NOW))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
     }
+
+    @Test
+    @DisplayName("markReceived 채팅중에서 직행_TRANSACTION_INVALID_STATE")
+    void receive_채팅중_거부() {
+        Transaction t = sale();
+        assertThatThrownBy(() -> t.markReceived(NOW))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
+    }
+
+    // ───────── cancel 단계별 (라운드 11) ─────────
 
     @Test
     @DisplayName("cancel 채팅중에서 정상")
@@ -149,21 +233,38 @@ class TransactionTest {
     }
 
     @Test
-    @DisplayName("cancel 예약에서 정상")
+    @DisplayName("cancel 예약에서 정상_escrowHoldAmount 보존 (환불 금액 추적)")
     void cancel_예약() {
         Transaction t = sale();
-        t.markAsReserved(NOW);
+        t.markAsReserved(NOW, PRICE);
         t.cancel(NOW.plusHours(1), null);
+
         assertThat(t.getStatus()).isEqualTo(TransactionStatus.취소);
+        assertThat(t.getEscrowHoldAmount()).isEqualTo(PRICE);  // 보존 — ApplicationService 가 환불 시 참조
     }
 
     @Test
-    @DisplayName("cancel 거래완료_거부")
+    @DisplayName("cancel 인계완료 이후_TRANSACTION_INVALID_STATE (라운드 11 — R2 분쟁 영역)")
+    void cancel_인계완료_거부() {
+        Transaction t = sale();
+        t.markAsReserved(NOW, PRICE);
+        t.markHandover(NOW.plusHours(1));
+
+        assertThatThrownBy(() -> t.cancel(NOW.plusHours(2), null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("cancel 거래완료 후_거부")
     void cancel_거래완료_거부() {
         Transaction t = sale();
-        t.markAsReserved(NOW);
-        t.markAsCompleted(NOW.plusHours(1));
-        assertThatThrownBy(() -> t.cancel(NOW.plusHours(2), null))
+        t.markAsReserved(NOW, PRICE);
+        t.markHandover(NOW.plusHours(1));
+        t.markReceived(NOW.plusHours(2));
+
+        assertThatThrownBy(() -> t.cancel(NOW.plusHours(3), null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.TRANSACTION_INVALID_STATE);
@@ -178,6 +279,8 @@ class TransactionTest {
                 .isInstanceOf(BusinessException.class);
     }
 
+    // ───────── helpers ─────────
+
     @Test
     @DisplayName("isSeller / isBuyer / isParticipant")
     void participants() {
@@ -191,6 +294,6 @@ class TransactionTest {
     }
 
     private static Transaction sale() {
-        return Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, 50_000L, null, null, null);
+        return Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, PRICE, null, null, null);
     }
 }

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -139,8 +139,8 @@ class SettlementRollbackIT {
     }
 
     @Test
-    @DisplayName("complete 정산 실패 (buyer 잔액 부족)_Item/Tx/PointHistory 모두 원복")
-    void complete_정산_실패_롤백() {
+    @DisplayName("라운드 11 — reserve 시 buyer 잔액 부족_INSUFFICIENT_POINT + Item/Tx/잔액/history 모두 원복")
+    void reserve_hold_실패_롤백() {
         Long sellerId = txTemplate.execute(s -> persistUser("seller"));
         Long buyerId = txTemplate.execute(s -> persistUser("buyer"));
         // buyer 잔액 = 10000 (price 50000 보다 부족)
@@ -156,35 +156,30 @@ class SettlementRollbackIT {
         Long txId = txTemplate.execute(s -> transactionService.create(
                 new TransactionCreateCommand(itemId, buyerId, null, null)
         ));
-        txTemplate.execute(s -> {
-            transactionService.reserve(txId, sellerId);
-            return null;
-        });
 
-        // 정산 시도 → buyer 잔액 부족으로 INSUFFICIENT_POINT
+        // reserve 시 hold 시도 → 잔액 부족으로 INSUFFICIENT_POINT (라운드 11 — 옛 정책은 거래완료 시점)
         assertThatThrownBy(() -> txTemplate.execute(s -> {
-            transactionService.complete(txId, sellerId);
+            transactionService.reserve(txId, sellerId);
             return null;
         }))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.INSUFFICIENT_POINT);
 
-        // verify — Item / Transaction / PointHistory / 잔액 모두 원복
+        // verify — Item / Transaction / PointHistory / 잔액 모두 원복 (markItemAsReserved 도 롤백)
         Item item = itemRepository.findById(itemId).orElseThrow();
-        assertThat(item.getStatus()).as("Item 은 예약 상태 유지 (거래완료 전이 X)").isEqualTo(ItemStatus.예약);
+        assertThat(item.getStatus()).as("Item 은 판매중 유지 (예약 전이 X)").isEqualTo(ItemStatus.판매중);
 
         Transaction tx = transactionRepository.findById(txId).orElseThrow();
-        assertThat(tx.getStatus()).as("Transaction 은 예약 상태 유지").isEqualTo(TransactionStatus.예약);
-        assertThat(tx.getCompletedAt()).isNull();
+        assertThat(tx.getStatus()).as("Tx 는 채팅중 유지").isEqualTo(TransactionStatus.채팅중);
+        assertThat(tx.getReservedAt()).isNull();
+        assertThat(tx.getEscrowHoldAmount()).isZero();
 
         assertThat(pointHistoryRepository.findByUserIdOrderByCreatedAtDesc(buyerId))
-                .as("buyer history 미적재").isEmpty();
-        assertThat(pointHistoryRepository.findByUserIdOrderByCreatedAtDesc(sellerId))
-                .as("seller history 미적재 (선행 적립도 함께 롤백)").isEmpty();
+                .as("buyer history 미적재 (거래보관 X)").isEmpty();
 
         assertThat(userRepository.findPointBalance(buyerId)).isEqualTo(10_000L);
-        assertThat(userRepository.findPointBalance(sellerId)).isZero();
+        assertThat(userRepository.findPointHold(buyerId)).as("hold 도 0").isZero();
     }
 
     @Test

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -135,6 +135,11 @@ class TransactionConcurrencyIT {
             sellerId = persistUser("seller");
             buyer1Id = persistUser("buyer1");
             buyer2Id = persistUser("buyer2");
+            // 라운드 11 — reserve 시 buyer 잔액 hold 되므로 사전 충전 필수
+            em.createNativeQuery("UPDATE users SET point_balance = 50000 WHERE id IN (?, ?)")
+                    .setParameter(1, buyer1Id)
+                    .setParameter(2, buyer2Id)
+                    .executeUpdate();
 
             itemId = itemService.register(new ItemRegisterCommand(
                     sellerId, null, "물건", "설명", 50_000L, null, null, TradeType.판매,
@@ -175,13 +180,7 @@ class TransactionConcurrencyIT {
         Item item = itemRepository.findById(itemId).orElseThrow();
         assertThat(item.getStatus()).isEqualTo(ItemStatus.예약);
 
-        // cleanup — @Commit 으로 데이터 남으니 후속 테스트 충돌 방지 (현재 클래스 단일 테스트라 실효 X, 안전 차원)
-        txTemplate.execute(status -> {
-            em.createNativeQuery("DELETE FROM transactions").executeUpdate();
-            em.createNativeQuery("DELETE FROM items").executeUpdate();
-            em.createNativeQuery("DELETE FROM users").executeUpdate();
-            return null;
-        });
+        cleanup();
     }
 
     private void tryReserve(Long txId, CountDownLatch start, CountDownLatch done,
@@ -201,6 +200,153 @@ class TransactionConcurrencyIT {
         } finally {
             done.countDown();
         }
+    }
+
+    /**
+     * 라운드 11 — 같은 buyer 가 두 거래 동시 reserve 시도, 잔액이 한 건만 충당 가능.
+     * Item 락이 없는 상황 (서로 다른 Item) 에서도 buyer 행 락이 직렬화 + atomic UPDATE 의 잔액 가드
+     * (WHERE point_balance >= :amount) 가 두 번째 호출을 INSUFFICIENT_POINT 로 차단.
+     */
+    @Test
+    @DisplayName("라운드 11 — 같은 buyer 두 거래 동시 reserve_잔액 한건만 충당_정확히 1건만 성공")
+    void buyer_hold_race() throws Exception {
+        // 별도 두 Item + 두 거래 (buyer 동일, 잔액 50000 한 건만 가능)
+        Long item2Id = txTemplate.execute(status -> itemService.register(new ItemRegisterCommand(
+                sellerId, null, "물건2", "설명", 50_000L, null, null, TradeType.판매, "서울", null, null
+        )));
+        Long txA = txTemplate.execute(status ->
+                transactionService.create(new TransactionCreateCommand(itemId, buyer1Id, null, null)));
+        Long txB = txTemplate.execute(status ->
+                transactionService.create(new TransactionCreateCommand(item2Id, buyer1Id, null, null)));
+        // 기존 setUp 의 tx1 (item1, buyer1) 를 cancel 해 같은 Item 재예약 가능 상태로
+        // → 위 txA 가 새 Item 거래라 tx1Id 는 무시 가능. 단, item.status=판매중 인지 보장 필요.
+        // setUp 직후 item1 은 판매중이라 OK.
+
+        ExecutorService exec = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicInteger success = new AtomicInteger();
+        AtomicInteger insufficient = new AtomicInteger();
+        AtomicInteger otherError = new AtomicInteger();
+
+        Runnable a = () -> tryReserveCounted(txA, start, done, success, insufficient, otherError);
+        Runnable b = () -> tryReserveCounted(txB, start, done, success, insufficient, otherError);
+
+        exec.submit(a);
+        exec.submit(b);
+        start.countDown();
+        boolean finished = done.await(10, TimeUnit.SECONDS);
+        exec.shutdown();
+
+        assertThat(finished).as("두 호출 10초 안에 완료").isTrue();
+        assertThat(success.get()).as("정확히 1건만 reserve 성공").isEqualTo(1);
+        assertThat(insufficient.get()).as("나머지 1건은 INSUFFICIENT_POINT").isEqualTo(1);
+        assertThat(otherError.get()).as("그 외 에러 없음").isZero();
+
+        // buyer 잔액: 50000 → 0 (1건 hold), point_hold = 50000
+        Long balance = (Long) em.createNativeQuery("SELECT point_balance FROM users WHERE id = ?")
+                .setParameter(1, buyer1Id).getSingleResult();
+        Long hold = (Long) em.createNativeQuery("SELECT point_hold FROM users WHERE id = ?")
+                .setParameter(1, buyer1Id).getSingleResult();
+        assertThat(balance).isZero();
+        assertThat(hold).isEqualTo(50_000L);
+
+        cleanup();
+    }
+
+    /**
+     * 라운드 11 — 동일 거래의 reserve 직후 cancel / markHandover 동시 호출. Transaction 비관적 락이
+     * 직렬화. cancel 이 먼저면 markHandover 가 TRANSACTION_INVALID_STATE, 반대도 마찬가지. 정확히 1건만 성공.
+     */
+    @Test
+    @DisplayName("라운드 11 — 예약된 거래에 cancel / handover 동시_정확히 1건만 성공 (Transaction 락 직렬화)")
+    void cancel_handover_race() throws Exception {
+        // tx1 reserve (buyer1) 먼저
+        txTemplate.execute(status -> {
+            transactionService.reserve(tx1Id, sellerId);
+            return null;
+        });
+
+        ExecutorService exec = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicInteger cancelOk = new AtomicInteger();
+        AtomicInteger handoverOk = new AtomicInteger();
+        AtomicInteger invalidState = new AtomicInteger();
+        AtomicInteger otherError = new AtomicInteger();
+
+        Runnable cancelTask = () -> {
+            try {
+                start.await();
+                transactionService.cancel(tx1Id, buyer1Id, "race");
+                cancelOk.incrementAndGet();
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.TRANSACTION_INVALID_STATE) invalidState.incrementAndGet();
+                else otherError.incrementAndGet();
+            } catch (Exception e) {
+                otherError.incrementAndGet();
+            } finally {
+                done.countDown();
+            }
+        };
+        Runnable handoverTask = () -> {
+            try {
+                start.await();
+                transactionService.markHandover(tx1Id, sellerId);
+                handoverOk.incrementAndGet();
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.TRANSACTION_INVALID_STATE) invalidState.incrementAndGet();
+                else otherError.incrementAndGet();
+            } catch (Exception e) {
+                otherError.incrementAndGet();
+            } finally {
+                done.countDown();
+            }
+        };
+
+        exec.submit(cancelTask);
+        exec.submit(handoverTask);
+        start.countDown();
+        boolean finished = done.await(10, TimeUnit.SECONDS);
+        exec.shutdown();
+
+        assertThat(finished).as("두 호출 10초 안에 완료").isTrue();
+        assertThat(cancelOk.get() + handoverOk.get()).as("정확히 1건만 성공").isEqualTo(1);
+        assertThat(invalidState.get()).as("패배자는 TRANSACTION_INVALID_STATE").isEqualTo(1);
+        assertThat(otherError.get()).as("그 외 에러 없음").isZero();
+
+        // 결과 status 검증 — 취소 또는 인계완료 중 하나
+        TransactionStatus finalStatus = txTemplate.execute(status ->
+                transactionService.getById(tx1Id, sellerId).status());
+        assertThat(finalStatus).isIn(TransactionStatus.취소, TransactionStatus.인계완료);
+
+        cleanup();
+    }
+
+    private void tryReserveCounted(Long txId, CountDownLatch start, CountDownLatch done,
+                                   AtomicInteger success, AtomicInteger insufficient, AtomicInteger otherError) {
+        try {
+            start.await();
+            transactionService.reserve(txId, sellerId);
+            success.incrementAndGet();
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == ErrorCode.INSUFFICIENT_POINT) insufficient.incrementAndGet();
+            else otherError.incrementAndGet();
+        } catch (Exception e) {
+            otherError.incrementAndGet();
+        } finally {
+            done.countDown();
+        }
+    }
+
+    private void cleanup() {
+        txTemplate.execute(status -> {
+            em.createNativeQuery("DELETE FROM point_histories").executeUpdate();
+            em.createNativeQuery("DELETE FROM transactions").executeUpdate();
+            em.createNativeQuery("DELETE FROM items").executeUpdate();
+            em.createNativeQuery("DELETE FROM users").executeUpdate();
+            return null;
+        });
     }
 
     private Long persistUser(String suffix) {

--- a/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
+++ b/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
@@ -85,6 +85,48 @@ public class InMemoryFakeUserRepository implements UserRepository {
     }
 
     @Override
+    public synchronized int holdForEscrow(Long userId, long amount) {
+        User user = store.get(userId);
+        if (user == null) return 0;
+        if (user.getPointBalance() < amount) return 0;
+        ReflectionTestUtils.setField(user, "pointBalance", user.getPointBalance() - amount);
+        ReflectionTestUtils.setField(user, "pointHold", user.getPointHold() + amount);
+        return 1;
+    }
+
+    @Override
+    public synchronized int releaseHold(Long userId, long amount) {
+        User user = store.get(userId);
+        if (user == null) return 0;
+        if (user.getPointHold() < amount) return 0;
+        ReflectionTestUtils.setField(user, "pointHold", user.getPointHold() - amount);
+        return 1;
+    }
+
+    @Override
+    public synchronized int refundHold(Long userId, long amount) {
+        User user = store.get(userId);
+        if (user == null) return 0;
+        if (user.getPointHold() < amount) return 0;
+        ReflectionTestUtils.setField(user, "pointHold", user.getPointHold() - amount);
+        ReflectionTestUtils.setField(user, "pointBalance", user.getPointBalance() + amount);
+        return 1;
+    }
+
+    @Override
+    public Long findPointHold(Long userId) {
+        User user = store.get(userId);
+        return user == null ? null : user.getPointHold();
+    }
+
+    @Override
+    public synchronized java.util.Optional<PointSnapshot> findPointSnapshot(Long userId) {
+        User user = store.get(userId);
+        if (user == null) return java.util.Optional.empty();
+        return java.util.Optional.of(new PointSnapshot(user.getPointBalance(), user.getPointHold()));
+    }
+
+    @Override
     public Page<User> findAllForAdmin(Pageable pageable) {
         List<User> all = store.values().stream()
                 .sorted(Comparator.comparing(User::getId).reversed())

--- a/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
+++ b/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
@@ -155,6 +155,29 @@ public class InMemoryFakeUserRepository implements UserRepository {
     }
 
     @Override
+    public long countSignupsBetween(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        return store.values().stream()
+                .filter(u -> {
+                    java.time.LocalDateTime c = u.getCreatedAt();
+                    return c != null && !c.isBefore(from) && c.isBefore(to);
+                })
+                .count();
+    }
+
+    @Override
+    public java.util.List<DailyCount> findDailySignups(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        java.util.Map<java.time.LocalDate, Long> grouped = new java.util.TreeMap<>();
+        for (User u : store.values()) {
+            java.time.LocalDateTime c = u.getCreatedAt();
+            if (c == null || c.isBefore(from) || !c.isBefore(to)) continue;
+            grouped.merge(c.toLocalDate(), 1L, Long::sum);
+        }
+        return grouped.entrySet().stream()
+                .map(e -> new DailyCount(e.getKey(), e.getValue()))
+                .toList();
+    }
+
+    @Override
     public Page<User> searchForAdmin(
             com.sseulang.domain.user.application.dto.AdminUserSearchCriteria criteria,
             java.time.LocalDateTime now,

--- a/src/test/java/com/sseulang/global/infra/payment/TossWebhookSignatureVerifierTest.java
+++ b/src/test/java/com/sseulang/global/infra/payment/TossWebhookSignatureVerifierTest.java
@@ -25,7 +25,7 @@ class TossWebhookSignatureVerifierTest {
     @Test
     @DisplayName("verify 시크릿 미설정_검증 비활성 (예외 X)")
     void verify_시크릿_미설정() {
-        TossProperties props = new TossProperties("ck", "sk", null, null, null);
+        TossProperties props = new TossProperties("ck", "sk", null, null, null, null);
         TossWebhookSignatureVerifier v = new TossWebhookSignatureVerifier(props, FIXED_CLOCK);
 
         assertThatCode(() -> v.verify("body", "anything", "anything")).doesNotThrowAnyException();
@@ -140,7 +140,7 @@ class TossWebhookSignatureVerifierTest {
     @Test
     @DisplayName("verify tolerance=0 면 timestamp 검증 비활성")
     void verify_tolerance_zero() {
-        TossProperties props = new TossProperties("ck", "sk", null, SECRET, 0L);
+        TossProperties props = new TossProperties("ck", "sk", null, SECRET, 0L, null);
         TossWebhookSignatureVerifier v = new TossWebhookSignatureVerifier(props, FIXED_CLOCK);
         String body = "body";
         // 1년 전이라도 timestamp 검증 안 함.
@@ -151,7 +151,7 @@ class TossWebhookSignatureVerifierTest {
     }
 
     private TossWebhookSignatureVerifier newVerifier() {
-        TossProperties props = new TossProperties("ck", "sk", null, SECRET, 300L);
+        TossProperties props = new TossProperties("ck", "sk", null, SECRET, 300L, null);
         return new TossWebhookSignatureVerifier(props, FIXED_CLOCK);
     }
 

--- a/src/test/java/com/sseulang/integration/EndToEndGuardScenariosIT.java
+++ b/src/test/java/com/sseulang/integration/EndToEndGuardScenariosIT.java
@@ -198,7 +198,7 @@ class EndToEndGuardScenariosIT {
     // ───────── 시나리오 2: 잔액 부족 정산 실패 ─────────
 
     @Test
-    @DisplayName("buyer 충전 안 한 상태_거래완료 시 INSUFFICIENT_POINT + 모든 상태 롤백")
+    @DisplayName("라운드 11 — buyer 충전 안 한 상태_예약 시점에 INSUFFICIENT_POINT + Item/Tx 모두 롤백")
     void scenario_잔액부족_롤백() throws Exception {
         // Seller — OAuth (verified=true). Item 등록.
         Cookie sellerAt = oauthLoginAndExtractAt("SELLER", "kakao-seller-" + UUID.randomUUID(),
@@ -212,26 +212,20 @@ class EndToEndGuardScenariosIT {
         // 거래 생성 — 채팅중 (자금 이동 없음).
         Long txId = createTransaction(buyerAt, itemId);
 
-        // Seller 예약 → 거래완료 시 정산 시도. buyer 잔액 0 < 50000 → INSUFFICIENT_POINT.
+        // 라운드 11 — Seller 예약 시 buyer hold 시도 → 잔액 0 < 50000 → INSUFFICIENT_POINT.
+        // (옛 정책은 거래완료 시점에 차감, 라운드 11 부터는 reserve 시점에 hold 함.)
         mvc.perform(patch("/api/v1/transactions/" + txId)
                         .with(csrf())
                         .cookie(sellerAt)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"action\":\"예약\"}"))
-                .andExpect(status().isOk());
-
-        mvc.perform(patch("/api/v1/transactions/" + txId)
-                        .with(csrf())
-                        .cookie(sellerAt)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"action\":\"거래완료\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.code").value("INSUFFICIENT_POINT"));
 
-        // 트랜잭션 롤백 검증 — Tx 상태 = 예약 (거래완료 X).
+        // 트랜잭션 롤백 검증 — Tx 상태 = 채팅중 (예약 X), Item 도 판매중 유지.
         mvc.perform(get("/api/v1/transactions/" + txId).cookie(buyerAt))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.status").value("예약"));
+                .andExpect(jsonPath("$.data.status").value("채팅중"));
     }
 
     // ───────── 시나리오 3: 출금 멱등성 ─────────

--- a/src/test/java/com/sseulang/integration/EndToEndHappyPathIT.java
+++ b/src/test/java/com/sseulang/integration/EndToEndHappyPathIT.java
@@ -62,7 +62,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *   <li>Buyer 가 토스 결제로 잔액 충전 (PG mock)</li>
  *   <li>Buyer 가 Item 으로 Transaction 생성 (채팅중)</li>
  *   <li>Seller 가 Transaction 예약</li>
- *   <li>Seller 가 Transaction 거래완료 → buyer 차감 + seller 적립 (정산)</li>
+ *   <li>Seller 인계확인 → 인계완료 (라운드 11)</li>
+ *   <li>Buyer 인수확인 → 거래완료 자동 전이 + 정산 (buyer hold 해제 + seller 적립)</li>
  *   <li>Buyer 가 Review 작성 (별점 기록)</li>
  * </ol>
  *
@@ -248,7 +249,7 @@ class EndToEndHappyPathIT {
                 .andReturn();
         Long txId = readId(txResult, "$.data.id");
 
-        // ───────── 6. Seller Transaction 예약 ─────────
+        // ───────── 6. Seller Transaction 예약 (라운드 11 — buyer hold 트리거) ─────────
         mvc.perform(patch("/api/v1/transactions/" + txId)
                         .with(csrf())
                         .cookie(sellerAt)
@@ -256,15 +257,23 @@ class EndToEndHappyPathIT {
                         .content("{\"action\":\"예약\"}"))
                 .andExpect(status().isOk());
 
-        // ───────── 7. Seller Transaction 거래완료 (정산) ─────────
+        // ───────── 7. Seller 인계확인 (라운드 11) ─────────
         mvc.perform(patch("/api/v1/transactions/" + txId)
                         .with(csrf())
                         .cookie(sellerAt)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"action\":\"거래완료\"}"))
+                        .content("{\"action\":\"인계확인\"}"))
                 .andExpect(status().isOk());
 
-        // 정산 검증 — buyer 잔액 차감 / seller 잔액 적립
+        // ───────── 8. Buyer 인수확인 (라운드 11 — 자동 거래완료 + 정산) ─────────
+        mvc.perform(patch("/api/v1/transactions/" + txId)
+                        .with(csrf())
+                        .cookie(buyerAt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"action\":\"인수확인\"}"))
+                .andExpect(status().isOk());
+
+        // 정산 검증 — buyer hold 해제 / seller 잔액 적립 + status=거래완료
         mvc.perform(get("/api/v1/transactions/" + txId).cookie(buyerAt))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.status").value("거래완료"));


### PR DESCRIPTION
## Summary

거래 흐름을 옛 즉시 정산(seller 단독 클릭) 에서 **escrow hold + 양쪽 확인** 모델로 전환 — buyer 보호 강화.

```
채팅중 → 예약(buyer hold) → 인계완료(seller 인계확인) → 거래완료(buyer 인수확인 + 정산)
                                                       └── 단계별 취소 (인계완료 이후 차단)
```

- 프론트와 5건 spec 합의 완료 (B-1 잔액 3분할 / B-2 PointHistory 라벨 / B-3 잔액 모델 A안 / B-4 알림 4단계 / B-5 무한 대기)
- **Codex 게이트 1 + 2 통과** (Critical 0, Warning 4건 모두 반영)
- 전체 회귀 PASS

## 주요 변경

**V16 마이그레이션**
- `transactions.status` ENUM `인계완료` 추가
- `transactions`: `handover_confirmed_at` / `receive_confirmed_at` / `escrow_hold_amount` (CHECK ≥ 0)
- `users.point_hold` (CHECK ≥ 0)
- `point_histories.point_type` ENUM `거래보관` / `거래환불` 추가

**잔액 hold (race-safe atomic UPDATE)**
- `User.pointHold` 필드
- `holdForEscrow` / `releaseHold` / `refundHold` / `findPointSnapshot` (단일 SELECT, 게이트 1 W-1)
- 가이드 §5.3 정합 — `WHERE balance >= :amount` 가드

**정산 흐름 (id-asc 락 순서)**
- `escrowHold(buyerId, amount, txId)`
- `escrowRelease(buyerId, sellerId, amount, txId)` — 양 user id-asc 락
- `escrowRefund(buyerId, amount, txId)`

**Transaction Aggregate**
- `markHandover` / `markReceived` 신설
- 옛 `markAsCompleted` / `canComplete` / `complete()` / `TRANSACTION_COMPLETION_UNAVAILABLE` 모두 제거

**Controller / DTO**
- `TransactionPatchAction` enum (예약/인계확인/인수확인/취소)
- ErrorCode 3종 (`TRANSACTION_HANDOVER_NOT_ALLOWED` / `RECEIVE_NOT_ALLOWED` / `HOLD_FAILED`)
- `GET /api/v1/users/me/point` (3분할: balance/holdAmount/totalBalance)
- `MeResponse.pointHold` 추가

**Notification 4단계 분리** (게이트 2 W-1 격리)
- 도메인 이벤트 4종 + `@TransactionalEventListener(AFTER_COMMIT)` + `REQUIRES_NEW` + try/catch
- linkType=TRANSACTION + linkId=txId
- 정산 알림 +N,000P 포함

## Codex 게이트 결과

**게이트 1 (round 1+2)**
- Critical 0
- W-1 잔액 race → `findPointSnapshot` 단일 SELECT
- W-2 atomic UPDATE @Version 의도 → Javadoc 정책 블록 추가
- S-1/N-1 OpenAPI → 라벨 갱신
- S-2 Clock 통일 → R1 follow-up 분리

**게이트 2 (PR 풀 리뷰)**
- Critical 0
- W2-1 Notification 예외 격리 → REQUIRES_NEW + try/catch
- W2-2 V16 prod 호환 → 주석 + R1 follow-up
- S2-1 PointReferenceType.ESCROW description → 갱신

## R1 Follow-up

- [ ] PointApplicationService Clock 주입 통일
- [ ] V16 분리 마이그레이션 (50만+ row prod 진입 시점)
- [ ] 인계완료 후 R2 분쟁 endpoint
- [ ] buyer 인수확인 reminder 알림 (N일 미인수)
- [ ] TransactionNotificationListener 단위 테스트 (이벤트 → 알림 변환 검증)

## Test plan

- [x] 단위 — TransactionTest 17 케이스 + TransactionApplicationServiceTest 16 케이스
- [x] 동시성 IT — Item 락 race + buyer_hold_race + cancel_handover_race
- [x] e2e IT — EndToEndHappyPathIT (예약 → 인계확인 → 인수확인 → 정산) + GuardScenariosIT (잔액 부족 차단) + SettlementRollbackIT (reserve hold 실패 롤백)
- [x] 전체 회귀 PASS (BUILD SUCCESSFUL)
- [ ] 프론트 합류 검증 — 잔액 페이지 3분할 / 거래 단계별 UI / 알림 4종 도착

## 프론트 작업 (합의 완료)

①~⑩ 10개 작업 — spec 받자마자 진행 (4시간 추정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)