### PR TITLE
feat: round 12 — 채팅방 나가기 + 거래 시작 채팅방 가드 (#3.1 #3.2)

### DIFF
--- a/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
+++ b/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
@@ -110,6 +110,33 @@ public class ChatRoomApplicationService {
         return enrichOne(room, userId);
     }
 
+    /**
+     * 라운드 12 (#3.2 #3.3) — 거래/거래대행이 채팅방 안에서 시작되는지 가드용. 참여자 검증 +
+     * chatRoom 메타 (itemId, left flags) 노출. 호출자가 itemId 일치 / leftFlags 별로 분기.
+     *
+     * <ul>
+     *   <li>ChatRoom 미존재 → CHAT_ROOM_NOT_FOUND</li>
+     *   <li>비참여자 → CHAT_FORBIDDEN</li>
+     * </ul>
+     *
+     * <p>본 메서드는 read-only — 잔액/상태 변경 가드는 호출자 ApplicationService 가 책임.</p>
+     */
+    public ChatRoomMeta findMetaForParticipant(Long chatRoomId, Long userId) {
+        ChatRoom room = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (!room.isParticipant(userId)) {
+            throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
+        }
+        return new ChatRoomMeta(room.getId(), room.getItemId(),
+                room.iLeft(userId), room.opponentLeft(userId));
+    }
+
+    /**
+     * 라운드 12 — 외부 도메인용 chat_room 메타 read model. {@code itemId} 는 거래 영역의
+     * chat_room ↔ item 일치 검증, {@code iLeft / opponentLeft} 는 거래대행 신청 시 한쪽 left 차단용.
+     */
+    public record ChatRoomMeta(Long chatRoomId, Long itemId, boolean iLeft, boolean opponentLeft) { }
+
     /** Message 도메인이 메시지 보낼 권한 검증 시 호출. 참여자 아니면 CHAT_FORBIDDEN. */
     public void requireParticipant(Long chatRoomId, Long userId) {
         ChatRoom room = chatRoomRepository.findById(chatRoomId)

--- a/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
+++ b/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
@@ -120,6 +120,40 @@ public class ChatRoomApplicationService {
     }
 
     /**
+     * 메시지 송신 가능 여부 검증 — 참여자 + 본인 left X + 상대방 left X.
+     * 본인 left → CHAT_FORBIDDEN (이미 나간 방).
+     * 상대방 left → CHAT_ROOM_OPPONENT_LEFT (상대방이 나가서 차단).
+     */
+    public void requireSendable(Long chatRoomId, Long userId) {
+        ChatRoom room = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (!room.isParticipant(userId)) {
+            throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
+        }
+        if (room.iLeft(userId)) {
+            throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
+        }
+        if (room.opponentLeft(userId)) {
+            throw new BusinessException(ErrorCode.CHAT_ROOM_OPPONENT_LEFT);
+        }
+    }
+
+    /**
+     * 채팅방 나가기 (soft hide) — 본인 측 left_at = NOW(). 데이터/메시지 보존.
+     * 본인 listMine 에서 제외, 상대방은 opponentLeft=true 응답 받음.
+     * 비참여자 호출은 CHAT_FORBIDDEN. 이미 left 상태도 idempotent (재호출 OK).
+     */
+    @Transactional
+    public void leave(Long roomId, Long userId) {
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (!room.isParticipant(userId)) {
+            throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
+        }
+        chatRoomRepository.markAsLeft(roomId, userId);
+    }
+
+    /**
      * 1:1 채팅방의 상대방 userId 반환. requireParticipant 검증을 동시에 수행.
      * 메시지 broadcast 시 상대방 알림 push 용.
      */

--- a/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
+++ b/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
@@ -27,6 +27,8 @@ public record ChatRoomResult(
         String itemTitle,
         String itemThumbnailUrl,
         boolean isSeller,                 // viewer 가 이 채팅방의 아이템 판매자인지
+        boolean iLeft,                    // 본인이 채팅방을 나갔는지 (soft hide)
+        boolean opponentLeft,             // 상대방이 채팅방을 나갔는지
         // 메타
         String lastMessage,
         LocalDateTime lastMessageAt,
@@ -61,12 +63,15 @@ public record ChatRoomResult(
             myUnread = 0;
         }
         boolean isSeller = itemSellerId != null && viewerId != null && itemSellerId.equals(viewerId);
+        boolean iLeft = c.iLeft(viewerId);
+        boolean opponentLeft = c.opponentLeft(viewerId);
         return new ChatRoomResult(
                 c.getId(), c.getItemId(),
                 c.getUser1Id(), c.getUser2Id(),
                 c.getUser1Unread(), c.getUser2Unread(),
                 opponentId, opponentNickname, opponentProfileImage, myUnread,
                 itemTitle, itemThumbnailUrl, isSeller,
+                iLeft, opponentLeft,
                 c.getLastMessage(), c.getLastMessageAt(),
                 c.isActive(),
                 c.getCreatedAt(), c.getUpdatedAt()

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoom.java
@@ -56,6 +56,12 @@ public class ChatRoom extends BaseEntity {
     @Column(name = "is_active", nullable = false)
     private boolean active;
 
+    @Column(name = "user1_left_at")
+    private LocalDateTime user1LeftAt;
+
+    @Column(name = "user2_left_at")
+    private LocalDateTime user2LeftAt;
+
     /**
      * {@code (itemId, requesterId, opponentId)} 로 채팅방 생성. {@code user1Id < user2Id} 강제 정규화.
      */
@@ -100,5 +106,49 @@ public class ChatRoom extends BaseEntity {
         } else if (userId.equals(user2Id)) {
             this.user2Unread = 0;
         }
+    }
+
+    /**
+     * 본인 측 채팅방을 soft hide. 본인이 user1 이면 user1LeftAt = now, user2 면 user2LeftAt = now.
+     * 이미 left 상태면 no-op (idempotent). 비참여자 호출은 IllegalStateException — 서비스가 사전 검증해야 함.
+     */
+    public void leave(Long userId, LocalDateTime now) {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId 는 필수입니다");
+        }
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+        if (userId.equals(user1Id)) {
+            if (this.user1LeftAt == null) {
+                this.user1LeftAt = now;
+            }
+        } else if (userId.equals(user2Id)) {
+            if (this.user2LeftAt == null) {
+                this.user2LeftAt = now;
+            }
+        } else {
+            throw new IllegalStateException("채팅방 참여자만 나갈 수 있습니다 — userId=" + userId);
+        }
+    }
+
+    /**
+     * 본인이 채팅방을 나갔는지. 비참여자는 false (의미 없는 질문이라 false 로 통일).
+     */
+    public boolean iLeft(Long userId) {
+        if (userId == null) return false;
+        if (userId.equals(user1Id)) return this.user1LeftAt != null;
+        if (userId.equals(user2Id)) return this.user2LeftAt != null;
+        return false;
+    }
+
+    /**
+     * 상대방이 채팅방을 나갔는지. 비참여자는 false (의미 없는 질문이라 false 로 통일).
+     */
+    public boolean opponentLeft(Long userId) {
+        if (userId == null) return false;
+        if (userId.equals(user1Id)) return this.user2LeftAt != null;
+        if (userId.equals(user2Id)) return this.user1LeftAt != null;
+        return false;
     }
 }

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoomRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoomRepository.java
@@ -29,4 +29,10 @@ public interface ChatRoomRepository {
      * 본인 unread 만 0 으로 atomic UPDATE. 비참여자는 영향 0. 권한 검증은 서비스 책임.
      */
     int markAsRead(Long chatRoomId, Long userId);
+
+    /**
+     * 본인 측 left_at 을 NOW() 로 atomic UPDATE (soft hide). 이미 left 면 그 값 유지.
+     * 비참여자는 0 행 영향 — 서비스가 사전 권한 검증. 이미 left 상태도 1 행 영향 가능 (CASE WHEN 로 보존).
+     */
+    int markAsLeft(Long chatRoomId, Long userId);
 }

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomJpaRepository.java
@@ -25,9 +25,14 @@ interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, Long> {
             @Param("u2") Long u2
     );
 
+    /**
+     * 본인 visibility 기준 채팅방 목록. user1 이면 user1LeftAt IS NULL, user2 면 user2LeftAt IS NULL.
+     * 본인이 left 한 방은 목록에서 제외 (soft hide). 상대방이 left 한 방은 그대로 노출.
+     */
     @Query("""
         SELECT c FROM ChatRoom c
-        WHERE c.user1Id = :userId OR c.user2Id = :userId
+        WHERE (c.user1Id = :userId AND c.user1LeftAt IS NULL)
+           OR (c.user2Id = :userId AND c.user2LeftAt IS NULL)
         ORDER BY
           CASE WHEN c.lastMessageAt IS NULL THEN 1 ELSE 0 END,
           c.lastMessageAt DESC,
@@ -65,4 +70,22 @@ interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, Long> {
           AND (c.user1Id = :userId OR c.user2Id = :userId)
     """)
     int markAsRead(@Param("roomId") Long roomId, @Param("userId") Long userId);
+
+    /**
+     * 본인 측 left_at 을 atomic UPDATE. 이미 nonnull 이면 보존 (idempotent).
+     * 비참여자는 0 행 영향. 본인 user 위치에 따라 한쪽 컬럼만 변경.
+     */
+    @Modifying
+    @Query("""
+        UPDATE ChatRoom c
+        SET c.user1LeftAt = CASE WHEN c.user1Id = :userId AND c.user1LeftAt IS NULL THEN :leftAt ELSE c.user1LeftAt END,
+            c.user2LeftAt = CASE WHEN c.user2Id = :userId AND c.user2LeftAt IS NULL THEN :leftAt ELSE c.user2LeftAt END
+        WHERE c.id = :roomId
+          AND (c.user1Id = :userId OR c.user2Id = :userId)
+    """)
+    int markAsLeft(
+            @Param("roomId") Long roomId,
+            @Param("userId") Long userId,
+            @Param("leftAt") LocalDateTime leftAt
+    );
 }

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomRepositoryImpl.java
@@ -48,4 +48,9 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
     public int markAsRead(Long chatRoomId, Long userId) {
         return jpa.markAsRead(chatRoomId, userId);
     }
+
+    @Override
+    public int markAsLeft(Long chatRoomId, Long userId) {
+        return jpa.markAsLeft(chatRoomId, userId, java.time.LocalDateTime.now());
+    }
 }

--- a/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/ChatRoomController.java
@@ -83,4 +83,16 @@ public class ChatRoomController {
     ) {
         return ApiResponse.ok(ChatRoomResponse.from(chatRoomService.markAsRead(id, requesterId)));
     }
+
+    @Operation(summary = "채팅방 나가기 (soft hide)",
+            description = "본인 측에서 채팅방 hide. 본인 listMine 에서 제외, 상대방은 opponentLeft=true 응답 받음 + 메시지 send 차단. "
+                    + "데이터·메시지는 보존 (audit 용). 참여자만 호출 (그 외 403 CHAT_FORBIDDEN). idempotent.")
+    @PatchMapping("/{id}/leave")
+    public ApiResponse<Void> leave(
+            @AuthenticationPrincipal Long requesterId,
+            @PathVariable("id") Long id
+    ) {
+        chatRoomService.leave(id, requesterId);
+        return ApiResponse.ok();
+    }
 }

--- a/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
@@ -17,6 +17,8 @@ public record ChatRoomResponse(
         @Schema(example = "아이폰 14 Pro", description = "아이템 제목") String itemTitle,
         @Schema(description = "아이템 썸네일 URL (없으면 null)") String itemThumbnailUrl,
         @Schema(example = "true", description = "viewer 가 이 채팅방의 아이템 판매자인지") boolean isSeller,
+        @Schema(example = "false", description = "본인이 채팅방을 나갔는지 (soft hide). true 면 본인 목록에서 제외됨") boolean iLeft,
+        @Schema(example = "false", description = "상대방이 채팅방을 나갔는지. true 면 메시지 send 차단 + 시스템 메시지 노출") boolean opponentLeft,
         // 메타
         @Schema(example = "안녕하세요...", description = "최근 메시지 미리보기") String lastMessage,
         LocalDateTime lastMessageAt,
@@ -35,6 +37,7 @@ public record ChatRoomResponse(
                 r.opponentId(), r.opponentNickname(), r.opponentProfileImage(),
                 r.myUnread(),
                 r.itemTitle(), r.itemThumbnailUrl(), r.isSeller(),
+                r.iLeft(), r.opponentLeft(),
                 r.lastMessage(), r.lastMessageAt(), r.active(),
                 r.user1Id(), r.user2Id(), r.user1Unread(), r.user2Unread(),
                 r.createdAt(), r.updatedAt()

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemViewAdapter.java
@@ -13,11 +13,11 @@ import java.util.Map;
  * 단일 SELECT IN — N+1 회피.
  */
 @Component
-class ItemViewAdapter implements ItemView {
+public class ItemViewAdapter implements ItemView {
 
     private final ItemJpaRepository jpa;
 
-    ItemViewAdapter(ItemJpaRepository jpa) {
+    public ItemViewAdapter(ItemJpaRepository jpa) {
         this.jpa = jpa;
     }
 

--- a/src/main/java/com/sseulang/domain/message/application/MessageApplicationService.java
+++ b/src/main/java/com/sseulang/domain/message/application/MessageApplicationService.java
@@ -66,6 +66,8 @@ public class MessageApplicationService {
      */
     @Transactional
     public MessageResult send(MessageSendCommand cmd) {
+        // soft hide 가드 — 본인이 left 한 방에 송신 X / 상대방이 left 한 방도 송신 X (#3.1).
+        chatRoomApplicationService.requireSendable(cmd.chatRoomId(), cmd.senderId());
         Long opponentId = chatRoomApplicationService.findOpponent(cmd.chatRoomId(), cmd.senderId());
 
         Message saved;

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -1,5 +1,6 @@
 package com.sseulang.domain.transaction.application;
 
+import com.sseulang.domain.chat.application.ChatRoomApplicationService;
 import com.sseulang.domain.item.application.ItemApplicationService;
 import com.sseulang.domain.item.application.dto.ItemForTransactionResult;
 import com.sseulang.domain.point.application.PointApplicationService;
@@ -53,6 +54,7 @@ public class TransactionApplicationService {
     private final ItemApplicationService itemApplicationService;
     private final PointApplicationService pointApplicationService;
     private final UserApplicationService userApplicationService;
+    private final ChatRoomApplicationService chatRoomApplicationService;
     private final ApplicationEventPublisher eventPublisher;
     private final java.time.Clock clock;
 
@@ -61,6 +63,7 @@ public class TransactionApplicationService {
             ItemApplicationService itemApplicationService,
             PointApplicationService pointApplicationService,
             UserApplicationService userApplicationService,
+            ChatRoomApplicationService chatRoomApplicationService,
             ApplicationEventPublisher eventPublisher,
             java.time.Clock clock
     ) {
@@ -68,27 +71,65 @@ public class TransactionApplicationService {
         this.itemApplicationService = itemApplicationService;
         this.pointApplicationService = pointApplicationService;
         this.userApplicationService = userApplicationService;
+        this.chatRoomApplicationService = chatRoomApplicationService;
         this.eventPublisher = eventPublisher;
         this.clock = clock;
     }
 
+    /**
+     * 거래 생성 — 라운드 12 (#3.2 + 판매자만 정책): 판매자가 채팅방 안에서 거래 시작.
+     *
+     * <p>검증 순서 (의도적):</p>
+     * <ol>
+     *   <li>chatRoomId 누락 → TX_CHATROOM_REQUIRED (다른 검증보다 먼저)</li>
+     *   <li>호출자(seller) verified — 자금 영향이라 이메일 인증 필수</li>
+     *   <li>chat_room 참여자 검증 + chatRoom.itemId == cmd.itemId 일치</li>
+     *   <li>호출자 == item.sellerId — 판매자만 거래 시작 가능 (TX_SELLER_ONLY)</li>
+     *   <li>한 채팅방 = 1 active transaction</li>
+     *   <li>buyer 도출 — chatRoom 의 상대방</li>
+     * </ol>
+     */
     @Transactional
     public Long create(TransactionCreateCommand cmd) {
-        // 거래 시작은 자금 영향 — 이메일 인증 필수 (게이트 1: 미인증 사용자 차단).
-        userApplicationService.requireVerified(cmd.buyerId());
-        ItemForTransactionResult info = itemApplicationService.findActiveForTransaction(cmd.itemId());
-        if (info.sellerId().equals(cmd.buyerId())) {
-            throw new BusinessException(ErrorCode.TRANSACTION_SELF_NOT_ALLOWED);
+        if (cmd.chatRoomId() == null) {
+            throw new BusinessException(ErrorCode.TX_CHATROOM_REQUIRED);
         }
+        // 호출자(seller) 인증 — 자금 흐름 진입자라 이메일 인증 필수.
+        userApplicationService.requireVerified(cmd.requesterId());
+
+        // Item 조회 먼저 — 미존재면 ITEM_NOT_FOUND (chatRoom 검증보다 우선).
+        ItemForTransactionResult info = itemApplicationService.findActiveForTransaction(cmd.itemId());
+
+        // 채팅방 가드 — 참여자 + chatRoom.itemId 일치 검증
+        ChatRoomApplicationService.ChatRoomMeta meta =
+                chatRoomApplicationService.findMetaForParticipant(cmd.chatRoomId(), cmd.requesterId());
+        if (!meta.itemId().equals(cmd.itemId())) {
+            throw new BusinessException(ErrorCode.TX_CHATROOM_ITEM_MISMATCH);
+        }
+
+        // 판매자만 거래 시작 가능 (#3.2 round 12 정책 변경)
+        if (!info.sellerId().equals(cmd.requesterId())) {
+            throw new BusinessException(ErrorCode.TX_SELLER_ONLY);
+        }
+
+        // 한 채팅방 = 1 active transaction 가드 (#3.2)
+        if (transactionRepository.existsActiveByChatRoomId(cmd.chatRoomId())) {
+            throw new BusinessException(ErrorCode.TX_ALREADY_ACTIVE_IN_ROOM);
+        }
+
+        // buyer 도출 — chatRoom 참여자 중 seller 가 아닌 쪽
+        Long buyerId = chatRoomApplicationService.findOpponent(cmd.chatRoomId(), cmd.requesterId());
+
         Transaction tx = Transaction.create(
                 info.itemId(),
                 info.sellerId(),
-                cmd.buyerId(),
+                buyerId,
                 info.tradeType(),
                 info.price(),
                 info.deposit(),
                 cmd.rentalStart(),
-                cmd.rentalEnd()
+                cmd.rentalEnd(),
+                cmd.chatRoomId()
         );
         return transactionRepository.save(tx).getId();
     }

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionCreateCommand.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionCreateCommand.java
@@ -2,9 +2,18 @@ package com.sseulang.domain.transaction.application.dto;
 
 import java.time.LocalDateTime;
 
+/**
+ * 거래 생성 Command. 라운드 12 (#3.2 + 판매자만 정책) — 채팅방 안에서 판매자가 거래 시작.
+ *
+ * @param requesterId 호출자(판매자) userId. 정책상 item.sellerId 와 일치해야 하며, 그렇지 않으면
+ *                    ApplicationService 가 TX_SELLER_ONLY 를 던진다. buyerId 는 chatRoom 의
+ *                    상대방에서 도출 (판매자가 거래 시작 시점에 명시 X).
+ * @param chatRoomId  채팅방 ID. null 이면 TX_CHATROOM_REQUIRED.
+ */
 public record TransactionCreateCommand(
         Long itemId,
-        Long buyerId,
+        Long requesterId,
+        Long chatRoomId,
         LocalDateTime rentalStart,
         LocalDateTime rentalEnd
 ) { }

--- a/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
@@ -46,6 +46,13 @@ public class Transaction extends BaseEntity {
     @Column(name = "buyer_id", nullable = false)
     private Long buyerId;
 
+    /**
+     * 라운드 12 (#3.2) — 거래 시작 채팅방 가드. V19 추가. 거래는 채팅방 안에서만 시작 가능,
+     * 한 채팅방 = 1 active transaction 정책. 이전 라운드 row 는 NULL (legacy).
+     */
+    @Column(name = "chat_room_id")
+    private Long chatRoomId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "trade_type", nullable = false)
     private TradeType tradeType;
@@ -108,7 +115,8 @@ public class Transaction extends BaseEntity {
             long price,
             Long deposit,
             LocalDateTime rentalStart,
-            LocalDateTime rentalEnd
+            LocalDateTime rentalEnd,
+            Long chatRoomId
     ) {
         if (itemId == null || itemId <= 0) {
             throw new IllegalArgumentException("itemId 는 양수여야 합니다");
@@ -128,6 +136,9 @@ public class Transaction extends BaseEntity {
         if (price < 0) {
             throw new IllegalArgumentException("price 는 0 이상이어야 합니다");
         }
+        if (chatRoomId != null && chatRoomId <= 0) {
+            throw new IllegalArgumentException("chatRoomId 는 양수여야 합니다");
+        }
         validateRentalFields(tradeType, deposit, rentalStart, rentalEnd);
 
         Transaction t = new Transaction();
@@ -139,6 +150,7 @@ public class Transaction extends BaseEntity {
         t.deposit = deposit;
         t.rentalStart = rentalStart;
         t.rentalEnd = rentalEnd;
+        t.chatRoomId = chatRoomId;
         t.status = TransactionStatus.채팅중;
         return t;
     }

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -26,6 +26,14 @@ public interface TransactionRepository {
 
     Transaction save(Transaction transaction);
 
+    /**
+     * 라운드 12 (#3.2) — 한 채팅방 = 1 active transaction 정책 가드.
+     *
+     * <p>active 정의: status NOT IN (거래완료, 취소). 즉 채팅중 / 예약 / 인계완료 단계는 모두 active.
+     * legacy chat_room_id IS NULL 거래는 본 쿼리 영향 X (chat_room_id 컬럼 = ? 매칭).</p>
+     */
+    boolean existsActiveByChatRoomId(Long chatRoomId);
+
     // ───────── 관리자 통계 ─────────
 
     /** 단일 GROUP BY 집계 — (status, count) 행 리스트 (가능한 모든 status 행 포함, 0 인 status 는 없음). */

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -23,6 +23,20 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
     Optional<Transaction> findByIdForUpdate(@Param("id") Long id);
 
     /**
+     * 라운드 12 (#3.2) — 한 채팅방 = 1 active transaction 가드.
+     * active = status NOT IN (거래완료, 취소). chat_room_id 미지정 (legacy) 거래는 매칭 X.
+     */
+    @Query("""
+            SELECT (COUNT(t) > 0) FROM Transaction t
+             WHERE t.chatRoomId = :chatRoomId
+               AND t.status NOT IN (
+                   com.sseulang.domain.transaction.domain.TransactionStatus.거래완료,
+                   com.sseulang.domain.transaction.domain.TransactionStatus.취소
+               )
+            """)
+    boolean existsActiveByChatRoomIdJpql(@Param("chatRoomId") Long chatRoomId);
+
+    /**
      * status 별 거래 건수 집계. 단일 쿼리 — N+1 없음. 결과는 status 가 한 번이라도 등장한 행만 옴
      * (0 건인 status 는 application 단에서 0 으로 채움). status 컬럼 인덱스 권장.
      */

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -38,6 +38,14 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     }
 
     @Override
+    public boolean existsActiveByChatRoomId(Long chatRoomId) {
+        if (chatRoomId == null) {
+            return false;
+        }
+        return jpa.existsActiveByChatRoomIdJpql(chatRoomId);
+    }
+
+    @Override
     public List<TransactionStatusCount> countGroupByStatus() {
         return jpa.countGroupByStatusJpql();
     }

--- a/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
@@ -34,14 +34,16 @@ public class TransactionController {
         this.transactionService = transactionService;
     }
 
-    @Operation(summary = "거래 생성 (buyer)",
-            description = "이메일 인증 필수. 본인 물품 / 비활성(예약/삭제) 물품 거부. 생성 즉시 status=채팅중.")
+    @Operation(summary = "거래 생성 (판매자)",
+            description = "이메일 인증 필수. 라운드 12 (#3.2): 판매자만 호출 가능 (TX_SELLER_ONLY). "
+                    + "chatRoomId 필수 — 채팅방 안에서만 거래 시작. buyerId 는 chatRoom 의 상대방에서 백엔드가 도출. "
+                    + "본인 물품 / 비활성(예약/삭제) 물품 거부. 생성 즉시 status=채팅중.")
     @PostMapping
     public ResponseEntity<ApiResponse<TransactionIdResponse>> create(
-            @AuthenticationPrincipal Long buyerId,
+            @AuthenticationPrincipal Long requesterId,
             @Valid @RequestBody TransactionCreateRequest request
     ) {
-        Long id = transactionService.create(request.toCommand(buyerId));
+        Long id = transactionService.create(request.toCommand(requesterId));
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.ok(new TransactionIdResponse(id)));
     }

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionCreateRequest.java
@@ -7,10 +7,18 @@ import jakarta.validation.constraints.Positive;
 
 import java.time.LocalDateTime;
 
-@Schema(description = "거래 생성 (구매자가 호출). 채팅중 상태로 시작. 대여 거래만 rentalStart/End 필요.")
+@Schema(description = "거래 생성 (판매자가 호출). 채팅중 상태로 시작. 라운드 12 (#3.2): chatRoomId 필수 — "
+        + "거래는 채팅방 안에서만 시작 가능. 호출자 != item.sellerId 면 TX_SELLER_ONLY. "
+        + "같은 채팅방에 진행 중 거래 있으면 TX_ALREADY_ACTIVE_IN_ROOM. "
+        + "buyerId 는 chatRoom 의 상대방에서 백엔드가 도출. 대여 거래만 rentalStart/End 필요.")
 public record TransactionCreateRequest(
         @Schema(description = "거래 대상 itemId", example = "42")
         @NotNull @Positive Long itemId,
+
+        @Schema(description = "거래가 시작될 채팅방 ID — buyer/seller 가 참여자여야 하고, "
+                + "chatRoom.itemId 가 요청 itemId 와 일치해야 함",
+                example = "7")
+        @NotNull @Positive Long chatRoomId,
 
         @Schema(description = "대여 시작 시각 (대여 거래 전용)", example = "2026-05-01T10:00:00", nullable = true)
         LocalDateTime rentalStart,
@@ -18,7 +26,7 @@ public record TransactionCreateRequest(
         @Schema(description = "대여 종료 시각 (대여 거래 전용, start 이후)", example = "2026-05-03T10:00:00", nullable = true)
         LocalDateTime rentalEnd
 ) {
-    public TransactionCreateCommand toCommand(Long buyerId) {
-        return new TransactionCreateCommand(itemId, buyerId, rentalStart, rentalEnd);
+    public TransactionCreateCommand toCommand(Long requesterId) {
+        return new TransactionCreateCommand(itemId, requesterId, chatRoomId, rentalStart, rentalEnd);
     }
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserViewAdapter.java
@@ -13,11 +13,11 @@ import java.util.Map;
  * 단일 SELECT IN — N+1 회피.
  */
 @Component
-class UserViewAdapter implements UserView {
+public class UserViewAdapter implements UserView {
 
     private final UserJpaRepository jpa;
 
-    UserViewAdapter(UserJpaRepository jpa) {
+    public UserViewAdapter(UserJpaRepository jpa) {
         this.jpa = jpa;
     }
 

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -74,6 +74,8 @@ public enum ErrorCode {
     // 채팅 / 알림
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
     CHAT_FORBIDDEN(HttpStatus.FORBIDDEN, "채팅방에 접근할 권한이 없습니다."),
+    CHAT_ROOM_OPPONENT_LEFT(HttpStatus.BAD_REQUEST, "상대방이 채팅방을 나가서 더 이상 메시지를 보낼 수 없습니다."),
+    CHAT_ROOM_ALREADY_LEFT(HttpStatus.BAD_REQUEST, "이미 나간 채팅방입니다."),
 
     // 리뷰
     REVIEW_DUPLICATED(HttpStatus.CONFLICT, "이미 작성한 리뷰입니다."),

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -53,6 +53,10 @@ public enum ErrorCode {
     TRANSACTION_HANDOVER_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "인계 확인은 판매자만 수행할 수 있습니다."),
     TRANSACTION_RECEIVE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "인수 확인은 구매자만 수행할 수 있습니다."),
     TRANSACTION_HOLD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "거래 보관 잔액 처리에 실패했습니다."),
+    TX_CHATROOM_REQUIRED(HttpStatus.BAD_REQUEST, "거래 시작은 채팅방 안에서만 가능합니다 (chatRoomId 필수)."),
+    TX_CHATROOM_ITEM_MISMATCH(HttpStatus.BAD_REQUEST, "채팅방의 물품과 거래 요청 물품이 다릅니다."),
+    TX_ALREADY_ACTIVE_IN_ROOM(HttpStatus.BAD_REQUEST, "해당 채팅방에 진행 중인 거래가 이미 있습니다."),
+    TX_SELLER_ONLY(HttpStatus.FORBIDDEN, "거래 시작은 판매자만 가능합니다."),
 
     // 결제 / 포인트
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
@@ -119,6 +123,9 @@ public enum ErrorCode {
     ESCROW_INVALID_STATE(HttpStatus.BAD_REQUEST, "현재 상태에서 수행할 수 없는 동작입니다."),
     ESCROW_FORM_INVALID(HttpStatus.BAD_REQUEST, "거래대행 신청 입력값이 올바르지 않습니다."),
     ESCROW_FEE_MISMATCH(HttpStatus.BAD_REQUEST, "수수료 정책이 변경되었습니다. 새 금액 확인 후 다시 시도해주세요."),
+    ESCROW_CHATROOM_REQUIRED(HttpStatus.BAD_REQUEST, "거래대행 신청은 채팅방 안에서만 가능합니다 (chatRoomId 필수)."),
+    ESCROW_TX_CHATROOM_MISMATCH(HttpStatus.BAD_REQUEST, "쓸랭 거래의 채팅방과 거래대행 신청 채팅방이 다릅니다."),
+    ESCROW_SELLER_ONLY(HttpStatus.FORBIDDEN, "거래대행 신청은 판매자만 가능합니다."),
 
     PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "요청 본문 크기가 한도를 초과합니다.");
 

--- a/src/main/resources/db/migration/V18__add_chat_room_left_at.sql
+++ b/src/main/resources/db/migration/V18__add_chat_room_left_at.sql
@@ -1,0 +1,11 @@
+-- V18: 채팅방 soft hide (한쪽이 나가도 데이터/메타 유지, 본인만 안 보이게)
+--
+-- 정책:
+--   * 본인이 나가면 user{N}_left_at = NOW(). 본인 채팅방 목록에서 제외 (visibility 필터).
+--   * 상대방은 채팅방 안에서 opponentLeft=true 응답 받음 → 프론트가 입력창 disable + 시스템 메시지 렌더.
+--   * 메시지 send 시 한쪽이 left 면 백엔드가 400 차단 (CHAT_ROOM_OPPONENT_LEFT / CHAT_FORBIDDEN).
+--   * 데이터 삭제 X — 향후 분쟁/audit 대비 메시지·메타 보존.
+
+ALTER TABLE chat_rooms
+    ADD COLUMN user1_left_at DATETIME NULL COMMENT 'user1 이 채팅방 나간 시각 (soft hide)',
+    ADD COLUMN user2_left_at DATETIME NULL COMMENT 'user2 가 채팅방 나간 시각 (soft hide)';

--- a/src/main/resources/db/migration/V19__add_transaction_escrow_chat_room.sql
+++ b/src/main/resources/db/migration/V19__add_transaction_escrow_chat_room.sql
@@ -1,0 +1,33 @@
+-- V19: 거래/거래대행 채팅방 가드 (#3.2 #3.3)
+--
+-- 정책:
+--   * 거래 시작은 채팅방 안에서만 — chat_room_id 가 어떤 채팅방에서 시작됐는지 추적.
+--   * 한 채팅방 = 1 active transaction 정책 강제 위해 (chat_room_id, status) 인덱스로 조회 비용 최소화.
+--   * 거래대행 신청도 동일하게 chat_room_id 추적.
+--
+-- 컬럼은 NULL 허용:
+--   * 기존 row (이전 라운드까지의 transaction/escrow_application) 는 chat_room_id 정보 없음 — legacy.
+--   * 신규 row 부터는 도메인 검증 (TX_CHATROOM_REQUIRED / ESCROW_CHATROOM_REQUIRED) 으로 NOT NULL 효과.
+--   * FK ON DELETE SET NULL — 채팅방 데이터 정리 시 거래/거래대행 row 보존, 채팅방 참조만 끊김.
+
+-- transactions
+ALTER TABLE transactions
+    ADD COLUMN chat_room_id BIGINT NULL COMMENT '거래가 시작된 채팅방 (한 채팅방 = 1 active transaction)';
+
+ALTER TABLE transactions
+    ADD CONSTRAINT fk_transactions_chat_room
+        FOREIGN KEY (chat_room_id) REFERENCES chat_rooms(id) ON DELETE SET NULL;
+
+ALTER TABLE transactions
+    ADD INDEX idx_transactions_chat_room_status (chat_room_id, status);
+
+-- escrow_applications
+ALTER TABLE escrow_applications
+    ADD COLUMN chat_room_id BIGINT NULL COMMENT '거래대행이 신청된 채팅방';
+
+ALTER TABLE escrow_applications
+    ADD CONSTRAINT fk_escrow_applications_chat_room
+        FOREIGN KEY (chat_room_id) REFERENCES chat_rooms(id) ON DELETE SET NULL;
+
+ALTER TABLE escrow_applications
+    ADD INDEX idx_escrow_applications_chat_room (chat_room_id);

--- a/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
@@ -151,4 +151,87 @@ class ChatRoomApplicationServiceTest {
                 .containsExactly(room1)
                 .doesNotContain(room2);
     }
+
+    @Test
+    @DisplayName("leave 정상_본인 listMine 에서 제외 + 상대방 opponentLeft=true")
+    void leave_정상() {
+        Long roomId = service.openFor(BUYER, itemId).id();
+
+        service.leave(roomId, BUYER);
+
+        // BUYER 측 listMine 에서 제외
+        Page<ChatRoomResult> buyerView = service.listMine(BUYER, PageRequest.of(0, 10));
+        assertThat(buyerView.getContent()).isEmpty();
+
+        // SELLER 입장에서 상대(BUYER)가 left → opponentLeft=true
+        ChatRoomResult sellerView = service.getOne(roomId, SELLER);
+        assertThat(sellerView.iLeft()).isFalse();
+        assertThat(sellerView.opponentLeft()).isTrue();
+
+        // BUYER 본인 입장에서 iLeft=true (단건 조회는 가능 — soft hide 라 데이터 보존)
+        ChatRoomResult buyerOne = service.getOne(roomId, BUYER);
+        assertThat(buyerOne.iLeft()).isTrue();
+    }
+
+    @Test
+    @DisplayName("leave 비참여자_CHAT_FORBIDDEN")
+    void leave_비참여자() {
+        Long roomId = service.openFor(BUYER, itemId).id();
+
+        assertThatThrownBy(() -> service.leave(roomId, OTHER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHAT_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("leave 없는 방_CHAT_ROOM_NOT_FOUND")
+    void leave_없음() {
+        assertThatThrownBy(() -> service.leave(9999L, BUYER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHAT_ROOM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("leave idempotent — 두 번 호출해도 OK")
+    void leave_idempotent() {
+        Long roomId = service.openFor(BUYER, itemId).id();
+        service.leave(roomId, BUYER);
+        // 두 번째 호출은 예외 X
+        service.leave(roomId, BUYER);
+    }
+
+    @Test
+    @DisplayName("requireSendable 본인 left → CHAT_FORBIDDEN")
+    void requireSendable_본인left() {
+        Long roomId = service.openFor(BUYER, itemId).id();
+        service.leave(roomId, BUYER);
+
+        assertThatThrownBy(() -> service.requireSendable(roomId, BUYER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHAT_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("requireSendable 상대방 left → CHAT_ROOM_OPPONENT_LEFT")
+    void requireSendable_상대left() {
+        Long roomId = service.openFor(BUYER, itemId).id();
+        service.leave(roomId, BUYER);
+
+        assertThatThrownBy(() -> service.requireSendable(roomId, SELLER))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHAT_ROOM_OPPONENT_LEFT);
+    }
+
+    @Test
+    @DisplayName("requireSendable 정상 — 양쪽 모두 안 나간 상태")
+    void requireSendable_정상() {
+        Long roomId = service.openFor(BUYER, itemId).id();
+        // throws X
+        service.requireSendable(roomId, BUYER);
+        service.requireSendable(roomId, SELLER);
+    }
 }

--- a/src/test/java/com/sseulang/domain/chat/application/InMemoryFakeChatRoomRepository.java
+++ b/src/test/java/com/sseulang/domain/chat/application/InMemoryFakeChatRoomRepository.java
@@ -36,7 +36,7 @@ public class InMemoryFakeChatRoomRepository implements ChatRoomRepository {
     @Override
     public Page<ChatRoom> findMine(Long userId, Pageable pageable) {
         List<ChatRoom> mine = store.values().stream()
-                .filter(c -> c.isParticipant(userId))
+                .filter(c -> c.isParticipant(userId) && !c.iLeft(userId))
                 .sorted(Comparator
                         .comparing((ChatRoom c) -> c.getLastMessageAt() == null ? 1 : 0)
                         .thenComparing(c -> c.getLastMessageAt(), Comparator.nullsLast(Comparator.reverseOrder()))
@@ -78,6 +78,23 @@ public class InMemoryFakeChatRoomRepository implements ChatRoomRepository {
             ReflectionTestUtils.setField(room, "user1Unread", 0);
         } else {
             ReflectionTestUtils.setField(room, "user2Unread", 0);
+        }
+        return 1;
+    }
+
+    @Override
+    public int markAsLeft(Long chatRoomId, Long userId) {
+        ChatRoom room = store.get(chatRoomId);
+        if (room == null || !room.isParticipant(userId)) return 0;
+        java.time.LocalDateTime now = java.time.LocalDateTime.now();
+        if (userId.equals(room.getUser1Id())) {
+            if (room.getUser1LeftAt() == null) {
+                ReflectionTestUtils.setField(room, "user1LeftAt", now);
+            }
+        } else {
+            if (room.getUser2LeftAt() == null) {
+                ReflectionTestUtils.setField(room, "user2LeftAt", now);
+            }
         }
         return 1;
     }

--- a/src/test/java/com/sseulang/domain/chat/domain/ChatRoomTest.java
+++ b/src/test/java/com/sseulang/domain/chat/domain/ChatRoomTest.java
@@ -3,6 +3,8 @@ package com.sseulang.domain.chat.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -53,5 +55,84 @@ class ChatRoomTest {
         assertThat(c.isParticipant(200L)).isTrue();
         assertThat(c.isParticipant(300L)).isFalse();
         assertThat(c.isParticipant(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("leave 본인_user1_left_at 설정")
+    void leave_user1() {
+        ChatRoom c = ChatRoom.openFor(10L, 100L, 200L);
+        LocalDateTime now = LocalDateTime.of(2026, 5, 8, 12, 0);
+
+        c.leave(100L, now);
+
+        assertThat(c.getUser1LeftAt()).isEqualTo(now);
+        assertThat(c.getUser2LeftAt()).isNull();
+        assertThat(c.iLeft(100L)).isTrue();
+        assertThat(c.iLeft(200L)).isFalse();
+        assertThat(c.opponentLeft(100L)).isFalse();
+        assertThat(c.opponentLeft(200L)).isTrue();
+    }
+
+    @Test
+    @DisplayName("leave 본인_user2_left_at 설정")
+    void leave_user2() {
+        ChatRoom c = ChatRoom.openFor(10L, 100L, 200L);
+        LocalDateTime now = LocalDateTime.of(2026, 5, 8, 12, 0);
+
+        c.leave(200L, now);
+
+        assertThat(c.getUser1LeftAt()).isNull();
+        assertThat(c.getUser2LeftAt()).isEqualTo(now);
+        assertThat(c.iLeft(200L)).isTrue();
+        assertThat(c.iLeft(100L)).isFalse();
+        assertThat(c.opponentLeft(200L)).isFalse();
+        assertThat(c.opponentLeft(100L)).isTrue();
+    }
+
+    @Test
+    @DisplayName("leave 이미_left_상태_idempotent")
+    void leave_idempotent() {
+        ChatRoom c = ChatRoom.openFor(10L, 100L, 200L);
+        LocalDateTime first = LocalDateTime.of(2026, 5, 8, 12, 0);
+        LocalDateTime second = LocalDateTime.of(2026, 5, 8, 13, 0);
+
+        c.leave(100L, first);
+        c.leave(100L, second);  // 다시 호출해도 첫 시각 유지
+
+        assertThat(c.getUser1LeftAt()).isEqualTo(first);
+    }
+
+    @Test
+    @DisplayName("leave 비참여자_IllegalStateException")
+    void leave_비참여자_거부() {
+        ChatRoom c = ChatRoom.openFor(10L, 100L, 200L);
+        LocalDateTime now = LocalDateTime.of(2026, 5, 8, 12, 0);
+
+        assertThatThrownBy(() -> c.leave(300L, now))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("leave null_userId/now_거부")
+    void leave_null_거부() {
+        ChatRoom c = ChatRoom.openFor(10L, 100L, 200L);
+        LocalDateTime now = LocalDateTime.of(2026, 5, 8, 12, 0);
+
+        assertThatThrownBy(() -> c.leave(null, now))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> c.leave(100L, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("iLeft / opponentLeft — 비참여자는 false")
+    void iLeft_비참여자_false() {
+        ChatRoom c = ChatRoom.openFor(10L, 100L, 200L);
+        c.leave(100L, LocalDateTime.now());
+
+        assertThat(c.iLeft(300L)).isFalse();
+        assertThat(c.iLeft(null)).isFalse();
+        assertThat(c.opponentLeft(300L)).isFalse();
+        assertThat(c.opponentLeft(null)).isFalse();
     }
 }

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -49,8 +49,12 @@ class ReviewApplicationServiceTest {
         UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, new InMemoryFakePointHistoryRepository());
+        com.sseulang.domain.chat.application.ChatRoomApplicationService chatSvc =
+                new com.sseulang.domain.chat.application.ChatRoomApplicationService(
+                        new com.sseulang.domain.chat.application.InMemoryFakeChatRoomRepository(),
+                        itemSvc, userSvc, null, null);
         TransactionApplicationService txSvc = new TransactionApplicationService(
-                txRepo, itemSvc, pointSvc, userSvc,
+                txRepo, itemSvc, pointSvc, userSvc, chatSvc,
                 (org.springframework.context.ApplicationEventPublisher) event -> {},
                 java.time.Clock.systemDefaultZone());
         service = new ReviewApplicationService(reviewRepo, txSvc, userSvc);
@@ -179,7 +183,7 @@ class ReviewApplicationServiceTest {
     }
 
     private Long persistTransaction(Long itemId, TransactionStatus status, LocalDateTime completedAt) {
-        Transaction tx = Transaction.create(itemId, SELLER, BUYER, TradeType.판매, 50_000L, null, null, null);
+        Transaction tx = Transaction.create(itemId, SELLER, BUYER, TradeType.판매, 50_000L, null, null, null, null);
         ReflectionTestUtils.setField(tx, "status", status);
         if (completedAt != null) {
             ReflectionTestUtils.setField(tx, "completedAt", completedAt);

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -46,6 +46,15 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
     }
 
     @Override
+    public boolean existsActiveByChatRoomId(Long chatRoomId) {
+        if (chatRoomId == null) return false;
+        return store.values().stream()
+                .anyMatch(t -> chatRoomId.equals(t.getChatRoomId())
+                        && t.getStatus() != TransactionStatus.거래완료
+                        && t.getStatus() != TransactionStatus.취소);
+    }
+
+    @Override
     public List<TransactionStatusCount> countGroupByStatus() {
         return store.values().stream()
                 .collect(Collectors.groupingBy(Transaction::getStatus, Collectors.counting()))

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -36,6 +36,7 @@ class TransactionApplicationServiceTest {
     private InMemoryFakeItemRepository itemRepo;
     private InMemoryFakeUserRepository userRepo;
     private InMemoryFakePointHistoryRepository pointHistoryRepo;
+    private com.sseulang.domain.chat.application.InMemoryFakeChatRoomRepository chatRoomRepo;
     private List<Object> publishedEvents;
     private ItemApplicationService itemSvc;
     private TransactionApplicationService service;
@@ -43,6 +44,7 @@ class TransactionApplicationServiceTest {
     private Long SELLER;
     private Long BUYER;
     private Long OUTSIDER;
+    private Long chatRoomId;
 
     @BeforeEach
     void setUp() {
@@ -63,9 +65,13 @@ class TransactionApplicationServiceTest {
                 new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(),
                 new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, pointHistoryRepo);
+        chatRoomRepo = new com.sseulang.domain.chat.application.InMemoryFakeChatRoomRepository();
+        com.sseulang.domain.chat.application.ChatRoomApplicationService chatSvc =
+                new com.sseulang.domain.chat.application.ChatRoomApplicationService(
+                        chatRoomRepo, itemSvc, userSvc, null, null);
         org.springframework.context.ApplicationEventPublisher publisher = publishedEvents::add;
         service = new TransactionApplicationService(
-                txRepo, itemSvc, pointSvc, userSvc, publisher, java.time.Clock.systemDefaultZone());
+                txRepo, itemSvc, pointSvc, userSvc, chatSvc, publisher, java.time.Clock.systemDefaultZone());
 
         SELLER = userRepo.save(User.createSocialUser(
                 SocialProvider.KAKAO, "k-seller", new Email("seller@x.com"), "seller", null
@@ -81,6 +87,10 @@ class TransactionApplicationServiceTest {
                 SELLER, null, "물건", "설명", 50_000L, null, null, TradeType.판매, "서울"
         ));
         itemId = item.getId();
+        // 라운드 12 (#3.2) — chatRoom 가드. BUYER ↔ SELLER 채팅방 미리 생성.
+        com.sseulang.domain.chat.domain.ChatRoom room =
+                com.sseulang.domain.chat.domain.ChatRoom.openFor(itemId, BUYER, SELLER);
+        chatRoomId = chatRoomRepo.save(room).getId();
     }
 
     // ───────── create ─────────
@@ -88,7 +98,7 @@ class TransactionApplicationServiceTest {
     @Test
     @DisplayName("create 정상_status=채팅중")
     void create_정상() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
 
         TransactionResult r = service.getById(txId, BUYER);
         assertThat(r.itemId()).isEqualTo(itemId);
@@ -100,13 +110,13 @@ class TransactionApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("create 본인 물품_TRANSACTION_SELF_NOT_ALLOWED")
-    void create_본인_거부() {
+    @DisplayName("create buyer 호출_TX_SELLER_ONLY (라운드 12 정책)")
+    void create_buyer_거부() {
         assertThatThrownBy(() ->
-                service.create(new TransactionCreateCommand(itemId, SELLER, null, null)))
+                service.create(new TransactionCreateCommand(itemId, BUYER, chatRoomId, null, null)))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.TRANSACTION_SELF_NOT_ALLOWED);
+                .isEqualTo(ErrorCode.TX_SELLER_ONLY);
     }
 
     @Test
@@ -117,7 +127,7 @@ class TransactionApplicationServiceTest {
         itemRepo.save(item);
 
         assertThatThrownBy(() ->
-                service.create(new TransactionCreateCommand(itemId, BUYER, null, null)))
+                service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null)))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ITEM_INVALID_STATE);
@@ -127,7 +137,7 @@ class TransactionApplicationServiceTest {
     @DisplayName("create 없는 Item_ITEM_NOT_FOUND")
     void create_없는_item() {
         assertThatThrownBy(() ->
-                service.create(new TransactionCreateCommand(9999L, BUYER, null, null)))
+                service.create(new TransactionCreateCommand(9999L, SELLER, chatRoomId, null, null)))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ITEM_NOT_FOUND);
@@ -138,7 +148,7 @@ class TransactionApplicationServiceTest {
     @Test
     @DisplayName("reserve 정상_buyer balance↓ + hold↑ + escrowHoldAmount + 거래보관 history + ReservedEvent")
     void reserve_정상_hold() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
         userRepo.creditPointBalance(BUYER, 50_000L);  // 잔액 충전
 
         service.reserve(txId, SELLER);
@@ -158,7 +168,7 @@ class TransactionApplicationServiceTest {
     @Test
     @DisplayName("reserve 잔액 부족_INSUFFICIENT_POINT")
     void reserve_잔액부족_거부() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
         userRepo.creditPointBalance(BUYER, 10_000L);  // 부족
 
         assertThatThrownBy(() -> service.reserve(txId, SELLER))
@@ -170,7 +180,7 @@ class TransactionApplicationServiceTest {
     @Test
     @DisplayName("reserve buyer 호출_TRANSACTION_FORBIDDEN")
     void reserve_buyer_거부() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
 
         assertThatThrownBy(() -> service.reserve(txId, BUYER))
                 .isInstanceOf(BusinessException.class)
@@ -181,7 +191,7 @@ class TransactionApplicationServiceTest {
     @Test
     @DisplayName("reserve 외부인_TRANSACTION_FORBIDDEN")
     void reserve_외부인_거부() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
 
         assertThatThrownBy(() -> service.reserve(txId, OUTSIDER))
                 .isInstanceOf(BusinessException.class)
@@ -198,8 +208,12 @@ class TransactionApplicationServiceTest {
         )).getId();
         userRepo.creditPointBalance(BUYER, 50_000L);
         userRepo.creditPointBalance(buyer2, 50_000L);
-        Long tx1 = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
-        Long tx2 = service.create(new TransactionCreateCommand(itemId, buyer2, null, null));
+        // 라운드 12: SELLER 가 두 buyer 와 각 채팅방에서 거래 시작 (두 채팅방 = 두 active 가능).
+        com.sseulang.domain.chat.domain.ChatRoom room2 =
+                com.sseulang.domain.chat.domain.ChatRoom.openFor(itemId, buyer2, SELLER);
+        Long chatRoomId2 = chatRoomRepo.save(room2).getId();
+        Long tx1 = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
+        Long tx2 = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId2, null, null));
 
         service.reserve(tx1, SELLER);
 
@@ -317,7 +331,7 @@ class TransactionApplicationServiceTest {
     @Test
     @DisplayName("cancel 채팅중 buyer_정상_Item 변경 없음 + 잔액 변동 없음")
     void cancel_채팅중() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
 
         service.cancel(txId, BUYER, "변심");
 
@@ -361,7 +375,7 @@ class TransactionApplicationServiceTest {
     @Test
     @DisplayName("cancel 외부인_TRANSACTION_FORBIDDEN")
     void cancel_외부인_거부() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
 
         assertThatThrownBy(() -> service.cancel(txId, OUTSIDER, null))
                 .isInstanceOf(BusinessException.class)
@@ -372,7 +386,7 @@ class TransactionApplicationServiceTest {
     @Test
     @DisplayName("getById 비참여자_TRANSACTION_FORBIDDEN")
     void getById_외부인_거부() {
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
 
         assertThatThrownBy(() -> service.getById(txId, OUTSIDER))
                 .isInstanceOf(BusinessException.class)
@@ -390,12 +404,16 @@ class TransactionApplicationServiceTest {
         userRepo.creditPointBalance(BUYER, 50_000L);
         userRepo.creditPointBalance(buyer2, 50_000L);
 
-        Long tx1 = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long tx1 = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
         service.reserve(tx1, SELLER);
         service.cancel(tx1, SELLER, "재예약 가능");
         assertThat(userRepo.findPointBalance(BUYER)).isEqualTo(50_000L);  // 환불 OK
 
-        Long tx2 = service.create(new TransactionCreateCommand(itemId, buyer2, null, null));
+        // 라운드 12 — buyer2 와 SELLER 의 새 chatRoom 필요 (한 채팅방=1 active 정책 + 거래 시작은 판매자만).
+        com.sseulang.domain.chat.domain.ChatRoom room2 =
+                com.sseulang.domain.chat.domain.ChatRoom.openFor(itemId, buyer2, SELLER);
+        Long chatRoom2Id = chatRoomRepo.save(room2).getId();
+        Long tx2 = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoom2Id, null, null));
         service.reserve(tx2, SELLER);
 
         assertThat(service.getById(tx2, SELLER).status()).isEqualTo(TransactionStatus.예약);
@@ -406,7 +424,7 @@ class TransactionApplicationServiceTest {
     /** buyer 충전 + 거래 생성 + reserve 까지 진행한 trasaction id 반환. */
     private Long reservedTxByBuyer() {
         userRepo.creditPointBalance(BUYER, 50_000L);
-        Long txId = service.create(new TransactionCreateCommand(itemId, BUYER, null, null));
+        Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
         service.reserve(txId, SELLER);
         return txId;
     }

--- a/src/test/java/com/sseulang/domain/transaction/domain/TransactionTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/domain/TransactionTest.java
@@ -24,7 +24,7 @@ class TransactionTest {
     @Test
     @DisplayName("create 판매_정상_status=채팅중, deposit/rental null")
     void create_판매_정상() {
-        Transaction t = Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, PRICE, null, null, null);
+        Transaction t = Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, PRICE, null, null, null, null);
 
         assertThat(t.getItemId()).isEqualTo(ITEM);
         assertThat(t.getSellerId()).isEqualTo(SELLER);
@@ -45,7 +45,7 @@ class TransactionTest {
     void create_대여_정상() {
         LocalDateTime start = NOW.plusDays(1);
         LocalDateTime end = NOW.plusDays(7);
-        Transaction t = Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 5_000L, 50_000L, start, end);
+        Transaction t = Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 5_000L, 50_000L, start, end, null);
 
         assertThat(t.getDeposit()).isEqualTo(50_000L);
         assertThat(t.getRentalStart()).isEqualTo(start);
@@ -56,7 +56,7 @@ class TransactionTest {
     @DisplayName("create seller==buyer_거부")
     void create_self_거부() {
         assertThatThrownBy(() ->
-                Transaction.create(ITEM, SELLER, SELLER, TradeType.판매, 1L, null, null, null))
+                Transaction.create(ITEM, SELLER, SELLER, TradeType.판매, 1L, null, null, null, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -64,10 +64,10 @@ class TransactionTest {
     @DisplayName("create 대여인데 deposit/rental 누락_거부")
     void create_대여_누락_거부() {
         assertThatThrownBy(() ->
-                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, null, NOW, NOW.plusDays(1)))
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, null, NOW, NOW.plusDays(1), null))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() ->
-                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, 10_000L, null, NOW.plusDays(1)))
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, 10_000L, null, NOW.plusDays(1), null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -75,10 +75,10 @@ class TransactionTest {
     @DisplayName("create 판매인데 deposit/rental 박으면_거부")
     void create_판매_보증금_거부() {
         assertThatThrownBy(() ->
-                Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, 1L, 10_000L, null, null))
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, 1L, 10_000L, null, null, null))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() ->
-                Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, 1L, null, NOW, NOW.plusDays(1)))
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, 1L, null, NOW, NOW.plusDays(1), null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -86,10 +86,10 @@ class TransactionTest {
     @DisplayName("create 음수 price/deposit_거부")
     void create_음수_거부() {
         assertThatThrownBy(() ->
-                Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, -1L, null, null, null))
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, -1L, null, null, null, null))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() ->
-                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, -1L, NOW, NOW.plusDays(1)))
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, -1L, NOW, NOW.plusDays(1), null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -97,10 +97,10 @@ class TransactionTest {
     @DisplayName("create rentalEnd <= rentalStart_거부")
     void create_rental_역전_거부() {
         assertThatThrownBy(() ->
-                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, 1_000L, NOW.plusDays(2), NOW.plusDays(1)))
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, 1_000L, NOW.plusDays(2), NOW.plusDays(1), null))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() ->
-                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, 1_000L, NOW, NOW))
+                Transaction.create(ITEM, SELLER, BUYER, TradeType.대여, 1L, 1_000L, NOW, NOW, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -294,6 +294,6 @@ class TransactionTest {
     }
 
     private static Transaction sale() {
-        return Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, PRICE, null, null, null);
+        return Transaction.create(ITEM, SELLER, BUYER, TradeType.판매, PRICE, null, null, null, null);
     }
 }

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.transaction.integration;
 
 import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.infrastructure.persistence.CategoryRepositoryImpl;
+import com.sseulang.domain.chat.domain.ChatRoom;
 import com.sseulang.domain.file.application.NoOpPresignedUrlGenerator;
 import com.sseulang.domain.file.domain.PresignedUrlGenerator;
 import com.sseulang.domain.item.application.ItemApplicationService;
@@ -88,7 +89,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         TransactionRepositoryImpl.class,
         TransactionApplicationService.class,
         // v8b — UserApplicationService 가 UserReportRepository 도 의존
-        com.sseulang.domain.report.infrastructure.persistence.UserReportRepositoryImpl.class
+        com.sseulang.domain.report.infrastructure.persistence.UserReportRepositoryImpl.class,
+        // 라운드 12 (#3.2) — TransactionApplicationService 가 ChatRoomApplicationService 의존 추가
+        com.sseulang.domain.chat.infrastructure.persistence.ChatRoomRepositoryImpl.class,
+        com.sseulang.domain.chat.application.ChatRoomApplicationService.class,
+        com.sseulang.domain.user.infrastructure.persistence.UserViewAdapter.class,
+        com.sseulang.domain.item.infrastructure.persistence.ItemViewAdapter.class
 })
 @Testcontainers
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
@@ -153,8 +159,9 @@ class SettlementRollbackIT {
                 sellerId, null, "물건", "설명", 50_000L, null, null, TradeType.판매,
                 "서울", null, null
         )));
+        Long chatRoomId = txTemplate.execute(s -> persistChatRoom(itemId, sellerId, buyerId));
         Long txId = txTemplate.execute(s -> transactionService.create(
-                new TransactionCreateCommand(itemId, buyerId, null, null)
+                new TransactionCreateCommand(itemId, sellerId, chatRoomId, null, null)
         ));
 
         // reserve 시 hold 시도 → 잔액 부족으로 INSUFFICIENT_POINT (라운드 11 — 옛 정책은 거래완료 시점)
@@ -258,5 +265,12 @@ class SettlementRollbackIT {
         em.persist(user);
         em.flush();
         return user.getId();
+    }
+
+    private Long persistChatRoom(Long itemId, Long userA, Long userB) {
+        ChatRoom cr = ChatRoom.openFor(itemId, userA, userB);
+        em.persist(cr);
+        em.flush();
+        return cr.getId();
     }
 }

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -2,6 +2,7 @@ package com.sseulang.domain.transaction.integration;
 
 import com.sseulang.domain.category.application.CategoryApplicationService;
 import com.sseulang.domain.category.infrastructure.persistence.CategoryRepositoryImpl;
+import com.sseulang.domain.chat.domain.ChatRoom;
 import com.sseulang.domain.file.application.NoOpPresignedUrlGenerator;
 import com.sseulang.domain.item.application.NoOpWishlistView;
 import com.sseulang.domain.item.application.ItemApplicationService;
@@ -78,7 +79,12 @@ import static org.assertj.core.api.Assertions.assertThat;
         TransactionRepositoryImpl.class,
         TransactionApplicationService.class,
         // v8b — UserApplicationService 가 UserReportRepository 도 의존
-        com.sseulang.domain.report.infrastructure.persistence.UserReportRepositoryImpl.class
+        com.sseulang.domain.report.infrastructure.persistence.UserReportRepositoryImpl.class,
+        // 라운드 12 (#3.2) — TransactionApplicationService 가 ChatRoomApplicationService 의존 추가
+        com.sseulang.domain.chat.infrastructure.persistence.ChatRoomRepositoryImpl.class,
+        com.sseulang.domain.chat.application.ChatRoomApplicationService.class,
+        com.sseulang.domain.user.infrastructure.persistence.UserViewAdapter.class,
+        com.sseulang.domain.item.infrastructure.persistence.ItemViewAdapter.class
 })
 @Testcontainers
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
@@ -124,6 +130,8 @@ class TransactionConcurrencyIT {
     private Long buyer1Id;
     private Long buyer2Id;
     private Long itemId;
+    private Long chatRoom1Id;
+    private Long chatRoom2Id;
     private Long tx1Id;
     private Long tx2Id;
 
@@ -146,8 +154,12 @@ class TransactionConcurrencyIT {
                     "서울", null, null
             ));
 
-            tx1Id = transactionService.create(new TransactionCreateCommand(itemId, buyer1Id, null, null));
-            tx2Id = transactionService.create(new TransactionCreateCommand(itemId, buyer2Id, null, null));
+            // 라운드 12 — 거래 시작은 채팅방 안에서만 + 판매자만. buyer 별 별도 채팅방.
+            chatRoom1Id = persistChatRoom(itemId, sellerId, buyer1Id);
+            chatRoom2Id = persistChatRoom(itemId, sellerId, buyer2Id);
+
+            tx1Id = transactionService.create(new TransactionCreateCommand(itemId, sellerId, chatRoom1Id, null, null));
+            tx2Id = transactionService.create(new TransactionCreateCommand(itemId, sellerId, chatRoom2Id, null, null));
             return null;
         });
     }
@@ -210,17 +222,16 @@ class TransactionConcurrencyIT {
     @Test
     @DisplayName("라운드 11 — 같은 buyer 두 거래 동시 reserve_잔액 한건만 충당_정확히 1건만 성공")
     void buyer_hold_race() throws Exception {
-        // 별도 두 Item + 두 거래 (buyer 동일, 잔액 50000 한 건만 가능)
+        // 별도 두 Item + 두 거래 (buyer 동일, 잔액 50000 한 건만 가능). 라운드 12 — 거래는 채팅방 안에서만 (판매자만).
         Long item2Id = txTemplate.execute(status -> itemService.register(new ItemRegisterCommand(
                 sellerId, null, "물건2", "설명", 50_000L, null, null, TradeType.판매, "서울", null, null
         )));
-        Long txA = txTemplate.execute(status ->
-                transactionService.create(new TransactionCreateCommand(itemId, buyer1Id, null, null)));
+        // setUp 의 tx1Id (item1+buyer1, chatRoom1) 그대로 사용 — buyer1 의 첫 번째 거래.
+        // 두 번째 거래는 item2 + 새 채팅방 (item2, seller, buyer1).
+        Long chatRoomB = txTemplate.execute(status -> persistChatRoom(item2Id, sellerId, buyer1Id));
+        Long txA = tx1Id;
         Long txB = txTemplate.execute(status ->
-                transactionService.create(new TransactionCreateCommand(item2Id, buyer1Id, null, null)));
-        // 기존 setUp 의 tx1 (item1, buyer1) 를 cancel 해 같은 Item 재예약 가능 상태로
-        // → 위 txA 가 새 Item 거래라 tx1Id 는 무시 가능. 단, item.status=판매중 인지 보장 필요.
-        // setUp 직후 item1 은 판매중이라 OK.
+                transactionService.create(new TransactionCreateCommand(item2Id, sellerId, chatRoomB, null, null)));
 
         ExecutorService exec = Executors.newFixedThreadPool(2);
         CountDownLatch start = new CountDownLatch(1);
@@ -360,5 +371,12 @@ class TransactionConcurrencyIT {
         em.persist(user);
         em.flush();
         return user.getId();
+    }
+
+    private Long persistChatRoom(Long itemId, Long userA, Long userB) {
+        ChatRoom cr = ChatRoom.openFor(itemId, userA, userB);
+        em.persist(cr);
+        em.flush();
+        return cr.getId();
     }
 }

--- a/src/test/java/com/sseulang/integration/EndToEndGuardScenariosIT.java
+++ b/src/test/java/com/sseulang/integration/EndToEndGuardScenariosIT.java
@@ -160,7 +160,7 @@ class EndToEndGuardScenariosIT {
                         .with(csrf())
                         .cookie(atCookie)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"itemId\":1}"))
+                        .content("{\"itemId\":1, \"chatRoomId\":1}"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error.code").value("AUTH_EMAIL_NOT_VERIFIED"));
 
@@ -209,8 +209,9 @@ class EndToEndGuardScenariosIT {
         Cookie buyerAt = oauthLoginAndExtractAt("BUYER", "kakao-buyer-" + UUID.randomUUID(),
                 "buyer-" + System.nanoTime() + "@e2e.test", "바이어");
 
-        // 거래 생성 — 채팅중 (자금 이동 없음).
-        Long txId = createTransaction(buyerAt, itemId);
+        // 거래 생성 — 채팅중 (자금 이동 없음). 라운드 12: buyer 가 채팅방 개설, seller 가 거래 시작.
+        Long chatRoomId = createChatRoom(buyerAt, itemId);
+        Long txId = createTransaction(sellerAt, itemId, chatRoomId);
 
         // 라운드 11 — Seller 예약 시 buyer hold 시도 → 잔액 0 < 50000 → INSUFFICIENT_POINT.
         // (옛 정책은 거래완료 시점에 차감, 라운드 11 부터는 reserve 시점에 hold 함.)
@@ -325,12 +326,23 @@ class EndToEndGuardScenariosIT {
         return readLong(result, "/data/id");
     }
 
-    private Long createTransaction(Cookie buyerAt, Long itemId) throws Exception {
-        MvcResult result = mvc.perform(post("/api/v1/transactions")
+    private Long createChatRoom(Cookie buyerAt, Long itemId) throws Exception {
+        MvcResult result = mvc.perform(post("/api/v1/chat-rooms")
                         .with(csrf())
                         .cookie(buyerAt)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"itemId\":" + itemId + "}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return readLong(result, "/data/id");
+    }
+
+    private Long createTransaction(Cookie sellerAt, Long itemId, Long chatRoomId) throws Exception {
+        MvcResult result = mvc.perform(post("/api/v1/transactions")
+                        .with(csrf())
+                        .cookie(sellerAt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"itemId\":" + itemId + ",\"chatRoomId\":" + chatRoomId + "}"))
                 .andExpect(status().isCreated())
                 .andReturn();
         return readLong(result, "/data/id");

--- a/src/test/java/com/sseulang/integration/EndToEndHappyPathIT.java
+++ b/src/test/java/com/sseulang/integration/EndToEndHappyPathIT.java
@@ -239,12 +239,21 @@ class EndToEndHappyPathIT {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.status").value("완료"));
 
-        // ───────── 5. Buyer Transaction create ─────────
-        MvcResult txResult = mvc.perform(post("/api/v1/transactions")
+        // ───────── 5. Buyer 채팅방 개설 + Seller Transaction create (라운드 12) ─────────
+        MvcResult roomResult = mvc.perform(post("/api/v1/chat-rooms")
                         .with(csrf())
                         .cookie(buyerAt)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"itemId\":" + itemId + "}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        Long chatRoomId = readId(roomResult, "$.data.id");
+
+        MvcResult txResult = mvc.perform(post("/api/v1/transactions")
+                        .with(csrf())
+                        .cookie(sellerAt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"itemId\":" + itemId + ",\"chatRoomId\":" + chatRoomId + "}"))
                 .andExpect(status().isCreated())
                 .andReturn();
         Long txId = readId(txResult, "$.data.id");


### PR DESCRIPTION
## Summary
라운드 12 PR-A — 채팅방/거래 정책 강화 (Step 1+2). #3.3 거래대행 + PR-B 는 다음 라운드.

### #3.1 채팅방 나가기 (commit 574d631)
- **PATCH /api/v1/chat-rooms/{id}/leave** — soft hide
- V18 마이그레이션: chat_rooms.user1_left_at, user2_left_at
- ChatRoom Aggregate: leave / iLeft / opponentLeft (idempotent)
- ChatRoomResponse 필드 추가: iLeft, opponentLeft
- 본인 left → listMine 에서 제외
- MessageApplicationService.send 가드: 본인 left → CHAT_FORBIDDEN, 상대 left → CHAT_ROOM_OPPONENT_LEFT

### #3.2 거래 시작 채팅방 가드 + 판매자만 (commit 62d0c83)
- **POST /api/v1/transactions** body 에 `chatRoomId` 필수
- 검증 순서: chatRoomId null → ITEM_NOT_FOUND → chatRoom 참여+itemId 일치 → seller 만 → active 1건
- 한 채팅방 = 1 active transaction 정책
- V19 마이그레이션: transactions.chat_room_id (FK + index)
- ErrorCode 4종: TX_CHATROOM_REQUIRED, TX_CHATROOM_ITEM_MISMATCH, TX_ALREADY_ACTIVE_IN_ROOM, TX_SELLER_ONLY

### 부수 변경
- UserViewAdapter / ItemViewAdapter public — IT @Import 가능하게
- 통합 테스트 마이그레이션: SettlementRollbackIT, TransactionConcurrencyIT, EndToEndHappyPathIT, EndToEndGuardScenariosIT (chatRoom 미리 생성 + seller 가 거래 시작)

## Test plan
- [x] 컴파일 + 전체 테스트 통과 (Step 2 직후)
- [ ] CI build green
- [ ] prod 배포 후 smoke test
  - 채팅방 나가기 → 본인 hide / 상대 opponentLeft=true
  - seller 가 채팅방 내 거래 시작 → 정상
  - buyer 가 거래 시작 시도 → 403 TX_SELLER_ONLY
  - 같은 채팅방 두 번째 거래 시도 → 400 TX_ALREADY_ACTIVE_IN_ROOM

@codex review — 보안 영역 (거래 상태 머신 + 채팅 가드) 게이트 2 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)