### PR TITLE
feat: round 12 PR-B-1/B-2 (skeleton) — 거래대행 미리보기 + 내부 신청 도메인 골격

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateCommand;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewCommand;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewResult;
 import com.sseulang.domain.escrow.application.dto.EscrowApplicationResult;
 import com.sseulang.domain.escrow.application.dto.EscrowLinkCreateCommand;
 import com.sseulang.domain.escrow.application.dto.EscrowLinkResult;
@@ -85,6 +87,40 @@ public class EscrowApplicationService {
         this.deliveryRepository = deliveryRepository;
         this.eventPublisher = eventPublisher;
         this.linkExpiryHours = linkExpiryHours;
+    }
+
+    // =============================================================
+    // Use case 0 — 폼 작성 중 수수료 미리보기 (PR-B 라운드 12)
+    // 좌표/물품/feePayer 받아서 거리·deliveryFee·commissionFee + buyer/seller 부담분 산정.
+    // application 생성 X — pure read.
+    // =============================================================
+    public EscrowApplicationPreviewResult previewFee(EscrowApplicationPreviewCommand cmd) {
+        if (cmd.tradeMode() == null || cmd.feePayer() == null
+                || cmd.weight() == null || cmd.volume() == null || cmd.fragility() == null
+                || cmd.pickupLat() == null || cmd.pickupLng() == null
+                || cmd.deliveryLat() == null || cmd.deliveryLng() == null) {
+            throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+        }
+        EscrowFeeSettings settings = feeSettingsRepository.findSingleton();
+        BigDecimal distance = EscrowFeeCalculator.distanceKm(
+                cmd.pickupLat().doubleValue(), cmd.pickupLng().doubleValue(),
+                cmd.deliveryLat().doubleValue(), cmd.deliveryLng().doubleValue()
+        );
+        FeeBreakdown fee = EscrowFeeCalculator.calculate(
+                settings, cmd.tradeMode(), cmd.itemPrice(), distance,
+                cmd.weight(), cmd.volume(), cmd.fragility()
+        );
+        long buyerPayable = computeBuyerOwed(cmd.tradeMode(), cmd.itemPrice(), fee, cmd.feePayer());
+        long sellerPayable = computeSellerOwed(fee, cmd.feePayer());
+        return new EscrowApplicationPreviewResult(
+                fee.distanceKm(),
+                fee.deliveryFee(),
+                fee.commissionFee(),
+                fee.totalFee(),
+                buyerPayable,
+                sellerPayable,
+                fee.commissionRate()
+        );
     }
 
     // =============================================================

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateInternalCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateInternalCommand.java
@@ -1,0 +1,45 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 내부 거래대행 신청 Command (PR-B-2 라운드 12). 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력.
+ *
+ * <p>외부 link 흐름과 차이:
+ * <ul>
+ *   <li>{@code linkToken} 미사용 — chatRoomId 로 채팅방 컨텍스트 검증.</li>
+ *   <li>{@code requesterId} 는 판매자 (initiator) — 정책상 sellerOnly 라 chat_room.user1/user2 중 sellerId 와 일치 검증.</li>
+ *   <li>buyer 는 chat_room 의 상대방에서 도출 (요청자 명시 X).</li>
+ * </ul>
+ */
+public record EscrowApplicationCreateInternalCommand(
+        Long requesterId,            // 판매자 = initiator
+        Long chatRoomId,
+        TradeMode tradeMode,
+        FeePayer feePayer,
+        long itemPrice,
+        String itemDescription,
+        String pickupAddress,
+        BigDecimal pickupLat,
+        BigDecimal pickupLng,
+        String deliveryAddress,
+        BigDecimal deliveryLat,
+        BigDecimal deliveryLng,
+        Weight weight,
+        Volume volume,
+        Fragility fragility,
+        String deliveryNotes,
+        long submittedDeliveryFee,
+        long submittedCommissionFee,
+        long submittedTotalFee,
+        BigDecimal submittedDistanceKm,
+        List<String> imageUrls
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationPreviewCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationPreviewCommand.java
@@ -1,0 +1,29 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+
+import java.math.BigDecimal;
+
+/**
+ * 거래대행 수수료 미리보기 Command — 신청 폼 작성 중 실시간 호출용.
+ * 백엔드가 좌표로 거리 계산 + 정책 적용 + share 산정해서 응답.
+ *
+ * <p>actually persisting 아무것도 안 함 — pure read.</p>
+ */
+public record EscrowApplicationPreviewCommand(
+        TradeMode tradeMode,
+        long itemPrice,
+        BigDecimal pickupLat,
+        BigDecimal pickupLng,
+        BigDecimal deliveryLat,
+        BigDecimal deliveryLng,
+        Weight weight,
+        Volume volume,
+        Fragility fragility,
+        FeePayer feePayer
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationPreviewResult.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationPreviewResult.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * 미리보기 응답. 실제 application 생성 X — 폼 작성 중 실시간 표시용.
+ *
+ * @param distanceKm     좌표 기반 산정 거리 (소수점 2)
+ * @param deliveryFee    라이더 보상 (원)
+ * @param commissionFee  플랫폼 수익 (Mode B 만 > 0)
+ * @param totalFee       총 fee (deliveryFee + commissionFee + (INTERNAL ? itemPrice : 0))
+ * @param buyerPayable   feePayer 별 buyer 부담분 (BOTH=50%, SELLER=0, BUYER=feeTotal)
+ * @param sellerPayable  feePayer 별 seller 부담분
+ * @param commissionRate snapshot — 정책 변경 시 실신청 시점에 재계산
+ */
+public record EscrowApplicationPreviewResult(
+        BigDecimal distanceKm,
+        long deliveryFee,
+        long commissionFee,
+        long totalFee,
+        long buyerPayable,
+        long sellerPayable,
+        BigDecimal commissionRate
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EntryType.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EntryType.java
@@ -1,0 +1,16 @@
+package com.sseulang.domain.escrow.domain;
+
+/**
+ * 거래대행 신청 진입 경로.
+ *
+ * <ul>
+ *   <li>{@link #EXTERNAL} — 기존 link 토큰 흐름. initiator 가 link 생성, receiver 가 form 제출.
+ *       link_id 가 application 에 채워짐.</li>
+ *   <li>{@link #INTERNAL} — 채팅방 내 신청 (PR-B-2 라운드 12). 판매자가 채팅방 안에서 신청 + 양쪽 정보 한 번에 입력.
+ *       link_id 는 NULL, chat_room_id 가 채워짐.</li>
+ * </ul>
+ */
+public enum EntryType {
+    INTERNAL,
+    EXTERNAL
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
@@ -37,8 +37,18 @@ public class EscrowApplication extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "link_id", nullable = false, updatable = false)
+    /**
+     * 외부 link 흐름의 link.id. 내부 chatRoom 흐름은 NULL (V20 라운드 12 PR-B-2).
+     */
+    @Column(name = "link_id", updatable = false)
     private Long linkId;
+
+    /**
+     * 진입 경로 — INTERNAL (채팅방 내 신청) | EXTERNAL (link 토큰 흐름).
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entry_type", nullable = false, length = 10, updatable = false)
+    private EntryType entryType;
 
     @Column(name = "initiator_id", nullable = false, updatable = false)
     private Long initiatorId;
@@ -179,6 +189,71 @@ public class EscrowApplication extends BaseEntity {
 
         EscrowApplication a = new EscrowApplication();
         a.linkId = linkId;
+        a.entryType = EntryType.EXTERNAL;
+        a.initiatorId = initiatorId;
+        a.receiverId = receiverId;
+        a.buyerId = buyerId;
+        a.sellerId = sellerId;
+        a.tradeMode = tradeMode;
+        a.feePayer = feePayer;
+        a.itemPrice = itemPrice;
+        a.itemDescription = itemDescription;
+        a.pickupAddress = pickupAddress;
+        a.pickupLat = pickupLat;
+        a.pickupLng = pickupLng;
+        a.deliveryAddress = deliveryAddress;
+        a.deliveryLat = deliveryLat;
+        a.deliveryLng = deliveryLng;
+        a.weight = weight;
+        a.volume = volume;
+        a.fragility = fragility;
+        a.deliveryNotes = deliveryNotes;
+        a.appliedDistanceKm = snapshot.distanceKm();
+        a.appliedDeliveryFee = snapshot.deliveryFee();
+        a.appliedCommissionFee = snapshot.commissionFee();
+        a.appliedTotalFee = snapshot.totalFee();
+        a.appliedCommissionRate = snapshot.commissionRate();
+        a.initiatorShare = initiatorShare;
+        a.receiverShare = receiverShare;
+        a.status = EscrowApplicationStatus.결제대기;
+        a.imageUrls = imageUrls;
+        return a;
+    }
+
+    /**
+     * 내부 chatRoom 흐름 (PR-B-2 라운드 12). 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력.
+     *
+     * <p>특징 (외부 link 흐름과 차이):
+     * <ul>
+     *   <li>{@code linkId = null} — link 미사용</li>
+     *   <li>{@code entryType = INTERNAL}</li>
+     *   <li>initiator = 신청자 (판매자), receiver = 채팅방 상대방 (구매자) — 정책상 sellerOnly 라 initiatorRole=seller 고정</li>
+     * </ul>
+     */
+    public static EscrowApplication createInternal(
+            Long initiatorId, Long receiverId,
+            TradeMode tradeMode, FeePayer feePayer,
+            long itemPrice, String itemDescription,
+            String pickupAddress, BigDecimal pickupLat, BigDecimal pickupLng,
+            String deliveryAddress, BigDecimal deliveryLat, BigDecimal deliveryLng,
+            Weight weight, Volume volume, Fragility fragility, String deliveryNotes,
+            FeeBreakdown snapshot,
+            long initiatorShare, long receiverShare,
+            String imageUrls
+    ) {
+        if (initiatorId == null || receiverId == null) {
+            throw new IllegalArgumentException("ids required");
+        }
+        if (initiatorId.equals(receiverId)) {
+            throw new BusinessException(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
+        }
+        // 내부 흐름은 판매자만 시작 — initiator = seller, receiver = buyer.
+        Long sellerId = initiatorId;
+        Long buyerId = receiverId;
+
+        EscrowApplication a = new EscrowApplication();
+        a.linkId = null;
+        a.entryType = EntryType.INTERNAL;
         a.initiatorId = initiatorId;
         a.receiverId = receiverId;
         a.buyerId = buyerId;

--- a/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
@@ -58,6 +58,20 @@ public class EscrowController {
     // =========================================================
     // Application
     // =========================================================
+    @Operation(summary = "거래대행 수수료 미리보기 (실시간)",
+            description = "폼 작성 중 좌표·물품·feePayer 보내면 거리·deliveryFee·commissionFee + buyer/seller 부담분 응답. application 생성 X.")
+    @PostMapping("/applications/preview")
+    public ApiResponse<com.sseulang.domain.escrow.presentation.dto.EscrowApplicationPreviewResponse> previewFee(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody com.sseulang.domain.escrow.presentation.dto.EscrowApplicationPreviewRequest request
+    ) {
+        return ApiResponse.ok(
+                com.sseulang.domain.escrow.presentation.dto.EscrowApplicationPreviewResponse.from(
+                        service.previewFee(request.toCommand())
+                )
+        );
+    }
+
     @Operation(summary = "거래대행 폼 제출 (수신자)",
             description = "이메일 인증 필수. linkToken 매칭 + atomic claim + snapshot 저장. 동일 사용자 재제출 시 idempotent.")
     @PostMapping("/applications")

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationPreviewRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationPreviewRequest.java
@@ -1,0 +1,47 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewCommand;
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+/**
+ * 거래대행 수수료 미리보기 요청 — 폼 작성 중 실시간 호출.
+ *
+ * <p>actually persisting 아무것도 안 함 — feePayer 별 buyer/seller 부담분만 응답.</p>
+ */
+@Schema(description = "거래대행 수수료 미리보기 (실시간) — 좌표·물품 정보·feePayer 받아 buyer/seller 부담분 응답.")
+public record EscrowApplicationPreviewRequest(
+        @Schema(example = "INTERNAL", allowableValues = {"INTERNAL", "EXTERNAL"})
+        @NotNull TradeMode tradeMode,
+
+        @Schema(example = "30000", description = "Mode B(INTERNAL)는 > 0, Mode A(EXTERNAL)는 0.")
+        @Min(0) long itemPrice,
+
+        @Schema(example = "37.5665") @NotNull BigDecimal pickupLat,
+        @Schema(example = "126.9780") @NotNull BigDecimal pickupLng,
+        @Schema(example = "37.5172") @NotNull BigDecimal deliveryLat,
+        @Schema(example = "127.0473") @NotNull BigDecimal deliveryLng,
+
+        @NotNull Weight weight,
+        @NotNull Volume volume,
+        @NotNull Fragility fragility,
+
+        @Schema(example = "both", allowableValues = {"buyer", "seller", "both"})
+        @NotNull FeePayer feePayer
+) {
+    public EscrowApplicationPreviewCommand toCommand() {
+        return new EscrowApplicationPreviewCommand(
+                tradeMode, itemPrice,
+                pickupLat, pickupLng, deliveryLat, deliveryLng,
+                weight, volume, fragility, feePayer
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationPreviewResponse.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationPreviewResponse.java
@@ -1,0 +1,27 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+@Schema(description = "거래대행 수수료 미리보기 응답.")
+public record EscrowApplicationPreviewResponse(
+        @Schema(example = "5.42") BigDecimal distanceKm,
+        @Schema(example = "4000") long deliveryFee,
+        @Schema(example = "1000") long commissionFee,
+        @Schema(example = "5000", description = "deliveryFee + commissionFee + (INTERNAL ? itemPrice : 0)")
+        long totalFee,
+        @Schema(example = "2500", description = "feePayer 별 구매자 부담분")
+        long buyerPayable,
+        @Schema(example = "2500", description = "feePayer 별 판매자 부담분")
+        long sellerPayable,
+        @Schema(example = "0.05") BigDecimal commissionRate
+) {
+    public static EscrowApplicationPreviewResponse from(EscrowApplicationPreviewResult r) {
+        return new EscrowApplicationPreviewResponse(
+                r.distanceKm(), r.deliveryFee(), r.commissionFee(), r.totalFee(),
+                r.buyerPayable(), r.sellerPayable(), r.commissionRate()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V20__escrow_internal_entry.sql
+++ b/src/main/resources/db/migration/V20__escrow_internal_entry.sql
@@ -1,0 +1,30 @@
+-- V20: 거래대행 내부 신청 흐름 (PR-B-2)
+--
+-- 정책:
+--   * 외부 link 흐름 (기존): initiator 가 link 생성 → receiver 가 form 제출 → application 생성
+--   * 내부 chatRoom 흐름 (신규): 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력 → application 생성. link 미사용.
+--
+-- 변경:
+--   * link_id 를 nullable 로 (내부 흐름은 link 없음)
+--   * entry_type 컬럼 추가 — INTERNAL | EXTERNAL 구분
+--   * 기존 row 는 모두 EXTERNAL (link 흐름) — backfill
+--
+-- 입력 분리 (양쪽 본인 영역만 입력) 정책은 다음 라운드에서 별도 컬럼/플래그로 추가.
+
+-- link_id NULL 허용
+ALTER TABLE escrow_applications
+    MODIFY COLUMN link_id BIGINT NULL COMMENT '외부 link 흐름의 link.id. 내부 chatRoom 흐름은 NULL.';
+
+-- entry_type 추가
+ALTER TABLE escrow_applications
+    ADD COLUMN entry_type VARCHAR(10) NOT NULL DEFAULT 'EXTERNAL'
+        COMMENT 'INTERNAL=채팅방 내 신청 / EXTERNAL=link 토큰 흐름';
+
+-- 기존 row 는 모두 link 흐름이라 EXTERNAL. DEFAULT 로 자동 backfill.
+-- 신규 INTERNAL row 는 ApplicationService.createInternalApplication 가 명시적으로 set.
+
+ALTER TABLE escrow_applications
+    ADD CONSTRAINT chk_escrow_applications_entry_type CHECK (entry_type IN ('INTERNAL', 'EXTERNAL'));
+
+ALTER TABLE escrow_applications
+    ADD INDEX idx_escrow_applications_entry_type (entry_type);

--- a/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
@@ -106,6 +106,56 @@ class EscrowApplicationServiceTest {
         ))).isInstanceOf(BusinessException.class);
     }
 
+    // ------------------------------- previewFee -------------------------------
+
+    @Test
+    @DisplayName("previewFee_BOTH_buyer/seller_50:50_분담")
+    void previewFee_both_5050() {
+        com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewResult r =
+                service.previewFee(new com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewCommand(
+                        TradeMode.INTERNAL, 30_000L,
+                        new BigDecimal("37.5065"), new BigDecimal("127.0530"),
+                        new BigDecimal("37.5144"), new BigDecimal("127.1058"),
+                        Weight.R1TO3, Volume.M, Fragility.F3, FeePayer.both
+                ));
+        assertThat(r.deliveryFee()).isPositive();
+        assertThat(r.commissionFee()).isPositive();
+        long feeTotal = r.deliveryFee() + r.commissionFee();
+        // BOTH: buyer = item + fee/2, seller = fee - fee/2
+        assertThat(r.buyerPayable()).isEqualTo(30_000L + feeTotal / 2);
+        assertThat(r.sellerPayable()).isEqualTo(feeTotal - feeTotal / 2);
+    }
+
+    @Test
+    @DisplayName("previewFee_BUYER_단독_buyer가_전액_부담")
+    void previewFee_buyer_only() {
+        com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewResult r =
+                service.previewFee(new com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewCommand(
+                        TradeMode.INTERNAL, 30_000L,
+                        new BigDecimal("37.5065"), new BigDecimal("127.0530"),
+                        new BigDecimal("37.5144"), new BigDecimal("127.1058"),
+                        Weight.R1TO3, Volume.M, Fragility.F3, FeePayer.buyer
+                ));
+        long feeTotal = r.deliveryFee() + r.commissionFee();
+        assertThat(r.buyerPayable()).isEqualTo(30_000L + feeTotal);
+        assertThat(r.sellerPayable()).isZero();
+    }
+
+    @Test
+    @DisplayName("previewFee_필수_누락_ESCROW_FORM_INVALID")
+    void previewFee_invalid() {
+        assertThatThrownBy(() -> service.previewFee(
+                new com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewCommand(
+                        null, 30_000L,
+                        new BigDecimal("37.5065"), new BigDecimal("127.0530"),
+                        new BigDecimal("37.5144"), new BigDecimal("127.1058"),
+                        Weight.R1TO3, Volume.M, Fragility.F3, FeePayer.both
+                )
+        )).isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ESCROW_FORM_INVALID);
+    }
+
     // ------------------------------ createApplication ------------------------------
 
     /** 거리 8.51km / weight=1to3 / volume=m / fragility=f3 / itemPrice=1.8M 시점의 산정값 (default settings 기준). */


### PR DESCRIPTION
## Summary
라운드 12 PR-B 일부 — 미리보기 endpoint + 내부 신청 도메인 골격 (endpoint 는 다음).

### B-1. 거래대행 수수료 미리보기 (commit 6fccca1)
- **POST /api/v1/escrow/applications/preview**
- 폼 작성 중 좌표·물품·feePayer 받아 거리·deliveryFee·commissionFee + buyer/seller 부담분 응답
- application 생성 X (pure read)
- ESCROW_FORM_INVALID 가드
- 단위 테스트 3 (BOTH 50:50 / BUYER 단독 / 필수 누락)

### B-2. 내부 신청 흐름 도메인 골격 (commit aee116f)
- V20 마이그레이션:
  - `link_id` nullable (내부 흐름은 link 미사용)
  - `entry_type` 컬럼 (INTERNAL | EXTERNAL) — 기존 row backfill
- `EntryType` enum 신설
- `EscrowApplication`:
  - `entryType` 필드 + 기존 `create()` 는 EXTERNAL 자동 set
  - `createInternal()` 정적 팩토리 — linkId=null, entryType=INTERNAL
- `EscrowApplicationCreateInternalCommand` DTO

내부 신청 service / endpoint / 단위 테스트는 다음 라운드 (PR-B-3) 에서 진행.

## Test plan
- [x] 전체 테스트 PASS (외부 link 흐름 변경 없음)
- [ ] CI build green
- [ ] prod 배포 후 미리보기 호출 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)