### PR TITLE
feat: round 12 PR-G — Inquiry validation 보강 (사진 필수 + 본문 최소 10자)

### DIFF
--- a/src/main/java/com/sseulang/domain/support/presentation/dto/InquiryCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/support/presentation/dto/InquiryCreateRequest.java
@@ -5,12 +5,13 @@ import com.sseulang.domain.support.domain.InquiryCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
-@Schema(description = "1:1 문의 작성. imageUrls 는 사전에 SUPPORT presigned 로 업로드한 S3 URL.")
+@Schema(description = "1:1 문의 작성. imageUrls 는 사전에 SUPPORT presigned 로 업로드한 S3 URL. 라운드 12 PR-G — 사진 1장 이상 필수 + 내용 최소 10자.")
 public record InquiryCreateRequest(
         @Schema(description = "카테고리", example = "결제", allowableValues = {"계정", "거래", "결제", "배송", "기타"})
         @NotNull InquiryCategory category,
@@ -18,13 +19,14 @@ public record InquiryCreateRequest(
         @Schema(example = "환불 처리가 안 됩니다", maxLength = 200)
         @NotBlank @Size(max = 200) String title,
 
-        @Schema(example = "어제 17시쯤 결제했는데 아직 환불이 안 됐습니다.")
-        @NotBlank String content,
+        @Schema(example = "어제 17시쯤 결제했는데 아직 환불이 안 됐습니다.", description = "본문 — 최소 10자")
+        @NotBlank @Size(min = 10, max = 5000, message = "내용은 10자 이상 입력해 주세요") String content,
 
         @Schema(example = "user@example.com", description = "답변 받을 이메일")
         @NotBlank @Email @Size(max = 255) String email,
 
-        @Schema(description = "첨부 이미지 URL 배열 (최대 5장, 선택)", nullable = true)
+        @Schema(description = "첨부 이미지 URL 배열 (1~5장 필수)")
+        @NotEmpty(message = "첨부 사진은 1장 이상 필수입니다")
         @Size(max = 5) List<@Size(max = 500) String> imageUrls
 ) {
     public InquiryCreateCommand toCommand() {


### PR DESCRIPTION
## Summary
PR-G 작업 일부 — Inquiry validation 보강.

- imageUrls @NotEmpty (1장 이상 필수)
- content @Size(min=10, max=5000) (본문 최소 10자)
- Item price/deposit @PositiveOrZero — 이미 적용됨 (작업 #기타 #3 마이너스 차단 OK)

작업 목록 #기타 #1 (사진 필수 + 길이) + #3 (가격 마이너스) 충족.
대여 보증금 원/% 선택 (#기타 #2) 은 별도 라운드.

## Test plan
- [x] 전체 테스트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)