### PR TITLE
feat: round 12 PR-B-3 (skeleton) — Escrow 내부 신청 chatRoomId 매핑

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateInternalCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateInternalCommand.java
@@ -22,6 +22,7 @@ import java.util.List;
 public record EscrowApplicationCreateInternalCommand(
         Long requesterId,            // 판매자 = initiator
         Long chatRoomId,
+        Long itemId,                 // chatRoom 의 item 검증용
         TradeMode tradeMode,
         FeePayer feePayer,
         long itemPrice,

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
@@ -50,6 +50,12 @@ public class EscrowApplication extends BaseEntity {
     @Column(name = "entry_type", nullable = false, length = 10, updatable = false)
     private EntryType entryType;
 
+    /**
+     * 내부 흐름의 채팅방 ID (V19 컬럼). 외부 link 흐름은 NULL.
+     */
+    @Column(name = "chat_room_id", updatable = false)
+    private Long chatRoomId;
+
     @Column(name = "initiator_id", nullable = false, updatable = false)
     private Long initiatorId;
 
@@ -231,6 +237,7 @@ public class EscrowApplication extends BaseEntity {
      * </ul>
      */
     public static EscrowApplication createInternal(
+            Long chatRoomId,
             Long initiatorId, Long receiverId,
             TradeMode tradeMode, FeePayer feePayer,
             long itemPrice, String itemDescription,
@@ -251,9 +258,13 @@ public class EscrowApplication extends BaseEntity {
         Long sellerId = initiatorId;
         Long buyerId = receiverId;
 
+        if (chatRoomId == null) {
+            throw new IllegalArgumentException("chatRoomId required for INTERNAL");
+        }
         EscrowApplication a = new EscrowApplication();
         a.linkId = null;
         a.entryType = EntryType.INTERNAL;
+        a.chatRoomId = chatRoomId;
         a.initiatorId = initiatorId;
         a.receiverId = receiverId;
         a.buyerId = buyerId;


### PR DESCRIPTION
## Summary
EscrowApplication 의 chat_room_id (V19 컬럼) 도메인 매핑.
- chatRoomId 필드 추가
- createInternal() 시그니처에 chatRoomId 필수 인자
- Command DTO 에 itemId 추가

Service.createInternalApplication / Controller endpoint 는 다음 라운드.

## Test plan
- [x] 전체 테스트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)