### PR TITLE
feat: round 12 PR-B-3 — 거래대행 내부 신청 endpoint (판매자만)

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateCommand;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateInternalCommand;
 import com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewCommand;
 import com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewResult;
 import com.sseulang.domain.escrow.application.dto.EscrowApplicationResult;
@@ -67,6 +68,8 @@ public class EscrowApplicationService {
     private final PointApplicationService pointApplicationService;
     private final DeliveryRepository deliveryRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final com.sseulang.domain.chat.application.ChatRoomApplicationService chatRoomApplicationService;
+    private final com.sseulang.domain.item.application.ItemApplicationService itemApplicationService;
     private final int linkExpiryHours;
 
     public EscrowApplicationService(
@@ -77,6 +80,8 @@ public class EscrowApplicationService {
             PointApplicationService pointApplicationService,
             DeliveryRepository deliveryRepository,
             ApplicationEventPublisher eventPublisher,
+            com.sseulang.domain.chat.application.ChatRoomApplicationService chatRoomApplicationService,
+            com.sseulang.domain.item.application.ItemApplicationService itemApplicationService,
             @Value("${app.escrow.link.expiry-hours:24}") int linkExpiryHours
     ) {
         this.linkRepository = linkRepository;
@@ -86,6 +91,8 @@ public class EscrowApplicationService {
         this.pointApplicationService = pointApplicationService;
         this.deliveryRepository = deliveryRepository;
         this.eventPublisher = eventPublisher;
+        this.chatRoomApplicationService = chatRoomApplicationService;
+        this.itemApplicationService = itemApplicationService;
         this.linkExpiryHours = linkExpiryHours;
     }
 
@@ -121,6 +128,70 @@ public class EscrowApplicationService {
                 sellerPayable,
                 fee.commissionRate()
         );
+    }
+
+    // =============================================================
+    // Use case 0b — 내부 신청 (PR-B-3 라운드 12). 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력.
+    // 외부 link 흐름 (createApplication) 와 분리.
+    // 검증: chatRoom 참여자 + chatRoom.itemId == cmd.itemId + 본인 == item.sellerId.
+    // =============================================================
+    @Transactional
+    public EscrowApplicationResult createInternalApplication(EscrowApplicationCreateInternalCommand cmd) {
+        userApplicationService.requireVerified(cmd.requesterId());
+
+        // chatRoom 참여자 검증 + 메타 (itemId)
+        com.sseulang.domain.chat.application.ChatRoomApplicationService.ChatRoomMeta meta =
+                chatRoomApplicationService.findMetaForParticipant(cmd.chatRoomId(), cmd.requesterId());
+        if (!meta.itemId().equals(cmd.itemId())) {
+            throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+        }
+        if (meta.iLeft() || meta.opponentLeft()) {
+            throw new BusinessException(ErrorCode.CHAT_ROOM_OPPONENT_LEFT);
+        }
+
+        // 판매자 검증 — itemId → item.sellerId == requesterId
+        var itemInfo = itemApplicationService.findActiveForTransaction(cmd.itemId());
+        if (!itemInfo.sellerId().equals(cmd.requesterId())) {
+            throw new BusinessException(ErrorCode.ESCROW_SELLER_ONLY);
+        }
+
+        // buyer = chatRoom 의 상대방
+        Long buyerId = chatRoomApplicationService.findOpponent(cmd.chatRoomId(), cmd.requesterId());
+
+        // fee 산정 (외부 흐름과 동일 방식)
+        EscrowFeeSettings settings = feeSettingsRepository.findSingleton();
+        BigDecimal calculatedDistance = EscrowFeeCalculator.distanceKm(
+                cmd.pickupLat().doubleValue(), cmd.pickupLng().doubleValue(),
+                cmd.deliveryLat().doubleValue(), cmd.deliveryLng().doubleValue()
+        );
+        FeeBreakdown calculated = EscrowFeeCalculator.calculate(
+                settings, cmd.tradeMode(), cmd.itemPrice(), calculatedDistance,
+                cmd.weight(), cmd.volume(), cmd.fragility()
+        );
+        EscrowFeeCalculator.verifyTolerance(
+                calculated, cmd.submittedDeliveryFee(), cmd.submittedCommissionFee(), cmd.submittedTotalFee()
+        );
+
+        // share 산정. initiator = seller, receiver = buyer (내부 흐름은 seller 가 시작).
+        long buyerOwed = computeBuyerOwed(cmd.tradeMode(), cmd.itemPrice(), calculated, cmd.feePayer());
+        long sellerOwed = computeSellerOwed(calculated, cmd.feePayer());
+        long initiatorShare = sellerOwed;
+        long receiverShare = buyerOwed;
+
+        EscrowApplication app = EscrowApplication.createInternal(
+                cmd.chatRoomId(),
+                cmd.requesterId(),  // initiator = seller
+                buyerId,            // receiver = buyer
+                cmd.tradeMode(), cmd.feePayer(),
+                cmd.itemPrice(), cmd.itemDescription(),
+                cmd.pickupAddress(), cmd.pickupLat(), cmd.pickupLng(),
+                cmd.deliveryAddress(), cmd.deliveryLat(), cmd.deliveryLng(),
+                cmd.weight(), cmd.volume(), cmd.fragility(), cmd.deliveryNotes(),
+                calculated, initiatorShare, receiverShare,
+                serializeImageUrls(cmd.imageUrls())
+        );
+        EscrowApplication saved = applicationRepository.save(app);
+        return EscrowApplicationResult.from(saved, parseImageUrls(saved.getImageUrls()));
     }
 
     // =============================================================

--- a/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
@@ -83,6 +83,19 @@ public class EscrowController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result));
     }
 
+    @Operation(summary = "거래대행 내부 신청 (판매자가 채팅방에서)",
+            description = "PR-B-3 라운드 12. 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력. link 토큰 미사용. "
+                    + "검증: chatRoom 참여자 + chatRoom.itemId == cmd.itemId + 본인 == item.sellerId. "
+                    + "에러: ESCROW_FORM_INVALID, CHAT_ROOM_OPPONENT_LEFT, ESCROW_SELLER_ONLY.")
+    @PostMapping("/applications/internal")
+    public ResponseEntity<ApiResponse<EscrowApplicationResult>> createInternalApplication(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody com.sseulang.domain.escrow.presentation.dto.EscrowApplicationCreateInternalRequest request
+    ) {
+        EscrowApplicationResult result = service.createInternalApplication(request.toCommand(userId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result));
+    }
+
     @Operation(summary = "본인 거래대행 신청 목록", description = "최신순. 필터는 후속 (5/11 단순).")
     @GetMapping("/applications/me")
     public ApiResponse<PageResponse<EscrowApplicationResult>> listMine(

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCreateInternalRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCreateInternalRequest.java
@@ -1,0 +1,65 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateInternalCommand;
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 거래대행 내부 신청 요청 (PR-B-3 라운드 12). 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력.
+ *
+ * <p>권한: 판매자만 (chat_room.itemId 의 sellerId 와 일치). 비참여자 / 미인증 / 비판매자 모두 차단.</p>
+ */
+@Schema(description = "내부 거래대행 신청 (채팅방 + 판매자만).")
+public record EscrowApplicationCreateInternalRequest(
+        @Schema(example = "7") @NotNull Long chatRoomId,
+        @Schema(example = "123") @NotNull Long itemId,
+
+        @Schema(example = "INTERNAL") @NotNull TradeMode tradeMode,
+        @Schema(example = "both") @NotNull FeePayer feePayer,
+
+        @Schema(example = "30000") @Min(0) long itemPrice,
+        @Schema(example = "맥북 프로") @NotBlank @Size(max = 500) String itemDescription,
+
+        @NotBlank @Size(max = 255) String pickupAddress,
+        @NotNull BigDecimal pickupLat,
+        @NotNull BigDecimal pickupLng,
+        @NotBlank @Size(max = 255) String deliveryAddress,
+        @NotNull BigDecimal deliveryLat,
+        @NotNull BigDecimal deliveryLng,
+
+        @NotNull Weight weight,
+        @NotNull Volume volume,
+        @NotNull Fragility fragility,
+        @Size(max = 500) String deliveryNotes,
+
+        @Min(0) long submittedDeliveryFee,
+        @Min(0) long submittedCommissionFee,
+        @Min(0) long submittedTotalFee,
+        @NotNull BigDecimal submittedDistanceKm,
+
+        @Size(max = 5) List<@Size(max = 500) String> imageUrls
+) {
+    public EscrowApplicationCreateInternalCommand toCommand(Long requesterId) {
+        return new EscrowApplicationCreateInternalCommand(
+                requesterId, chatRoomId, itemId,
+                tradeMode, feePayer,
+                itemPrice, itemDescription,
+                pickupAddress, pickupLat, pickupLng,
+                deliveryAddress, deliveryLat, deliveryLng,
+                weight, volume, fragility, deliveryNotes,
+                submittedDeliveryFee, submittedCommissionFee, submittedTotalFee, submittedDistanceKm,
+                imageUrls
+        );
+    }
+}

--- a/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
@@ -63,9 +63,15 @@ class EscrowApplicationServiceTest {
         when(userService.getById(anyLong())).thenReturn(stub);
 
         deliveryRepo = new com.sseulang.domain.delivery.application.InMemoryFakeDeliveryRepository();
+        // 라운드 12 PR-B-3 — 내부 흐름 의존 추가 (외부 link 흐름 테스트엔 미사용 → mock 으로만 stub)
+        com.sseulang.domain.chat.application.ChatRoomApplicationService chatRoomService =
+                mock(com.sseulang.domain.chat.application.ChatRoomApplicationService.class);
+        com.sseulang.domain.item.application.ItemApplicationService itemAppService =
+                mock(com.sseulang.domain.item.application.ItemApplicationService.class);
         service = new EscrowApplicationService(
                 linkRepo, appRepo, settingsRepo,
                 userService, pointService, deliveryRepo, eventPublisher,
+                chatRoomService, itemAppService,
                 24
         );
     }


### PR DESCRIPTION
## Summary
- POST /api/v1/escrow/applications/internal — 채팅방 안에서 판매자가 거래대행 신청
- EscrowApplicationService.createInternalApplication() 메서드 신설
- 검증: chatRoom 참여자 + chatRoom.itemId 일치 + 본인 == item.sellerId

@codex review — 거래대행 자금 흐름 영역. 게이트 1 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)