### PR TITLE
feat: round 12 PR-F #9 — 관리자 대시보드 신고 위젯

### DIFF
--- a/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
+++ b/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
@@ -81,6 +81,16 @@ public class UserReportApplicationService {
         return repository.countPending();
     }
 
+    /** 차트 dashboard — 처리 완료 (처리완료 + 반려) 신고 수. */
+    public long countResolved() {
+        return repository.countResolved();
+    }
+
+    /** 차트 dashboard — 특정 시점 이후 생성된 신고 건수 (전체 status). */
+    public long countCreatedSince(java.time.LocalDateTime since) {
+        return repository.countCreatedSince(since);
+    }
+
     private UserReport findOrThrow(Long reportId) {
         return repository.findById(reportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REPORT_NOT_FOUND));

--- a/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
+++ b/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
@@ -22,4 +22,10 @@ public interface UserReportRepository {
 
     /** 차트 dashboard summary — 처리 대기 신고 수 (status IN (접수, 처리중)). */
     long countPending();
+
+    /** 차트 dashboard — 처리 완료 신고 수 (status IN (처리완료, 반려)). */
+    long countResolved();
+
+    /** 차트 dashboard — 특정 시점 이후 생성된 신고 건수 (전체 status). */
+    long countCreatedSince(java.time.LocalDateTime since);
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
@@ -33,4 +33,12 @@ interface UserReportJpaRepository extends JpaRepository<UserReport, Long> {
     /** 차트 dashboard summary — 처리 대기 (접수 또는 처리중) 신고 수. */
     @Query("SELECT COUNT(r) FROM UserReport r WHERE r.status IN (com.sseulang.domain.report.domain.ReportStatus.접수, com.sseulang.domain.report.domain.ReportStatus.처리중)")
     long countPending();
+
+    /** 차트 dashboard — 처리 완료 (처리완료 또는 반려) 신고 수. */
+    @Query("SELECT COUNT(r) FROM UserReport r WHERE r.status IN (com.sseulang.domain.report.domain.ReportStatus.처리완료, com.sseulang.domain.report.domain.ReportStatus.반려)")
+    long countResolved();
+
+    /** 차트 dashboard — 특정 시점 이후 생성된 신고 건수 (전체 status). */
+    @Query("SELECT COUNT(r) FROM UserReport r WHERE r.createdAt >= :since")
+    long countCreatedSince(@org.springframework.data.repository.query.Param("since") java.time.LocalDateTime since);
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
@@ -49,4 +49,14 @@ public class UserReportRepositoryImpl implements UserReportRepository {
     public long countPending() {
         return jpa.countPending();
     }
+
+    @Override
+    public long countResolved() {
+        return jpa.countResolved();
+    }
+
+    @Override
+    public long countCreatedSince(java.time.LocalDateTime since) {
+        return jpa.countCreatedSince(since);
+    }
 }

--- a/src/main/java/com/sseulang/domain/stats/application/AdminDashboardChartsResult.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminDashboardChartsResult.java
@@ -18,7 +18,8 @@ public record AdminDashboardChartsResult(
         Summary summary,
         List<DailyCount> signupTrend,
         List<TradeTypeCount> tradeByType,
-        List<StatusGroupCount> tradeByStatus
+        List<StatusGroupCount> tradeByStatus,
+        ReportsSummary reportsSummary
 ) {
     public record Summary(
             UsersSummary users,
@@ -26,6 +27,15 @@ public record AdminDashboardChartsResult(
             MonthTradesSummary monthTrades,
             long pendingReports
     ) { }
+
+    /**
+     * 관리자 대시보드 신고 위젯 (PR-F #9 라운드 12).
+     *
+     * @param pending        처리 대기 (접수 + 처리중)
+     * @param resolved       처리 완료 (처리완료 + 반려)
+     * @param totalLast7Days 최근 7일 (생성 기준, 전체 status)
+     */
+    public record ReportsSummary(long pending, long resolved, long totalLast7Days) { }
 
     public record UsersSummary(long total, long monthDelta) { }
 

--- a/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
@@ -103,8 +103,18 @@ public class AdminStatsService {
                 buildSummary(today),
                 buildSignupTrend(start, end, fromTs, toExclusive),
                 buildTradeByType(fromTs, toExclusive),
-                buildTradeByStatus(fromTs, toExclusive)
+                buildTradeByStatus(fromTs, toExclusive),
+                buildReportsSummary(today)
         );
+    }
+
+    /** PR-F #9 라운드 12 — 신고 위젯 (pending / resolved / 최근 7일). */
+    private AdminDashboardChartsResult.ReportsSummary buildReportsSummary(LocalDate today) {
+        long pending = userReportService.countPending();
+        long resolved = userReportService.countResolved();
+        LocalDateTime sevenDaysAgo = today.minusDays(6).atStartOfDay();
+        long last7Days = userReportService.countCreatedSince(sevenDaysAgo);
+        return new AdminDashboardChartsResult.ReportsSummary(pending, resolved, last7Days);
     }
 
     private AdminDashboardChartsResult.Summary buildSummary(LocalDate today) {

--- a/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardChartsResponse.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardChartsResponse.java
@@ -6,21 +6,34 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 
-@Schema(description = "관리자 차트 dashboard — 카드 4종 + 차트 3종 (signupTrend / tradeByType / tradeByStatus).")
+@Schema(description = "관리자 차트 dashboard — 카드 4종 + 차트 3종 + 신고 위젯.")
 public record AdminDashboardChartsResponse(
         Summary summary,
         List<DailyCount> signupTrend,
         List<TradeTypeCount> tradeByType,
-        List<StatusGroupCount> tradeByStatus
+        List<StatusGroupCount> tradeByStatus,
+        ReportsSummary reportsSummary
 ) {
     public static AdminDashboardChartsResponse from(AdminDashboardChartsResult r) {
         return new AdminDashboardChartsResponse(
                 Summary.from(r.summary()),
                 r.signupTrend().stream().map(s -> new DailyCount(s.date(), s.count())).toList(),
                 r.tradeByType().stream().map(t -> new TradeTypeCount(t.type(), t.count())).toList(),
-                r.tradeByStatus().stream().map(s -> new StatusGroupCount(s.status(), s.count())).toList()
+                r.tradeByStatus().stream().map(s -> new StatusGroupCount(s.status(), s.count())).toList(),
+                new ReportsSummary(
+                        r.reportsSummary().pending(),
+                        r.reportsSummary().resolved(),
+                        r.reportsSummary().totalLast7Days()
+                )
         );
     }
+
+    @Schema(description = "PR-F #9 라운드 12 — 관리자 대시보드 신고 위젯.")
+    public record ReportsSummary(
+            @Schema(example = "5", description = "처리 대기 (접수 + 처리중)") long pending,
+            @Schema(example = "23", description = "처리 완료 (처리완료 + 반려)") long resolved,
+            @Schema(example = "8", description = "최근 7일 신고 수 (생성 기준, 전체 status)") long totalLast7Days
+    ) { }
 
     @Schema(description = "요약 카드 4종 + 비교값.")
     public record Summary(

--- a/src/test/java/com/sseulang/domain/report/application/InMemoryFakeUserReportRepository.java
+++ b/src/test/java/com/sseulang/domain/report/application/InMemoryFakeUserReportRepository.java
@@ -63,4 +63,18 @@ public class InMemoryFakeUserReportRepository implements UserReportRepository {
                 .filter(r -> r.getStatus() == ReportStatus.접수 || r.getStatus() == ReportStatus.처리중)
                 .count();
     }
+
+    @Override
+    public long countResolved() {
+        return store.values().stream()
+                .filter(r -> r.getStatus() == ReportStatus.처리완료 || r.getStatus() == ReportStatus.반려)
+                .count();
+    }
+
+    @Override
+    public long countCreatedSince(java.time.LocalDateTime since) {
+        return store.values().stream()
+                .filter(r -> r.getCreatedAt() != null && !r.getCreatedAt().isBefore(since))
+                .count();
+    }
 }


### PR DESCRIPTION
## Summary
GET /api/v1/admin/stats/dashboard/charts 응답에 `reportsSummary` 추가.

```json
{
  ...기존 필드,
  "reportsSummary": {
    "pending": 5,
    "resolved": 23,
    "totalLast7Days": 8
  }
}
```

프론트는 클릭 시 `GET /api/v1/admin/reports` 로 이동.

## Test plan
- [x] 전체 테스트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)