### PR TITLE
feat: round 12 PR-B-4 (skeleton) — 거래대행 입력 분리 도메인 골격

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
@@ -56,6 +56,25 @@ public class EscrowApplication extends BaseEntity {
     @Column(name = "chat_room_id", updatable = false)
     private Long chatRoomId;
 
+    /**
+     * 판매자 영역 (출발지/물품) 입력 완료 — PR-B-4 라운드 12. 외부 흐름은 항상 TRUE.
+     */
+    @Column(name = "seller_info_filled", nullable = false)
+    private boolean sellerInfoFilled;
+
+    /**
+     * 구매자 영역 (수령지/연락처) 입력 완료. 외부 흐름은 항상 TRUE.
+     * 양쪽 모두 TRUE 가 되면 fee 산정 + status 가 정보입력대기 → 결제대기 로 전환.
+     */
+    @Column(name = "buyer_info_filled", nullable = false)
+    private boolean buyerInfoFilled;
+
+    /**
+     * 수령자 연락처 (구매자 영역) — 내부 흐름의 buyer-info PATCH 시 입력.
+     */
+    @Column(name = "receiver_phone", length = 20)
+    private String receiverPhone;
+
     @Column(name = "initiator_id", nullable = false, updatable = false)
     private Long initiatorId;
 
@@ -196,6 +215,9 @@ public class EscrowApplication extends BaseEntity {
         EscrowApplication a = new EscrowApplication();
         a.linkId = linkId;
         a.entryType = EntryType.EXTERNAL;
+        // 외부 link 흐름은 receiver 가 form 제출 시 양쪽 정보 모두 입력 → 양쪽 filled.
+        a.sellerInfoFilled = true;
+        a.buyerInfoFilled = true;
         a.initiatorId = initiatorId;
         a.receiverId = receiverId;
         a.buyerId = buyerId;
@@ -265,6 +287,10 @@ public class EscrowApplication extends BaseEntity {
         a.linkId = null;
         a.entryType = EntryType.INTERNAL;
         a.chatRoomId = chatRoomId;
+        // PR-B-3 단순 흐름 — 현재 createInternal 은 양쪽 정보 한 번에 입력. PR-B-4 의 draft 흐름은
+        // 별도 createInternalDraft + patchSellerInfo / patchBuyerInfo 로 분리 (후속 commit).
+        a.sellerInfoFilled = true;
+        a.buyerInfoFilled = true;
         a.initiatorId = initiatorId;
         a.receiverId = receiverId;
         a.buyerId = buyerId;

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationStatus.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationStatus.java
@@ -4,12 +4,17 @@ package com.sseulang.domain.escrow.domain;
  * Escrow application 상태머신.
  *
  * <pre>
+ *   [내부 흐름 — PR-B-4]
+ *   정보입력대기 → (양쪽 입력 완료) → 결제대기 → 결제완료 → 진행중 → 완료
+ *
+ *   [외부 link 흐름]
  *   결제대기 → 결제완료 (양쪽 share 결제 — feePayer 별 분기) → 진행중 (라이더 자동 매칭)
  *   진행중   → 완료 (Mode B: buyer 수령 확인 + 정산 / Mode A: 배송완료 + 정산)
  *   any 시점 → 취소 (시점별 환불 정책 — 결정 #6)
  * </pre>
  */
 public enum EscrowApplicationStatus {
+    정보입력대기,
     결제대기,
     결제완료,
     진행중,
@@ -21,7 +26,7 @@ public enum EscrowApplicationStatus {
     }
 
     public boolean isPaymentDone() {
-        return this != 결제대기;
+        return this != 결제대기 && this != 정보입력대기;
     }
 
     /** 매칭 후 시점 — 취소 시 fee 100% 부담 정책 (결정 #6 갱신). */

--- a/src/main/resources/db/migration/V21__escrow_info_split.sql
+++ b/src/main/resources/db/migration/V21__escrow_info_split.sql
@@ -1,0 +1,35 @@
+-- V21: 거래대행 양 당사자 입력 분리 (PR-B-4 라운드 12)
+--
+-- 정책:
+--   * 내부 흐름 (INTERNAL): 판매자가 신청 시 본인 영역만 입력 → status = 정보입력대기
+--     구매자가 본인 영역 PATCH → buyerInfoFilled=true → fee 산정 + status = 결제대기
+--   * 외부 흐름 (EXTERNAL): 기존 link 흐름 그대로 — receiver 가 form 제출 시 모든 정보 입력 + 즉시 결제대기.
+--
+-- 컬럼:
+--   * seller_info_filled / buyer_info_filled 신규 (양쪽 입력 완료 추적)
+--   * receiver_phone 신규 (구매자 영역 — 수령자 연락처)
+--   * 기존 delivery_*, weight/volume/fragility 등은 내부 흐름의 draft 단계엔 미입력 가능 → nullable
+--     (외부 흐름은 application 생성 시점에 모두 채워지므로 영향 없음)
+--
+-- 상태머신 신규: 정보입력대기 (status CHECK 갱신)
+
+-- status CHECK 갱신
+ALTER TABLE escrow_applications
+    DROP CHECK chk_escrow_applications_status;
+ALTER TABLE escrow_applications
+    ADD CONSTRAINT chk_escrow_applications_status
+        CHECK (status IN ('정보입력대기', '결제대기', '결제완료', '진행중', '완료', '취소'));
+
+-- 플래그 + 신규 컬럼
+ALTER TABLE escrow_applications
+    ADD COLUMN seller_info_filled BOOLEAN NOT NULL DEFAULT TRUE
+        COMMENT '판매자 영역(출발지/물품) 입력 완료. 외부 흐름은 항상 TRUE — DEFAULT TRUE 로 backfill.',
+    ADD COLUMN buyer_info_filled  BOOLEAN NOT NULL DEFAULT TRUE
+        COMMENT '구매자 영역(수령지/연락처) 입력 완료. 외부 흐름은 항상 TRUE.',
+    ADD COLUMN receiver_phone     VARCHAR(20) NULL
+        COMMENT '수령자 연락처 (구매자 영역 — 내부 흐름은 buyer-info PATCH 시 입력).';
+
+-- 신규 INTERNAL 신청 (PR-B-4 이후) 부터 buyer_info_filled=FALSE 로 시작 (도메인 로직).
+-- 기존 row 는 모두 외부 흐름 + 양쪽 입력 완료 상태라 DEFAULT TRUE backfill OK.
+
+-- delivery_*, weight/volume/fragility 는 향후 PR 에서 nullable 검토 (현재 외부 흐름이 NOT NULL 강제 하므로 일단 그대로).


### PR DESCRIPTION
## Summary
V21 마이그레이션 + 도메인 골격. 실제 draft → patch 흐름은 다음 commit.

- status enum 에 '정보입력대기' 추가
- seller_info_filled / buyer_info_filled / receiver_phone 컬럼

기존 외부/내부 흐름 변경 없음 — 모두 양쪽 TRUE 로 진입.

## Test plan
- [x] 전체 테스트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)