### PR TITLE
feat: round 12 PR-B-4 — 거래대행 양 당사자 입력 분리 본체

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -195,6 +195,106 @@ public class EscrowApplicationService {
     }
 
     // =============================================================
+    // Use case 0c — 내부 draft (PR-B-4 라운드 12). 판매자가 본인 영역만 입력 → 정보입력대기.
+    // 구매자는 patchBuyerInfo 로 본인 영역 추가 입력 → 양쪽 filled 시 결제대기 전환.
+    // =============================================================
+    @Transactional
+    public EscrowApplicationResult createInternalDraft(
+            com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateInternalDraftCommand cmd
+    ) {
+        userApplicationService.requireVerified(cmd.requesterId());
+
+        com.sseulang.domain.chat.application.ChatRoomApplicationService.ChatRoomMeta meta =
+                chatRoomApplicationService.findMetaForParticipant(cmd.chatRoomId(), cmd.requesterId());
+        if (!meta.itemId().equals(cmd.itemId())) {
+            throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+        }
+        if (meta.iLeft() || meta.opponentLeft()) {
+            throw new BusinessException(ErrorCode.CHAT_ROOM_OPPONENT_LEFT);
+        }
+
+        // 판매자만
+        var itemInfo = itemApplicationService.findActiveForTransaction(cmd.itemId());
+        if (!itemInfo.sellerId().equals(cmd.requesterId())) {
+            throw new BusinessException(ErrorCode.ESCROW_SELLER_ONLY);
+        }
+
+        Long buyerId = chatRoomApplicationService.findOpponent(cmd.chatRoomId(), cmd.requesterId());
+
+        EscrowApplication app = EscrowApplication.createInternalDraft(
+                cmd.chatRoomId(),
+                cmd.requesterId(), buyerId,
+                cmd.tradeMode(), cmd.feePayer(),
+                cmd.itemPrice(), cmd.itemDescription(),
+                cmd.pickupAddress(), cmd.pickupLat(), cmd.pickupLng(),
+                cmd.weight(), cmd.volume(), cmd.fragility(), cmd.deliveryNotes(),
+                serializeImageUrls(cmd.imageUrls())
+        );
+        EscrowApplication saved = applicationRepository.save(app);
+        return EscrowApplicationResult.from(saved, parseImageUrls(saved.getImageUrls()));
+    }
+
+    // =============================================================
+    // Use case 0d — 판매자 영역 수정 (PR-B-4).
+    // =============================================================
+    @Transactional
+    public EscrowApplicationResult patchSellerInfo(
+            Long applicationId,
+            Long requesterId,
+            com.sseulang.domain.escrow.application.dto.EscrowSellerInfoPatchCommand cmd
+    ) {
+        EscrowApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        if (!app.getSellerId().equals(requesterId)) {
+            throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
+        }
+        app.patchSellerInfo(
+                cmd.pickupAddress(), cmd.pickupLat(), cmd.pickupLng(),
+                cmd.weight(), cmd.volume(), cmd.fragility(),
+                cmd.itemPrice(), cmd.itemDescription(), cmd.deliveryNotes()
+        );
+        return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()));
+    }
+
+    // =============================================================
+    // Use case 0e — 구매자 영역 입력 (PR-B-4). 양쪽 filled 시 결제대기 전환.
+    // =============================================================
+    @Transactional
+    public EscrowApplicationResult patchBuyerInfo(
+            Long applicationId,
+            Long requesterId,
+            com.sseulang.domain.escrow.application.dto.EscrowBuyerInfoPatchCommand cmd
+    ) {
+        userApplicationService.requireVerified(requesterId);
+        EscrowApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        if (!app.getBuyerId().equals(requesterId)) {
+            throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
+        }
+        app.patchBuyerInfo(cmd.deliveryAddress(), cmd.deliveryLat(), cmd.deliveryLng(), cmd.receiverPhone());
+
+        // 양쪽 filled — fee 산정 + 결제대기 전환
+        if (app.isSellerInfoFilled() && app.isBuyerInfoFilled()) {
+            EscrowFeeSettings settings = feeSettingsRepository.findSingleton();
+            BigDecimal distance = EscrowFeeCalculator.distanceKm(
+                    app.getPickupLat().doubleValue(), app.getPickupLng().doubleValue(),
+                    app.getDeliveryLat().doubleValue(), app.getDeliveryLng().doubleValue()
+            );
+            FeeBreakdown calculated = EscrowFeeCalculator.calculate(
+                    settings, app.getTradeMode(), app.getItemPrice(), distance,
+                    app.getWeight(), app.getVolume(), app.getFragility()
+            );
+            long buyerOwed = computeBuyerOwed(app.getTradeMode(), app.getItemPrice(), calculated, app.getFeePayer());
+            long sellerOwed = computeSellerOwed(calculated, app.getFeePayer());
+            long initiatorShare = sellerOwed;  // initiator = seller (내부 흐름)
+            long receiverShare = buyerOwed;    // receiver = buyer
+            app.transitionToReadyForPayment(calculated, initiatorShare, receiverShare);
+        }
+
+        return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()));
+    }
+
+    // =============================================================
     // Use case 1 — 신청자가 link 생성
     // =============================================================
     @Transactional

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateInternalDraftCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateInternalDraftCommand.java
@@ -1,0 +1,35 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 내부 draft 신청 (PR-B-4) — 판매자가 본인 영역만 입력하여 정보입력대기 상태 생성.
+ * 구매자 영역 (delivery_*, receiver_phone) 은 buyer-info PATCH 로 별도 입력.
+ *
+ * <p>fee 산정은 양쪽 입력 완료 후 transitionToReadyForPayment 시점.</p>
+ */
+public record EscrowApplicationCreateInternalDraftCommand(
+        Long requesterId,
+        Long chatRoomId,
+        Long itemId,
+        TradeMode tradeMode,
+        FeePayer feePayer,
+        long itemPrice,
+        String itemDescription,
+        String pickupAddress,
+        BigDecimal pickupLat,
+        BigDecimal pickupLng,
+        Weight weight,
+        Volume volume,
+        Fragility fragility,
+        String deliveryNotes,
+        List<String> imageUrls
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowBuyerInfoPatchCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowBuyerInfoPatchCommand.java
@@ -1,0 +1,15 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * 구매자 영역 입력 (PR-B-4) — 정보입력대기 상태에서만.
+ * 수령지 + 수령자 연락처. 양쪽 filled 시 ApplicationService 가 fee 산정 + 결제대기 전환.
+ */
+public record EscrowBuyerInfoPatchCommand(
+        String deliveryAddress,
+        BigDecimal deliveryLat,
+        BigDecimal deliveryLng,
+        String receiverPhone
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowSellerInfoPatchCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowSellerInfoPatchCommand.java
@@ -1,0 +1,24 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+
+import java.math.BigDecimal;
+
+/**
+ * 판매자 영역 수정 (PR-B-4) — 정보입력대기 상태에서만.
+ * 출발지 / 물품 정보 / 가격을 수정 가능. delivery 좌표는 영향 없음.
+ */
+public record EscrowSellerInfoPatchCommand(
+        String pickupAddress,
+        BigDecimal pickupLat,
+        BigDecimal pickupLng,
+        Weight weight,
+        Volume volume,
+        Fragility fragility,
+        long itemPrice,
+        String itemDescription,
+        String deliveryNotes
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
@@ -110,13 +110,14 @@ public class EscrowApplication extends BaseEntity {
     @Column(name = "pickup_lng", nullable = false, precision = 10, scale = 7, updatable = false)
     private BigDecimal pickupLng;
 
-    @Column(name = "delivery_address", nullable = false, length = 255, updatable = false)
+    /** 수령지 — 내부 draft 단계엔 NULL, buyer-info PATCH 시 입력. */
+    @Column(name = "delivery_address", length = 255)
     private String deliveryAddress;
 
-    @Column(name = "delivery_lat", nullable = false, precision = 10, scale = 7, updatable = false)
+    @Column(name = "delivery_lat", precision = 10, scale = 7)
     private BigDecimal deliveryLat;
 
-    @Column(name = "delivery_lng", nullable = false, precision = 10, scale = 7, updatable = false)
+    @Column(name = "delivery_lng", precision = 10, scale = 7)
     private BigDecimal deliveryLng;
 
     @Enumerated(EnumType.STRING)
@@ -134,28 +135,29 @@ public class EscrowApplication extends BaseEntity {
     @Column(name = "delivery_notes", length = 500, updatable = false)
     private String deliveryNotes;
 
-    // ===== snapshot — 운영 settings 변경 무관 lock =====
-    @Column(name = "applied_distance_km", nullable = false, precision = 8, scale = 2, updatable = false)
+    // ===== snapshot — 양쪽 입력 완료 후 산정. 정보입력대기 단계엔 NULL. =====
+    @Column(name = "applied_distance_km", precision = 8, scale = 2)
     private BigDecimal appliedDistanceKm;
 
-    @Column(name = "applied_delivery_fee", nullable = false, updatable = false)
-    private long appliedDeliveryFee;
+    @Column(name = "applied_delivery_fee")
+    private Long appliedDeliveryFee;
 
-    @Column(name = "applied_commission_fee", nullable = false, updatable = false)
-    private long appliedCommissionFee;
+    @Column(name = "applied_commission_fee")
+    private Long appliedCommissionFee;
 
-    @Column(name = "applied_total_fee", nullable = false, updatable = false)
-    private long appliedTotalFee;
+    @Column(name = "applied_total_fee")
+    private Long appliedTotalFee;
 
-    @Column(name = "applied_commission_rate", nullable = false, precision = 5, scale = 4, updatable = false)
+    @Column(name = "applied_commission_rate", precision = 5, scale = 4)
     private BigDecimal appliedCommissionRate;
 
     // ===== 결제 추적 =====
-    @Column(name = "initiator_share", nullable = false, updatable = false)
-    private long initiatorShare;
+    /** 신청자(initiator) 결제 분담분. 양쪽 입력 완료 후 산정. */
+    @Column(name = "initiator_share")
+    private Long initiatorShare;
 
-    @Column(name = "receiver_share", nullable = false, updatable = false)
-    private long receiverShare;
+    @Column(name = "receiver_share")
+    private Long receiverShare;
 
     @Column(name = "initiator_paid_at")
     private LocalDateTime initiatorPaidAt;
@@ -319,6 +321,122 @@ public class EscrowApplication extends BaseEntity {
         a.status = EscrowApplicationStatus.결제대기;
         a.imageUrls = imageUrls;
         return a;
+    }
+
+    /**
+     * 내부 draft 흐름 (PR-B-4 라운드 12) — 판매자가 본인 영역만 입력하여 application 생성.
+     *
+     * <p>특징:
+     * <ul>
+     *   <li>{@code status = 정보입력대기}, {@code sellerInfoFilled = true}, {@code buyerInfoFilled = false}</li>
+     *   <li>구매자 영역 (delivery_*, receiver_phone) 은 NULL — 구매자가 buyer-info PATCH 시 입력</li>
+     *   <li>fee snapshot / share 는 NULL — 양쪽 입력 완료 후 transitionToReadyForPayment 시점에 산정</li>
+     *   <li>initiator = seller, receiver = buyer (내부 흐름은 sellerOnly 정책)</li>
+     * </ul>
+     */
+    public static EscrowApplication createInternalDraft(
+            Long chatRoomId,
+            Long initiatorId, Long receiverId,
+            TradeMode tradeMode, FeePayer feePayer,
+            long itemPrice, String itemDescription,
+            String pickupAddress, BigDecimal pickupLat, BigDecimal pickupLng,
+            Weight weight, Volume volume, Fragility fragility, String deliveryNotes,
+            String imageUrls
+    ) {
+        if (chatRoomId == null || initiatorId == null || receiverId == null) {
+            throw new IllegalArgumentException("ids required");
+        }
+        if (initiatorId.equals(receiverId)) {
+            throw new BusinessException(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
+        }
+        EscrowApplication a = new EscrowApplication();
+        a.linkId = null;
+        a.entryType = EntryType.INTERNAL;
+        a.chatRoomId = chatRoomId;
+        a.sellerInfoFilled = true;
+        a.buyerInfoFilled = false;
+        a.initiatorId = initiatorId;
+        a.receiverId = receiverId;
+        a.sellerId = initiatorId;   // 판매자만 시작
+        a.buyerId = receiverId;
+        a.tradeMode = tradeMode;
+        a.feePayer = feePayer;
+        a.itemPrice = itemPrice;
+        a.itemDescription = itemDescription;
+        a.pickupAddress = pickupAddress;
+        a.pickupLat = pickupLat;
+        a.pickupLng = pickupLng;
+        a.weight = weight;
+        a.volume = volume;
+        a.fragility = fragility;
+        a.deliveryNotes = deliveryNotes;
+        a.status = EscrowApplicationStatus.정보입력대기;
+        a.imageUrls = imageUrls;
+        // delivery_*, receiver_phone, applied_*, share 는 NULL — buyer-info PATCH 시점에 채워짐.
+        return a;
+    }
+
+    /**
+     * 판매자 영역 수정 (PR-B-4) — 정보입력대기 상태에서만. updatable 컬럼 대상.
+     * delivery 좌표는 영향 없음 (구매자 영역).
+     */
+    public void patchSellerInfo(
+            String pickupAddress, BigDecimal pickupLat, BigDecimal pickupLng,
+            Weight weight, Volume volume, Fragility fragility,
+            long itemPrice, String itemDescription, String deliveryNotes
+    ) {
+        if (this.status != EscrowApplicationStatus.정보입력대기) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        this.pickupAddress = pickupAddress;
+        this.pickupLat = pickupLat;
+        this.pickupLng = pickupLng;
+        this.weight = weight;
+        this.volume = volume;
+        this.fragility = fragility;
+        this.itemPrice = itemPrice;
+        this.itemDescription = itemDescription;
+        this.deliveryNotes = deliveryNotes;
+        this.sellerInfoFilled = true;
+    }
+
+    /**
+     * 구매자 영역 입력 (PR-B-4) — 정보입력대기 상태에서만.
+     * buyerInfoFilled=true 로 set. 호출자(ApplicationService)가 양쪽 filled 시 transitionToReadyForPayment 호출.
+     */
+    public void patchBuyerInfo(
+            String deliveryAddress, BigDecimal deliveryLat, BigDecimal deliveryLng,
+            String receiverPhone
+    ) {
+        if (this.status != EscrowApplicationStatus.정보입력대기) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        this.deliveryAddress = deliveryAddress;
+        this.deliveryLat = deliveryLat;
+        this.deliveryLng = deliveryLng;
+        this.receiverPhone = receiverPhone;
+        this.buyerInfoFilled = true;
+    }
+
+    /**
+     * 양쪽 입력 완료 — fee 산정 결과 + share 를 set + 결제대기 진입.
+     * ApplicationService 가 EscrowFeeCalculator 로 산정한 snapshot 을 주입.
+     */
+    public void transitionToReadyForPayment(FeeBreakdown snapshot, long initiatorShare, long receiverShare) {
+        if (this.status != EscrowApplicationStatus.정보입력대기) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (!this.sellerInfoFilled || !this.buyerInfoFilled) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        this.appliedDistanceKm = snapshot.distanceKm();
+        this.appliedDeliveryFee = snapshot.deliveryFee();
+        this.appliedCommissionFee = snapshot.commissionFee();
+        this.appliedTotalFee = snapshot.totalFee();
+        this.appliedCommissionRate = snapshot.commissionRate();
+        this.initiatorShare = initiatorShare;
+        this.receiverShare = receiverShare;
+        this.status = EscrowApplicationStatus.결제대기;
     }
 
     /** 수신자 결제 완료 — 결정 #5 H2 (수신자 먼저). 모든 share 충족 시 결제완료 진입. */

--- a/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
@@ -96,6 +96,42 @@ public class EscrowController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result));
     }
 
+    @Operation(summary = "거래대행 내부 draft (판매자가 본인 영역만 입력)",
+            description = "PR-B-4 라운드 12. 판매자가 본인 영역(출발지/물품/가격) 만 입력 → status=정보입력대기. "
+                    + "구매자가 buyer-info PATCH 시 양쪽 filled → 자동으로 결제대기 전환 + fee 산정. "
+                    + "에러: ESCROW_FORM_INVALID, CHAT_ROOM_OPPONENT_LEFT, ESCROW_SELLER_ONLY.")
+    @PostMapping("/applications/internal/draft")
+    public ResponseEntity<ApiResponse<EscrowApplicationResult>> createInternalDraft(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody com.sseulang.domain.escrow.presentation.dto.EscrowApplicationCreateInternalDraftRequest request
+    ) {
+        EscrowApplicationResult result = service.createInternalDraft(request.toCommand(userId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result));
+    }
+
+    @Operation(summary = "판매자 영역 수정 (정보입력대기 상태)",
+            description = "PR-B-4. 본인이 sellerId 인 경우만. 정보입력대기 외 상태 호출 시 ESCROW_INVALID_STATE.")
+    @PatchMapping("/applications/{id}/seller-info")
+    public ApiResponse<EscrowApplicationResult> patchSellerInfo(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id,
+            @Valid @RequestBody com.sseulang.domain.escrow.presentation.dto.EscrowSellerInfoPatchRequest request
+    ) {
+        return ApiResponse.ok(service.patchSellerInfo(id, userId, request.toCommand()));
+    }
+
+    @Operation(summary = "구매자 영역 입력 (정보입력대기 상태)",
+            description = "PR-B-4. 본인이 buyerId 인 경우만. 양쪽 입력 완료 시 자동 fee 산정 + 결제대기 전환. "
+                    + "정보입력대기 외 상태 호출 시 ESCROW_INVALID_STATE.")
+    @PatchMapping("/applications/{id}/buyer-info")
+    public ApiResponse<EscrowApplicationResult> patchBuyerInfo(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id,
+            @Valid @RequestBody com.sseulang.domain.escrow.presentation.dto.EscrowBuyerInfoPatchRequest request
+    ) {
+        return ApiResponse.ok(service.patchBuyerInfo(id, userId, request.toCommand()));
+    }
+
     @Operation(summary = "본인 거래대행 신청 목록", description = "최신순. 필터는 후속 (5/11 단순).")
     @GetMapping("/applications/me")
     public ApiResponse<PageResponse<EscrowApplicationResult>> listMine(

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCreateInternalDraftRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCreateInternalDraftRequest.java
@@ -1,0 +1,50 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateInternalDraftCommand;
+import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Schema(description = "내부 거래대행 draft 신청 — 판매자가 본인 영역만 입력. 구매자는 buyer-info PATCH 로 별도 입력.")
+public record EscrowApplicationCreateInternalDraftRequest(
+        @Schema(example = "7") @NotNull Long chatRoomId,
+        @Schema(example = "123") @NotNull Long itemId,
+
+        @Schema(example = "INTERNAL") @NotNull TradeMode tradeMode,
+        @Schema(example = "both") @NotNull FeePayer feePayer,
+
+        @Schema(example = "30000") @Min(0) long itemPrice,
+        @Schema(example = "맥북 프로") @NotBlank @Size(max = 500) String itemDescription,
+
+        @NotBlank @Size(max = 255) String pickupAddress,
+        @NotNull BigDecimal pickupLat,
+        @NotNull BigDecimal pickupLng,
+
+        @NotNull Weight weight,
+        @NotNull Volume volume,
+        @NotNull Fragility fragility,
+        @Size(max = 500) String deliveryNotes,
+
+        @Size(max = 5) List<@Size(max = 500) String> imageUrls
+) {
+    public EscrowApplicationCreateInternalDraftCommand toCommand(Long requesterId) {
+        return new EscrowApplicationCreateInternalDraftCommand(
+                requesterId, chatRoomId, itemId,
+                tradeMode, feePayer,
+                itemPrice, itemDescription,
+                pickupAddress, pickupLat, pickupLng,
+                weight, volume, fragility, deliveryNotes,
+                imageUrls
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowBuyerInfoPatchRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowBuyerInfoPatchRequest.java
@@ -1,0 +1,28 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.application.dto.EscrowBuyerInfoPatchCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+
+@Schema(description = "구매자 영역 입력 — 정보입력대기 상태에서만. 수령지 + 수령자 연락처. "
+        + "양쪽 입력 완료 시 자동으로 fee 산정 + 결제대기 전환.")
+public record EscrowBuyerInfoPatchRequest(
+        @NotBlank @Size(max = 255) String deliveryAddress,
+        @NotNull BigDecimal deliveryLat,
+        @NotNull BigDecimal deliveryLng,
+
+        @NotBlank @Pattern(regexp = "^[0-9\\-+]+$", message = "전화번호 형식이 올바르지 않습니다")
+        @Size(max = 20)
+        String receiverPhone
+) {
+    public EscrowBuyerInfoPatchCommand toCommand() {
+        return new EscrowBuyerInfoPatchCommand(
+                deliveryAddress, deliveryLat, deliveryLng, receiverPhone
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowSellerInfoPatchRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowSellerInfoPatchRequest.java
@@ -1,0 +1,34 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.application.dto.EscrowSellerInfoPatchCommand;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+
+@Schema(description = "판매자 영역 수정 — 정보입력대기 상태에서만 호출. 출발지/물품/가격.")
+public record EscrowSellerInfoPatchRequest(
+        @NotBlank @Size(max = 255) String pickupAddress,
+        @NotNull BigDecimal pickupLat,
+        @NotNull BigDecimal pickupLng,
+        @NotNull Weight weight,
+        @NotNull Volume volume,
+        @NotNull Fragility fragility,
+        @Min(0) long itemPrice,
+        @NotBlank @Size(max = 500) String itemDescription,
+        @Size(max = 500) String deliveryNotes
+) {
+    public EscrowSellerInfoPatchCommand toCommand() {
+        return new EscrowSellerInfoPatchCommand(
+                pickupAddress, pickupLat, pickupLng,
+                weight, volume, fragility,
+                itemPrice, itemDescription, deliveryNotes
+        );
+    }
+}

--- a/src/main/resources/db/migration/V22__escrow_buyer_info_nullable.sql
+++ b/src/main/resources/db/migration/V22__escrow_buyer_info_nullable.sql
@@ -1,0 +1,31 @@
+-- V22: 거래대행 입력 분리 본체 (PR-B-4 라운드 12)
+--
+-- 정책:
+--   * 내부 draft 흐름 — 판매자가 본인 영역만 입력하여 application 생성 (status=정보입력대기).
+--     이 시점에 구매자 영역 (delivery_*, receiver_phone) 은 미입력 → NULL 허용.
+--   * 구매자가 buyer-info PATCH → buyerInfoFilled=true + fee 산정 + status=결제대기 전환.
+--   * 외부 link 흐름은 변경 없음 — application 생성 시점에 모두 채워짐 (도메인 검증).
+--
+-- 변경 컬럼 (NOT NULL → NULL):
+--   * delivery_address / delivery_lat / delivery_lng
+--
+-- weight / volume / fragility 는 판매자 영역 (물품 정보) 이라 NOT NULL 유지.
+-- applied_* (fee snapshot) 컬럼은 양쪽 입력 완료 후 채워지므로 NULL 허용 필요.
+
+ALTER TABLE escrow_applications
+    MODIFY COLUMN delivery_address  VARCHAR(255)  NULL COMMENT '수령지 — 내부 draft 단계엔 NULL, buyer-info PATCH 시 입력',
+    MODIFY COLUMN delivery_lat      DECIMAL(10,7) NULL COMMENT '수령지 위도 — buyer-info PATCH 시 입력',
+    MODIFY COLUMN delivery_lng      DECIMAL(10,7) NULL COMMENT '수령지 경도 — buyer-info PATCH 시 입력';
+
+-- fee snapshot — 양쪽 입력 완료 후 산정 (transitionToReadyForPayment 시점) → NULL 허용
+ALTER TABLE escrow_applications
+    MODIFY COLUMN applied_distance_km     DECIMAL(8,2) NULL,
+    MODIFY COLUMN applied_delivery_fee    BIGINT       NULL,
+    MODIFY COLUMN applied_commission_fee  BIGINT       NULL,
+    MODIFY COLUMN applied_total_fee       BIGINT       NULL,
+    MODIFY COLUMN applied_commission_rate DECIMAL(5,4) NULL;
+
+-- share — fee snapshot 기반 산정. 동일하게 NULL 허용.
+ALTER TABLE escrow_applications
+    MODIFY COLUMN initiator_share BIGINT NULL,
+    MODIFY COLUMN receiver_share  BIGINT NULL;


### PR DESCRIPTION
## Summary

판매자 draft → 구매자 입력 → 양쪽 filled 시 자동 결제대기 전환.

### 신규 endpoint
- POST /api/v1/escrow/applications/internal/draft — 판매자 본인 영역만 입력 (정보입력대기)
- PATCH /api/v1/escrow/applications/{id}/seller-info — 판매자 영역 수정
- PATCH /api/v1/escrow/applications/{id}/buyer-info — 구매자 영역 입력 (자동 결제대기 전환)

### V22 마이그레이션
- delivery_*, applied_*, share NULLABLE (draft 단계엔 NULL)

### 검증
- 판매자만 draft 생성 (ESCROW_SELLER_ONLY)
- seller-info PATCH 는 sellerId 본인만 (ESCROW_FORBIDDEN)
- buyer-info PATCH 는 buyerId 본인만 + 이메일 인증 필수
- 정보입력대기 외 상태 호출 시 ESCROW_INVALID_STATE

외부 link 흐름 영향 없음.

@codex review — 자금 흐름 가드 (양쪽 filled 시 fee 산정 + 상태 전환) 게이트 1 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)