### PR TITLE
feat: round 12 PR-F #6 — admin 물품 강제 삭제 endpoint

### DIFF
--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -144,6 +144,24 @@ public class ItemApplicationService {
     }
 
     /**
+     * Admin 우회 삭제 (라운드 12 PR-F #6). owner 검증 우회 — admin chain (ROLE_ADMIN) 만 호출.
+     * soft delete (status=삭제). 관련 거래/채팅방은 유지. audit 로그.
+     */
+    @Transactional
+    public void adminDelete(Long id, Long adminId) {
+        Item item = itemRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        if (item.getStatus() == ItemStatus.삭제) {
+            // idempotent — 이미 삭제 상태면 no-op.
+            return;
+        }
+        item.markAsDeleted();
+        org.slf4j.LoggerFactory.getLogger(ItemApplicationService.class)
+                .warn("[admin] item soft-deleted itemId={} sellerId={} adminId={}",
+                        item.getId(), item.getSellerId(), adminId);
+    }
+
+    /**
      * 부분 추가 — 본인 + 이메일 인증 + 5장 한도 체크 (도메인). temp 폴더 url 은 promote, 정식 폴더 url 은
      * 그대로 재사용 (no-op). 응답으로 반영 후 전체 image url 리스트 반환.
      */

--- a/src/main/java/com/sseulang/domain/item/presentation/AdminItemController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/AdminItemController.java
@@ -1,0 +1,39 @@
+package com.sseulang.domain.item.presentation;
+
+import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin 의 물품 관리. 라운드 12 PR-F #6 — admin 이 본인 아닌 물품도 soft delete 가능.
+ *
+ * <p>admin chain (ROLE_ADMIN 강제) — user chain 의 {@link ItemController#delete} 와 분리.</p>
+ */
+@Tag(name = "AdminItem", description = "관리자 — 물품 관리")
+@RestController
+@RequestMapping("/api/v1/admin/items")
+public class AdminItemController {
+
+    private final ItemApplicationService itemService;
+
+    public AdminItemController(ItemApplicationService itemService) {
+        this.itemService = itemService;
+    }
+
+    @Operation(summary = "[관리자] 물품 강제 삭제 (soft delete)",
+            description = "owner 검증 우회. status=삭제 전환. 관련 거래/채팅방은 유지. audit 로그 기록.")
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal Long adminId,
+            @PathVariable("id") Long id
+    ) {
+        itemService.adminDelete(id, adminId);
+        return ApiResponse.ok();
+    }
+}


### PR DESCRIPTION
## Summary
프론트 PR #52 의 admin [삭제] 버튼 동작 위한 단독 PR.

- DELETE /api/v1/admin/items/{id}
- admin chain (ROLE_ADMIN) + owner 검증 우회
- soft delete (status=삭제) + audit log
- idempotent

## 프론트 작업
호출 URL 만 `/items/{id}` → `/admin/items/{id}` 변경.

## Test plan
- [x] 전체 테스트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)