### PR TITLE
feat: round 12 PR-B-5 — 거래대행 포인트 결제 + 라이더 자동 매칭

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -460,6 +460,75 @@ public class EscrowApplicationService {
     }
 
     // =============================================================
+    // Use case 4b — 포인트 잔액 결제 (PR-B-5 라운드 12).
+    // 토스 결제창 X — 포인트 잔액에서 본인 share 만큼 차감 + paid 마킹.
+    // 양쪽 paid 시 자동 결제완료 + EscrowConfirmedEvent → 라이더 매칭.
+    // =============================================================
+    @Transactional
+    public EscrowApplicationStatus payShare(Long applicationId, Long payerId) {
+        userApplicationService.requireVerified(payerId);
+
+        EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+
+        if (app.getStatus() != EscrowApplicationStatus.결제대기) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (app.isPaymentTimedOut()) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+
+        long expectedShare;
+        if (payerId.equals(app.getInitiatorId())) {
+            if (app.getInitiatorPaidAt() != null) {
+                throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+            }
+            expectedShare = app.getInitiatorShare() == null ? 0L : app.getInitiatorShare();
+        } else if (payerId.equals(app.getReceiverId())) {
+            if (app.getReceiverPaidAt() != null) {
+                throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+            }
+            expectedShare = app.getReceiverShare() == null ? 0L : app.getReceiverShare();
+        } else {
+            throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
+        }
+
+        if (expectedShare <= 0) {
+            // 본인 share 가 0 — 결제 의무 없음.
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+
+        // 포인트 잔액 차감 (atomic UPDATE — 잔액 부족 시 INSUFFICIENT_POINT throw)
+        pointApplicationService.deduct(
+                payerId, expectedShare,
+                com.sseulang.domain.point.domain.PointHistoryType.결제,
+                com.sseulang.domain.point.domain.PointReferenceType.ESCROW,
+                app.getId(),
+                "거래대행 결제 — 본인 분담분"
+        );
+
+        // paid 마킹
+        if (payerId.equals(app.getInitiatorId())) {
+            app.markInitiatorPaid();
+        } else {
+            app.markReceiverPaid();
+        }
+
+        // 양쪽 결제 완료 시 EscrowConfirmedEvent 발행 → Delivery 도메인 라이더 자동 매칭
+        if (app.getStatus() == EscrowApplicationStatus.결제완료) {
+            eventPublisher.publishEvent(new EscrowConfirmedEvent(
+                    app.getId(),
+                    app.getPickupAddress(), app.getPickupLat().doubleValue(), app.getPickupLng().doubleValue(),
+                    app.getDeliveryAddress(), app.getDeliveryLat().doubleValue(), app.getDeliveryLng().doubleValue(),
+                    app.getItemDescription(),
+                    app.getAppliedDeliveryFee(),
+                    app.getBuyerId()
+            ));
+        }
+        return app.getStatus();
+    }
+
+    // =============================================================
     // Use case 4 — 결제 confirm 후 호출 (Payment 도메인이 호출)
     // =============================================================
     @Transactional

--- a/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.escrow.presentation;
 import com.sseulang.domain.escrow.application.EscrowApplicationService;
 import com.sseulang.domain.escrow.application.dto.EscrowApplicationResult;
 import com.sseulang.domain.escrow.application.dto.EscrowLinkResult;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
 import com.sseulang.domain.escrow.presentation.dto.EscrowApplicationCancelRequest;
 import com.sseulang.domain.escrow.presentation.dto.EscrowApplicationCreateRequest;
 import com.sseulang.domain.escrow.presentation.dto.EscrowLinkCreateRequest;
@@ -130,6 +131,18 @@ public class EscrowController {
             @Valid @RequestBody com.sseulang.domain.escrow.presentation.dto.EscrowBuyerInfoPatchRequest request
     ) {
         return ApiResponse.ok(service.patchBuyerInfo(id, userId, request.toCommand()));
+    }
+
+    @Operation(summary = "본인 share 포인트 결제 (PR-B-5)",
+            description = "결제대기 상태에서 본인 share 만큼 포인트 잔액 차감. 양쪽 결제 완료 시 자동 결제완료 + 라이더 매칭. "
+                    + "에러: 400 INSUFFICIENT_POINT (잔액 부족), 400 ESCROW_INVALID_STATE (상태/시점/이미 결제됨), 403 ESCROW_FORBIDDEN (참여자 아님).")
+    @PostMapping("/applications/{id}/pay")
+    public ApiResponse<com.sseulang.domain.escrow.presentation.dto.EscrowPayResponse> payShare(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        EscrowApplicationStatus status = service.payShare(id, userId);
+        return ApiResponse.ok(new com.sseulang.domain.escrow.presentation.dto.EscrowPayResponse(status.name()));
     }
 
     @Operation(summary = "본인 거래대행 신청 목록", description = "최신순. 필터는 후속 (5/11 단순).")

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowPayResponse.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowPayResponse.java
@@ -1,0 +1,13 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 거래대행 결제 응답 (PR-B-5 라운드 12).
+ *
+ * @param status 호출 후 application 상태. 한쪽만 paid 면 "결제대기" 유지, 양쪽 paid 시 "결제완료" 또는 그 이후 (라이더 매칭 결과에 따라).
+ */
+@Schema(description = "거래대행 본인 share 결제 응답 — 후속 상태 노출.")
+public record EscrowPayResponse(
+        @Schema(example = "결제완료", description = "결제대기 | 결제완료 | 진행중") String status
+) { }


### PR DESCRIPTION
## Summary
POST /api/v1/escrow/applications/{id}/pay — 본인 share 포인트 차감 + 양쪽 paid 시 자동 결제완료 + 라이더 매칭.

- 결제대기 상태 + 본인 참여자 + share>0 + 아직 paid 안된 상태 검증
- 포인트 잔액 차감 (atomic, INSUFFICIENT_POINT)
- markPaid → 양쪽 완료 시 EscrowConfirmedEvent → Delivery 도메인 자동 매칭
- 응답: { status }

@codex review — 자금 흐름 (포인트 잔액 차감 + 양쪽 결제 race) 게이트 1 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)