### PR TITLE
feat: round 12 PR-C #5 (skeleton) — ChatRoom.tradeMode 컬럼 + UNIQUE 키 변경

### DIFF
--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoom.java
@@ -3,6 +3,8 @@ package com.sseulang.domain.chat.domain;
 import com.sseulang.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -63,9 +65,18 @@ public class ChatRoom extends BaseEntity {
     private LocalDateTime user2LeftAt;
 
     /**
-     * {@code (itemId, requesterId, opponentId)} 로 채팅방 생성. {@code user1Id < user2Id} 강제 정규화.
+     * 채팅방 거래방식 — 판매 / 대여 / 나눔 (PR-C 라운드 12).
+     * UNIQUE(item_id, user1_id, user2_id, trade_mode) — 같은 두 사용자 + 같은 물품이라도 거래방식 다르면 별도 방.
      */
-    public static ChatRoom openFor(Long itemId, Long requesterId, Long opponentId) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trade_mode", nullable = false, length = 10)
+    private com.sseulang.domain.item.domain.TradeType tradeMode;
+
+    /**
+     * 라운드 12 PR-C — tradeMode 인자 추가. {@code user1Id < user2Id} 강제 정규화.
+     */
+    public static ChatRoom openFor(Long itemId, Long requesterId, Long opponentId,
+                                   com.sseulang.domain.item.domain.TradeType tradeMode) {
         if (itemId == null || itemId <= 0) {
             throw new IllegalArgumentException("itemId 는 양수여야 합니다");
         }
@@ -78,6 +89,9 @@ public class ChatRoom extends BaseEntity {
         if (requesterId.equals(opponentId)) {
             throw new IllegalArgumentException("requester 와 opponent 는 같을 수 없습니다");
         }
+        if (tradeMode == null) {
+            throw new IllegalArgumentException("tradeMode 는 필수입니다");
+        }
 
         ChatRoom cr = new ChatRoom();
         cr.itemId = itemId;
@@ -86,7 +100,14 @@ public class ChatRoom extends BaseEntity {
         cr.user1Unread = 0;
         cr.user2Unread = 0;
         cr.active = true;
+        cr.tradeMode = tradeMode;
         return cr;
+    }
+
+    /** @deprecated PR-C 라운드 12 — tradeMode 인자 받는 4-arg openFor 사용. */
+    @Deprecated
+    public static ChatRoom openFor(Long itemId, Long requesterId, Long opponentId) {
+        return openFor(itemId, requesterId, opponentId, com.sseulang.domain.item.domain.TradeType.판매);
     }
 
     public boolean isParticipant(Long userId) {

--- a/src/main/resources/db/migration/V23__chat_room_trade_mode.sql
+++ b/src/main/resources/db/migration/V23__chat_room_trade_mode.sql
@@ -1,0 +1,24 @@
+-- V23: 채팅방 거래방식 분리 (PR-C 라운드 12)
+--
+-- 정책 (작업 목록 #채팅 #5):
+--   * 구매자가 채팅 신청 시 구매(판매) / 대여 / 나눔 중 선택.
+--   * 같은 (item, user1, user2) 쌍이라도 거래방식이 다르면 별도 채팅방.
+--   * UNIQUE(item_id, user1_id, user2_id) → UNIQUE(item_id, user1_id, user2_id, trade_mode).
+--
+-- 기존 row 는 trade_mode='판매' 로 backfill (대다수가 판매 거래 가정).
+-- 도메인은 itemId 기준 트레이드 타입과 매핑되어 검증 — 다른 mode 시도 시 도메인 검증.
+
+ALTER TABLE chat_rooms
+    ADD COLUMN trade_mode VARCHAR(10) NOT NULL DEFAULT '판매'
+        COMMENT '채팅방 거래방식 — 판매 | 대여 | 나눔';
+
+ALTER TABLE chat_rooms
+    ADD CONSTRAINT chk_chat_rooms_trade_mode CHECK (trade_mode IN ('판매', '대여', '나눔'));
+
+-- 신 UNIQUE 먼저 추가 — item_id 가 앞이라 fk_chat_rooms_item 의 인덱스를 자동 활용 (MySQL 1553 회피).
+ALTER TABLE chat_rooms
+    ADD CONSTRAINT uk_chat_rooms_item_users_mode UNIQUE (item_id, user1_id, user2_id, trade_mode);
+
+-- 이제 구 UNIQUE drop 가능.
+ALTER TABLE chat_rooms
+    DROP INDEX uk_chat_rooms_item_users;


### PR DESCRIPTION
## Summary
- V23: chat_rooms.trade_mode 컬럼 + UNIQUE(item_id, user1_id, user2_id, trade_mode)
- ChatRoom 엔티티 tradeMode 매핑 + 4-arg openFor

API 변경은 다음 commit (ApplicationService / Request DTO / Repository tradeMode 인자).

## Test plan
- [x] 전체 테스트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)