### PR TITLE
feat: round 12 PR-C #6 — 채팅방 시스템 카드 (lazy 첫 메시지 시)

### DIFF
--- a/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
+++ b/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
@@ -28,6 +28,7 @@ public class ChatRoomApplicationService {
     private static final String UNIQUE_ITEM_USERS = "uk_chat_rooms_item_users";
 
     private final ChatRoomRepository chatRoomRepository;
+    private final com.sseulang.domain.chat.domain.ChatRoomCardRepository chatRoomCardRepository;
     private final ItemApplicationService itemApplicationService;
     private final com.sseulang.domain.user.application.UserApplicationService userApplicationService;
     private final UserView userView;
@@ -35,12 +36,14 @@ public class ChatRoomApplicationService {
 
     public ChatRoomApplicationService(
             ChatRoomRepository chatRoomRepository,
+            com.sseulang.domain.chat.domain.ChatRoomCardRepository chatRoomCardRepository,
             ItemApplicationService itemApplicationService,
             com.sseulang.domain.user.application.UserApplicationService userApplicationService,
             UserView userView,
             ItemView itemView
     ) {
         this.chatRoomRepository = chatRoomRepository;
+        this.chatRoomCardRepository = chatRoomCardRepository;
         this.itemApplicationService = itemApplicationService;
         this.userApplicationService = userApplicationService;
         this.userView = userView;
@@ -95,7 +98,49 @@ public class ChatRoomApplicationService {
         if (!room.isParticipant(requesterId)) {
             throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
         }
-        return enrichOne(room, requesterId);
+        ChatRoomResult base = enrichOne(room, requesterId);
+        // 라운드 12 PR-C #6 — systemCard 단건 fetch (없으면 null)
+        ChatRoomResult.SystemCard card = chatRoomCardRepository.findByChatRoomId(id)
+                .map(ChatRoomResult.SystemCard::from)
+                .orElse(null);
+        return new ChatRoomResult(
+                base.id(), base.itemId(),
+                base.user1Id(), base.user2Id(),
+                base.user1Unread(), base.user2Unread(),
+                base.opponentId(), base.opponentNickname(), base.opponentProfileImage(), base.myUnread(),
+                base.itemTitle(), base.itemThumbnailUrl(), base.isSeller(),
+                base.iLeft(), base.opponentLeft(),
+                base.lastMessage(), base.lastMessageAt(),
+                base.active(), base.createdAt(), base.updatedAt(),
+                card
+        );
+    }
+
+    /**
+     * 라운드 12 PR-C #6 — 첫 메시지 발신 시점에 호출. 카드 미존재 시 생성 (멱등).
+     * MessageApplicationService.send 에서 호출.
+     */
+    @Transactional
+    public void ensureSystemCard(Long chatRoomId) {
+        if (chatRoomCardRepository.findByChatRoomId(chatRoomId).isPresent()) {
+            return;
+        }
+        ChatRoom room = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        var itemMap = itemView.findByIds(List.of(room.getItemId()));
+        var item = itemMap.get(room.getItemId());
+        if (item == null) {
+            return;  // 아이템 삭제 등 — 카드 생성 skip (best-effort)
+        }
+        com.sseulang.domain.chat.domain.ChatRoomCard card = com.sseulang.domain.chat.domain.ChatRoomCard.create(
+                chatRoomId, room.getTradeMode(),
+                item.id(), item.title(), item.thumbnailUrl(), item.price()
+        );
+        try {
+            chatRoomCardRepository.save(card);
+        } catch (org.springframework.dao.DuplicateKeyException race) {
+            // 다른 트랜잭션이 먼저 생성 — 무시 (멱등)
+        }
     }
 
     /**

--- a/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
+++ b/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
@@ -34,8 +34,24 @@ public record ChatRoomResult(
         LocalDateTime lastMessageAt,
         boolean active,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        // 라운드 12 PR-C #6 — 채팅방 시스템 카드 (첫 메시지 시점에 lazy 생성, getOne 응답에만 enrich)
+        SystemCard systemCard
 ) {
+    /**
+     * 채팅방 시스템 카드 — 거래방식 + 아이템 정보 (snapshot).
+     */
+    public record SystemCard(
+            com.sseulang.domain.item.domain.TradeType tradeMode,
+            Long itemId,
+            String itemTitle,
+            String thumbnailUrl,
+            Long price
+    ) {
+        public static SystemCard from(com.sseulang.domain.chat.domain.ChatRoomCard c) {
+            return new SystemCard(c.getTradeMode(), c.getItemId(), c.getItemTitle(), c.getThumbnailUrl(), c.getPrice());
+        }
+    }
     /**
      * viewerId 기준 derive. opponent / item join 정보는 호출자가 fetch 후 전달 (없으면 null/빈 문자열 OK).
      * viewerId 가 참여자 아니면 IAE — 서비스가 사전 권한 검증 책임.
@@ -62,6 +78,34 @@ public record ChatRoomResult(
             opponentId = null;
             myUnread = 0;
         }
+        return from(c, viewerId, opponentNickname, opponentProfileImage, itemTitle, itemThumbnailUrl, itemSellerId, null);
+    }
+
+    /**
+     * 라운드 12 PR-C #6 — systemCard 포함 enrich (getOne 응답 전용).
+     */
+    public static ChatRoomResult from(
+            ChatRoom c,
+            Long viewerId,
+            String opponentNickname,
+            String opponentProfileImage,
+            String itemTitle,
+            String itemThumbnailUrl,
+            Long itemSellerId,
+            SystemCard systemCard
+    ) {
+        Long opponentId;
+        int myUnread;
+        if (viewerId != null && viewerId.equals(c.getUser1Id())) {
+            opponentId = c.getUser2Id();
+            myUnread = c.getUser1Unread();
+        } else if (viewerId != null && viewerId.equals(c.getUser2Id())) {
+            opponentId = c.getUser1Id();
+            myUnread = c.getUser2Unread();
+        } else {
+            opponentId = null;
+            myUnread = 0;
+        }
         boolean isSeller = itemSellerId != null && viewerId != null && itemSellerId.equals(viewerId);
         boolean iLeft = c.iLeft(viewerId);
         boolean opponentLeft = c.opponentLeft(viewerId);
@@ -74,7 +118,8 @@ public record ChatRoomResult(
                 iLeft, opponentLeft,
                 c.getLastMessage(), c.getLastMessageAt(),
                 c.isActive(),
-                c.getCreatedAt(), c.getUpdatedAt()
+                c.getCreatedAt(), c.getUpdatedAt(),
+                systemCard
         );
     }
 }

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoomCard.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoomCard.java
@@ -1,0 +1,68 @@
+package com.sseulang.domain.chat.domain;
+
+import com.sseulang.domain.item.domain.TradeType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.Instant;
+
+/**
+ * 채팅방 시스템 카드 (PR-C #6 라운드 12). 첫 메시지 send 시점에 lazy 생성 후 채팅방에서 영구 노출.
+ *
+ * <p>MongoDB {@code chat_room_cards} 컬렉션 — chatRoomId 당 1건 (UNIQUE).
+ * 내용: 거래방식 + 아이템 title + thumbnail + 가격 (snapshot — 거래 시점 그대로 보존).</p>
+ */
+@Document(collection = "chat_room_cards")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomCard {
+
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
+    @Field("chat_room_id")
+    private Long chatRoomId;
+
+    @Field("trade_mode")
+    private TradeType tradeMode;
+
+    @Field("item_id")
+    private Long itemId;
+
+    @Field("item_title")
+    private String itemTitle;
+
+    @Field("thumbnail_url")
+    private String thumbnailUrl;
+
+    @Field("price")
+    private Long price;
+
+    @CreatedDate
+    @Field("created_at")
+    private Instant createdAt;
+
+    public static ChatRoomCard create(Long chatRoomId, TradeType tradeMode,
+                                      Long itemId, String itemTitle,
+                                      String thumbnailUrl, Long price) {
+        if (chatRoomId == null) throw new IllegalArgumentException("chatRoomId 는 필수입니다");
+        if (tradeMode == null) throw new IllegalArgumentException("tradeMode 는 필수입니다");
+        if (itemId == null) throw new IllegalArgumentException("itemId 는 필수입니다");
+        if (itemTitle == null || itemTitle.isBlank()) throw new IllegalArgumentException("itemTitle 은 필수입니다");
+        ChatRoomCard c = new ChatRoomCard();
+        c.chatRoomId = chatRoomId;
+        c.tradeMode = tradeMode;
+        c.itemId = itemId;
+        c.itemTitle = itemTitle;
+        c.thumbnailUrl = thumbnailUrl;
+        c.price = price;
+        return c;
+    }
+}

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoomCardRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoomCardRepository.java
@@ -1,0 +1,13 @@
+package com.sseulang.domain.chat.domain;
+
+import java.util.Optional;
+
+/**
+ * 채팅방 시스템 카드 Repository — chatRoomId UNIQUE.
+ */
+public interface ChatRoomCardRepository {
+
+    Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId);
+
+    ChatRoomCard save(ChatRoomCard card);
+}

--- a/src/main/java/com/sseulang/domain/chat/domain/ItemView.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ItemView.java
@@ -17,6 +17,9 @@ public interface ItemView {
      */
     Map<Long, ItemProjection> findByIds(Collection<Long> itemIds);
 
-    /** 채팅 응답용 아이템 최소 projection. 제목 + 썸네일 + 판매자 id (viewer 본인=isSeller 판정용). */
-    record ItemProjection(Long id, String title, String thumbnailUrl, Long sellerId) { }
+    /**
+     * 채팅 응답용 아이템 최소 projection. 제목 + 썸네일 + 판매자 id (viewer 본인=isSeller 판정용).
+     * 라운드 12 PR-C #6 — 시스템 카드 생성 시 price 도 필요해 필드 추가 (snapshot).
+     */
+    record ItemProjection(Long id, String title, String thumbnailUrl, Long sellerId, Long price) { }
 }

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomCardMongoRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomCardMongoRepository.java
@@ -1,0 +1,10 @@
+package com.sseulang.domain.chat.infrastructure.persistence;
+
+import com.sseulang.domain.chat.domain.ChatRoomCard;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+interface ChatRoomCardMongoRepository extends MongoRepository<ChatRoomCard, String> {
+    Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId);
+}

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomCardRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomCardRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.sseulang.domain.chat.infrastructure.persistence;
+
+import com.sseulang.domain.chat.domain.ChatRoomCard;
+import com.sseulang.domain.chat.domain.ChatRoomCardRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+class ChatRoomCardRepositoryImpl implements ChatRoomCardRepository {
+
+    private final ChatRoomCardMongoRepository mongo;
+
+    ChatRoomCardRepositoryImpl(ChatRoomCardMongoRepository mongo) {
+        this.mongo = mongo;
+    }
+
+    @Override
+    public Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId) {
+        return mongo.findByChatRoomId(chatRoomId);
+    }
+
+    @Override
+    public ChatRoomCard save(ChatRoomCard card) {
+        return mongo.save(card);
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemViewAdapter.java
@@ -28,7 +28,7 @@ public class ItemViewAdapter implements ItemView {
         }
         Map<Long, ItemProjection> result = new HashMap<>();
         for (Item i : jpa.findAllById(itemIds)) {
-            result.put(i.getId(), new ItemProjection(i.getId(), i.getTitle(), i.getThumbnailUrl(), i.getSellerId()));
+            result.put(i.getId(), new ItemProjection(i.getId(), i.getTitle(), i.getThumbnailUrl(), i.getSellerId(), i.getPrice()));
         }
         return result;
     }

--- a/src/main/java/com/sseulang/domain/message/application/MessageApplicationService.java
+++ b/src/main/java/com/sseulang/domain/message/application/MessageApplicationService.java
@@ -70,6 +70,9 @@ public class MessageApplicationService {
         chatRoomApplicationService.requireSendable(cmd.chatRoomId(), cmd.senderId());
         Long opponentId = chatRoomApplicationService.findOpponent(cmd.chatRoomId(), cmd.senderId());
 
+        // 라운드 12 PR-C #6 — 첫 메시지 발신 시점에 systemCard lazy 생성 (멱등).
+        chatRoomApplicationService.ensureSystemCard(cmd.chatRoomId());
+
         Message saved;
         boolean hasImages = cmd.imageUrls() != null && !cmd.imageUrls().isEmpty();
         if (hasImages) {

--- a/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
@@ -35,7 +35,7 @@ class ChatRoomApplicationServiceTest {
         itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
-        service = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView());
+        service = new ChatRoomApplicationService(roomRepo, new com.sseulang.domain.chat.application.InMemoryFakeChatRoomCardRepository(), itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView());
 
         Item item = itemRepo.save(Item.create(
                 SELLER, null, "물건", "설명", 50_000L, null, null, TradeType.판매, null

--- a/src/test/java/com/sseulang/domain/chat/application/InMemoryFakeChatRoomCardRepository.java
+++ b/src/test/java/com/sseulang/domain/chat/application/InMemoryFakeChatRoomCardRepository.java
@@ -1,0 +1,24 @@
+package com.sseulang.domain.chat.application;
+
+import com.sseulang.domain.chat.domain.ChatRoomCard;
+import com.sseulang.domain.chat.domain.ChatRoomCardRepository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class InMemoryFakeChatRoomCardRepository implements ChatRoomCardRepository {
+
+    private final Map<Long, ChatRoomCard> store = new HashMap<>();
+
+    @Override
+    public Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId) {
+        return Optional.ofNullable(store.get(chatRoomId));
+    }
+
+    @Override
+    public ChatRoomCard save(ChatRoomCard card) {
+        store.put(card.getChatRoomId(), card);
+        return card;
+    }
+}

--- a/src/test/java/com/sseulang/domain/chat/application/NoOpChatRoomCardRepository.java
+++ b/src/test/java/com/sseulang/domain/chat/application/NoOpChatRoomCardRepository.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.chat.application;
+
+import com.sseulang.domain.chat.domain.ChatRoomCard;
+import com.sseulang.domain.chat.domain.ChatRoomCardRepository;
+import java.util.Optional;
+
+/**
+ * MongoDB 없는 슬라이스 테스트 (예: SettlementRollbackIT 등 @DataJpaTest)에서 @Import 로 명시 등록.
+ * 항상 빈 결과 — 시스템 카드 fetch 가 빠짐.
+ *
+ * <p>@Component 제거 — SpringBootTest 자동 스캔 시 ChatRoomCardRepositoryImpl 과 충돌 방지.
+ * @Import 가 클래스 import 시 Spring 이 빈 등록 (no-arg 생성자 활용).</p>
+ */
+public class NoOpChatRoomCardRepository implements ChatRoomCardRepository {
+
+    @Override
+    public Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public ChatRoomCard save(ChatRoomCard card) {
+        return card;
+    }
+}

--- a/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
@@ -48,7 +48,7 @@ class MessageApplicationServiceTest {
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
-        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView());
+        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, new com.sseulang.domain.chat.application.InMemoryFakeChatRoomCardRepository(), itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView());
         NotificationApplicationService notifSvc = new NotificationApplicationService(notifRepo, new com.sseulang.domain.user.application.InMemoryFakeUserRepository());
         // 단위 테스트에선 트랜잭션 컨텍스트 X — AFTER_COMMIT listener 직접 호출하는 fake event publisher.
         ChatRealtimeEventListener listener = new ChatRealtimeEventListener(publisher);

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -52,6 +52,7 @@ class ReviewApplicationServiceTest {
         com.sseulang.domain.chat.application.ChatRoomApplicationService chatSvc =
                 new com.sseulang.domain.chat.application.ChatRoomApplicationService(
                         new com.sseulang.domain.chat.application.InMemoryFakeChatRoomRepository(),
+                        new com.sseulang.domain.chat.application.InMemoryFakeChatRoomCardRepository(),
                         itemSvc, userSvc, null, null);
         TransactionApplicationService txSvc = new TransactionApplicationService(
                 txRepo, itemSvc, pointSvc, userSvc, chatSvc,

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -68,7 +68,7 @@ class TransactionApplicationServiceTest {
         chatRoomRepo = new com.sseulang.domain.chat.application.InMemoryFakeChatRoomRepository();
         com.sseulang.domain.chat.application.ChatRoomApplicationService chatSvc =
                 new com.sseulang.domain.chat.application.ChatRoomApplicationService(
-                        chatRoomRepo, itemSvc, userSvc, null, null);
+                        chatRoomRepo, new com.sseulang.domain.chat.application.InMemoryFakeChatRoomCardRepository(), itemSvc, userSvc, null, null);
         org.springframework.context.ApplicationEventPublisher publisher = publishedEvents::add;
         service = new TransactionApplicationService(
                 txRepo, itemSvc, pointSvc, userSvc, chatSvc, publisher, java.time.Clock.systemDefaultZone());

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -94,7 +94,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         com.sseulang.domain.chat.infrastructure.persistence.ChatRoomRepositoryImpl.class,
         com.sseulang.domain.chat.application.ChatRoomApplicationService.class,
         com.sseulang.domain.user.infrastructure.persistence.UserViewAdapter.class,
-        com.sseulang.domain.item.infrastructure.persistence.ItemViewAdapter.class
+        com.sseulang.domain.item.infrastructure.persistence.ItemViewAdapter.class,
+        // 라운드 12 PR-C #6 — ChatRoomApplicationService 가 ChatRoomCardRepository 의존 추가 (Mongo). DataJpaTest 라 NoOp 주입.
+        com.sseulang.domain.chat.application.NoOpChatRoomCardRepository.class
 })
 @Testcontainers
 @Transactional(propagation = Propagation.NOT_SUPPORTED)

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -84,7 +84,9 @@ import static org.assertj.core.api.Assertions.assertThat;
         com.sseulang.domain.chat.infrastructure.persistence.ChatRoomRepositoryImpl.class,
         com.sseulang.domain.chat.application.ChatRoomApplicationService.class,
         com.sseulang.domain.user.infrastructure.persistence.UserViewAdapter.class,
-        com.sseulang.domain.item.infrastructure.persistence.ItemViewAdapter.class
+        com.sseulang.domain.item.infrastructure.persistence.ItemViewAdapter.class,
+        // 라운드 12 PR-C #6 — ChatRoomCardRepository 의존 (Mongo, DataJpaTest 라 NoOp).
+        com.sseulang.domain.chat.application.NoOpChatRoomCardRepository.class
 })
 @Testcontainers
 @Transactional(propagation = Propagation.NOT_SUPPORTED)

--- a/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
@@ -54,7 +54,7 @@ class StompAuthChannelInterceptorTest {
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
-        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView());
+        ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, new com.sseulang.domain.chat.application.InMemoryFakeChatRoomCardRepository(), itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView());
 
         validTokens.clear();
         jwtProvider = mock(JwtProvider.class);


### PR DESCRIPTION
## Summary
첫 메시지 send 시점에 `chat_room_cards` 컬렉션에 카드 lazy 생성 (멱등). GET /chat-rooms/{id} 응답에 systemCard 필드.

## 프론트
```jsonc
GET /api/v1/chat-rooms/{id}
응답: {
  ...기존 필드,
  "systemCard": {
    "tradeMode": "판매" | "대여" | "나눔",
    "itemId": 42,
    "itemTitle": "맥북 프로",
    "thumbnailUrl": "https://...",
    "price": 30000
  } | null
}
```

## Test plan
- [x] 전체 테스트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)