### PR TITLE
feat: round 12 PR-F #8 — 활동 정지 누적 200일 자동 탈퇴

### DIFF
--- a/src/main/java/com/sseulang/domain/auth/domain/EmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/EmailSender.java
@@ -16,4 +16,10 @@ public interface EmailSender {
      * SMTP 미설치 환경에선 LogEmailSender 가 콘솔 출력만 하고 안전 fallback.
      */
     void sendInquiryReplyEmail(String toEmail, String subject, String html);
+
+    /**
+     * 활동 정지 누적 200일 도달로 자동 탈퇴 처리되었음을 안내 (round 12 PR-F #8).
+     * 발송 실패는 호출자에서 swallow — 자동 탈퇴 자체는 이미 commit 된 상태.
+     */
+    void sendAutoWithdrawnEmail(String toEmail, int cumulativeSuspendDays);
 }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/email/LogEmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/email/LogEmailSender.java
@@ -34,4 +34,9 @@ public class LogEmailSender implements EmailSender {
     public void sendInquiryReplyEmail(String toEmail, String subject, String html) {
         log.info("[inquiry-reply] to={} subject={} (html len={})", toEmail, subject, html == null ? 0 : html.length());
     }
+
+    @Override
+    public void sendAutoWithdrawnEmail(String toEmail, int cumulativeSuspendDays) {
+        log.info("[auto-withdrawn] to={} cumulativeSuspendDays={}", toEmail, cumulativeSuspendDays);
+    }
 }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSender.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 public class SmtpEmailSender implements EmailSender {
 
     private static final String SUBJECT = "[쓸랭] 이메일 인증을 완료해 주세요";
+    private static final String AUTO_WITHDRAWN_SUBJECT = "[쓸랭] 활동 정지 누적 200일 도달 — 계정 자동 탈퇴 안내";
 
     private final JavaMailSender mailSender;
     private final String fromAddress;
@@ -49,6 +50,11 @@ public class SmtpEmailSender implements EmailSender {
         sendHtml(toEmail, subject, html);
     }
 
+    @Override
+    public void sendAutoWithdrawnEmail(String toEmail, int cumulativeSuspendDays) {
+        sendHtml(toEmail, AUTO_WITHDRAWN_SUBJECT, buildAutoWithdrawnHtml(cumulativeSuspendDays));
+    }
+
     private void sendHtml(String toEmail, String subject, String html) {
         MimeMessage message = mailSender.createMimeMessage();
         try {
@@ -66,6 +72,20 @@ public class SmtpEmailSender implements EmailSender {
             // 운영 모니터링 대상 — 5/6 이후 outbox 도입 시 비동기 retry 로 강화.
             throw new RuntimeException("이메일 발송 실패: " + e.getMessage(), e);
         }
+    }
+
+    private static String buildAutoWithdrawnHtml(int cumulativeSuspendDays) {
+        return """
+                <!doctype html>
+                <html>
+                  <body style="font-family:sans-serif;line-height:1.6;color:#333">
+                    <h2>쓸랭 계정 자동 탈퇴 안내</h2>
+                    <p>회원님의 계정이 활동 정지 누적 <b>%d일</b> 도달로 자동 탈퇴 처리되었습니다.</p>
+                    <p>운영 정책상 누적 정지 200일 이상은 자동 탈퇴 대상입니다 (이용약관 제○조).</p>
+                    <p>문의는 고객센터(support@sseulang.store) 로 보내 주세요.</p>
+                  </body>
+                </html>
+                """.formatted(cumulativeSuspendDays);
     }
 
     private static String buildHtml(String verificationUrl) {

--- a/src/main/java/com/sseulang/domain/user/application/AutoWithdrawalScheduler.java
+++ b/src/main/java/com/sseulang/domain/user/application/AutoWithdrawalScheduler.java
@@ -1,0 +1,53 @@
+package com.sseulang.domain.user.application;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 활동 정지 누적 200일 이상 도달 사용자 자동 탈퇴 배치 (라운드 12 PR-F #8).
+ *
+ * <p>1차 트리거는 {@code UserApplicationService.adminSuspend} 내부 동기 분기 — 보통은 거기서 처리된다.
+ * 본 스케줄러는 안전망: DB 수동 수정, 마이그레이션 backfill, 정책 변경 등으로 누락된 사용자를 매일 새벽 1시에
+ * 청소한다.</p>
+ *
+ * <p>각 사용자는 별도 트랜잭션으로 처리 — 한 건 실패해도 다음 건 진행. 메일 발송 실패는 swallow.</p>
+ */
+@Component
+public class AutoWithdrawalScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(AutoWithdrawalScheduler.class);
+
+    /** 한 cycle 에 처리할 최대 건수 — 대량 발생 시 다음 cycle 로 자연 분산. */
+    private static final int BATCH_LIMIT = 100;
+
+    private final UserApplicationService userService;
+
+    public AutoWithdrawalScheduler(UserApplicationService userService) {
+        this.userService = userService;
+    }
+
+    /** 매일 새벽 1시 KST. */
+    @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
+    public void run() {
+        List<Long> targets = userService.findAutoWithdrawTargetIds(BATCH_LIMIT);
+        if (targets.isEmpty()) {
+            return;
+        }
+        log.info("[auto-withdraw] target {} 명 처리 시작", targets.size());
+        int processed = 0;
+        for (Long id : targets) {
+            try {
+                if (userService.processAutoWithdrawal(id)) {
+                    processed++;
+                }
+            } catch (Exception e) {
+                log.error("[auto-withdraw] userId={} 처리 실패 (다음 cycle 재시도)", id, e);
+            }
+        }
+        log.info("[auto-withdraw] target {} 명 중 {} 명 탈퇴 처리", targets.size(), processed);
+    }
+}

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -7,6 +7,8 @@ import com.sseulang.domain.user.domain.User;
 import com.sseulang.domain.user.domain.UserRepository;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +21,8 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class UserApplicationService {
 
+    private static final Logger log = LoggerFactory.getLogger(UserApplicationService.class);
+
     /** 휴면 판정 — 90일 이상 미접속이면 dormant. status derive 와 search 양쪽에서 공유. */
     private static final int DORMANT_THRESHOLD_DAYS = 90;
     private static final String USER_ROLE = "USER";
@@ -27,6 +31,7 @@ public class UserApplicationService {
     private final com.sseulang.domain.transaction.domain.TransactionRepository transactionRepository;
     private final com.sseulang.domain.report.domain.UserReportRepository userReportRepository;
     private final com.sseulang.domain.auth.domain.RefreshTokenStore refreshTokenStore;
+    private final com.sseulang.domain.auth.domain.EmailSender emailSender;
     private final java.time.Clock clock;
 
     public UserApplicationService(
@@ -34,12 +39,14 @@ public class UserApplicationService {
             com.sseulang.domain.transaction.domain.TransactionRepository transactionRepository,
             com.sseulang.domain.report.domain.UserReportRepository userReportRepository,
             com.sseulang.domain.auth.domain.RefreshTokenStore refreshTokenStore,
+            com.sseulang.domain.auth.domain.EmailSender emailSender,
             java.time.Clock clock
     ) {
         this.userRepository = userRepository;
         this.transactionRepository = transactionRepository;
         this.userReportRepository = userReportRepository;
         this.refreshTokenStore = refreshTokenStore;
+        this.emailSender = emailSender;
         this.clock = clock;
     }
 
@@ -307,12 +314,28 @@ public class UserApplicationService {
         }
     }
 
-    /** 관리자 시한부 활동정지 — N일 동안. days >= 1. RT 즉시 무효화. */
+    /**
+     * 관리자 시한부 활동정지 — N일 동안. days >= 1. RT 즉시 무효화.
+     * 라운드 12 PR-F #8 — 누적 정지 200일 이상 도달 시 자동 탈퇴 처리 + 안내 메일 발송.
+     */
     @Transactional
     public void adminSuspend(Long userId, int days) {
         User u = getById(userId);
         u.suspend(days, java.time.LocalDateTime.now(clock));
         refreshTokenStore.revokeAll(USER_ROLE, userId);
+        if (u.isAutoWithdrawTarget()) {
+            u.markAutoWithdrawn();
+            sendAutoWithdrawnNotice(u);
+        }
+    }
+
+    /** 발송 실패는 swallow — soft delete 자체는 트랜잭션 commit 으로 확정. */
+    private void sendAutoWithdrawnNotice(User u) {
+        try {
+            emailSender.sendAutoWithdrawnEmail(u.email().value(), u.getCumulativeSuspendDays());
+        } catch (RuntimeException e) {
+            log.error("[auto-withdraw] 안내 메일 발송 실패 userId={} reason={}", u.getId(), e.getMessage(), e);
+        }
     }
 
     /** 관리자 활동정지 즉시 해제. */
@@ -320,6 +343,30 @@ public class UserApplicationService {
     public void adminUnsuspend(Long userId) {
         User u = getById(userId);
         u.unsuspend();
+    }
+
+    /**
+     * 라운드 12 PR-F #8 — 자동 탈퇴 배치 후크. 누적 200일 이상 + 살아있는 사용자 일괄 처리.
+     * adminSuspend 직후 동기 분기는 1차 트리거이고, 이 메서드는 안전망 (DB 수동 변경/마이그레이션 케이스).
+     * 각 user 는 별도 트랜잭션으로 처리 — 한 건 실패해도 다음 건 진행.
+     */
+    public java.util.List<Long> findAutoWithdrawTargetIds(int limit) {
+        return userRepository.findAutoWithdrawTargetIds(200, limit);
+    }
+
+    /**
+     * 단건 자동 탈퇴 처리. 이미 deleted 거나 누적 미달이면 no-op. 안내 메일 발송 + RT 무효화.
+     */
+    @Transactional
+    public boolean processAutoWithdrawal(Long userId) {
+        User u = userRepository.findById(userId).orElse(null);
+        if (u == null || !u.isAutoWithdrawTarget()) {
+            return false;
+        }
+        u.markAutoWithdrawn();
+        refreshTokenStore.revokeAll(USER_ROLE, userId);
+        sendAutoWithdrawnNotice(u);
+        return true;
     }
 
     /**

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -91,6 +91,13 @@ public class User extends BaseEntity {
     @Column(name = "suspend_days")
     private Integer suspendDays;
 
+    /**
+     * 활동 정지 누적 일수 (라운드 12 PR-F #8). 200일 이상 자동 탈퇴 (soft delete).
+     * suspend() 호출 시마다 += days. 기존 row 는 0 (V24 부터 누적 시작).
+     */
+    @Column(name = "cumulative_suspend_days", nullable = false)
+    private int cumulativeSuspendDays;
+
     @Column(name = "is_deleted", nullable = false)
     private boolean deleted;
 
@@ -274,7 +281,9 @@ public class User extends BaseEntity {
         this.lastLoginAt = now;
     }
 
-    /** 시한부 활동정지. days >= 1. now 부터 N일 동안. */
+    /**
+     * 시한부 활동정지. days >= 1. now 부터 N일 동안. 라운드 12 PR-F #8 — cumulative_suspend_days 누적.
+     */
     public void suspend(int days, LocalDateTime now) {
         if (days < 1) {
             throw new IllegalArgumentException("days 는 1 이상이어야 합니다");
@@ -284,6 +293,17 @@ public class User extends BaseEntity {
         }
         this.suspendedAt = now;
         this.suspendDays = days;
+        this.cumulativeSuspendDays += days;
+    }
+
+    /** 라운드 12 PR-F #8 — 누적 정지 200일 이상 도달 시 자동 탈퇴 대상. */
+    public boolean isAutoWithdrawTarget() {
+        return !this.deleted && this.cumulativeSuspendDays >= 200;
+    }
+
+    /** 라운드 12 PR-F #8 — 자동 탈퇴 처리 (soft delete). */
+    public void markAutoWithdrawn() {
+        this.deleted = true;
     }
 
     /** 활동정지 즉시 해제. */

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -138,4 +138,10 @@ public interface UserRepository {
      * keyword null/blank → 빈 리스트.
      */
     java.util.List<Long> findIdsByKeywordLike(String keyword, int limit);
+
+    /**
+     * 라운드 12 PR-F #8 — 누적 정지 일수가 {@code threshold} 이상이면서 아직 soft delete 되지 않은
+     * 사용자 id 청크. id ASC. 배치 자동 탈퇴 처리용.
+     */
+    java.util.List<Long> findAutoWithdrawTargetIds(int threshold, int limit);
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -249,4 +249,16 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
              ORDER BY u.id ASC
             """)
     java.util.List<Long> findIdsByKeywordLike(@Param("kw") String kw, org.springframework.data.domain.Pageable pageable);
+
+    /**
+     * 라운드 12 PR-F #8 — 누적 정지 일수 ≥ threshold 이면서 아직 살아있는 사용자 id.
+     * 자동 탈퇴 배치 처리용. id ASC.
+     */
+    @Query("""
+            SELECT u.id FROM User u
+             WHERE u.cumulativeSuspendDays >= :threshold
+               AND u.deleted = false
+             ORDER BY u.id ASC
+            """)
+    java.util.List<Long> findAutoWithdrawTargetIds(@Param("threshold") int threshold, org.springframework.data.domain.Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -157,4 +157,10 @@ public class UserRepositoryImpl implements UserRepository {
         }
         return jpa.findIdsByKeywordLike(keyword.strip(), org.springframework.data.domain.PageRequest.of(0, limit));
     }
+
+    @Override
+    public java.util.List<Long> findAutoWithdrawTargetIds(int threshold, int limit) {
+        if (limit <= 0) return java.util.Collections.emptyList();
+        return jpa.findAutoWithdrawTargetIds(threshold, org.springframework.data.domain.PageRequest.of(0, limit));
+    }
 }

--- a/src/main/resources/db/migration/V24__user_cumulative_suspend.sql
+++ b/src/main/resources/db/migration/V24__user_cumulative_suspend.sql
@@ -1,0 +1,15 @@
+-- V24: 활동 정지 누적 일수 + 자동 탈퇴 (PR-F #8 라운드 12)
+--
+-- 정책:
+--   * suspend() 호출 시마다 cumulative_suspend_days += days. 누적 200일 이상 → 자동 soft delete.
+--   * 자동 탈퇴 = is_deleted=1 전환 + 안내 메일 발송. 데이터 보존.
+--   * 배치 job (매일 새벽) 이 점검 후 처리. 또는 suspend 호출 직후 도메인 메서드가 자체 검사.
+--
+-- 기존 row 는 DEFAULT 0 — 이전 정지 이력은 합산 X (누적 시작 시점 V24 부터).
+
+ALTER TABLE users
+    ADD COLUMN cumulative_suspend_days INT NOT NULL DEFAULT 0
+        COMMENT '활동 정지 누적 일수 — 200일 이상 자동 탈퇴 (PR-F #8 라운드 12)';
+
+ALTER TABLE users
+    ADD INDEX idx_users_cumulative_suspend (cumulative_suspend_days);

--- a/src/test/java/com/sseulang/domain/auth/application/NoOpEmailSender.java
+++ b/src/test/java/com/sseulang/domain/auth/application/NoOpEmailSender.java
@@ -1,0 +1,13 @@
+package com.sseulang.domain.auth.application;
+
+import com.sseulang.domain.auth.domain.EmailSender;
+
+/**
+ * 단위 테스트용 no-op {@link EmailSender}. 메일 발송이 검증 대상이 아닌 service 단위 테스트가 사용.
+ * 메일 발송 검증이 필요한 곳은 Mockito mock 또는 콜백 캡처 fake 를 별도 사용.
+ */
+public class NoOpEmailSender implements EmailSender {
+    @Override public void sendVerificationEmail(String toEmail, String verificationUrl) { }
+    @Override public void sendInquiryReplyEmail(String toEmail, String subject, String html) { }
+    @Override public void sendAutoWithdrawnEmail(String toEmail, int cumulativeSuspendDays) { }
+}

--- a/src/test/java/com/sseulang/domain/delivery/integration/DeliveryConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/delivery/integration/DeliveryConcurrencyIT.java
@@ -65,6 +65,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         UserRepositoryImpl.class,
         UserApplicationService.class,
         com.sseulang.domain.auth.application.NoOpRefreshTokenStore.class,
+        com.sseulang.domain.auth.application.NoOpEmailSender.class,
         // UserApplicationService 가 v8b 부터 Transaction/UserReport repo 의존 — slice 에 명시 추가.
         // (Clock 은 SseulangApplication @Bean 이 자동 제공)
         com.sseulang.domain.transaction.infrastructure.persistence.TransactionRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
@@ -43,7 +43,7 @@ class PaymentApplicationServiceTest {
         gateway = new FakePaymentGateway();
         userRepo = new InMemoryFakeUserRepository();
         pointHistoryRepo = new InMemoryFakePointHistoryRepository();
-        userService = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
+        userService = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), new com.sseulang.domain.auth.application.NoOpEmailSender(), java.time.Clock.systemDefaultZone());
         PointApplicationService pointSvc = new PointApplicationService(userService, pointHistoryRepo);
         TossProperties tossProps = new TossProperties(CLIENT_KEY, "test_sk_secret", null, null, null, null);
         service = new PaymentApplicationService(

--- a/src/test/java/com/sseulang/domain/point/application/PointApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/point/application/PointApplicationServiceTest.java
@@ -35,7 +35,7 @@ class PointApplicationServiceTest {
     void setUp() {
         userRepo = new InMemoryFakeUserRepository();
         historyRepo = new InMemoryFakePointHistoryRepository();
-        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), new com.sseulang.domain.auth.application.NoOpEmailSender(), java.time.Clock.systemDefaultZone());
         service = new PointApplicationService(userSvc, historyRepo);
 
         buyerId = userRepo.save(User.createSocialUser(

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -46,7 +46,7 @@ class ReviewApplicationServiceTest {
         userRepo = new InMemoryFakeUserRepository();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), new com.sseulang.domain.auth.application.NoOpEmailSender(), java.time.Clock.systemDefaultZone());
         ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, new InMemoryFakePointHistoryRepository());
         com.sseulang.domain.chat.application.ChatRoomApplicationService chatSvc =

--- a/src/test/java/com/sseulang/domain/support/application/InquiryApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/support/application/InquiryApplicationServiceTest.java
@@ -41,6 +41,7 @@ class InquiryApplicationServiceTest {
         com.sseulang.domain.auth.domain.EmailSender emailSender = new com.sseulang.domain.auth.domain.EmailSender() {
             @Override public void sendVerificationEmail(String t, String u) { }
             @Override public void sendInquiryReplyEmail(String t, String s, String h) { }
+            @Override public void sendAutoWithdrawnEmail(String t, int d) { }
         };
         // 단위 테스트용 — AFTER_COMMIT 이벤트는 트랜잭션 밖이라 fire 안 됨. 알림/메일 사이드 이펙트는 별도 IT.
         org.springframework.context.ApplicationEventPublisher eventPublisher = event -> { };

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -59,6 +59,7 @@ class TransactionApplicationServiceTest {
                 new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(),
                 new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(),
                 new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(),
+                new com.sseulang.domain.auth.application.NoOpEmailSender(),
                 java.time.Clock.systemDefaultZone());
         itemSvc = new ItemApplicationService(
                 itemRepo, catSvc, userSvc,

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -84,6 +84,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         UserRepositoryImpl.class,
         UserApplicationService.class,
         com.sseulang.domain.auth.application.NoOpRefreshTokenStore.class,
+        com.sseulang.domain.auth.application.NoOpEmailSender.class,
         PointHistoryRepositoryImpl.class,
         PointApplicationService.class,
         TransactionRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -74,6 +74,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         UserRepositoryImpl.class,
         UserApplicationService.class,
         com.sseulang.domain.auth.application.NoOpRefreshTokenStore.class,
+        com.sseulang.domain.auth.application.NoOpEmailSender.class,
         PointHistoryRepositoryImpl.class,
         PointApplicationService.class,
         TransactionRepositoryImpl.class,

--- a/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
+++ b/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
@@ -214,4 +214,15 @@ public class InMemoryFakeUserRepository implements UserRepository {
                 .limit(limit)
                 .toList();
     }
+
+    @Override
+    public java.util.List<Long> findAutoWithdrawTargetIds(int threshold, int limit) {
+        if (limit <= 0) return java.util.Collections.emptyList();
+        return store.values().stream()
+                .filter(u -> !u.isDeleted() && u.getCumulativeSuspendDays() >= threshold)
+                .map(User::getId)
+                .sorted()
+                .limit(limit)
+                .toList();
+    }
 }

--- a/src/test/java/com/sseulang/domain/user/application/UserApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/user/application/UserApplicationServiceTest.java
@@ -263,4 +263,105 @@ class UserApplicationServiceTest {
                 .as("countActive 별도 쿼리라 이중 차감 없음 — 이전 (total - blocked - deleted) 방식이면 -4 였을 케이스")
                 .isEqualTo(1L);
     }
+
+    // ───────── 라운드 12 PR-F #8 — 활동 정지 누적 200일 자동 탈퇴 ─────────
+
+    @org.junit.jupiter.api.Nested
+    @DisplayName("adminSuspend / processAutoWithdrawal — 200일 누적 자동 탈퇴")
+    class AutoWithdraw {
+
+        private InMemoryFakeUserRepository userRepo;
+        private CapturingEmailSender mailFake;
+        private com.sseulang.domain.auth.application.NoOpRefreshTokenStore rtStore;
+        private UserApplicationService svc;
+
+        @org.junit.jupiter.api.BeforeEach
+        void setUp() {
+            userRepo = new InMemoryFakeUserRepository();
+            mailFake = new CapturingEmailSender();
+            rtStore = new com.sseulang.domain.auth.application.NoOpRefreshTokenStore();
+            svc = new UserApplicationService(
+                    userRepo,
+                    new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(),
+                    new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(),
+                    rtStore,
+                    mailFake,
+                    java.time.Clock.systemDefaultZone()
+            );
+        }
+
+        @Test
+        @DisplayName("adminSuspend_누적 200 미만은 자동 탈퇴 X")
+        void adminSuspend_미달() {
+            User u = userRepo.save(User.createSocialUser(SocialProvider.KAKAO, "k-1", EMAIL, "n", null));
+            svc.adminSuspend(u.getId(), 50);
+            svc.adminSuspend(u.getId(), 100);
+
+            assertThat(u.getCumulativeSuspendDays()).isEqualTo(150);
+            assertThat(u.isDeleted()).isFalse();
+            assertThat(mailFake.toCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("adminSuspend_누적 200 도달_markAutoWithdrawn + 안내 메일 발송")
+        void adminSuspend_도달_자동탈퇴() {
+            User u = userRepo.save(User.createSocialUser(SocialProvider.KAKAO, "k-2", EMAIL, "n", null));
+            svc.adminSuspend(u.getId(), 199);
+            assertThat(u.isDeleted()).as("199일은 아직 미만").isFalse();
+            assertThat(mailFake.toCount()).isZero();
+
+            svc.adminSuspend(u.getId(), 1);  // 누적 200
+
+            assertThat(u.isDeleted()).as("정확히 200 도달 시 자동 탈퇴").isTrue();
+            assertThat(u.getCumulativeSuspendDays()).isEqualTo(200);
+            assertThat(mailFake.toCount()).isOne();
+            assertThat(mailFake.lastTo).isEqualTo(EMAIL.value());
+            assertThat(mailFake.lastDays).isEqualTo(200);
+        }
+
+        @Test
+        @DisplayName("processAutoWithdrawal_이미 deleted 또는 미달 user 는 no-op")
+        void processAutoWithdrawal_noop() {
+            User u = userRepo.save(User.createSocialUser(SocialProvider.KAKAO, "k-3", EMAIL, "n", null));
+
+            assertThat(svc.processAutoWithdrawal(u.getId())).as("미달").isFalse();
+            assertThat(mailFake.toCount()).isZero();
+
+            u.suspend(300, java.time.LocalDateTime.now());
+            u.markAutoWithdrawn();
+            assertThat(svc.processAutoWithdrawal(u.getId())).as("이미 deleted").isFalse();
+            assertThat(mailFake.toCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("findAutoWithdrawTargetIds_200 이상 + 살아있는 user 만 반환")
+        void findTargets_filter() {
+            User a = userRepo.save(User.createSocialUser(SocialProvider.KAKAO, "k-a", new Email("a@x.com"), "n", null));
+            User b = userRepo.save(User.createSocialUser(SocialProvider.KAKAO, "k-b", new Email("b@x.com"), "n", null));
+            User c = userRepo.save(User.createSocialUser(SocialProvider.KAKAO, "k-c", new Email("c@x.com"), "n", null));
+            User d = userRepo.save(User.createSocialUser(SocialProvider.KAKAO, "k-d", new Email("d@x.com"), "n", null));
+
+            a.suspend(199, java.time.LocalDateTime.now());  // 미달
+            b.suspend(200, java.time.LocalDateTime.now());  // 대상
+            c.suspend(500, java.time.LocalDateTime.now());  // 대상
+            d.suspend(300, java.time.LocalDateTime.now());
+            d.markAutoWithdrawn();                            // 이미 처리됨
+
+            assertThat(svc.findAutoWithdrawTargetIds(100))
+                    .containsExactlyInAnyOrder(b.getId(), c.getId());
+        }
+    }
+
+    /** EmailSender 호출 capture — 발송 검증용 fake. */
+    private static class CapturingEmailSender implements com.sseulang.domain.auth.domain.EmailSender {
+        private final java.util.List<String> tos = new java.util.ArrayList<>();
+        String lastTo;
+        int lastDays;
+        @Override public void sendVerificationEmail(String to, String url) { }
+        @Override public void sendInquiryReplyEmail(String to, String s, String h) { }
+        @Override public void sendAutoWithdrawnEmail(String to, int days) {
+            tos.add(to); lastTo = to; lastDays = days;
+        }
+        int toCount() { return tos.size(); }
+    }
 }

--- a/src/test/java/com/sseulang/domain/user/domain/UserTest.java
+++ b/src/test/java/com/sseulang/domain/user/domain/UserTest.java
@@ -3,6 +3,8 @@ package com.sseulang.domain.user.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -96,5 +98,44 @@ class UserTest {
     void hasPassword_소셜() {
         User social = User.createSocialUser(SocialProvider.KAKAO, "k-1", EMAIL, "kakao", null);
         assertThat(social.hasPassword()).isFalse();
+    }
+
+    @Test
+    @DisplayName("suspend_여러번 호출시 cumulativeSuspendDays 합산")
+    void suspend_누적_합산() {
+        User u = User.createSocialUser(SocialProvider.KAKAO, "k-2", EMAIL, "n", null);
+        LocalDateTime now = LocalDateTime.now();
+        u.suspend(7, now);
+        u.suspend(30, now.plusDays(10));
+        u.suspend(60, now.plusDays(50));
+        assertThat(u.getCumulativeSuspendDays()).isEqualTo(97);
+    }
+
+    @Test
+    @DisplayName("isAutoWithdrawTarget_누적 200 미만은 false")
+    void isAutoWithdrawTarget_미달() {
+        User u = User.createSocialUser(SocialProvider.KAKAO, "k-3", EMAIL, "n", null);
+        u.suspend(150, LocalDateTime.now());
+        assertThat(u.isAutoWithdrawTarget()).isFalse();
+    }
+
+    @Test
+    @DisplayName("isAutoWithdrawTarget_누적 200 도달은 true (경계 포함)")
+    void isAutoWithdrawTarget_경계() {
+        User u = User.createSocialUser(SocialProvider.KAKAO, "k-4", EMAIL, "n", null);
+        u.suspend(100, LocalDateTime.now());
+        u.suspend(100, LocalDateTime.now().plusDays(50));
+        assertThat(u.getCumulativeSuspendDays()).isEqualTo(200);
+        assertThat(u.isAutoWithdrawTarget()).isTrue();
+    }
+
+    @Test
+    @DisplayName("isAutoWithdrawTarget_이미 deleted 이면 false")
+    void isAutoWithdrawTarget_이미_탈퇴() {
+        User u = User.createSocialUser(SocialProvider.KAKAO, "k-5", EMAIL, "n", null);
+        u.suspend(250, LocalDateTime.now());
+        u.markAutoWithdrawn();
+        assertThat(u.isDeleted()).isTrue();
+        assertThat(u.isAutoWithdrawTarget()).isFalse();
     }
 }

--- a/src/test/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationServiceTest.java
@@ -40,7 +40,7 @@ class WithdrawalApplicationServiceTest {
         withdrawalRepo = new InMemoryFakeWithdrawalRepository();
         userRepo = new InMemoryFakeUserRepository();
         historyRepo = new InMemoryFakePointHistoryRepository();
-        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), java.time.Clock.systemDefaultZone());
+        UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), new com.sseulang.domain.auth.application.NoOpEmailSender(), java.time.Clock.systemDefaultZone());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, historyRepo);
         // self 는 REQUIRES_NEW proxy 용 — 단위 테스트엔 Spring 컨텍스트 없으니 자기 자신을 주입.
         // 단위 테스트의 InMemoryFake 는 deadlock/duplicate 던지지 않으므로 catch 경로 미진입.

--- a/src/test/java/com/sseulang/domain/withdrawal/integration/WithdrawalSettlementIT.java
+++ b/src/test/java/com/sseulang/domain/withdrawal/integration/WithdrawalSettlementIT.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         UserRepositoryImpl.class,
         UserApplicationService.class,
         com.sseulang.domain.auth.application.NoOpRefreshTokenStore.class,
+        com.sseulang.domain.auth.application.NoOpEmailSender.class,
         PointHistoryRepositoryImpl.class,
         PointApplicationService.class,
         WithdrawalRepositoryImpl.class,


### PR DESCRIPTION
## Summary
- 활동 정지 누적 일수 ≥ 200 도달 시 자동 soft delete + 안내 메일 (`A, 자동 탈퇴 후 고객 이메일로 명시` 결정)
- 1차 트리거는 `adminSuspend` 직후 동기 분기, 안전망으로 매일 새벽 1시 KST 스케줄러
- 메일 발송 실패는 swallow — soft delete 자체는 트랜잭션 commit 으로 확정

## 변경 영역
- `V24__user_cumulative_suspend.sql` — `users.cumulative_suspend_days INT NOT NULL DEFAULT 0` + 인덱스
- `User.suspend(days, now)` — `cumulativeSuspendDays += days` 누적
- `User.isAutoWithdrawTarget()` — `!deleted && cumulative >= 200` (경계 inclusive)
- `User.markAutoWithdrawn()` — soft delete (deleted=true)
- `UserApplicationService.adminSuspend` — suspend 직후 isAutoWithdrawTarget 체크 → mark + email
- `UserApplicationService.processAutoWithdrawal` + `findAutoWithdrawTargetIds` — 배치 후크
- `AutoWithdrawalScheduler` — `@Scheduled(cron = "0 0 1 * * *")` 청크 100 단위
- `EmailSender.sendAutoWithdrawnEmail` 신규 + Log/Smtp 어댑터 구현

## Test plan
- [x] User Aggregate 단위 테스트 — 누적 합산 / 경계 200 / 이미 탈퇴 user 는 false
- [x] UserApplicationService 단위 — adminSuspend 200 도달 시 mark + email 1회
- [x] processAutoWithdrawal no-op (미달 / 이미 deleted)
- [x] findAutoWithdrawTargetIds 필터 (≥200 + alive 만)
- [x] `./gradlew test` 721 PASS / 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)