### PR TITLE
feat: round 12 PR-D 잔여 — 판매/대여 이중 등록 + 주석 정리

### DIFF
--- a/src/main/java/com/sseulang/domain/admin/application/AdminApplicationService.java
+++ b/src/main/java/com/sseulang/domain/admin/application/AdminApplicationService.java
@@ -9,17 +9,6 @@ import com.sseulang.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Admin 본인 정보 조회용 read-only 서비스. 로그인 흐름은 {@link AdminLoginService} 가 담당.
- *
- * <p><b>admin 권한 두 출처 모두 처리</b>:
- * <ul>
- *   <li>{@code admins} 테이블 — username/password 로 로그인한 admin (subject=admin.id)</li>
- *   <li>{@code users} 테이블 — OAuth allowlist 매치 사용자 ({@code app.admin.user-emails}, subject=user.id)</li>
- * </ul>
- * SecurityConfig admin chain 은 JWT role=ADMIN 만 검증하므로 두 출처 모두 같은 chain 통과.
- * 본 서비스가 subject id 로 두 테이블 순차 조회 — admins 우선, 없으면 users fallback.</p>
- */
 @Service
 @Transactional(readOnly = true)
 public class AdminApplicationService {
@@ -35,17 +24,15 @@ public class AdminApplicationService {
         this.userService = userService;
     }
 
-    /**
-     * subject id 로 admin 본인 정보 조회. admins 테이블 우선, 없으면 OAuth allowlist 매치 user 로 fallback.
-     * 양쪽 모두 미존재 시 USER_NOT_FOUND.
-     */
+    
+
     public AdminMeResponse getMe(Long subjectId) {
         Admin admin = adminRepository.findById(subjectId).orElse(null);
         if (admin != null) {
             return AdminMeResponse.from(admin);
         }
-        // OAuth allowlist 매치 admin — users 테이블 fallback. UserApplicationService.getById 가
-        // 미존재 시 USER_NOT_FOUND throw 라 양쪽 fail 시 동일 에러로 노출.
+        
+        
         var user = userService.getById(subjectId);
         return AdminMeResponse.fromUser(user);
     }

--- a/src/main/java/com/sseulang/domain/admin/application/AdminLoginService.java
+++ b/src/main/java/com/sseulang/domain/admin/application/AdminLoginService.java
@@ -13,25 +13,13 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
-/**
- * 관리자 로그인 — username + BCrypt password 검증 → JWT 발급 (subject=admin.id, role=ADMIN).
- *
- * <p>일반 사용자 로그인 ({@link com.sseulang.domain.auth.application.OAuthLoginService}) 와 별도로
- * 관리하지만, JWT 발급 / RefreshTokenStore 인프라는 공유. 관리자가 발급받은 토큰의 subject 는
- * {@code admin.id}, role 은 {@code ADMIN} — admin chain 의 ROLE_ADMIN 가드와 정합.</p>
- *
- * <p>실패 응답은 {@link ErrorCode#AUTH_LOGIN_FAILED} 로 통일 (username 존재 여부 노출 X, CLAUDE.md §4 보안 룰).</p>
- */
 @Service
 public class AdminLoginService {
 
     private static final String ADMIN_ROLE = "ADMIN";
 
-    /**
-     * username enumeration timing 공격 방어용 sentinel 평문.
-     * <p>실제 admin password 와 충돌 가능성을 사실상 0 으로 만들기 위해 긴 random sentinel 사용.
-     * 충돌하더라도 admin 측에서 isActive() 체크 + role 차원 격리로 부수 피해 없음.</p>
-     */
+    
+
     private static final String DUMMY_PASSWORD_PLAINTEXT = "__sseulang_dummy_admin_sentinel_v1__";
 
     private final AdminRepository adminRepository;
@@ -39,11 +27,8 @@ public class AdminLoginService {
     private final JwtProvider jwtProvider;
     private final RefreshTokenStore refreshTokenStore;
     private final Duration refreshTokenTtl;
-    /**
-     * username 미존재 / inactive 분기에서도 동일 비용으로 {@code matches()} 를 강제하기 위한 dummy hash.
-     * 생성자에서 주입된 {@link PasswordEncoder} 로 직접 encode — 하드코딩 시 인코더 종류 / 형식 어긋남
-     * 위험을 제거하고 항상 유효 형식 보장 (게이트 2 보강). 시작 시 1회 BCrypt 비용 ~50ms.
-     */
+    
+
     private final String dummyPasswordHash;
 
     public AdminLoginService(
@@ -66,7 +51,7 @@ public class AdminLoginService {
             throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
         }
         Admin admin = adminRepository.findByUsername(username).orElse(null);
-        // 미존재여도 dummy hash 로 항상 BCrypt 를 돌려 timing 균일화 (단락 평가 X).
+        
         String hashToCompare = (admin != null) ? admin.getPassword() : dummyPasswordHash;
         boolean passwordOk = passwordEncoder.matches(password, hashToCompare);
 

--- a/src/main/java/com/sseulang/domain/admin/domain/Admin.java
+++ b/src/main/java/com/sseulang/domain/admin/domain/Admin.java
@@ -11,12 +11,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * Admin Aggregate Root. V1 스키마 {@code admins} 매핑.
- *
- * <p>일반 사용자 ({@code users}) 와 별도 테이블로 관리. 관리자 인증 흐름은
- * {@code AdminLoginService} 가 username + BCrypt password 검증 + JWT 발급 (subject=admin.id, role=ADMIN).</p>
- */
 @Entity
 @Table(name = "admins")
 @Getter

--- a/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
+++ b/src/main/java/com/sseulang/domain/admin/presentation/AdminAuthController.java
@@ -16,10 +16,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 관리자 로그인 진입점. SecurityConfig 의 {@code /api/v1/auth/**} permitAll 영역.
- * 일반 사용자 OAuth 흐름 ({@link com.sseulang.domain.auth.presentation.AuthController}) 와 분리.
- */
 @Tag(name = "AdminAuth", description = "관리자 로그인")
 @RestController
 @RequestMapping("/api/v1/auth/admin")

--- a/src/main/java/com/sseulang/domain/admin/presentation/AdminMeController.java
+++ b/src/main/java/com/sseulang/domain/admin/presentation/AdminMeController.java
@@ -10,10 +10,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 관리자 본인 정보 조회 — admin chain ROLE_ADMIN 강제 ({@code /api/v1/admin/**}).
- * 일반 사용자의 {@code GET /api/v1/users/me} 는 ROLE_USER 만 허용 (ADMIN 차단) 이라 admin 별도 endpoint.
- */
 @Tag(name = "AdminMe", description = "관리자 — 본인 정보")
 @RestController
 @RequestMapping("/api/v1/admin/me")

--- a/src/main/java/com/sseulang/domain/admin/presentation/dto/AdminMeResponse.java
+++ b/src/main/java/com/sseulang/domain/admin/presentation/dto/AdminMeResponse.java
@@ -3,12 +3,6 @@ package com.sseulang.domain.admin.presentation.dto;
 import com.sseulang.domain.admin.domain.Admin;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * 관리자 본인 정보 — 프론트가 admin 로그인 후 store 초기화에 사용.
- *
- * <p>일반 사용자 {@code MeResponse} 와 별도 — admin 은 잔액/리뷰/email 등 사용자 자원이 없고,
- * 시스템상 {@code admins} 와 {@code users} 테이블이 분리되어 있다 (admin chain ROLE_ADMIN 만 통과).</p>
- */
 @Schema(description = "관리자 본인 정보 (헤더/store 초기화용).")
 public record AdminMeResponse(
         @Schema(example = "1") Long id,
@@ -20,7 +14,7 @@ public record AdminMeResponse(
         return new AdminMeResponse(a.getId(), a.getUsername(), a.getName(), a.getRole());
     }
 
-    /** OAuth allowlist 매치 admin — users 테이블 기반. email 을 username 자리에, nickname 을 name 자리에. */
+    
     public static AdminMeResponse fromUser(com.sseulang.domain.user.domain.User u) {
         return new AdminMeResponse(u.getId(), u.getEmail(), u.getNickname(), "ADMIN");
     }

--- a/src/main/java/com/sseulang/domain/auth/application/EmailDispatchEventListener.java
+++ b/src/main/java/com/sseulang/domain/auth/application/EmailDispatchEventListener.java
@@ -8,17 +8,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-/**
- * 이메일 인증 메일 비동기 발송 listener. 트랜잭션 commit 후 발송 (follow-up #41 atomicity 보장):
- * <ul>
- *   <li>user / token 은 commit 된 후라 메일 발송 실패해도 dangling 없음</li>
- *   <li>발송 실패는 로깅만 — 사용자가 {@code /resend-verification} 으로 재시도</li>
- *   <li>{@code AFTER_COMMIT} phase — 트랜잭션 롤백 시 listener 호출 X (가입 실패 → 메일 발송 X)</li>
- * </ul>
- *
- * <p>현재는 동기 처리 (호출 스레드). 응답 지연 issue 발생 시 {@code @Async} 추가 또는 outbox
- * 패턴으로 교체.</p>
- */
 @Component
 public class EmailDispatchEventListener {
 
@@ -35,7 +24,7 @@ public class EmailDispatchEventListener {
         try {
             emailSender.sendVerificationEmail(event.email(), event.verificationUrl());
         } catch (RuntimeException e) {
-            // 가입은 이미 commit 됨 — 메일 발송 실패만 로깅. 사용자가 /resend-verification 으로 재시도.
+            
             log.error("[email-dispatch] 발송 실패 email={} reason={}", event.email(), e.getMessage(), e);
         }
     }

--- a/src/main/java/com/sseulang/domain/auth/application/EmailVerificationService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/EmailVerificationService.java
@@ -21,36 +21,21 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * 이메일 인증 토큰 발급 + 검증.
- *
- * <p>흐름:
- * <ol>
- *   <li>{@link #issueSignupToken} — 가입 직후 또는 재발송. 토큰 생성 → DB 저장 → 메일 발송.</li>
- *   <li>{@link #verifyToken} — 사용자가 메일 링크 클릭. 토큰 매칭 → 만료/재사용 가드 → user.markEmailVerified.</li>
- * </ol>
- *
- * <p>토큰: 32자 UUID (충돌/brute-force 안전). 만료: 24시간. 새 토큰 발급 시 같은 user 의 기존
- * 미사용 SIGNUP 토큰 모두 invalidate — 메일 폭탄 / 토큰 누적 차단 (게이트 1 round 2).
- * 재발송은 60초 cooldown.</p>
- */
 @Service
 @Transactional(readOnly = true)
 public class EmailVerificationService {
 
     private static final Duration TOKEN_TTL = Duration.ofHours(24);
-    /** 동일 user 의 인증 메일 재발송 최소 간격 — 메일 폭탄 방어 (게이트 1 round 2). */
+    
     private static final Duration RESEND_COOLDOWN = Duration.ofSeconds(60);
 
-    /**
-     * userId → 마지막 발송 시각. in-memory 단일 인스턴스 가정. 다중 인스턴스 배포 시 Redis-backed
-     * counter 로 교체 권장 (5/6 이후 후속). prod 1대 운영 기준 충분.
-     */
+    
+
     private final Map<Long, LocalDateTime> lastIssuedAt = new ConcurrentHashMap<>();
 
     private final EmailVerificationRepository verificationRepository;
     private final UserApplicationService userService;
-    private final EmailSender emailSender;  // 직접 호출은 deprecated — 이벤트 listener 가 발송 (follow-up #41)
+    private final EmailSender emailSender;  
     private final ApplicationEventPublisher eventPublisher;
     private final Clock clock;
     private final String verificationUrlBase;
@@ -72,20 +57,10 @@ public class EmailVerificationService {
         this.verificationUrlBase = verificationUrlBase;
     }
 
-    /**
-     * SIGNUP 토큰 발급 + 메일 발송. 호출 시:
-     * <ol>
-     *   <li>해당 user 의 기존 미사용 SIGNUP 토큰 모두 무효화 (구 토큰 누적 차단).</li>
-     *   <li>새 토큰 생성/저장/메일 발송.</li>
-     *   <li>userId 별 마지막 발송 시각 기록 — 재발송 cooldown 가드 기준.</li>
-     * </ol>
-     * 가입 직후 흐름 (LocalAuthService.signup) 에서도 호출되며, 가입 시점엔 기존 토큰이 없어 invalidate 는 no-op.
-     */
-    /**
-     * SIGNUP 토큰 발급 + 메일 발송 이벤트 발행 (follow-up #41 atomicity).
-     * 메일 발송은 트랜잭션 commit 후 별도 listener 가 처리 — 메일 시스템 다운 시에도
-     * user/token 은 보존, 사용자가 {@code /resend-verification} 으로 재시도 가능.
-     */
+    
+
+    
+
     @Transactional
     public void issueSignupToken(Long userId, String email) {
         LocalDateTime now = LocalDateTime.now(clock);
@@ -93,17 +68,13 @@ public class EmailVerificationService {
         String token = generateToken();
         LocalDateTime expiresAt = now.plus(TOKEN_TTL);
         verificationRepository.save(EmailVerification.issue(userId, token, VerificationPurpose.SIGNUP, expiresAt));
-        // AFTER_COMMIT 으로 발송 — 본 트랜잭션 롤백 시 메일 발송 X.
+        
         eventPublisher.publishEvent(new EmailDispatchRequestedEvent(email, verificationUrlBase + "?token=" + token));
         lastIssuedAt.put(userId, now);
     }
 
-    /**
-     * 토큰 검증 + user.markEmailVerified. 만료/재사용/없음 모두 명시 ErrorCode.
-     *
-     * <p>{@link EmailVerificationRepository#markUsedIfValid} atomic UPDATE 로 동시 검증 race 차단
-     * (follow-up #42). 정확히 1건만 1 rows affected — 다른 요청은 0 rows → 사유 분기.</p>
-     */
+    
+
     @Transactional
     public void verifyToken(String token) {
         if (token == null || token.isBlank()) {
@@ -112,7 +83,7 @@ public class EmailVerificationService {
         LocalDateTime now = LocalDateTime.now(clock);
         int affected = verificationRepository.markUsedIfValid(token, now);
         if (affected == 0) {
-            // 사유 분기 — 미존재 / 이미 사용 / 만료 중 정확한 ErrorCode 결정.
+            
             EmailVerification ver = verificationRepository.findByToken(token)
                     .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID));
             if (ver.isUsed()) {
@@ -121,26 +92,23 @@ public class EmailVerificationService {
             if (ver.isExpired(now)) {
                 throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_EXPIRED);
             }
-            // 정상적으론 도달 불가 — race 우승자 트랜잭션이 아직 commit 전 인 보기 드문 경우.
+            
             throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID);
         }
-        // atomic UPDATE 성공. user 조회 + verified 플래그 마킹.
+        
         EmailVerification ver = verificationRepository.findByToken(token)
                 .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID));
         User user = userService.getById(ver.getUserId());
         user.markEmailVerified();
     }
 
-    /**
-     * 인증 메일 재발송 — 본인 user 만 호출. 이미 verified 면 no-op (멱등).
-     * 직전 발송 후 {@link #RESEND_COOLDOWN} 이내 재호출은 {@code AUTH_VERIFICATION_RESEND_TOO_SOON} 거부 —
-     * 메일 폭탄 방어 (게이트 1 round 2).
-     */
+    
+
     @Transactional
     public void resendForUser(Long userId) {
         User user = userService.getById(userId);
         if (user.isEmailVerified()) {
-            return;  // 이미 인증된 사용자 — 토큰 발급/메일 발송 모두 skip
+            return;  
         }
         LocalDateTime now = LocalDateTime.now(clock);
         LocalDateTime last = lastIssuedAt.get(userId);
@@ -152,7 +120,7 @@ public class EmailVerificationService {
     }
 
     private static String generateToken() {
-        // 32자 UUID hex (대시 제거) — brute-force 안전한 충분한 entropy.
+        
         return UUID.randomUUID().toString().replace("-", "");
     }
 }

--- a/src/main/java/com/sseulang/domain/auth/application/LocalAuthService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/LocalAuthService.java
@@ -17,20 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
-/**
- * LOCAL (email + password) 가입/로그인 흐름. OAuth 와 분리된 별도 service.
- *
- * <p>보안 정책:
- * <ul>
- *   <li>가입: BCrypt 해싱 후 저장. 사전 email 중복 체크 + UNIQUE race 패배자 보정.</li>
- *   <li>로그인: 미존재 user / 차단 / 비밀번호 불일치 모두 {@link ErrorCode#AUTH_LOGIN_FAILED} 통합 응답
- *       (email 존재 여부 leak 방지). dummy hash 로 timing 균일화 (미존재 user 분기에서도 BCrypt 비용
- *       태움 — username enumeration timing 공격 방어, AdminLogin 패턴과 동일).</li>
- *   <li>비밀번호 정책: 8자 이상, 72자 이하 (BCrypt 72-byte limit).</li>
- * </ul>
- *
- * <p>가입 직후 자동 JWT 발급 — 별도 로그인 호출 없이 즉시 인증된 세션. OAuth 흐름과 동일.</p>
- */
 @Service
 public class LocalAuthService {
 
@@ -38,10 +24,8 @@ public class LocalAuthService {
     private static final int MIN_PASSWORD_LENGTH = 8;
     private static final int MAX_PASSWORD_LENGTH = 72;
 
-    /**
-     * username enumeration timing 공격 방어용 sentinel. 미존재 user 분기에서도 BCrypt cost 를
-     * 강제 태우기 위해 항상 호출. AdminLoginService 와 동일 패턴.
-     */
+    
+
     private static final String DUMMY_PASSWORD_PLAINTEXT = "__sseulang_dummy_user_sentinel_v1__";
 
     private final UserRepository userRepository;
@@ -51,9 +35,8 @@ public class LocalAuthService {
     private final RefreshTokenStore refreshTokenStore;
     private final EmailVerificationService verificationService;
     private final Duration refreshTokenTtl;
-    /**
-     * 생성자 시점에 실제 인코더로 encode — 하드코딩 시 인코더 변경/형식 깨짐 위험 제거 (게이트 2 보강).
-     */
+    
+
     private final String dummyPasswordHash;
 
     public LocalAuthService(
@@ -75,19 +58,13 @@ public class LocalAuthService {
         this.dummyPasswordHash = passwordEncoder.encode(DUMMY_PASSWORD_PLAINTEXT);
     }
 
-    /**
-     * LOCAL 가입 + 자동 로그인. email 중복 시 {@link ErrorCode#USER_EMAIL_DUPLICATED} (다른 provider
-     * 로 이미 가입돼있어도 동일 — 가이드 §12 정책).
-     *
-     * <p>{@code @Transactional} — user 저장 + 인증 토큰 발급을 한 트랜잭션으로 묶어 atomicity 보장
-     * (follow-up #41). 메일 발송은 트랜잭션 commit 후 별도 listener 가 처리 — 메일 다운 시에도
-     * user/token 보존, 재발송으로 회복 가능.</p>
-     */
+    
+
     @Transactional
     public TokenPair signup(Email email, String rawPassword, String nickname) {
         validatePassword(rawPassword);
 
-        // 사전 중복 체크 (fast path) — UNIQUE race 의 1차 가드. 마지막 가드는 DB UNIQUE.
+        
         userRepository.findByEmail(email).ifPresent(u -> {
             throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);
         });
@@ -97,53 +74,48 @@ public class LocalAuthService {
         try {
             saved = userRepository.save(User.createLocalUser(email, hashed, nickname));
         } catch (DataIntegrityViolationException race) {
-            // UNIQUE race 패배 — 다른 트랜잭션이 같은 email 로 먼저 가입. 명시 거부 (다른 제약 위반은 원본 throw).
+            
             if (userRepository.findByEmail(email).isPresent()) {
                 throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);
             }
             throw race;
         }
-        // 가입 직후 인증 메일 발송. 사용자는 verified=false 상태로 자동 로그인되며, 민감 기능은
-        // verified=true 가 될 때까지 차단 (UserApplicationService.requireVerified).
+        
+        
         verificationService.issueSignupToken(saved.getId(), saved.getEmail());
         return issueTokens(saved);
     }
 
-    /**
-     * LOCAL 로그인. 미존재 user / 비밀번호 불일치 / 차단·삭제 계정 모두 동일 응답으로 통합 —
-     * email 존재 여부 / 계정 상태 leak 차단. dummy hash 로 BCrypt timing 균일.
-     */
+    
+
     public TokenPair login(Email email, String rawPassword) {
         if (rawPassword == null || rawPassword.isEmpty()) {
             throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
         }
-        // BCrypt 72-byte 초과 입력은 truncation 위험 — login 도 byte 가드 (signup 과 동일).
-        // 실패는 LOGIN_FAILED 통합 (이메일 존재 여부 leak 방지, AdminLogin 패턴).
+        
+        
         if (rawPassword.length() > MAX_PASSWORD_LENGTH
                 || rawPassword.getBytes(StandardCharsets.UTF_8).length > MAX_PASSWORD_LENGTH) {
             throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
         }
         User user = userRepository.findByEmail(email).orElse(null);
-        // 미존재 / 비번 미보유(소셜 가입자) 계정에서도 dummy hash 로 BCrypt cost 강제.
+        
         String hashToCompare = (user != null && user.hasPassword()) ? user.getPassword() : dummyPasswordHash;
         boolean passwordOk = passwordEncoder.matches(rawPassword, hashToCompare);
 
-        // SUSPENDED (시한부 정지) 도 LOGIN_FAILED 로 통합 — 정지 사실 leak 방지 + 기존 패스워드로 우회 차단
-        // (Codex round 9 hotfix). isAccessibleAt 은 blocked/deleted/suspended 통합 가드.
+        
+        
         boolean accessible = user != null && user.isAccessibleAt(java.time.LocalDateTime.now());
         if (user == null || !user.hasPassword() || !accessible || !passwordOk) {
             throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
         }
-        // 휴면 판정 기준 — 응답 status 가 ACTIVE 로 자동 복귀.
+        
         userService.recordLogin(user.getId());
         return issueTokens(user);
     }
 
-    /**
-     * 비밀번호 길이 검증. BCrypt 는 평문을 UTF-8 인코딩한 byte 길이 72 까지만 처리하고 그 이상은
-     * 자동 truncation 됨 — char-length 만 보면 한글 등 multi-byte 문자가 통과되어 보안 약화 (게이트 1).
-     * char + UTF-8 byte 둘 다 검증.
-     */
+    
+
     private void validatePassword(String rawPassword) {
         if (rawPassword == null
                 || rawPassword.length() < MIN_PASSWORD_LENGTH

--- a/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/OAuthLoginService.java
@@ -24,27 +24,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/**
- * 소셜 로그인 흐름 — provider 검증 → user 조회/생성 → JWT 발급 + RT 저장.
- *
- * <p>기본 role 은 "USER". 별도로 {@code app.admin.user-emails} 화이트리스트에 매치되는 email 의
- * OAuth user 는 role="ADMIN" 으로 JWT 발급 — 본인 SSO 로 admin 페이지 접근 가능. admin 페이지의
- * 별도 username/password 로그인 ({@code admins} 테이블) 흐름과 병존.</p>
- *
- * <p><b>권한 회수 운영 절차 (게이트 1 W-1)</b>: allowlist 에서 email 제거만으로는 이미 발급된
- * AT(30분) / RT(7일) 가 즉시 무효화되지 않는다 — 발급 시점 기준이라 그 후 refresh 도 ADMIN role 로
- * rotate 된다. 운영자가 즉시 권한 회수가 필요하면:
- * <ol>
- *   <li>{@code ADMIN_USER_EMAILS} 환경변수에서 해당 email 제거 + 재배포 (이후 신규 로그인은 USER)</li>
- *   <li>{@code RefreshTokenStore.revokeAll("ADMIN", userId)} 호출 — RT 무효화 (Redis tv INCR)</li>
- *   <li>해당 사용자에게 강제 logout 안내 — AT 30분 만료까지는 잔존</li>
- * </ol>
- * R1 follow-up: 운영자 일괄 revoke endpoint (admin 측에서 호출) 추가 검토.</p>
- *
- * <p>클래스 단위 {@code @Transactional} 의도적으로 미적용 — 가이드 §3.10 "외부 API 호출은 트랜잭션
- * 밖에서". UserApplicationService 가 자체 트랜잭션을 가지며, RefreshTokenStore.save 는 Redis 라
- * JPA 트랜잭션 밖. AT 발급은 stateless.</p>
- */
 @Slf4j
 @Service
 public class OAuthLoginService {
@@ -58,10 +37,8 @@ public class OAuthLoginService {
     private final RefreshTokenStore refreshTokenStore;
     private final Duration refreshTokenTtl;
 
-    /**
-     * 본인 OAuth 로그인 시 ROLE_ADMIN JWT 를 발급할 email 화이트리스트 (lowercase 정규화).
-     * 빈 set 이면 모두 USER 로 발급. {@code app.admin.user-emails} (콤마구분) 에서 주입.
-     */
+    
+
     private final Set<String> adminUserEmails;
 
     public OAuthLoginService(
@@ -104,8 +81,8 @@ public class OAuthLoginService {
         try {
             info = impl.exchangeCodeAndFetch(code, redirectUri);
         } catch (ExternalApiException e) {
-            // 외부 인프라 예외 → 사용자 응답은 AUTH_OAUTH_FAILED 통일.
-            // 원인은 cause 에 보존 + 운영용 로그.
+            
+            
             log.warn("OAuth provider {} 호출 실패: {}", provider, e.getExternalServiceName(), e);
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
@@ -118,17 +95,17 @@ public class OAuthLoginService {
                 info.profileImage()
         );
 
-        // SUSPENDED (시한부 정지) 도 USER_BLOCKED 통합 — Codex round 9 hotfix.
+        
         if (!user.isAccessibleAt(java.time.LocalDateTime.now())) {
             throw new BusinessException(ErrorCode.USER_BLOCKED);
         }
 
-        // 휴면 판정 기준 — 응답 status 가 ACTIVE 로 자동 복귀.
+        
         userService.recordLogin(user.getId());
 
-        // role 결정 — email allowlist 매치 시 ADMIN, 아니면 기본 USER.
-        // RefreshTokenStore 의 (role,userId) 격리 — 같은 userId 가 USER/ADMIN 양쪽 RT 보유 가능하지만
-        // 일반적으로 마지막 로그인 흐름의 role 만 사용 (logout-rotate 가 cleanup).
+        
+        
+        
         String role = isAdminEmail(user.getEmail()) ? ADMIN_ROLE : DEFAULT_ROLE;
         if (ADMIN_ROLE.equals(role)) {
             log.warn("[admin-oauth][PROMOTE] OAuth user.id={} email={} → role=ADMIN JWT 발급",
@@ -136,7 +113,7 @@ public class OAuthLoginService {
         }
 
         String at = jwtProvider.issueAccessToken(user.getId(), role);
-        // tv: store 의 현재 버전을 RT claim 에 박는다. 이후 revokeAll → INCR 시 본 RT 는 mismatch 로 거부됨.
+        
         long tv = refreshTokenStore.currentTokenVersion(role, user.getId());
         String rt = jwtProvider.issueRefreshToken(user.getId(), role, tv);
         String rtJti = jwtProvider.parse(rt).jti();

--- a/src/main/java/com/sseulang/domain/auth/application/RefreshTokenRotationService.java
+++ b/src/main/java/com/sseulang/domain/auth/application/RefreshTokenRotationService.java
@@ -14,15 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.Duration;
 
-/**
- * Auth 세션 lifecycle.
- *
- * <ul>
- *   <li>{@code rotate}: oldRT 를 atomic 하게 consume → 통과 시 새 AT/RT 발급. 재사용 탐지 시 전체 폐기.</li>
- *   <li>{@code logout}: AT jti 를 블랙리스트에 등록 + RT 폐기. 만료/변조 토큰은 조용히 무시.</li>
- *   <li>{@code revoke}: RT 단일 폐기 — 내부용 호환 (logout 이 권장).</li>
- * </ul>
- */
 @Service
 @Transactional
 public class RefreshTokenRotationService {
@@ -53,26 +44,26 @@ public class RefreshTokenRotationService {
     }
 
     public TokenPair rotate(String oldRefreshToken) {
-        JwtClaims claims = jwtProvider.parse(oldRefreshToken);  // AUTH_TOKEN_EXPIRED / INVALID
+        JwtClaims claims = jwtProvider.parse(oldRefreshToken);  
         Long userId = claims.userId();
         String role = claims.role();
         String oldJti = claims.jti();
         Long claimTv = claims.tokenVersion();
         if (role == null || role.isBlank() || claimTv == null) {
-            // RT 에 role / tv 누락 — 토큰 변조 또는 구버전 토큰. 보수적으로 INVALID 응답.
+            
             throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
         }
 
-        // atomic Lua: (1) claimTv == currentTv 검증, (2) jti DEL.
-        // false = (a) 버전 mismatch (revokeAll 이후) 또는 (b) 이미 사용된 jti → 탈취 의심.
+        
+        
         if (!refreshTokenStore.consume(role, userId, oldJti, claimTv)) {
             refreshTokenStore.revokeAll(role, userId);
             throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
         }
 
-        // SUSPENDED/blocked/deleted 사용자의 RT 재사용 차단 — Codex round 9 hotfix.
-        // ROLE_USER 만 검사 (admin 은 admins 테이블 + 정지 메커니즘 없음). user 미존재는 무시 —
-        // RT consume 통과한 시점이라 race 외엔 정상 미존재 케이스 없음. accessible=false 일 때만 차단.
+        
+        
+        
         if (USER_ROLE.equals(role)) {
             var userOpt = userRepository.findById(userId);
             if (userOpt.isPresent() && !userOpt.get().isAccessibleAt(java.time.LocalDateTime.now(clock))) {
@@ -103,11 +94,11 @@ public class RefreshTokenRotationService {
             JwtClaims claims = jwtProvider.parse(refreshToken);
             String role = claims.role();
             if (role == null || role.isBlank()) {
-                return;  // role 누락 토큰은 어차피 rotate 거부됨
+                return;  
             }
             refreshTokenStore.revoke(role, claims.userId(), claims.jti());
         } catch (BusinessException ignored) {
-            // 만료/변조 토큰은 어차피 사용 불가 — 조용히 흘려보냄
+            
         }
     }
 
@@ -122,7 +113,7 @@ public class RefreshTokenRotationService {
                 accessTokenBlacklist.blacklist(claims.jti(), Duration.ofSeconds(remainingSeconds));
             }
         } catch (BusinessException ignored) {
-            // 만료/변조 AT 는 어차피 필터에서 거부됨
+            
         }
     }
 }

--- a/src/main/java/com/sseulang/domain/auth/application/dto/TokenPair.java
+++ b/src/main/java/com/sseulang/domain/auth/application/dto/TokenPair.java
@@ -1,7 +1,4 @@
 package com.sseulang.domain.auth.application.dto;
 
-/**
- * Access / Refresh Token 한 쌍. ApplicationService 결과 DTO.
- */
 public record TokenPair(String accessToken, String refreshToken) {
 }

--- a/src/main/java/com/sseulang/domain/auth/application/event/EmailDispatchRequestedEvent.java
+++ b/src/main/java/com/sseulang/domain/auth/application/event/EmailDispatchRequestedEvent.java
@@ -1,13 +1,5 @@
 package com.sseulang.domain.auth.application.event;
 
-/**
- * 이메일 인증 메일 발송 요청 이벤트. {@link com.sseulang.domain.auth.application.EmailVerificationService}
- * 가 토큰 INSERT 후 발행. 별도 listener 가 {@code @TransactionalEventListener(AFTER_COMMIT)} 로
- * 받아 메일 발송 — 트랜잭션 commit 후 발송이라 메일 시스템 다운 시에도 user/token 은 보존,
- * 가입 자체는 차단되지 않음 (follow-up #41).
- *
- * <p>발송 실패는 로그만 — 사용자가 {@code /api/v1/auth/resend-verification} 으로 재시도 가능.</p>
- */
 public record EmailDispatchRequestedEvent(
         String email,
         String verificationUrl

--- a/src/main/java/com/sseulang/domain/auth/domain/AccessTokenBlacklist.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/AccessTokenBlacklist.java
@@ -2,22 +2,12 @@ package com.sseulang.domain.auth.domain;
 
 import java.time.Duration;
 
-/**
- * Access Token jti 블랙리스트 — 명시적 logout 시 즉시 폐기 흐름.
- *
- * AT 는 만료가 짧지만(30분) logout 직후의 위험 윈도우를 막기 위해 jti 단위로 폐기 가능해야 한다.
- * (가이드 §4.1 의 {@code AUTH_TOKEN_REVOKED} 사용 의도)
- *
- * 디바이스 단위 — 한 디바이스에서 logout 해도 다른 디바이스의 AT 는 유효.
- */
 public interface AccessTokenBlacklist {
 
-    /**
-     * jti 를 블랙리스트에 등록. TTL 은 보통 AT 의 잔여 만료시간으로 잡으면
-     * 자연 만료와 함께 자동 정리된다.
-     */
+    
+
     void blacklist(String jti, Duration ttl);
 
-    /** 블랙리스트 hit 인지 확인. */
+    
     boolean isBlacklisted(String jti);
 }

--- a/src/main/java/com/sseulang/domain/auth/domain/EmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/EmailSender.java
@@ -1,25 +1,15 @@
 package com.sseulang.domain.auth.domain;
 
-/**
- * 이메일 발송 추상화. 도메인 layer 인터페이스 — SMTP / SES / SendGrid 등 구현은 infrastructure.
- *
- * <p>본 PR scope: {@code LogEmailSender} (개발용 — 콘솔에 인증 URL 출력) 만 구현. prod SMTP
- * 어댑터는 5/6 이후 후속.</p>
- */
 public interface EmailSender {
 
-    /** 이메일 인증 토큰 발송. URL 은 호출자(EmailVerificationService) 가 token 으로 조립해 전달. */
+    
     void sendVerificationEmail(String toEmail, String verificationUrl);
 
-    /**
-     * 1:1 문의 답변 완료 알림 (round 8c #9). subject/text 모두 호출자 책임 — 본 어댑터는 발송만.
-     * SMTP 미설치 환경에선 LogEmailSender 가 콘솔 출력만 하고 안전 fallback.
-     */
+    
+
     void sendInquiryReplyEmail(String toEmail, String subject, String html);
 
-    /**
-     * 활동 정지 누적 200일 도달로 자동 탈퇴 처리되었음을 안내 (round 12 PR-F #8).
-     * 발송 실패는 호출자에서 swallow — 자동 탈퇴 자체는 이미 commit 된 상태.
-     */
+    
+
     void sendAutoWithdrawnEmail(String toEmail, int cumulativeSuspendDays);
 }

--- a/src/main/java/com/sseulang/domain/auth/domain/EmailVerification.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/EmailVerification.java
@@ -17,10 +17,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * 이메일 인증 토큰. 가입 직후 발급되고 사용자가 메일의 링크 클릭 시 verifyToken 으로 소진.
- * 한 user 가 여러 토큰 보유 가능 (재발송 시) — 검증 시 가장 최근 미사용 토큰 매칭.
- */
 @Entity
 @Table(name = "email_verifications")
 @Getter
@@ -54,7 +50,7 @@ public class EmailVerification extends BaseEntity {
             throw new IllegalArgumentException("userId 는 양수여야 합니다");
         }
         if (token == null || token.length() < TOKEN_LENGTH_MIN) {
-            // 짧은 토큰은 brute-force 위험 — 32자 이상 강제 (UUID + extra entropy 조합).
+            
             throw new IllegalArgumentException("token 은 " + TOKEN_LENGTH_MIN + "자 이상이어야 합니다");
         }
         if (purpose == null) {
@@ -71,14 +67,13 @@ public class EmailVerification extends BaseEntity {
         return v;
     }
 
-    /**
-     * 토큰 사용 처리. 만료 / 이미 사용된 토큰은 거부 (멱등 X — 재사용 차단).
-     */
+    
+
     public void markUsed(LocalDateTime now) {
         if (usedAt != null) {
             throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_INVALID);
         }
-        // 만료 경계는 닫힘 — expiresAt 와 같은 시각도 만료된 것으로 간주 (Codex 게이트 1 round 2 nit).
+        
         if (now == null || !now.isBefore(expiresAt)) {
             throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOKEN_EXPIRED);
         }
@@ -90,7 +85,7 @@ public class EmailVerification extends BaseEntity {
     }
 
     public boolean isExpired(LocalDateTime now) {
-        // expiresAt 시각 자체가 만료 경계 — !isBefore 로 닫힘 처리.
+        
         return now != null && !now.isBefore(expiresAt);
     }
 }

--- a/src/main/java/com/sseulang/domain/auth/domain/EmailVerificationRepository.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/EmailVerificationRepository.java
@@ -8,20 +8,11 @@ public interface EmailVerificationRepository {
 
     Optional<EmailVerification> findByToken(String token);
 
-    /**
-     * 해당 user 의 미사용 SIGNUP 토큰을 모두 used 처리. 새 토큰 발급 직전 호출 — 메일 폭탄/구토큰 누적 차단.
-     * 영향받은 행 수 반환.
-     */
+    
+
     int invalidateUnusedSignupTokens(Long userId, java.time.LocalDateTime now);
 
-    /**
-     * 토큰 단일 atomic 소진 (follow-up #42 race 차단).
-     *
-     * <p>{@code UPDATE email_verifications SET used_at=? WHERE token=? AND used_at IS NULL
-     * AND expires_at > ?} — 동시 두 요청이 같은 token 으로 도달해도 정확히 1건만 1 rows affected.
-     * 0 rows = 미존재 / 이미 사용 / 만료 — 호출자가 사유 분기 (선택).</p>
-     *
-     * @return 영향 행 수 (0 또는 1)
-     */
+    
+
     int markUsedIfValid(String token, java.time.LocalDateTime now);
 }

--- a/src/main/java/com/sseulang/domain/auth/domain/OAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/OAuthProvider.java
@@ -2,26 +2,11 @@ package com.sseulang.domain.auth.domain;
 
 import com.sseulang.domain.user.domain.SocialProvider;
 
-/**
- * 소셜 로그인 provider 추상화. 도메인 layer 인터페이스 — Spring/HTTP 의존 X.
- * 각 provider 별 구현(KAKAO/GOOGLE)은 {@code domain/auth/infrastructure/oauth} 에 위치.
- *
- * <h2>예외 계약</h2>
- * <ul>
- *   <li>외부 API 호출 자체 실패 (network / 5xx / parse 등 인프라성) →
- *       {@link com.sseulang.global.exception.ExternalApiException} (가이드 §3.10 anti-corruption).
- *       호출자(ApplicationService 등)가 정책에 맞춰 BusinessException 으로 변환.</li>
- *   <li>토큰 무효 / 동의 항목 누락 / 검증 안 된 이메일 / 응답 비정상 →
- *       {@code BusinessException(ErrorCode.AUTH_OAUTH_FAILED)}.</li>
- * </ul>
- */
 public interface OAuthProvider {
 
     SocialProvider supports();
 
-    /**
-     * Authorization Code Grant — code + redirectUri 로 provider token endpoint 호출,
-     * access_token 교환 후 user info 조회. Client Secret 켜져있어도 안전.
-     */
+    
+
     OAuthUserInfo exchangeCodeAndFetch(String code, String redirectUri);
 }

--- a/src/main/java/com/sseulang/domain/auth/domain/OAuthUserInfo.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/OAuthUserInfo.java
@@ -3,9 +3,6 @@ package com.sseulang.domain.auth.domain;
 import com.sseulang.domain.user.domain.Email;
 import com.sseulang.domain.user.domain.SocialProvider;
 
-/**
- * Provider API 가 돌려준 사용자 정보의 도메인 표현. profileImage 는 nullable.
- */
 public record OAuthUserInfo(
         SocialProvider provider,
         String providerId,

--- a/src/main/java/com/sseulang/domain/auth/domain/RefreshTokenStore.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/RefreshTokenStore.java
@@ -2,57 +2,23 @@ package com.sseulang.domain.auth.domain;
 
 import java.time.Duration;
 
-/**
- * Refresh Token 저장소 인터페이스. 도메인 layer 순수 POJO — Spring/JPA/Redis 의존 X.
- * 구현은 {@code domain/auth/infrastructure/persistence}.
- *
- * <p>Key 차원: {@code (role, userId, jti)} — 일반 사용자(role=USER) 와 관리자(role=ADMIN) 가
- * 동일 숫자 id 를 가질 수 있으므로 role 도 포함해야 세션 격리가 보장된다.</p>
- *
- * <h2>Token Version (게이트 1 race 보강)</h2>
- * 각 (role, userId) 마다 단조 증가 정수 {@code tokenVersion} 을 둔다.
- * <ul>
- *   <li>RT 발급 직전 {@link #currentTokenVersion} 으로 현재 값 조회 → JWT claim {@code tv} 로 박는다.</li>
- *   <li>{@link #revokeAll} 은 INCR 한 번으로 종료 (SCAN 없음). 이후 발급된 RT 의 claim.tv 와
- *       mismatch → consume 단계에서 즉시 거부.</li>
- *   <li>{@link #consume} 은 (claimTv == currentTv) 검증 + jti 폐기를 원자 실행 (Redis Lua).</li>
- * </ul>
- *
- * <p>이전 SCAN→DEL 구현은 revokeAll 도중 동시 save 된 RT 가 살아남는 race 가 있었다.
- * tokenVersion 은 키 검사 자체를 무력화하므로 race-free.</p>
- *
- * <h2>Rotation 정책</h2>
- * <ul>
- *   <li>발급: {@link #currentTokenVersion} → JWT 발급 → {@link #save}</li>
- *   <li>Rotation: {@link #consume} 으로 atomic 검증·폐기 (false 면 재사용 탐지)</li>
- *   <li>logout: {@link #revoke}</li>
- *   <li>재사용 탐지·강제 로그아웃: {@link #revokeAll} (INCR)</li>
- * </ul>
- */
 public interface RefreshTokenStore {
 
-    /**
-     * 현재 (role, userId) 의 tokenVersion 조회. 한 번도 revokeAll 호출되지 않았으면 0 반환.
-     * RT 발급 직전 호출하여 JWT claim {@code tv} 로 박는다.
-     */
+    
+
     long currentTokenVersion(String role, Long userId);
 
-    /** 발급 시 호출 — (role, userId, jti) 를 지정 TTL 로 저장. tv 는 JWT claim 에만 보관. */
+    
     void save(String role, Long userId, String jti, Duration ttl);
 
-    /**
-     * Rotation 의 핵심 — atomic 하게 (1) claimTv==currentTv 검증, (2) jti 폐기.
-     * 둘 다 통과하면 true. 아니면 false (= 버전 mismatch 또는 이미 폐기된 jti).
-     * isValid+revoke 두 단계를 Redis Lua 로 race 없이 합친 형태.
-     */
+    
+
     boolean consume(String role, Long userId, String jti, long claimTv);
 
-    /** 명시적 logout 등 — 단일 jti 폐기. 없어도 무방. */
+    
     void revoke(String role, Long userId, String jti);
 
-    /**
-     * 해당 (role, userId) 의 모든 Refresh Token 폐기 — INCR tokenVersion 한 번.
-     * 진행 중 동시 save 가 있어도 이후 consume 에서 모두 mismatch 로 거부됨.
-     */
+    
+
     void revokeAll(String role, Long userId);
 }

--- a/src/main/java/com/sseulang/domain/auth/domain/VerificationPurpose.java
+++ b/src/main/java/com/sseulang/domain/auth/domain/VerificationPurpose.java
@@ -1,6 +1,5 @@
 package com.sseulang.domain.auth.domain;
 
-/** 이메일 인증 토큰 용도. SIGNUP 만 본 PR scope, PASSWORD_RESET 등은 후속. */
 public enum VerificationPurpose {
     SIGNUP
 }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/email/LogEmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/email/LogEmailSender.java
@@ -7,17 +7,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-/**
- * 개발/테스트용 EmailSender — 실제 SMTP 호출 없이 로그에 인증 URL 만 출력.
- * prod 환경에서는 별도 SMTP 어댑터(SES/SendGrid) 가 등록되어야 한다 (5/6 이후 후속).
- *
- * <p>{@code @Profile({"local","dev","test"})} — 명시 allowlist. {@code @Profile("!prod")} 는
- * prod 프로필 누락(빈 active profile) 시 빈이 활성화돼 토큰 URL 이 운영 로그에 새는 회귀 위험.
- * prod 는 SMTP 어댑터 미등록 시 부팅 실패하도록 둔다 (게이트 1 round 2).</p>
- *
- * <p>또한 {@code app.email.smtp-enabled=true} 면 비활성 — local 에서도 SMTP 직접 테스트 가능하도록.
- * matchIfMissing=true 라 미설정 (local default) 은 LogEmailSender 활성화.</p>
- */
 @Component
 @Profile({"local", "dev", "test"})
 @ConditionalOnProperty(name = "app.email.smtp-enabled", havingValue = "false", matchIfMissing = true)

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSender.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/email/SmtpEmailSender.java
@@ -11,16 +11,6 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 
-/**
- * prod SMTP {@link EmailSender} 구현. Spring Mail (JavaMailSender) 사용.
- *
- * <p>활성화: {@code app.email.smtp-enabled=true} (prod 는 application-prod.yml 에서 강제 true,
- * local 은 .env 에서 SMTP 정보 채우면 켤 수 있음). false / 미설정 시 {@link LogEmailSender} 가 활성.
- * SMTP 설정은 {@code spring.mail.*} 환경변수 주입.</p>
- *
- * <p>발송 실패 시 {@link RuntimeException} 으로 throw — 호출자(LocalAuthService.signup) 가 회원 가입
- * 실패로 트랜잭션 롤백. 5/6 이후 outbox 패턴 도입 시 비동기 발송으로 변경 가능.</p>
- */
 @Component
 @ConditionalOnProperty(name = "app.email.smtp-enabled", havingValue = "true")
 public class SmtpEmailSender implements EmailSender {
@@ -69,7 +59,7 @@ public class SmtpEmailSender implements EmailSender {
         try {
             mailSender.send(message);
         } catch (MailException e) {
-            // 운영 모니터링 대상 — 5/6 이후 outbox 도입 시 비동기 retry 로 강화.
+            
             throw new RuntimeException("이메일 발송 실패: " + e.getMessage(), e);
         }
     }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/GoogleOAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/GoogleOAuthProvider.java
@@ -17,16 +17,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
-/**
- * 구글 Authorization Code → access_token 교환 + 사용자 정보 조회.
- *
- * <ol>
- *   <li>{@code POST https://oauth2.googleapis.com/token} — code/client_id/client_secret/redirect_uri</li>
- *   <li>{@code GET https://www.googleapis.com/oauth2/v3/userinfo} with Bearer access_token</li>
- * </ol>
- *
- * <p>{@code email_verified=false} 이면 보안상 인증 실패 처리.</p>
- */
 @Component
 public class GoogleOAuthProvider implements OAuthProvider {
 

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/KakaoOAuthProvider.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/oauth/KakaoOAuthProvider.java
@@ -17,18 +17,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
-/**
- * 카카오 Authorization Code → access_token 교환 + 사용자 정보 조회.
- *
- * <ol>
- *   <li>{@code POST https://kauth.kakao.com/oauth/token} — code/client_id/client_secret/redirect_uri</li>
- *   <li>{@code GET https://kapi.kakao.com/v2/user/me} with Bearer access_token</li>
- * </ol>
- *
- * <p>Client Secret 옵션이 켜져 있어도 안전 — 서버에서 secret 동봉. 프론트는 code 만 알면 됨.</p>
- *
- * <p>모든 실패(토큰 무효 / 네트워크 / 응답 파싱 / 동의 항목 누락)는 {@code AUTH_OAUTH_FAILED} 로 통일.</p>
- */
 @Component
 public class KakaoOAuthProvider implements OAuthProvider {
 
@@ -86,7 +74,7 @@ public class KakaoOAuthProvider implements OAuthProvider {
                     .retrieve()
                     .body(TokenResponse.class);
         } catch (RestClientException e) {
-            // 잘못된 code/redirectUri 도 카카오가 4xx 로 떨굼 — 인프라 + 비즈니스 분리 어려워 통합 처리.
+            
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
         if (res == null || res.accessToken() == null || res.accessToken().isBlank()) {
@@ -120,7 +108,7 @@ public class KakaoOAuthProvider implements OAuthProvider {
         if (email == null || nickname == null) {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }
-        // is_email_valid + is_email_verified 둘 다 true 만 허용.
+        
         if (!Boolean.TRUE.equals(account.isEmailValid()) || !Boolean.TRUE.equals(account.isEmailVerified())) {
             throw new BusinessException(ErrorCode.AUTH_OAUTH_FAILED);
         }

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/EmailVerificationJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/EmailVerificationJpaRepository.java
@@ -13,9 +13,8 @@ interface EmailVerificationJpaRepository extends JpaRepository<EmailVerification
 
     Optional<EmailVerification> findByToken(String token);
 
-    /**
-     * 단일 atomic UPDATE — 해당 user 의 미사용 SIGNUP 토큰 일괄 만료. 새 토큰 발급 직전 호출.
-     */
+    
+
     @Modifying
     @Query("""
             UPDATE EmailVerification v
@@ -26,10 +25,8 @@ interface EmailVerificationJpaRepository extends JpaRepository<EmailVerification
             """)
     int invalidateUnusedSignupTokens(@Param("userId") Long userId, @Param("now") LocalDateTime now);
 
-    /**
-     * 토큰 atomic 소진 — 동시 두 요청이 같은 token 으로 도달해도 1건만 성공 (follow-up #42).
-     * clearAutomatically + flushAutomatically 로 영속성 컨텍스트 동기화.
-     */
+    
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             UPDATE EmailVerification v

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisAccessTokenBlacklist.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisAccessTokenBlacklist.java
@@ -6,10 +6,6 @@ import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
 
-/**
- * Redis 백엔드. Key 패턴: {@code auth:atbl:{jti}} → marker "1", TTL = AT 잔여 만료시간.
- * jti 가 글로벌 유니크라 user 차원의 prefix 불필요.
- */
 @Repository
 public class RedisAccessTokenBlacklist implements AccessTokenBlacklist {
 

--- a/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStore.java
+++ b/src/main/java/com/sseulang/domain/auth/infrastructure/persistence/RedisRefreshTokenStore.java
@@ -10,46 +10,18 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 
-/**
- * Redis 백엔드.
- *
- * <h2>키 패턴</h2>
- * <ul>
- *   <li>{@code auth:rt:{ROLE}:{userId}:{jti}} → marker "1", TTL = RT 유효기간</li>
- *   <li>{@code auth:rtv:{ROLE}:{userId}} → 현재 tokenVersion (Long). 단조 증가, 부재 시 0 으로 간주.</li>
- * </ul>
- *
- * <h2>race-free 보장</h2>
- * <p>이전 SCAN→DEL 구현은 revokeAll 도중 동시 save 가 슬그머니 끼어들면 새 RT 가 살아남는 race
- * 가 있었다. 본 구현은 {@code consume} 을 Lua 로 (1) tokenVersion 검증, (2) jti DEL 한 번에
- * 묶어 race 를 제거한다. {@code revokeAll} 은 단순 INCR — 이후 발급된 RT 의 claim.tv 와
- * mismatch → consume 단계 즉시 거부. (게이트 1 보강)</p>
- *
- * <p>role 차원 격리는 동일 — user/admin 동일 숫자 id 공존 시 키 충돌 방지.</p>
- *
- * <p>TODO(Cluster): 추후 Redis Cluster 도입 시 multi-key Lua 가 같은 슬롯에 떨어지도록
- * hash tag {@code {ROLE:userId}} 적용 필요. 현재 standalone 사용으로 미적용.</p>
- */
 @Repository
 public class RedisRefreshTokenStore implements RefreshTokenStore {
 
     private static final String KEY_PREFIX = "auth:rt:";
     private static final String VERSION_KEY_PREFIX = "auth:rtv:";
     private static final String MARKER = "1";
-    /**
-     * revokeAll 직후 versionKey TTL — RT TTL(보통 7일) 보다 길게 잡아 사용자 재로그인 grace window 확보.
-     * 30일 비활성 시 rtv 도 자연 회수 (follow-up #34).
-     */
+    
+
     private static final Duration VERSION_KEY_TTL_AFTER_REVOKE = Duration.ofDays(30);
 
-    /**
-     * Lua: (1) currentTv 조회 (없으면 "0"), (2) claimTv 와 비교, (3) 일치하면 DEL jti 시도.
-     * <ul>
-     *   <li>반환 -1 = 버전 mismatch (revokeAll 이후 발급된 RT 가 아닌 구버전)</li>
-     *   <li>반환 0  = 버전은 맞지만 jti 가 이미 폐기됨 (재사용 탐지 시그널)</li>
-     *   <li>반환 1  = 정상 consume</li>
-     * </ul>
-     */
+    
+
     private static final RedisScript<Long> CONSUME_SCRIPT = new DefaultRedisScript<>(
             """
             local cur = redis.call('GET', KEYS[1])
@@ -75,7 +47,7 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
         try {
             return Long.parseLong(v);
         } catch (NumberFormatException e) {
-            // 손상된 값 — 보수적으로 0 처리 (다음 revokeAll 호출이 INCR 로 정상화).
+            
             return 0L;
         }
     }
@@ -83,8 +55,8 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
     @Override
     public void save(String role, Long userId, String jti, Duration ttl) {
         redis.opsForValue().set(jtiKey(role, userId, jti), MARKER, ttl);
-        // versionKey TTL = RT TTL — 비활성 사용자 rtv 잔존 차단 (follow-up #34).
-        // 기존 값 보존 + TTL 갱신 (없으면 "0" 으로 신규).
+        
+        
         String vKey = versionKey(role, userId);
         if (Boolean.TRUE.equals(redis.hasKey(vKey))) {
             redis.expire(vKey, ttl);
@@ -100,7 +72,7 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
                 List.of(versionKey(role, userId), jtiKey(role, userId, jti)),
                 Long.toString(claimTv)
         );
-        // result == 1 → consume 성공. -1 / 0 / null 모두 false (호출자가 revokeAll + INVALID 처리).
+        
         return result != null && result == 1L;
     }
 
@@ -111,11 +83,11 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
 
     @Override
     public void revokeAll(String role, Long userId) {
-        // INCR 한 방. 진행 중 동시 save 가 있어도 이후 consume 의 tv 검증에서 mismatch 로 거부.
-        // 폐기된 jti 키들은 TTL 만료까지 잔존하지만 의미상 무효 (consume 단계에서 막힘).
+        
+        
         String vKey = versionKey(role, userId);
         redis.opsForValue().increment(vKey);
-        // INCR 가 새 키 만들면 TTL=-1 — 비활성 사용자 누적 차단 위해 명시 expire (follow-up #34).
+        
         redis.expire(vKey, VERSION_KEY_TTL_AFTER_REVOKE);
     }
 

--- a/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/AuthController.java
@@ -74,14 +74,12 @@ public class AuthController {
         return setAuthCookiesWithMe(pair);
     }
 
-    /**
-     * 발급된 AT 에서 userId 추출 → 본인 정보 조회 → 응답 body 에 포함.
-     * 프론트가 로그인 후 별도 /users/me 호출 없이 바로 store 초기화 가능.
-     */
+    
+
     private ResponseEntity<ApiResponse<MeResponse>> setAuthCookiesWithMe(TokenPair pair) {
         ResponseCookie at = cookieUtil.accessTokenCookie(pair.accessToken());
         ResponseCookie rt = cookieUtil.refreshTokenCookie(pair.refreshToken());
-        // JWT role claim 그대로 응답에 노출 — 프론트가 ADMIN/USER 분기 (마이페이지 → 관리 페이지 redirect 등).
+        
         var claims = jwtProvider.parse(pair.accessToken());
         MeResponse me = MeResponse.from(userService.getById(claims.userId()), claims.role());
         return ResponseEntity.ok()

--- a/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/EmailVerificationController.java
@@ -12,15 +12,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 이메일 인증 — verify (token 검증, 익명 호출) + resend (재발송, 인증 필수).
- *
- * <p>SecurityConfig 정책:
- * <ul>
- *   <li>{@code /verify-email} — PUBLIC_AUTH_ENDPOINTS, CSRF 면제 (사용자가 메일 링크 클릭하는 흐름)</li>
- *   <li>{@code /resend-verification} — auth 필수 (hasRole("USER")) + CSRF 적용 (게이트 1 round 2 보강)</li>
- * </ul>
- */
 @Tag(name = "EmailVerification", description = "이메일 인증 메일 발송/확인")
 @RestController
 @RequestMapping("/api/v1/auth")

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/LocalSignupRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/LocalSignupRequest.java
@@ -5,10 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-/**
- * LOCAL 가입 요청. 비밀번호는 BCrypt 72-byte limit + 보안 정책으로 8~72자.
- * 길이/형식 추가 검증은 LocalAuthService 가 도메인 룰로 한 번 더 가드.
- */
 @Schema(description = "이메일 + 비밀번호 + 닉네임으로 LOCAL 가입")
 public record LocalSignupRequest(
         @Schema(description = "이메일 (최대 100자, RFC 5322 형식)", example = "alice@sseulang.test", maxLength = 100)

--- a/src/main/java/com/sseulang/domain/auth/presentation/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/sseulang/domain/auth/presentation/dto/OAuthLoginRequest.java
@@ -3,13 +3,6 @@ package com.sseulang.domain.auth.presentation.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-/**
- * 소셜 로그인 요청 본문 — Authorization Code Grant.
- *
- * <p>프론트는 카카오/구글 OAuth redirect 받은 {@code code} 와 본인이 사용한 {@code redirectUri} 만
- * 그대로 전달. 백엔드가 provider token endpoint 에 client_id/client_secret 동봉해 access_token
- * 으로 교환 + user info 조회. Client Secret 활성화돼도 안전.</p>
- */
 @Schema(description = "OAuth Authorization Code Grant — 프론트가 redirect 로 받은 code + redirectUri 전달.")
 public record OAuthLoginRequest(
         @Schema(

--- a/src/main/java/com/sseulang/domain/banner/application/BannerApplicationService.java
+++ b/src/main/java/com/sseulang/domain/banner/application/BannerApplicationService.java
@@ -15,9 +15,6 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 
-/**
- * 배너 흐름 — 관리자 CRUD + activate/deactivate, 사용자는 활성 + 윈도우 안 배너만 sort_order 순으로.
- */
 @Service
 @Transactional(readOnly = true)
 public class BannerApplicationService {

--- a/src/main/java/com/sseulang/domain/banner/domain/Banner.java
+++ b/src/main/java/com/sseulang/domain/banner/domain/Banner.java
@@ -13,12 +13,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * Banner Aggregate Root. V1 스키마 {@code banners} 매핑.
- *
- * <p>배너는 {@code is_active} + 게시 윈도우 (startsAt/endsAt) 두 축으로 노출 결정.
- * sort_order 가 작을수록 먼저 노출.</p>
- */
 @Entity
 @Table(name = "banners")
 @Getter
@@ -110,7 +104,7 @@ public class Banner extends BaseEntity {
         this.active = false;
     }
 
-    /** 사용자 노출 — active + 게시 윈도우 안. */
+    
     public boolean isVisibleAt(LocalDateTime now) {
         if (!active || now == null) {
             return false;

--- a/src/main/java/com/sseulang/domain/banner/domain/BannerRepository.java
+++ b/src/main/java/com/sseulang/domain/banner/domain/BannerRepository.java
@@ -15,9 +15,9 @@ public interface BannerRepository {
 
     void deleteById(Long id);
 
-    /** 사용자 — 활성 + 윈도우 안 배너, sort_order ASC 정렬. */
+    
     List<Banner> findVisibleSorted(LocalDateTime now);
 
-    /** 관리자 — 전체 페이징. created_at DESC. */
+    
     Page<Banner> findAllForAdmin(Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/BannerController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-/** 사용자 활성 배너 목록 — sort_order 정렬. */
 @Tag(name = "Banner", description = "배너 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/banners")

--- a/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerResponse.java
+++ b/src/main/java/com/sseulang/domain/banner/presentation/dto/BannerResponse.java
@@ -5,11 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-/**
- * 메인 배너 응답. {@code adminId} 는 의도적으로 미노출 — 일반 사용자에게 운영자 식별 정보가
- * 새는 것을 차단 (audit 정보). admin 페이지의 banner 관리도 동일 schema 사용 (관리자가 누가
- * 만들었는지 식별할 필요 X — 필요 시 직접 DB 감사 로그 조회).
- */
 @Schema(description = "메인 배너 — 클릭 시 linkUrl 로 이동. active+startsAt~endsAt 로 노출 제어.")
 public record BannerResponse(
         @Schema(example = "2") Long id,

--- a/src/main/java/com/sseulang/domain/block/application/UserBlockApplicationService.java
+++ b/src/main/java/com/sseulang/domain/block/application/UserBlockApplicationService.java
@@ -24,7 +24,7 @@ public class UserBlockApplicationService {
         this.repository = repository;
     }
 
-    /** 멱등 차단 추가. 자기 차단 거부, 이미 차단되어 있으면 무시. UNIQUE race 좁은 catch. */
+    
     @Transactional
     public void block(Long blockerId, Long blockedId) {
         if (blockerId.equals(blockedId)) {

--- a/src/main/java/com/sseulang/domain/block/domain/UserBlock.java
+++ b/src/main/java/com/sseulang/domain/block/domain/UserBlock.java
@@ -15,10 +15,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-/**
- * 사용자 차단 Aggregate. {@code user_blocks} 테이블 — UNIQUE(blocker_id, blocked_id),
- * CHECK blocker != blocked.
- */
 @Entity
 @Table(name = "user_blocks")
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/sseulang/domain/block/domain/UserBlockRepository.java
+++ b/src/main/java/com/sseulang/domain/block/domain/UserBlockRepository.java
@@ -9,7 +9,7 @@ public interface UserBlockRepository {
 
     UserBlock save(UserBlock block);
 
-    /** 멱등 삭제. 영향 행 수 반환. */
+    
     int deleteByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
 
     Page<UserBlock> findByBlockerId(Long blockerId, Pageable pageable);

--- a/src/main/java/com/sseulang/domain/category/application/CategoryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/category/application/CategoryApplicationService.java
@@ -24,10 +24,8 @@ public class CategoryApplicationService {
         this.categoryRepository = categoryRepository;
     }
 
-    /**
-     * 활성 카테고리 전체를 트리로 조립해 반환. 단일 SELECT 결과를 in-memory 로 그룹핑한다.
-     * Repository 가 parent NULL → parentId asc → sortOrder asc 순으로 정렬해주므로 1-pass 로 조립 가능.
-     */
+    
+
     public List<CategoryNodeResult> getActiveTree() {
         List<Category> all = categoryRepository.findAllActiveSorted();
 
@@ -46,10 +44,8 @@ public class CategoryApplicationService {
         return roots;
     }
 
-    /**
-     * 라운드 12 PR-D — 활성 카테고리 이름 부분일치 검색 (자동완성용).
-     * keyword 가 null/blank 이면 빈 리스트.
-     */
+    
+
     public List<CategoryResult> searchByKeyword(String keyword) {
         if (keyword == null || keyword.isBlank()) {
             return List.of();
@@ -65,11 +61,8 @@ public class CategoryApplicationService {
         return new CategoryResult(c.getId(), c.getParentId(), c.getName(), c.getSortOrder());
     }
 
-    /**
-     * 다른 도메인 ApplicationService 가 카테고리 존재 검증할 때 사용. {@code id} 가 null 이면
-     * 검증 스킵 (카테고리 미지정 허용 정책). CLAUDE.md §3.3 의 "다른 도메인 Repository 직접 호출 금지"
-     * 룰에 맞춰 외부 도메인이 본 메서드만 의존하게 한다.
-     */
+    
+
     public void requireExists(Long id) {
         if (id == null) {
             return;

--- a/src/main/java/com/sseulang/domain/category/application/dto/CategoryNodeResult.java
+++ b/src/main/java/com/sseulang/domain/category/application/dto/CategoryNodeResult.java
@@ -2,7 +2,6 @@ package com.sseulang.domain.category.application.dto;
 
 import java.util.List;
 
-/** 카테고리 트리 노드. 자식이 없으면 {@code children} 은 빈 리스트. */
 public record CategoryNodeResult(
         Long id,
         String name,

--- a/src/main/java/com/sseulang/domain/category/application/dto/CategoryResult.java
+++ b/src/main/java/com/sseulang/domain/category/application/dto/CategoryResult.java
@@ -1,6 +1,5 @@
 package com.sseulang.domain.category.application.dto;
 
-/** 카테고리 단건 평탄 결과 (트리 미포함). */
 public record CategoryResult(
         Long id,
         Long parentId,

--- a/src/main/java/com/sseulang/domain/category/domain/Category.java
+++ b/src/main/java/com/sseulang/domain/category/domain/Category.java
@@ -11,15 +11,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * Category Aggregate Root. V1 스키마 {@code categories} 매핑 (self-ref).
- *
- * <p>트리 깊이는 시드(`V2__seed_categories.sql`) 기준 2단(1차→2차). 도메인 자체에 깊이 제한
- * 강제는 없음 — Application/Service 에서 트리 조립 시 단일 SELECT 후 in-memory 그룹핑.</p>
- *
- * <p>parent 는 self-ref FK 로 두되 도메인 모델은 {@code parentId(Long)} 만 보유. {@code @ManyToOne}
- * 자기참조는 N+1 위험이 커서 명시 ID 만 들고 트리는 어플리케이션 레이어에서 조립.</p>
- */
 @Entity
 @Table(name = "categories")
 @Getter

--- a/src/main/java/com/sseulang/domain/category/domain/CategoryRepository.java
+++ b/src/main/java/com/sseulang/domain/category/domain/CategoryRepository.java
@@ -3,21 +3,15 @@ package com.sseulang.domain.category.domain;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * Category Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
- * 구현은 {@code domain/category/infrastructure/persistence}.
- */
 public interface CategoryRepository {
 
     Optional<Category> findById(Long id);
 
-    /**
-     * 활성 카테고리 전부 조회. parent_id 우선(NULL 먼저), sort_order 순. 트리 조립은 호출자가 in-memory 로.
-     */
+    
+
     List<Category> findAllActiveSorted();
 
-    /**
-     * 활성 카테고리 이름 부분일치 검색 (LIKE %keyword%). sort_order ASC. 라운드 12 PR-D 자동완성용.
-     */
+    
+
     List<Category> searchByKeyword(String keyword);
 }

--- a/src/main/java/com/sseulang/domain/category/infrastructure/persistence/CategoryJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/category/infrastructure/persistence/CategoryJpaRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-/** Spring Data JPA — {@link CategoryRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
 interface CategoryJpaRepository extends JpaRepository<Category, Long> {
 
     @Query("""

--- a/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
+++ b/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
@@ -24,7 +24,7 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class ChatRoomApplicationService {
 
-    /** V1 스키마 {@code uk_chat_rooms_item_users} — 동시 openFor race 시 멱등 처리 (Codex 게이트 2 패턴). */
+    
     private static final String UNIQUE_ITEM_USERS = "uk_chat_rooms_item_users";
 
     private final ChatRoomRepository chatRoomRepository;
@@ -50,11 +50,8 @@ public class ChatRoomApplicationService {
         this.itemView = itemView;
     }
 
-    /**
-     * 물품 ID 로 채팅방 생성 (가이드 §6.1). 멱등 — 이미 있으면 기존 반환.
-     * 본인 물품 거부 (자기 자신과 채팅 X). UNIQUE race 는 좁은 catch 후 재조회.
-     * 미인증 사용자의 채팅 스팸 방지 — verified 가드 (게이트 1 round 2).
-     */
+    
+
     @Transactional
     public ChatRoomResult openFor(Long requesterId, Long itemId,
                                   com.sseulang.domain.item.domain.TradeType tradeMode) {
@@ -63,19 +60,18 @@ public class ChatRoomApplicationService {
         if (sellerId.equals(requesterId)) {
             throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
         }
-        // tradeMode null 이면 item 의 tradeType 그대로 (라운드 12 — 같은 item 다중 mode 는 PR-D 이후 실용)
+        
+        
         com.sseulang.domain.item.domain.TradeType mode = tradeMode != null
                 ? tradeMode
-                : itemApplicationService.findActiveForTransaction(itemId).tradeType();
+                : pickPrimary(itemApplicationService.findActiveForTransaction(itemId).tradeTypes());
         ChatRoom room = chatRoomRepository.findByItemAndUsers(itemId, requesterId, sellerId, mode)
                 .orElseGet(() -> createWithRaceGuard(itemId, requesterId, sellerId, mode));
         return enrichOne(room, requesterId);
     }
 
-    /**
-     * 본인 채팅방 페이징 — 페이지 결과의 opponent userId / itemId 들을 모아 단일 SELECT IN 으로 batch
-     * fetch (N+1 회피). viewer 기준 derive 후 응답.
-     */
+    
+
     public Page<ChatRoomResult> listMine(Long userId, Pageable pageable) {
         Page<ChatRoom> page = chatRoomRepository.findMine(userId, pageable);
         if (page.isEmpty()) {
@@ -99,7 +95,7 @@ public class ChatRoomApplicationService {
             throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
         }
         ChatRoomResult base = enrichOne(room, requesterId);
-        // 라운드 12 PR-C #6 — systemCard 단건 fetch (없으면 null)
+        
         ChatRoomResult.SystemCard card = chatRoomCardRepository.findByChatRoomId(id)
                 .map(ChatRoomResult.SystemCard::from)
                 .orElse(null);
@@ -116,10 +112,8 @@ public class ChatRoomApplicationService {
         );
     }
 
-    /**
-     * 라운드 12 PR-C #6 — 첫 메시지 발신 시점에 호출. 카드 미존재 시 생성 (멱등).
-     * MessageApplicationService.send 에서 호출.
-     */
+    
+
     @Transactional
     public void ensureSystemCard(Long chatRoomId) {
         if (chatRoomCardRepository.findByChatRoomId(chatRoomId).isPresent()) {
@@ -130,7 +124,7 @@ public class ChatRoomApplicationService {
         var itemMap = itemView.findByIds(List.of(room.getItemId()));
         var item = itemMap.get(room.getItemId());
         if (item == null) {
-            return;  // 아이템 삭제 등 — 카드 생성 skip (best-effort)
+            return;  
         }
         com.sseulang.domain.chat.domain.ChatRoomCard card = com.sseulang.domain.chat.domain.ChatRoomCard.create(
                 chatRoomId, room.getTradeMode(),
@@ -139,14 +133,12 @@ public class ChatRoomApplicationService {
         try {
             chatRoomCardRepository.save(card);
         } catch (org.springframework.dao.DuplicateKeyException race) {
-            // 다른 트랜잭션이 먼저 생성 — 무시 (멱등)
+            
         }
     }
 
-    /**
-     * 본인 unread 0 으로 리셋. 본인이 참여자가 아니면 atomic UPDATE 가 영향 0 — 그 경우 사전 권한
-     * 검증 후 CHAT_FORBIDDEN. 응답으로 갱신된 채팅방 반환 (myUnread = 0).
-     */
+    
+
     @Transactional
     public ChatRoomResult markAsRead(Long roomId, Long userId) {
         ChatRoom room = chatRoomRepository.findById(roomId)
@@ -155,22 +147,13 @@ public class ChatRoomApplicationService {
             throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
         }
         chatRoomRepository.markAsRead(roomId, userId);
-        // entity 메모리 상태도 동기화 (응답에 fresh 값 반영)
+        
         room.markAsRead(userId);
         return enrichOne(room, userId);
     }
 
-    /**
-     * 라운드 12 (#3.2 #3.3) — 거래/거래대행이 채팅방 안에서 시작되는지 가드용. 참여자 검증 +
-     * chatRoom 메타 (itemId, left flags) 노출. 호출자가 itemId 일치 / leftFlags 별로 분기.
-     *
-     * <ul>
-     *   <li>ChatRoom 미존재 → CHAT_ROOM_NOT_FOUND</li>
-     *   <li>비참여자 → CHAT_FORBIDDEN</li>
-     * </ul>
-     *
-     * <p>본 메서드는 read-only — 잔액/상태 변경 가드는 호출자 ApplicationService 가 책임.</p>
-     */
+    
+
     public ChatRoomMeta findMetaForParticipant(Long chatRoomId, Long userId) {
         ChatRoom room = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
@@ -178,16 +161,17 @@ public class ChatRoomApplicationService {
             throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
         }
         return new ChatRoomMeta(room.getId(), room.getItemId(),
+                room.getTradeMode(),
                 room.iLeft(userId), room.opponentLeft(userId));
     }
 
-    /**
-     * 라운드 12 — 외부 도메인용 chat_room 메타 read model. {@code itemId} 는 거래 영역의
-     * chat_room ↔ item 일치 검증, {@code iLeft / opponentLeft} 는 거래대행 신청 시 한쪽 left 차단용.
-     */
-    public record ChatRoomMeta(Long chatRoomId, Long itemId, boolean iLeft, boolean opponentLeft) { }
+    
 
-    /** Message 도메인이 메시지 보낼 권한 검증 시 호출. 참여자 아니면 CHAT_FORBIDDEN. */
+    public record ChatRoomMeta(Long chatRoomId, Long itemId,
+                               com.sseulang.domain.item.domain.TradeType tradeMode,
+                               boolean iLeft, boolean opponentLeft) { }
+
+    
     public void requireParticipant(Long chatRoomId, Long userId) {
         ChatRoom room = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
@@ -196,11 +180,8 @@ public class ChatRoomApplicationService {
         }
     }
 
-    /**
-     * 메시지 송신 가능 여부 검증 — 참여자 + 본인 left X + 상대방 left X.
-     * 본인 left → CHAT_FORBIDDEN (이미 나간 방).
-     * 상대방 left → CHAT_ROOM_OPPONENT_LEFT (상대방이 나가서 차단).
-     */
+    
+
     public void requireSendable(Long chatRoomId, Long userId) {
         ChatRoom room = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
@@ -215,11 +196,8 @@ public class ChatRoomApplicationService {
         }
     }
 
-    /**
-     * 채팅방 나가기 (soft hide) — 본인 측 left_at = NOW(). 데이터/메시지 보존.
-     * 본인 listMine 에서 제외, 상대방은 opponentLeft=true 응답 받음.
-     * 비참여자 호출은 CHAT_FORBIDDEN. 이미 left 상태도 idempotent (재호출 OK).
-     */
+    
+
     @Transactional
     public void leave(Long roomId, Long userId) {
         ChatRoom room = chatRoomRepository.findById(roomId)
@@ -230,10 +208,8 @@ public class ChatRoomApplicationService {
         chatRoomRepository.markAsLeft(roomId, userId);
     }
 
-    /**
-     * 1:1 채팅방의 상대방 userId 반환. requireParticipant 검증을 동시에 수행.
-     * 메시지 broadcast 시 상대방 알림 push 용.
-     */
+    
+
     public Long findOpponent(Long chatRoomId, Long requesterId) {
         ChatRoom room = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
@@ -243,16 +219,14 @@ public class ChatRoomApplicationService {
         return requesterId.equals(room.getUser1Id()) ? room.getUser2Id() : room.getUser1Id();
     }
 
-    /**
-     * 메시지 발신 시 ChatRoom 메타 갱신 — last_message / last_message_at / 상대방 unread 카운트.
-     * 단일 atomic UPDATE. 가이드 §4.10 — MongoDB↔MySQL 트랜잭션 분리 (실패 시 보상 X).
-     */
+    
+
     @Transactional
     public void recordIncomingMessage(Long chatRoomId, Long senderId, String preview) {
         chatRoomRepository.recordIncomingMessage(chatRoomId, senderId, preview);
     }
 
-    /** 단건 enrich — opponent + item batch fetch 후 ChatRoomResult.from. */
+    
     private ChatRoomResult enrichOne(ChatRoom room, Long viewerId) {
         Long opponentId = viewerId.equals(room.getUser1Id()) ? room.getUser2Id() : room.getUser1Id();
         Map<Long, UserView.UserProjection> userMap = userView.findByIds(List.of(opponentId));
@@ -291,6 +265,22 @@ public class ChatRoomApplicationService {
             }
             throw violation;
         }
+    }
+
+    
+    private static com.sseulang.domain.item.domain.TradeType pickPrimary(
+            java.util.Set<com.sseulang.domain.item.domain.TradeType> types
+    ) {
+        if (types == null || types.isEmpty()) {
+            throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
+        }
+        if (types.contains(com.sseulang.domain.item.domain.TradeType.판매)) {
+            return com.sseulang.domain.item.domain.TradeType.판매;
+        }
+        if (types.contains(com.sseulang.domain.item.domain.TradeType.대여)) {
+            return com.sseulang.domain.item.domain.TradeType.대여;
+        }
+        return com.sseulang.domain.item.domain.TradeType.나눔;
     }
 
     private static boolean isUniqueConflict(DataIntegrityViolationException violation) {

--- a/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
+++ b/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
@@ -4,43 +4,35 @@ import com.sseulang.domain.chat.domain.ChatRoom;
 
 import java.time.LocalDateTime;
 
-/**
- * 채팅방 응답 — viewer 기준으로 자동 enrich. ApplicationService 가 batch fetch 로 채움.
- *
- * <p>raw 필드 (user1Id/user2Id/user1Unread/user2Unread) 는 호환을 위해 유지하되, 프론트는
- * viewer 기준 derived 필드 ({@code opponentId} / {@code myUnread} / {@code opponent*})만 봐도 됨.
- * raw 필드는 향후 v2 API 에서 제거 예정.</p>
- */
 public record ChatRoomResult(
         Long id,
         Long itemId,
-        // raw 필드 (정규화 — user1Id < user2Id) — 호환용
+        
         Long user1Id,
         Long user2Id,
         int user1Unread,
         int user2Unread,
-        // viewer-aware enrich
+        
         Long opponentId,
         String opponentNickname,
         String opponentProfileImage,
         int myUnread,
         String itemTitle,
         String itemThumbnailUrl,
-        boolean isSeller,                 // viewer 가 이 채팅방의 아이템 판매자인지
-        boolean iLeft,                    // 본인이 채팅방을 나갔는지 (soft hide)
-        boolean opponentLeft,             // 상대방이 채팅방을 나갔는지
-        // 메타
+        boolean isSeller,                 
+        boolean iLeft,                    
+        boolean opponentLeft,             
+        
         String lastMessage,
         LocalDateTime lastMessageAt,
         boolean active,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        // 라운드 12 PR-C #6 — 채팅방 시스템 카드 (첫 메시지 시점에 lazy 생성, getOne 응답에만 enrich)
+        
         SystemCard systemCard
 ) {
-    /**
-     * 채팅방 시스템 카드 — 거래방식 + 아이템 정보 (snapshot).
-     */
+    
+
     public record SystemCard(
             com.sseulang.domain.item.domain.TradeType tradeMode,
             Long itemId,
@@ -52,10 +44,8 @@ public record ChatRoomResult(
             return new SystemCard(c.getTradeMode(), c.getItemId(), c.getItemTitle(), c.getThumbnailUrl(), c.getPrice());
         }
     }
-    /**
-     * viewerId 기준 derive. opponent / item join 정보는 호출자가 fetch 후 전달 (없으면 null/빈 문자열 OK).
-     * viewerId 가 참여자 아니면 IAE — 서비스가 사전 권한 검증 책임.
-     */
+    
+
     public static ChatRoomResult from(
             ChatRoom c,
             Long viewerId,
@@ -74,16 +64,15 @@ public record ChatRoomResult(
             opponentId = c.getUser1Id();
             myUnread = c.getUser2Unread();
         } else {
-            // viewer 가 참여자 아님 — 호출자가 사전 검증 책임. enrich 못 하므로 null/0 으로 둠.
+            
             opponentId = null;
             myUnread = 0;
         }
         return from(c, viewerId, opponentNickname, opponentProfileImage, itemTitle, itemThumbnailUrl, itemSellerId, null);
     }
 
-    /**
-     * 라운드 12 PR-C #6 — systemCard 포함 enrich (getOne 응답 전용).
-     */
+    
+
     public static ChatRoomResult from(
             ChatRoom c,
             Long viewerId,

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoom.java
@@ -15,15 +15,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * ChatRoom Aggregate Root. V1 스키마 {@code chat_rooms} 매핑 — 메타데이터만 (메시지는 MongoDB, Day 6).
- *
- * <p>가이드 §4.10: 1:1 고정. UNIQUE(item_id, user1_id, user2_id) — 같은 두 사용자 + 같은 물품 은 단일 방.
- * 정규화: 항상 {@code user1Id < user2Id} 강제 → 두 user 쌍이 어떤 순서로 들어와도 동일 행 매칭.</p>
- *
- * <p>last_message / last_message_at / unread 카운트 갱신은 메시지 도메인(Day 6)이 담당.
- * 본 PR 은 채팅방 메타 + 멱등 생성/조회만.</p>
- */
 @Entity
 @Table(name = "chat_rooms")
 @Getter
@@ -64,17 +55,14 @@ public class ChatRoom extends BaseEntity {
     @Column(name = "user2_left_at")
     private LocalDateTime user2LeftAt;
 
-    /**
-     * 채팅방 거래방식 — 판매 / 대여 / 나눔 (PR-C 라운드 12).
-     * UNIQUE(item_id, user1_id, user2_id, trade_mode) — 같은 두 사용자 + 같은 물품이라도 거래방식 다르면 별도 방.
-     */
+    
+
     @Enumerated(EnumType.STRING)
     @Column(name = "trade_mode", nullable = false, length = 10)
     private com.sseulang.domain.item.domain.TradeType tradeMode;
 
-    /**
-     * 라운드 12 PR-C — tradeMode 인자 추가. {@code user1Id < user2Id} 강제 정규화.
-     */
+    
+
     public static ChatRoom openFor(Long itemId, Long requesterId, Long opponentId,
                                    com.sseulang.domain.item.domain.TradeType tradeMode) {
         if (itemId == null || itemId <= 0) {
@@ -104,7 +92,7 @@ public class ChatRoom extends BaseEntity {
         return cr;
     }
 
-    /** @deprecated PR-C 라운드 12 — tradeMode 인자 받는 4-arg openFor 사용. */
+    
     @Deprecated
     public static ChatRoom openFor(Long itemId, Long requesterId, Long opponentId) {
         return openFor(itemId, requesterId, opponentId, com.sseulang.domain.item.domain.TradeType.판매);
@@ -114,10 +102,8 @@ public class ChatRoom extends BaseEntity {
         return userId != null && (userId.equals(user1Id) || userId.equals(user2Id));
     }
 
-    /**
-     * 본인이 user1 이면 user1Unread = 0, user2 면 user2Unread = 0. 상대방 unread 는 그대로.
-     * 호출자가 사전에 isParticipant 검증해야 함 (서비스 책임).
-     */
+    
+
     public void markAsRead(Long userId) {
         if (userId == null) {
             throw new IllegalArgumentException("userId 는 필수입니다");
@@ -129,10 +115,8 @@ public class ChatRoom extends BaseEntity {
         }
     }
 
-    /**
-     * 본인 측 채팅방을 soft hide. 본인이 user1 이면 user1LeftAt = now, user2 면 user2LeftAt = now.
-     * 이미 left 상태면 no-op (idempotent). 비참여자 호출은 IllegalStateException — 서비스가 사전 검증해야 함.
-     */
+    
+
     public void leave(Long userId, LocalDateTime now) {
         if (userId == null) {
             throw new IllegalArgumentException("userId 는 필수입니다");
@@ -153,9 +137,8 @@ public class ChatRoom extends BaseEntity {
         }
     }
 
-    /**
-     * 본인이 채팅방을 나갔는지. 비참여자는 false (의미 없는 질문이라 false 로 통일).
-     */
+    
+
     public boolean iLeft(Long userId) {
         if (userId == null) return false;
         if (userId.equals(user1Id)) return this.user1LeftAt != null;
@@ -163,9 +146,8 @@ public class ChatRoom extends BaseEntity {
         return false;
     }
 
-    /**
-     * 상대방이 채팅방을 나갔는지. 비참여자는 false (의미 없는 질문이라 false 로 통일).
-     */
+    
+
     public boolean opponentLeft(Long userId) {
         if (userId == null) return false;
         if (userId.equals(user1Id)) return this.user2LeftAt != null;

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoomCard.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoomCard.java
@@ -12,12 +12,6 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.Instant;
 
-/**
- * 채팅방 시스템 카드 (PR-C #6 라운드 12). 첫 메시지 send 시점에 lazy 생성 후 채팅방에서 영구 노출.
- *
- * <p>MongoDB {@code chat_room_cards} 컬렉션 — chatRoomId 당 1건 (UNIQUE).
- * 내용: 거래방식 + 아이템 title + thumbnail + 가격 (snapshot — 거래 시점 그대로 보존).</p>
- */
 @Document(collection = "chat_room_cards")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoomCardRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoomCardRepository.java
@@ -2,9 +2,6 @@ package com.sseulang.domain.chat.domain;
 
 import java.util.Optional;
 
-/**
- * 채팅방 시스템 카드 Repository — chatRoomId UNIQUE.
- */
 public interface ChatRoomCardRepository {
 
     Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId);

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoomRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoomRepository.java
@@ -9,32 +9,25 @@ public interface ChatRoomRepository {
 
     Optional<ChatRoom> findById(Long id);
 
-    /**
-     * 정규화된 (user1, user2) 쌍 + itemId + tradeMode 로 기존 방 조회.
-     * 라운드 12 PR-C — 같은 사용자/아이템 쌍이라도 거래방식 다르면 별도 방이므로 tradeMode 도 매칭 키.
-     */
+    
+
     Optional<ChatRoom> findByItemAndUsers(Long itemId, Long userA, Long userB,
                                           com.sseulang.domain.item.domain.TradeType tradeMode);
 
-    /** 내가 참여자인 채팅방 목록 — last_message_at desc (null 은 후순위). */
+    
     Page<ChatRoom> findMine(Long userId, Pageable pageable);
 
     ChatRoom save(ChatRoom chatRoom);
 
-    /**
-     * 메시지 발신 시 last_message + last_message_at + 상대방 unread 를 단일 atomic UPDATE 로 갱신.
-     * 가이드 §4.10 — 동시 메시지 발신 race 안전 (마지막 SQL 이 win).
-     */
+    
+
     int recordIncomingMessage(Long chatRoomId, Long senderId, String preview);
 
-    /**
-     * 본인 unread 만 0 으로 atomic UPDATE. 비참여자는 영향 0. 권한 검증은 서비스 책임.
-     */
+    
+
     int markAsRead(Long chatRoomId, Long userId);
 
-    /**
-     * 본인 측 left_at 을 NOW() 로 atomic UPDATE (soft hide). 이미 left 면 그 값 유지.
-     * 비참여자는 0 행 영향 — 서비스가 사전 권한 검증. 이미 left 상태도 1 행 영향 가능 (CASE WHEN 로 보존).
-     */
+    
+
     int markAsLeft(Long chatRoomId, Long userId);
 }

--- a/src/main/java/com/sseulang/domain/chat/domain/ItemView.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ItemView.java
@@ -3,23 +3,13 @@ package com.sseulang.domain.chat.domain;
 import java.util.Collection;
 import java.util.Map;
 
-/**
- * Chat 도메인이 채팅방 응답에 아이템 제목/썸네일을 자동 join 으로 채울 때 쓰는 read-only 포트.
- * 구현은 {@code item.infrastructure} 어댑터.
- *
- * <p>CLAUDE.md §3.3 — 단방향 의존, N+1 회피용 batch read.</p>
- */
 public interface ItemView {
 
-    /**
-     * itemId 들에 대한 (id → projection) 맵. 미존재 id 는 맵에서 빠짐 (삭제된 아이템 등).
-     * 비어있으면 빈 맵 반환 — DB 호출 안 함.
-     */
+    
+
     Map<Long, ItemProjection> findByIds(Collection<Long> itemIds);
 
-    /**
-     * 채팅 응답용 아이템 최소 projection. 제목 + 썸네일 + 판매자 id (viewer 본인=isSeller 판정용).
-     * 라운드 12 PR-C #6 — 시스템 카드 생성 시 price 도 필요해 필드 추가 (snapshot).
-     */
+    
+
     record ItemProjection(Long id, String title, String thumbnailUrl, Long sellerId, Long price) { }
 }

--- a/src/main/java/com/sseulang/domain/chat/domain/UserView.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/UserView.java
@@ -3,20 +3,12 @@ package com.sseulang.domain.chat.domain;
 import java.util.Collection;
 import java.util.Map;
 
-/**
- * Chat 도메인이 채팅방 응답에 상대방 닉네임/프로필을 자동 join 으로 채울 때 쓰는 read-only 포트.
- * 구현은 {@code user.infrastructure} 어댑터.
- *
- * <p>CLAUDE.md §3.3 — 다른 도메인 Repository 직접 호출 금지. 단방향 의존 + N+1 회피용 batch read.</p>
- */
 public interface UserView {
 
-    /**
-     * userId 들에 대한 (id → projection) 맵. 미존재 id 는 맵에서 빠짐.
-     * 비어있으면 빈 맵 반환 — DB 호출 안 함.
-     */
+    
+
     Map<Long, UserProjection> findByIds(Collection<Long> userIds);
 
-    /** 채팅 응답용 사용자 최소 projection. 닉네임 + 프로필이미지만. */
+    
     record UserProjection(Long id, String nickname, String profileImage) { }
 }

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomJpaRepository.java
@@ -27,10 +27,8 @@ interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, Long> {
             @Param("tradeMode") com.sseulang.domain.item.domain.TradeType tradeMode
     );
 
-    /**
-     * 본인 visibility 기준 채팅방 목록. user1 이면 user1LeftAt IS NULL, user2 면 user2LeftAt IS NULL.
-     * 본인이 left 한 방은 목록에서 제외 (soft hide). 상대방이 left 한 방은 그대로 노출.
-     */
+    
+
     @Query("""
         SELECT c FROM ChatRoom c
         WHERE (c.user1Id = :userId AND c.user1LeftAt IS NULL)
@@ -42,10 +40,8 @@ interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, Long> {
     """)
     Page<ChatRoom> findMine(@Param("userId") Long userId, Pageable pageable);
 
-    /**
-     * 단일 atomic UPDATE — last_message / last_message_at / 상대방 unread 갱신.
-     * 발신자 본인 unread 는 0 으로 (자기가 보낸 메시지는 안 읽음 카운트 X).
-     */
+    
+
     @Modifying
     @Query("""
         UPDATE ChatRoom c
@@ -62,7 +58,7 @@ interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, Long> {
             @Param("sentAt") LocalDateTime sentAt
     );
 
-    /** 본인 unread 0 으로 atomic UPDATE. 비참여자는 영향 0. */
+    
     @Modifying
     @Query("""
         UPDATE ChatRoom c
@@ -73,10 +69,8 @@ interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, Long> {
     """)
     int markAsRead(@Param("roomId") Long roomId, @Param("userId") Long userId);
 
-    /**
-     * 본인 측 left_at 을 atomic UPDATE. 이미 nonnull 이면 보존 (idempotent).
-     * 비참여자는 0 행 영향. 본인 user 위치에 따라 한쪽 컬럼만 변경.
-     */
+    
+
     @Modifying
     @Query("""
         UPDATE ChatRoom c

--- a/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public record ChatRoomResponse(
         @Schema(example = "8") Long id,
         @Schema(example = "42") Long itemId,
-        // viewer 기준 derived 필드 — 프론트는 이것만 보면 됨
+        
         @Schema(example = "200", description = "viewer 의 상대방 사용자 id") Long opponentId,
         @Schema(example = "쓸랭이", description = "상대방 닉네임") String opponentNickname,
         @Schema(description = "상대방 프로필 이미지 URL (없으면 null)") String opponentProfileImage,
@@ -19,11 +19,11 @@ public record ChatRoomResponse(
         @Schema(example = "true", description = "viewer 가 이 채팅방의 아이템 판매자인지") boolean isSeller,
         @Schema(example = "false", description = "본인이 채팅방을 나갔는지 (soft hide). true 면 본인 목록에서 제외됨") boolean iLeft,
         @Schema(example = "false", description = "상대방이 채팅방을 나갔는지. true 면 메시지 send 차단 + 시스템 메시지 노출") boolean opponentLeft,
-        // 메타
+        
         @Schema(example = "안녕하세요...", description = "최근 메시지 미리보기") String lastMessage,
         LocalDateTime lastMessageAt,
         @Schema(description = "false 면 차단/예약 등으로 비활성") boolean active,
-        // raw — 호환용 (향후 제거 예정)
+        
         @Schema(description = "정규화 raw — user1Id < user2Id. 호환용 유지, 신규 코드는 opponentId 사용 권장") Long user1Id,
         @Schema(description = "정규화 raw — 호환용 유지") Long user2Id,
         @Schema(description = "raw — user1 미읽음. 호환용 유지, 신규 코드는 myUnread 사용 권장") int user1Unread,

--- a/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
@@ -21,24 +21,6 @@ import java.time.LocalDateTime;
 import java.util.EnumMap;
 import java.util.Map;
 
-/**
- * Delivery (배달대행) ApplicationService — 트랜잭션 경계 + 도메인 흐름 조율.
- *
- * <p>핵심 흐름:
- * <ol>
- *   <li>{@link #create} — 요청자 등록 (이메일 인증 가드)</li>
- *   <li>{@link #accept} — 라이더 수락 (conditional UPDATE 로 race 차단, 본인 거래 차단)</li>
- *   <li>{@link #markPickedUp} / {@link #markDelivered} — 라이더 상태 전이</li>
- *   <li>{@link #complete} — 요청자가 정산 확인 → 포인트 이동 (요청자 차감 + 라이더 적립)</li>
- *   <li>{@link #cancel} — 요청자 취소 (모집중 한정)</li>
- * </ol>
- *
- * <p>정산({@link #complete})은 {@link PointApplicationService#transferForDelivery} 한 번에
- * 차감/적립 + history 두 건 적재가 한 트랜잭션으로 묶여 정합성 보장.</p>
- *
- * <p>가이드 §3.3 — Repository 인터페이스만 의존 (구현은 infrastructure). 다른 도메인은
- * UserApplicationService / PointApplicationService 만 호출.</p>
- */
 @Service
 @Transactional(readOnly = true)
 public class DeliveryApplicationService {
@@ -63,13 +45,8 @@ public class DeliveryApplicationService {
         this.eventPublisher = eventPublisher;
     }
 
-    /**
-     * 요청 등록. 요청자 이메일 인증 필수 (가이드 §4 보안 / §10 happy path).
-     *
-     * <p>현재 정책: <b>등록 시점에 fee escrow 안 함</b> — 정산({@link #complete}) 시점에 차감.
-     * 등록 단계 잔액 체크도 안 함 (라이더가 수락 후 요청자 잔액이 부족해지면 정산 실패 →
-     * 라이더 항의 가능). 5/6 이전 단순화 정책. follow-up: hold 패턴 도입 고려.</p>
-     */
+    
+
     @Transactional
     public DeliveryResult create(DeliveryCreateCommand cmd) {
         userApplicationService.requireVerified(cmd.requesterId());
@@ -86,13 +63,8 @@ public class DeliveryApplicationService {
         return DeliveryResult.from(deliveryRepository.save(d));
     }
 
-    /**
-     * 라이더 수락. 본인 거래 차단 + conditional UPDATE 로 동시 수락 race 차단.
-     *
-     * <p>{@link DeliveryRepository#acceptIfStillOpen} 가 {@code WHERE status='모집중'} 조건을
-     * 락 없이 atomic 하게 평가 — 영향 행 0 이면 이미 다른 라이더가 수락했거나 취소된 상태.
-     * 수락한 라이더는 {@link DeliveryRequest#acceptBy} 호출 결과와 일치 (DB 갱신 = aggregate 갱신).</p>
-     */
+    
+
     @Transactional
     public DeliveryResult accept(Long deliveryId, Long riderId) {
         userApplicationService.requireVerified(riderId);
@@ -100,8 +72,8 @@ public class DeliveryApplicationService {
         if (d.isRequester(riderId)) {
             throw new BusinessException(ErrorCode.DELIVERY_SELF_NOT_ALLOWED);
         }
-        // 사전 조회에서 이미 취소/종료 상태면 ALREADY_ACCEPTED 가 아닌 INVALID_STATE 가 더 정확.
-        // (게이트 1 round 2 — Warning) update 이후 race 패배는 아래 분기에서 통일 처리.
+        
+        
         if (d.getStatus() != com.sseulang.domain.delivery.domain.DeliveryStatus.모집중) {
             if (d.getStatus() == com.sseulang.domain.delivery.domain.DeliveryStatus.수락) {
                 throw new BusinessException(ErrorCode.DELIVERY_ALREADY_ACCEPTED);
@@ -111,16 +83,16 @@ public class DeliveryApplicationService {
         LocalDateTime now = LocalDateTime.now();
         int affected = deliveryRepository.acceptIfStillOpen(deliveryId, riderId, now);
         if (affected == 0) {
-            // 본인 거래/취소는 위에서 사전 검증으로 차단 — 여기 도달하는 affected=0 은
-            // 실제 동시 accept race 패배 케이스. REPEATABLE_READ snapshot 으로 인해 같은 트랜잭션의
-            // findById 가 race 우승자 commit 을 못 보는 케이스 회피 위해 ALREADY_ACCEPTED 로 통일.
+            
+            
+            
             findOrThrow(deliveryId);
             throw new BusinessException(ErrorCode.DELIVERY_ALREADY_ACCEPTED);
         }
         return DeliveryResult.from(findOrThrow(deliveryId));
     }
 
-    /** 라이더 픽업 — 수락한 라이더만. */
+    
     @Transactional
     public DeliveryResult markPickedUp(Long deliveryId, Long riderId) {
         DeliveryRequest d = findOrThrow(deliveryId);
@@ -131,7 +103,7 @@ public class DeliveryApplicationService {
         return DeliveryResult.from(d);
     }
 
-    /** 라이더 배송 완료 — 수락한 라이더만. */
+    
     @Transactional
     public DeliveryResult markDelivered(Long deliveryId, Long riderId) {
         DeliveryRequest d = findOrThrow(deliveryId);
@@ -139,24 +111,15 @@ public class DeliveryApplicationService {
             throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
         }
         d.markDelivered(LocalDateTime.now());
-        // Mode A escrow 자동 정산 트리거 — listener (EscrowApplicationService) 가 분기 처리.
+        
         eventPublisher.publishEvent(new com.sseulang.domain.delivery.domain.event.DeliveryDeliveredEvent(
                 d.getId(), d.getEscrowApplicationId()
         ));
         return DeliveryResult.from(d);
     }
 
-    /**
-     * 요청자 정산 확인 → 포인트 이동 + 상태 전이.
-     *
-     * <p>게이트 1 round 1 — Critical 1: {@link DeliveryRepository#findByIdForUpdate} 로 row 락을
-     * 먼저 획득해 동시 complete 2건이 모두 정산 진입하는 race 차단. 락 획득 후 상태 검증 →
-     * {@code transferForDelivery} → {@code markSettled} 순서. 한 트랜잭션 안에서 잔액 변동 실패 시
-     * 상태 전이도 함께 롤백.</p>
-     *
-     * <p>요청자 잔액 부족 시 INSUFFICIENT_POINT — 라이더의 선행 적립 (id-asc 순서에 따라 먼저
-     * 처리될 수 있음) 도 같은 트랜잭션 안이라 함께 롤백. 상태 전이도 롤백되므로 재시도 가능.</p>
-     */
+    
+
     @Transactional
     public DeliveryResult complete(Long deliveryId, Long requesterId) {
         DeliveryRequest d = deliveryRepository.findByIdForUpdate(deliveryId)
@@ -175,18 +138,13 @@ public class DeliveryApplicationService {
                 "배달 정산: delivery#" + d.getId()
         );
         d.markSettled(LocalDateTime.now());
-        // 위치 캐시 즉시 만료 — 정산완료 후 개인정보 잔류 방지 (Codex 게이트 2 W1).
+        
         locationCache.evict(deliveryId);
         return DeliveryResult.from(d);
     }
 
-    /**
-     * 요청자 취소 — 모집중 한정. 잔액 이동 없음 (등록 시 escrow 안 했음).
-     *
-     * <p>게이트 1 round 1 — Critical 2: {@link DeliveryRepository#cancelIfStillOpen} 조건부
-     * UPDATE 로 accept vs cancel race 차단. 영향 행 0 이면 본인 자원 아니거나 이미 수락/취소된 상태.
-     * 사유 분기를 위해 후처리 조회로 메시지 결정.</p>
-     */
+    
+
     @Transactional
     public DeliveryResult cancel(Long deliveryId, Long requesterId, String reason) {
         if (reason != null && reason.length() > 255) {
@@ -200,17 +158,17 @@ public class DeliveryApplicationService {
             if (!current.isRequester(requesterId)) {
                 throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
             }
-            // 이미 수락된 / 취소된 / 그 이후 단계 — 모집중 아님.
+            
             throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
         }
-        // 모집중에서 취소된 케이스 — 위치 캐시 보통 비어있지만 안전망으로 evict.
+        
         locationCache.evict(deliveryId);
         return DeliveryResult.from(findOrThrow(deliveryId));
     }
 
     public DeliveryResult getById(Long deliveryId, Long requesterId) {
         DeliveryRequest d = findOrThrow(deliveryId);
-        // 모집중은 누구나 조회 가능 (라이더가 수락 결정 위해). 그 외는 참여자만.
+        
         if (!d.getStatus().canAccept() && !d.isParticipant(requesterId)) {
             throw new BusinessException(ErrorCode.DELIVERY_FORBIDDEN);
         }
@@ -221,10 +179,8 @@ public class DeliveryApplicationService {
         return deliveryRepository.findOpenList(pageable).map(DeliveryResult::from);
     }
 
-    /**
-     * 외부 도메인이 참여자 검증할 때 사용 (예: STOMP location SUBSCRIBE 인가).
-     * 참여자 아니면 {@link ErrorCode#DELIVERY_FORBIDDEN}.
-     */
+    
+
     public void requireParticipant(Long deliveryId, Long userId) {
         DeliveryRequest d = findOrThrow(deliveryId);
         if (!d.isParticipant(userId)) {
@@ -232,10 +188,8 @@ public class DeliveryApplicationService {
         }
     }
 
-    /**
-     * 외부 도메인이 라이더 본인 검증할 때 사용 (예: STOMP location publish 권한).
-     * 수락된 라이더 아니면 {@link ErrorCode#DELIVERY_FORBIDDEN}.
-     */
+    
+
     public void requireRider(Long deliveryId, Long userId) {
         DeliveryRequest d = findOrThrow(deliveryId);
         if (!d.isRider(userId)) {
@@ -243,10 +197,8 @@ public class DeliveryApplicationService {
         }
     }
 
-    /**
-     * 라이더 본인 + 위치 추적 가능 상태({@link DeliveryStatus#canTrackLocation}) 검증.
-     * 위치 publish 진입 가드 — 종료(배송완료/정산완료/취소) 후 위치 보낼 수 없게 함 (Codex 게이트 2 W1).
-     */
+    
+
     public void requireRiderTrackable(Long deliveryId, Long userId) {
         DeliveryRequest d = findOrThrow(deliveryId);
         if (!d.isRider(userId)) {
@@ -257,7 +209,7 @@ public class DeliveryApplicationService {
         }
     }
 
-    /** 참여자 + 위치 추적 가능 상태 — 종료 후 위치 조회/구독 차단. */
+    
     public void requireParticipantTrackable(Long deliveryId, Long userId) {
         DeliveryRequest d = findOrThrow(deliveryId);
         if (!d.isParticipant(userId)) {
@@ -277,10 +229,8 @@ public class DeliveryApplicationService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
     }
 
-    /**
-     * 관리자 dashboard 용 배달대행 통계 (follow-up #52). status 별 카운트 + 정산완료 fee 합계.
-     * 모든 status 가 byStatus 에 포함됨 — 0 건이면 0L. 단일 GROUP BY + 단일 SUM 쿼리.
-     */
+    
+
     public DeliveryStatsResult adminGetStats() {
         Map<DeliveryStatus, Long> byStatus = new EnumMap<>(DeliveryStatus.class);
         for (DeliveryStatus s : DeliveryStatus.values()) {

--- a/src/main/java/com/sseulang/domain/delivery/application/DeliveryLocationApplicationService.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/DeliveryLocationApplicationService.java
@@ -13,33 +13,12 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * 배달 실시간 위치 publish/subscribe 흐름 (follow-up #51).
- *
- * <ul>
- *   <li>{@link #publishLocation} — 라이더가 STOMP SEND 또는 REST 로 좌표 push.
- *       권한+상태 검증(rider 본인 + canTrackLocation) → recordedAt drift 정정 → rate limit →
- *       좌표 검증({@link DeliveryLocation} VO) → Redis 캐시 → STOMP broadcast.</li>
- *   <li>{@link #findLast} — 참여자가 마지막 위치 조회 (재연결 / 최초 진입). 추적 가능 상태에서만.</li>
- * </ul>
- *
- * <p><b>저장 정책</b>: DB 저장 X — Redis 휘발 캐시 (TTL 30분, 마지막 1건만). history 보관 안 함.
- * 정산완료/취소 시 즉시 evict ({@link DeliveryApplicationService#complete}/{@code cancel}).</p>
- *
- * <p><b>Rate limit</b>: 같은 (deliveryId, riderId) 에 대해 최소 publish 간격 1초. in-memory 라
- * 다중 인스턴스 배포 시 인스턴스 별 한도 — 라이더 권장 5초 주기 가이드와 합쳐 충분 (필요 시 follow-up
- * 으로 Redis SETNX 전환).</p>
- *
- * <p><b>recordedAt drift</b>: 서버 시각 ± 60초만 허용 — 디바이스 시계 어긋남이나 미래/과거 시각
- * 위변조 차단. drift 초과 시 서버 시각으로 덮어쓰기 (DELIVERY_LOCATION_INVALID 던지지 않음 —
- * UX 측 흐름 끊지 않기 위함).</p>
- */
 @Service
 public class DeliveryLocationApplicationService {
 
-    /** 같은 (deliveryId, riderId) 최소 publish 간격. */
+    
     private static final Duration MIN_PUBLISH_INTERVAL = Duration.ofSeconds(1);
-    /** recordedAt 허용 drift (서버 시각 기준 ±). */
+    
     private static final Duration MAX_RECORDED_AT_DRIFT = Duration.ofSeconds(60);
 
     private final DeliveryApplicationService deliveryApplicationService;
@@ -47,7 +26,7 @@ public class DeliveryLocationApplicationService {
     private final RealtimePublisher realtimePublisher;
     private final Clock clock;
 
-    /** 라이더 publish 빈도 제한용 in-memory 카운터. key = "{deliveryId}:{riderId}". value = last epoch millis. */
+    
     private final ConcurrentHashMap<String, Long> lastPublishMillis = new ConcurrentHashMap<>();
 
     public DeliveryLocationApplicationService(
@@ -62,10 +41,8 @@ public class DeliveryLocationApplicationService {
         this.clock = clock;
     }
 
-    /**
-     * 라이더 좌표 push. rider + canTrackLocation 검증 → drift 정정 → rate limit → 좌표 검증 → 캐시 + broadcast.
-     * 빈도 제한 초과 시 {@link ErrorCode#DELIVERY_LOCATION_TOO_FREQUENT}.
-     */
+    
+
     public void publishLocation(
             Long deliveryId, Long riderId,
             double latitude, double longitude,
@@ -85,16 +62,14 @@ public class DeliveryLocationApplicationService {
         realtimePublisher.publishDeliveryLocation(deliveryId, location);
     }
 
-    /** 참여자 + 추적 가능 상태일 때만 마지막 위치 조회. 캐시 미존재 시 빈 Optional. */
+    
     public Optional<DeliveryLocation> findLast(Long deliveryId, Long viewerId) {
         deliveryApplicationService.requireParticipantTrackable(deliveryId, viewerId);
         return locationCache.findLast(deliveryId);
     }
 
-    /**
-     * recordedAt 이 서버 시각 기준 ±{@value #MAX_RECORDED_AT_DRIFT} 초 안이면 그대로,
-     * drift 초과 / null 이면 서버 시각으로 정정. UX 흐름 안 끊고 디바이스 시계 어긋남 방어.
-     */
+    
+
     private static Instant sanitizeRecordedAt(Instant recordedAt, Instant now) {
         if (recordedAt == null) {
             return now;
@@ -103,10 +78,8 @@ public class DeliveryLocationApplicationService {
         return diff.compareTo(MAX_RECORDED_AT_DRIFT) > 0 ? now : recordedAt;
     }
 
-    /**
-     * 같은 (deliveryId, riderId) 의 직전 publish 시각과 비교. 1초 이내 재호출은 거부.
-     * ConcurrentHashMap.compute 로 atomic — 동시 호출 1개만 통과. 결과는 array 캡처로 외부 전달.
-     */
+    
+
     private boolean tryAcquireRate(Long deliveryId, Long riderId, long nowMillis) {
         String key = deliveryId + ":" + riderId;
         long minInterval = MIN_PUBLISH_INTERVAL.toMillis();
@@ -116,7 +89,7 @@ public class DeliveryLocationApplicationService {
                 passed[0] = true;
                 return nowMillis;
             }
-            return last;  // 변경 안 함 — 거부 (passed 그대로 false)
+            return last;  
         });
         return passed[0];
     }

--- a/src/main/java/com/sseulang/domain/delivery/application/EscrowToDeliveryEventListener.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/EscrowToDeliveryEventListener.java
@@ -13,15 +13,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.LocalDateTime;
 
-/**
- * 거래대행 (Escrow) 결제완료 → 배달대행 (Delivery) 모집중 row 자동 생성.
- * 결정 #7 P1 — Delivery 도메인 재사용 + DomainEvent 약결합.
- *
- * <p>{@code AFTER_COMMIT} phase — Escrow 트랜잭션 commit 된 후 listener 호출. 새 delivery row 는
- * 별도 트랜잭션에서 INSERT (REQUIRES_NEW) — escrow 트랜잭션 종료 후이므로 이미 분리된 흐름.</p>
- *
- * <p>5/11 시점 자동 라이더 매칭 X — dummy rider 로 운영자가 수동 PATCH /accept 호출 (X1 follow-up).</p>
- */
 @Component
 public class EscrowToDeliveryEventListener {
 
@@ -50,7 +41,7 @@ public class EscrowToDeliveryEventListener {
             log.info("[escrow→delivery] delivery 모집중 자동 생성 — escrowApplicationId={} deliveryId={}",
                     event.escrowApplicationId(), saved.getId());
         } catch (RuntimeException e) {
-            // commit 후 실패 시 — escrow 는 결제완료 상태로 유지, delivery 만 누락. 운영자 수동 복구.
+            
             log.error("[escrow→delivery] delivery 생성 실패 — escrowApplicationId={} reason={}",
                     event.escrowApplicationId(), e.getMessage(), e);
         }

--- a/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryCreateCommand.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryCreateCommand.java
@@ -2,10 +2,6 @@ package com.sseulang.domain.delivery.application.dto;
 
 import java.time.LocalDateTime;
 
-/**
- * 배달 요청 등록 Command. 문자열 필드는 compact constructor 에서 정규화 (trim/길이 검증).
- * Aggregate 의 create 와 검증 책임 분리: 여기는 표현 검증, Aggregate 는 비즈니스 룰.
- */
 public record DeliveryCreateCommand(
         Long requesterId,
         String pickupAddress,

--- a/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryStatsResult.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/dto/DeliveryStatsResult.java
@@ -5,9 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 
-/**
- * 관리자 dashboard 용 배달대행 통계.
- */
 @Schema(description = "관리자 dashboard — 배달대행 통계.")
 public record DeliveryStatsResult(
         @Schema(example = "42", description = "전체 배달 요청 수") long total,

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryLocation.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryLocation.java
@@ -5,18 +5,6 @@ import com.sseulang.global.exception.ErrorCode;
 
 import java.time.Instant;
 
-/**
- * 라이더 실시간 위치 VO. WGS84 좌표 + 정확도 + 기록 시각.
- *
- * <p>DB 저장 X — Redis 휘발 캐시 (TTL 30분). 마지막 위치만 보존하므로 history 없음.
- * 좌표 범위 검증은 생성 시 강제. 위경도가 한국 범위(33~39N / 124~132E) 밖이면
- * {@link ErrorCode#DELIVERY_LOCATION_INVALID} — GPS 노이즈 / 변조 차단.</p>
- *
- * @param latitude   위도 (33.0 ~ 39.0, 한국 범위)
- * @param longitude  경도 (124.0 ~ 132.0, 한국 범위)
- * @param accuracyM  GPS 정확도 (m). null 허용. ≥ 0
- * @param recordedAt 라이더 디바이스 측 기록 시각. null 허용 — 서버가 채움
- */
 public record DeliveryLocation(
         double latitude,
         double longitude,
@@ -24,7 +12,7 @@ public record DeliveryLocation(
         Instant recordedAt
 ) {
 
-    /** WGS84 위경도 한국 범위 (서비스 영역). 해외 배달 도입 시 확장. */
+    
     private static final double LAT_MIN = 33.0;
     private static final double LAT_MAX = 39.0;
     private static final double LNG_MIN = 124.0;

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryLocationCache.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryLocationCache.java
@@ -2,24 +2,14 @@ package com.sseulang.domain.delivery.domain;
 
 import java.util.Optional;
 
-/**
- * 배달의 마지막 위치를 휘발 저장하는 캐시 포트. 구현은 Redis 어댑터.
- *
- * <p>설계:</p>
- * <ul>
- *   <li>key: {@code delivery:loc:{deliveryId}}</li>
- *   <li>TTL: 30분 (배달 시간 ≪ 30분 가정. 정산완료 후 자동 만료)</li>
- *   <li>마지막 위치 1건만 — history X (DB 비저장 정책, 가이드 §4.13)</li>
- * </ul>
- */
 public interface DeliveryLocationCache {
 
-    /** 마지막 위치 저장 (덮어쓰기). TTL 갱신. */
+    
     void save(Long deliveryId, DeliveryLocation location);
 
-    /** 마지막 위치 조회. 미존재 / TTL 만료 시 빈 Optional. */
+    
     Optional<DeliveryLocation> findLast(Long deliveryId);
 
-    /** 강제 만료 — 정산완료 / 취소 시 즉시 정리 (선택). */
+    
     void evict(Long deliveryId);
 }

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
@@ -7,59 +7,36 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * Delivery Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
- * 구현은 {@code domain/delivery/infrastructure/persistence}.
- */
 public interface DeliveryRepository {
 
     DeliveryRequest save(DeliveryRequest delivery);
 
     Optional<DeliveryRequest> findById(Long id);
 
-    /**
-     * 정산({@code complete}) 진입 시 비관적 락 획득. 동시 complete 호출 race 를 직렬화.
-     * (게이트 1 round 1 — Critical 1: 동시 complete 시 잔액 2회 변동 가능 회귀 차단.)
-     */
+    
+
     Optional<DeliveryRequest> findByIdForUpdate(Long id);
 
-    /**
-     * 라이더 수락 race 차단용 conditional UPDATE.
-     *
-     * <p>{@code UPDATE deliveries SET rider_id=?, status='수락', accepted_at=?
-     * WHERE id=? AND status='모집중' AND requester_id <> ?} — 영향 행 수가 1 이면 수락 성공.
-     * 0 이면 race 패배 / 취소됨 / 본인 거래 (게이트 1 round 1 — W-3: SQL 레벨에서도 본인 거래 차단).</p>
-     *
-     * @return 영향 행 수 (0 또는 1)
-     */
+    
+
     int acceptIfStillOpen(Long deliveryId, Long riderId, LocalDateTime acceptedAt);
 
-    /**
-     * 요청자 취소 race 차단용 conditional UPDATE.
-     *
-     * <p>{@code UPDATE deliveries SET status='취소', canceled_at=?, cancel_reason=?
-     * WHERE id=? AND requester_id=? AND status='모집중'} — 영향 행 수가 1 이면 취소 성공,
-     * 0 이면 이미 수락됐거나 (cancel vs accept race) 취소된 상태 / 본인 자원 아님.</p>
-     *
-     * <p>(게이트 1 round 1 — Critical 2: cancel 이 일반 로드 후 set 이라 accept conditional UPDATE
-     * 결과를 덮어써 "수락 → 취소" race 발생하던 회귀 차단.)</p>
-     *
-     * @return 영향 행 수 (0 또는 1)
-     */
+    
+
     int cancelIfStillOpen(Long deliveryId, Long requesterId, LocalDateTime canceledAt, String reason);
 
-    /** 모집중 상태의 페이징 목록 — 라이더가 수락 가능한 후보. */
+    
     Page<DeliveryRequest> findOpenList(Pageable pageable);
 
-    /** 사용자가 요청자 또는 라이더로 참여한 요청 페이징. */
+    
     Page<DeliveryRequest> findByParticipant(Long userId, Pageable pageable);
 
-    /** status 별 카운트 집계 (admin stats). 단일 GROUP BY — N+1 없음. */
+    
     List<DeliveryStatusCount> countGroupByStatus();
 
-    /** 정산완료 상태의 fee 총합 (admin stats). 누적 라이더 수익 추정. */
+    
     long sumSettledFee();
 
-    /** 거래대행 application 으로 자동 생성된 delivery 조회 — Escrow 정산 시 rider 식별용. */
+    
     Optional<DeliveryRequest> findByEscrowApplicationId(Long escrowApplicationId);
 }

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRequest.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRequest.java
@@ -17,15 +17,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * Delivery Aggregate Root. V8 스키마 {@code deliveries} 매핑.
- *
- * <p>가이드 §1 4축 중 "배달대행" 도메인. 요청자가 등록 → 라이더 수락 → 픽업 → 배송 → 정산.
- * 정산 시 요청자 포인트 차감 + 라이더 적립을 ApplicationService 가 한 트랜잭션으로 처리.
- * 본 Aggregate 는 단일 요청의 상태 머신만 책임. 수락 race 는 conditional UPDATE 가 가드.</p>
- *
- * <p>Setter 없음. 상태 변경은 명시 비즈니스 메서드만.</p>
- */
 @Entity
 @Table(name = "deliveries")
 @Getter
@@ -90,11 +81,11 @@ public class DeliveryRequest extends BaseEntity {
     @Column(name = "cancel_reason", length = MAX_CANCEL_REASON)
     private String cancelReason;
 
-    /** 거래대행 (Escrow) 결제완료 → 자동 생성된 delivery 의 application 참조. NULL = 일반 배달대행. */
+    
     @Column(name = "escrow_application_id")
     private Long escrowApplicationId;
 
-    /** Escrow 결제완료 시 EscrowConfirmedEvent listener 가 호출. 일반 create 와 동일 + escrow_application_id 표시. */
+    
     public static DeliveryRequest createFromEscrow(
             Long requesterId,
             Long escrowApplicationId,
@@ -152,12 +143,8 @@ public class DeliveryRequest extends BaseEntity {
         return d;
     }
 
-    /**
-     * 라이더가 수락 — 모집중 → 수락. 본인이 등록한 요청은 수락 거부.
-     *
-     * <p>주의: race 가드는 ApplicationService 의 conditional UPDATE 가 1차 — 본 메서드는 정상 흐름에서만
-     * 호출되며 본인 거래만 추가로 차단한다.</p>
-     */
+    
+
     public void acceptBy(Long riderId, LocalDateTime now) {
         if (riderId == null || riderId <= 0) {
             throw new IllegalArgumentException("riderId 는 양수여야 합니다");
@@ -173,7 +160,7 @@ public class DeliveryRequest extends BaseEntity {
         this.acceptedAt = now;
     }
 
-    /** 라이더 픽업 — 수락 → 배송중. 라이더 본인만 호출 가능 (호출자 검증). */
+    
     public void markPickedUp(LocalDateTime now) {
         if (!status.canPickup()) {
             throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
@@ -182,7 +169,7 @@ public class DeliveryRequest extends BaseEntity {
         this.pickedUpAt = now;
     }
 
-    /** 라이더 배송 완료 — 배송중 → 배송완료. */
+    
     public void markDelivered(LocalDateTime now) {
         if (!status.canDeliver()) {
             throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
@@ -191,10 +178,8 @@ public class DeliveryRequest extends BaseEntity {
         this.deliveredAt = now;
     }
 
-    /**
-     * 요청자 정산 확인 — 배송완료 → 정산완료. 포인트 이동(차감/적립)은 ApplicationService 가
-     * 같은 트랜잭션 안에서 별도 호출.
-     */
+    
+
     public void markSettled(LocalDateTime now) {
         if (!status.canSettle()) {
             throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);
@@ -203,7 +188,7 @@ public class DeliveryRequest extends BaseEntity {
         this.completedAt = now;
     }
 
-    /** 요청자 취소 — 모집중만. */
+    
     public void cancelByRequester(LocalDateTime now, String reason) {
         if (!status.canRequesterCancel()) {
             throw new BusinessException(ErrorCode.DELIVERY_INVALID_STATE);

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryStatus.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryStatus.java
@@ -1,18 +1,7 @@
 package com.sseulang.domain.delivery.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 배달대행 요청 상태. DB VARCHAR(20) ENUM 매핑.
- *
- * <pre>
- *   모집중 → 수락 → 배송중 → 배송완료 → 정산완료
- *      └→ 취소 (요청자, 모집중 한정 — 5/6 이전 단순화)
- * </pre>
- *
- * <p>수락 단계에서 race 가 있으므로 ApplicationService 가 conditional UPDATE
- * ({@code WHERE id = ? AND status = '모집중'}) 로 동시 수락 차단. 본 enum 은 단일 row
- * 의 다음 전이가 가능한지 표현만 한다.</p>
- */
+
 @Schema(description = "배달 상태. 모집중→수락→배송중→배송완료→정산완료 (또는 취소).")
 public enum DeliveryStatus {
     모집중,
@@ -26,42 +15,34 @@ public enum DeliveryStatus {
         return this == 정산완료 || this == 취소;
     }
 
-    /** 라이더가 수락 가능한 상태 (모집중 → 수락). */
+    
     public boolean canAccept() {
         return this == 모집중;
     }
 
-    /** 라이더가 픽업 처리 가능한 상태 (수락 → 배송중). */
+    
     public boolean canPickup() {
         return this == 수락;
     }
 
-    /** 라이더가 배송 완료 처리 가능한 상태 (배송중 → 배송완료). */
+    
     public boolean canDeliver() {
         return this == 배송중;
     }
 
-    /** 요청자가 정산 확인 가능한 상태 (배송완료 → 정산완료). 포인트 이동은 호출자 책임. */
+    
     public boolean canSettle() {
         return this == 배송완료;
     }
 
-    /**
-     * 요청자가 취소 가능한 상태 (모집중 한정). 수락 이후 취소는 5/6 이후 분쟁 정책 도입 시 확장.
-     */
+    
+
     public boolean canRequesterCancel() {
         return this == 모집중;
     }
 
-    /**
-     * 라이더 좌표 publish / 참여자 위치 조회가 의미 있는 상태.
-     * <ul>
-     *   <li>{@code 수락}: 라이더가 픽업 장소 이동 중</li>
-     *   <li>{@code 배송중}: 픽업 후 도착지 이동 중</li>
-     * </ul>
-     * 모집중(아직 라이더 없음) / 배송완료 / 정산완료 / 취소(종료) 는 false — 위치 추적 의미 없음 +
-     * 종료 후 위치 publish/조회 차단으로 개인정보 잔류 방지 (Codex 게이트 2 W1).
-     */
+    
+
     public boolean canTrackLocation() {
         return this == 수락 || this == 배송중;
     }

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryStatusCount.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryStatusCount.java
@@ -1,4 +1,3 @@
 package com.sseulang.domain.delivery.domain;
 
-/** Delivery status 별 카운트 집계 row (admin stats 용). */
 public record DeliveryStatusCount(DeliveryStatus status, long count) {}

--- a/src/main/java/com/sseulang/domain/delivery/domain/event/DeliveryDeliveredEvent.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/event/DeliveryDeliveredEvent.java
@@ -1,11 +1,5 @@
 package com.sseulang.domain.delivery.domain.event;
 
-/**
- * 라이더가 배송완료 처리한 시점 발행. Escrow Mode A (EXTERNAL) 거래의 자동 정산 트리거.
- *
- * @param deliveryId            완료된 배달 id
- * @param escrowApplicationId   거래대행 연결된 application id (NULL = 일반 배달, NOT NULL = escrow 자동 정산 대상)
- */
 public record DeliveryDeliveredEvent(
         Long deliveryId,
         Long escrowApplicationId

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
@@ -16,19 +16,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-/** Spring Data JPA — {@link DeliveryRepositoryImpl} 가 wrapping. 외부 직접 import 금지. */
 interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
 
-    /** 정산 진입 직렬화 — SELECT FOR UPDATE 로 동시 complete race 차단 (게이트 1 round 1). */
+    
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT d FROM DeliveryRequest d WHERE d.id = :id")
     Optional<DeliveryRequest> findByIdForUpdate(@Param("id") Long id);
 
-    /**
-     * 라이더 수락 race 차단 — conditional UPDATE.
-     * <p>{@code WHERE status='모집중' AND requester_id <> riderId} 로 동시 두 라이더 중 하나만
-     * 1 rows affected. SQL 자체에 본인 거래 차단 (이중 방어 — 게이트 1 round 1 W-3).</p>
-     */
+    
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             UPDATE DeliveryRequest d
@@ -43,10 +39,8 @@ interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
                           @Param("riderId") Long riderId,
                           @Param("acceptedAt") LocalDateTime acceptedAt);
 
-    /**
-     * 요청자 취소 race 차단 — conditional UPDATE. accept 와 동시 발생 시 한 쪽만 성공.
-     * (게이트 1 round 1 — Critical 2.)
-     */
+    
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             UPDATE DeliveryRequest d
@@ -64,7 +58,7 @@ interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
 
     Page<DeliveryRequest> findByStatusOrderByRequestedAtDesc(DeliveryStatus status, Pageable pageable);
 
-    /** 요청자 또는 라이더로 참여한 요청. */
+    
     @Query("""
             SELECT d FROM DeliveryRequest d
              WHERE d.requesterId = :userId
@@ -73,7 +67,7 @@ interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
             """)
     Page<DeliveryRequest> findByParticipant(@Param("userId") Long userId, Pageable pageable);
 
-    /** status 별 건수 — 단일 GROUP BY (admin stats follow-up #52). */
+    
     @Query("""
             SELECT new com.sseulang.domain.delivery.domain.DeliveryStatusCount(d.status, COUNT(d))
               FROM DeliveryRequest d
@@ -81,7 +75,7 @@ interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
             """)
     List<DeliveryStatusCount> countGroupByStatusJpql();
 
-    /** 정산완료 fee 합계. NULL → 0 변환은 호출자(Impl)가 처리. */
+    
     @Query("""
             SELECT COALESCE(SUM(d.fee), 0)
               FROM DeliveryRequest d

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/redis/RedisDeliveryLocationCache.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/redis/RedisDeliveryLocationCache.java
@@ -10,16 +10,6 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.util.Optional;
 
-/**
- * {@link DeliveryLocationCache} Redis 어댑터. JSON 직렬화 + TTL 30분.
- *
- * <p>키 패턴: {@code delivery:loc:{deliveryId}}. {@code save} 호출마다 TTL 갱신
- * (라이더가 publish 멈추면 30분 후 자동 정리).</p>
- *
- * <p>Redis 미가용 / 직렬화 실패 시 RuntimeException — 호출자(ApplicationService) 가
- * trans 안에서 호출하지만 broadcast 실패는 critical 아니라 호출자 측에서 catch 해 무시 가능.
- * 본 어댑터는 단순 에러 그대로 던짐.</p>
- */
 @Component
 class RedisDeliveryLocationCache implements DeliveryLocationCache {
 
@@ -53,7 +43,7 @@ class RedisDeliveryLocationCache implements DeliveryLocationCache {
         try {
             return Optional.of(objectMapper.readValue(json, DeliveryLocation.class));
         } catch (JsonProcessingException e) {
-            // 손상된 JSON — 삭제 + 빈 응답
+            
             redis.delete(key(deliveryId));
             return Optional.empty();
         }

--- a/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryLocationController.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryLocationController.java
@@ -14,14 +14,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 배달 실시간 위치 REST fallback (follow-up #51).
- *
- * <p>STOMP 구독을 막 시작한 클라이언트 (재연결 / 최초 진입) 가 마지막 좌표를 즉시 받기 위한
- * snapshot endpoint. 이후 갱신은 STOMP topic 으로.</p>
- *
- * <p>참여자(요청자/라이더) 만. 그 외 403 DELIVERY_FORBIDDEN. 캐시 미존재 시 204 No Content.</p>
- */
 @Tag(name = "Delivery", description = "배달 실시간 위치 (REST fallback)")
 @RestController
 @RequestMapping("/api/v1/deliveries/{id}/location")

--- a/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryLocationStompController.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/DeliveryLocationStompController.java
@@ -9,22 +9,6 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 
-/**
- * 라이더 좌표 STOMP SEND 핸들러 (follow-up #51).
- *
- * <pre>
- *   destination: /app/delivery/{deliveryId}/location
- *   payload    : DeliveryLocationMessage (lat, lng, accuracyM?, recordedAt?)
- *   broadcast  : /topic/delivery/{deliveryId}/location  (참여자만 SUBSCRIBE 가능)
- * </pre>
- *
- * <p>인증은 {@link com.sseulang.global.websocket.StompAuthChannelInterceptor} 의 CONNECT
- * 단계에서 이미 처리. 본 핸들러는 Authentication 의 principal(userId) 만 추출 후 라이더 검증을
- * ApplicationService 에 위임.</p>
- *
- * <p>SEND 자체는 화이트리스트 X — ApplicationService 가 라이더 본인 검증으로 거부.
- * 다른 사용자가 임의의 destination 으로 SEND 보내도 publishLocation 의 requireRider 가 차단.</p>
- */
 @Controller
 public class DeliveryLocationStompController {
 

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryLocationMessage.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/DeliveryLocationMessage.java
@@ -4,11 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 
-/**
- * 배달 실시간 위치 메시지 (STOMP SEND / 응답 broadcast / REST 응답 공용).
- *
- * <p>한국 좌표 범위(33~39N / 124~132E) 밖이면 백엔드에서 400 거절. accuracy/recordedAt 은 옵션.</p>
- */
 @Schema(description = "배달 실시간 위치 — 한국 위경도 범위 강제. accuracy/recordedAt 옵션.")
 public record DeliveryLocationMessage(
         @Schema(example = "37.4979", description = "WGS84 위도 (33.0~39.0)")

--- a/src/main/java/com/sseulang/domain/escrow/application/DeliveryDeliveredEventListener.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/DeliveryDeliveredEventListener.java
@@ -9,12 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-/**
- * Delivery 배송완료 → Escrow Mode A 자동 정산 트리거 (게이트 1 round 1 — Warning).
- *
- * <p>{@code AFTER_COMMIT} phase — Delivery markDelivered 트랜잭션 commit 후 별도 트랜잭션
- * (REQUIRES_NEW) 으로 escrow settle. escrow_application_id NULL = 일반 배달이라 무시.</p>
- */
 @Component
 public class DeliveryDeliveredEventListener {
 
@@ -30,12 +24,12 @@ public class DeliveryDeliveredEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onDeliveryDelivered(DeliveryDeliveredEvent event) {
         if (event.escrowApplicationId() == null) {
-            return;  // 일반 배달 — escrow 정산 무관
+            return;  
         }
         try {
             escrowService.settleAfterDelivery(event.escrowApplicationId());
         } catch (RuntimeException e) {
-            // 정산 실패 시 escrow 는 진행중 상태 유지. 운영자 수동 복구.
+            
             log.error("[escrow-settle] Mode A 자동 정산 실패 — escrowApplicationId={} reason={}",
                     event.escrowApplicationId(), e.getMessage(), e);
         }

--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -43,18 +43,6 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * 거래대행 (Escrow) 흐름의 트랜잭션 경계. 8 use case + 결제 통합 + 정산 흐름.
- *
- * <p>핵심 보안/정합성 (Codex 게이트 1 영역):
- * <ul>
- *   <li>link 첫 폼 제출 atomic UPDATE (race-safe) — 결정 #2/3</li>
- *   <li>snapshot 보존 — 운영 settings 변경 무관 lock — 결정 #9/12</li>
- *   <li>fee mismatch ±10원 검증 — 결정 #10</li>
- *   <li>매칭 후 취소 100% 부담 정책 — 결정 #6 (cancel 메서드 분기)</li>
- *   <li>자기거래 차단 (initiator != receiver, buyer != seller)</li>
- * </ul>
- */
 @Service
 @Transactional(readOnly = true)
 public class EscrowApplicationService {
@@ -96,11 +84,11 @@ public class EscrowApplicationService {
         this.linkExpiryHours = linkExpiryHours;
     }
 
-    // =============================================================
-    // Use case 0 — 폼 작성 중 수수료 미리보기 (PR-B 라운드 12)
-    // 좌표/물품/feePayer 받아서 거리·deliveryFee·commissionFee + buyer/seller 부담분 산정.
-    // application 생성 X — pure read.
-    // =============================================================
+    
+    
+    
+    
+    
     public EscrowApplicationPreviewResult previewFee(EscrowApplicationPreviewCommand cmd) {
         if (cmd.tradeMode() == null || cmd.feePayer() == null
                 || cmd.weight() == null || cmd.volume() == null || cmd.fragility() == null
@@ -130,16 +118,16 @@ public class EscrowApplicationService {
         );
     }
 
-    // =============================================================
-    // Use case 0b — 내부 신청 (PR-B-3 라운드 12). 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력.
-    // 외부 link 흐름 (createApplication) 와 분리.
-    // 검증: chatRoom 참여자 + chatRoom.itemId == cmd.itemId + 본인 == item.sellerId.
-    // =============================================================
+    
+    
+    
+    
+    
     @Transactional
     public EscrowApplicationResult createInternalApplication(EscrowApplicationCreateInternalCommand cmd) {
         userApplicationService.requireVerified(cmd.requesterId());
 
-        // chatRoom 참여자 검증 + 메타 (itemId)
+        
         com.sseulang.domain.chat.application.ChatRoomApplicationService.ChatRoomMeta meta =
                 chatRoomApplicationService.findMetaForParticipant(cmd.chatRoomId(), cmd.requesterId());
         if (!meta.itemId().equals(cmd.itemId())) {
@@ -149,16 +137,16 @@ public class EscrowApplicationService {
             throw new BusinessException(ErrorCode.CHAT_ROOM_OPPONENT_LEFT);
         }
 
-        // 판매자 검증 — itemId → item.sellerId == requesterId
+        
         var itemInfo = itemApplicationService.findActiveForTransaction(cmd.itemId());
         if (!itemInfo.sellerId().equals(cmd.requesterId())) {
             throw new BusinessException(ErrorCode.ESCROW_SELLER_ONLY);
         }
 
-        // buyer = chatRoom 의 상대방
+        
         Long buyerId = chatRoomApplicationService.findOpponent(cmd.chatRoomId(), cmd.requesterId());
 
-        // fee 산정 (외부 흐름과 동일 방식)
+        
         EscrowFeeSettings settings = feeSettingsRepository.findSingleton();
         BigDecimal calculatedDistance = EscrowFeeCalculator.distanceKm(
                 cmd.pickupLat().doubleValue(), cmd.pickupLng().doubleValue(),
@@ -172,7 +160,7 @@ public class EscrowApplicationService {
                 calculated, cmd.submittedDeliveryFee(), cmd.submittedCommissionFee(), cmd.submittedTotalFee()
         );
 
-        // share 산정. initiator = seller, receiver = buyer (내부 흐름은 seller 가 시작).
+        
         long buyerOwed = computeBuyerOwed(cmd.tradeMode(), cmd.itemPrice(), calculated, cmd.feePayer());
         long sellerOwed = computeSellerOwed(calculated, cmd.feePayer());
         long initiatorShare = sellerOwed;
@@ -180,8 +168,8 @@ public class EscrowApplicationService {
 
         EscrowApplication app = EscrowApplication.createInternal(
                 cmd.chatRoomId(),
-                cmd.requesterId(),  // initiator = seller
-                buyerId,            // receiver = buyer
+                cmd.requesterId(),  
+                buyerId,            
                 cmd.tradeMode(), cmd.feePayer(),
                 cmd.itemPrice(), cmd.itemDescription(),
                 cmd.pickupAddress(), cmd.pickupLat(), cmd.pickupLng(),
@@ -194,10 +182,10 @@ public class EscrowApplicationService {
         return EscrowApplicationResult.from(saved, parseImageUrls(saved.getImageUrls()));
     }
 
-    // =============================================================
-    // Use case 0c — 내부 draft (PR-B-4 라운드 12). 판매자가 본인 영역만 입력 → 정보입력대기.
-    // 구매자는 patchBuyerInfo 로 본인 영역 추가 입력 → 양쪽 filled 시 결제대기 전환.
-    // =============================================================
+    
+    
+    
+    
     @Transactional
     public EscrowApplicationResult createInternalDraft(
             com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateInternalDraftCommand cmd
@@ -213,7 +201,7 @@ public class EscrowApplicationService {
             throw new BusinessException(ErrorCode.CHAT_ROOM_OPPONENT_LEFT);
         }
 
-        // 판매자만
+        
         var itemInfo = itemApplicationService.findActiveForTransaction(cmd.itemId());
         if (!itemInfo.sellerId().equals(cmd.requesterId())) {
             throw new BusinessException(ErrorCode.ESCROW_SELLER_ONLY);
@@ -234,9 +222,9 @@ public class EscrowApplicationService {
         return EscrowApplicationResult.from(saved, parseImageUrls(saved.getImageUrls()));
     }
 
-    // =============================================================
-    // Use case 0d — 판매자 영역 수정 (PR-B-4).
-    // =============================================================
+    
+    
+    
     @Transactional
     public EscrowApplicationResult patchSellerInfo(
             Long applicationId,
@@ -256,9 +244,9 @@ public class EscrowApplicationService {
         return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()));
     }
 
-    // =============================================================
-    // Use case 0e — 구매자 영역 입력 (PR-B-4). 양쪽 filled 시 결제대기 전환.
-    // =============================================================
+    
+    
+    
     @Transactional
     public EscrowApplicationResult patchBuyerInfo(
             Long applicationId,
@@ -273,7 +261,7 @@ public class EscrowApplicationService {
         }
         app.patchBuyerInfo(cmd.deliveryAddress(), cmd.deliveryLat(), cmd.deliveryLng(), cmd.receiverPhone());
 
-        // 양쪽 filled — fee 산정 + 결제대기 전환
+        
         if (app.isSellerInfoFilled() && app.isBuyerInfoFilled()) {
             EscrowFeeSettings settings = feeSettingsRepository.findSingleton();
             BigDecimal distance = EscrowFeeCalculator.distanceKm(
@@ -286,17 +274,17 @@ public class EscrowApplicationService {
             );
             long buyerOwed = computeBuyerOwed(app.getTradeMode(), app.getItemPrice(), calculated, app.getFeePayer());
             long sellerOwed = computeSellerOwed(calculated, app.getFeePayer());
-            long initiatorShare = sellerOwed;  // initiator = seller (내부 흐름)
-            long receiverShare = buyerOwed;    // receiver = buyer
+            long initiatorShare = sellerOwed;  
+            long receiverShare = buyerOwed;    
             app.transitionToReadyForPayment(calculated, initiatorShare, receiverShare);
         }
 
         return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()));
     }
 
-    // =============================================================
-    // Use case 1 — 신청자가 link 생성
-    // =============================================================
+    
+    
+    
     @Transactional
     public EscrowLinkResult createLink(EscrowLinkCreateCommand cmd) {
         userApplicationService.requireVerified(cmd.initiatorId());
@@ -312,9 +300,9 @@ public class EscrowApplicationService {
         return EscrowLinkResult.from(saved, initiator.getNickname());
     }
 
-    // =============================================================
-    // Use case 2 — link 진입 (비로그인 OK, 결정 #1 A1)
-    // =============================================================
+    
+    
+    
     public EscrowLinkResult getByToken(String linkToken) {
         EscrowLink link = linkRepository.findByLinkToken(linkToken)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_LINK_NOT_FOUND));
@@ -331,10 +319,10 @@ public class EscrowApplicationService {
         return EscrowLinkResult.from(link, initiator.getNickname());
     }
 
-    // =============================================================
-    // Use case 3 — 폼 제출 (수신자 확정 + application 생성)
-    // 결정 #2 B3 + #3 C1+C3 (atomic + idempotent)
-    // =============================================================
+    
+    
+    
+    
     @Transactional
     public EscrowApplicationResult createApplication(EscrowApplicationCreateCommand cmd) {
         userApplicationService.requireVerified(cmd.receiverId());
@@ -342,17 +330,17 @@ public class EscrowApplicationService {
         EscrowLink link = linkRepository.findByLinkToken(cmd.linkToken())
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_LINK_NOT_FOUND));
 
-        // idempotent — 이미 본인이 receiver 면 기존 application 반환
+        
         if (cmd.receiverId().equals(link.getReceiverId())) {
             return applicationRepository.findByLinkId(link.getId())
                     .map(a -> EscrowApplicationResult.from(a, parseImageUrls(a.getImageUrls())))
                     .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_INVALID_STATE));
         }
 
-        // race lose / 본인 차단 / 만료 일괄 검증 — atomic UPDATE
+        
         int affected = linkRepository.claimReceiverIfAvailable(link.getId(), cmd.receiverId());
         if (affected == 0) {
-            // 어떤 사유인지 분기
+            
             if (link.getInitiatorId().equals(cmd.receiverId())) {
                 throw new BusinessException(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
             }
@@ -362,7 +350,7 @@ public class EscrowApplicationService {
             throw new BusinessException(ErrorCode.ESCROW_LINK_ALREADY_TAKEN);
         }
 
-        // snapshot — fee 산정
+        
         EscrowFeeSettings settings = feeSettingsRepository.findSingleton();
         BigDecimal calculatedDistance = EscrowFeeCalculator.distanceKm(
                 cmd.pickupLat().doubleValue(), cmd.pickupLng().doubleValue(),
@@ -372,12 +360,12 @@ public class EscrowApplicationService {
                 settings, link.getTradeMode(), cmd.itemPrice(), calculatedDistance,
                 cmd.weight(), cmd.volume(), cmd.fragility()
         );
-        // 결정 #10 — ±10원 tolerance
+        
         EscrowFeeCalculator.verifyTolerance(
                 calculated, cmd.submittedDeliveryFee(), cmd.submittedCommissionFee(), cmd.submittedTotalFee()
         );
 
-        // share 산정 — feePayer 별 분기 (결정 #5)
+        
         long buyerOwed = computeBuyerOwed(link.getTradeMode(), cmd.itemPrice(), calculated, link.getFeePayer());
         long sellerOwed = computeSellerOwed(calculated, link.getFeePayer());
         long initiatorShare = link.getInitiatorRole() == InitiatorRole.buyer ? buyerOwed : sellerOwed;
@@ -395,21 +383,19 @@ public class EscrowApplicationService {
                 serializeImageUrls(cmd.imageUrls())
         );
         EscrowApplication saved = applicationRepository.save(app);
-        // link 상태 → 완료
+        
         link.markAsCompleted();
         return EscrowApplicationResult.from(saved, parseImageUrls(saved.getImageUrls()));
     }
 
-    /**
-     * Mode B 의 buyer 부담 = itemPrice + (feePayer 별 fee 분담).
-     * Mode A 의 buyer 부담 = (feePayer 별 fee 분담).
-     */
+    
+
     private long computeBuyerOwed(TradeMode mode, long itemPrice, FeeBreakdown fee, FeePayer payer) {
         long feeTotal = fee.deliveryFee() + fee.commissionFee();
         long buyerFeeShare = switch (payer) {
             case buyer -> feeTotal;
             case seller -> 0L;
-            case both -> feeTotal / 2;  // 정수 원 단위 — 홀수 1원 차이는 buyer 가 더 부담
+            case both -> feeTotal / 2;  
         };
         return (mode == TradeMode.INTERNAL ? itemPrice : 0L) + buyerFeeShare;
     }
@@ -419,14 +405,12 @@ public class EscrowApplicationService {
         return switch (payer) {
             case buyer -> 0L;
             case seller -> feeTotal;
-            case both -> feeTotal - feeTotal / 2;  // 나머지 (홀수면 buyer 가 1 더, seller 가 1 적게)
+            case both -> feeTotal - feeTotal / 2;  
         };
     }
 
-    /**
-     * Payment 도메인이 startCharge 단계에서 호출 — payer / share / status 검증.
-     * 검증 통과한 amount 만 Payment 진입 (위변조 방지 + race-safe).
-     */
+    
+
     public void verifyChargeIntent(Long applicationId, Long payerId, long amount) {
         EscrowApplication app = applicationRepository.findById(applicationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
@@ -451,7 +435,7 @@ public class EscrowApplicationService {
             throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
         }
         if (expectedShare <= 0) {
-            // 본인 share 가 0 인데 결제 시도 — 부정 시도.
+            
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
         }
         if (expectedShare != amount) {
@@ -459,11 +443,11 @@ public class EscrowApplicationService {
         }
     }
 
-    // =============================================================
-    // Use case 4b — 포인트 잔액 결제 (PR-B-5 라운드 12).
-    // 토스 결제창 X — 포인트 잔액에서 본인 share 만큼 차감 + paid 마킹.
-    // 양쪽 paid 시 자동 결제완료 + EscrowConfirmedEvent → 라이더 매칭.
-    // =============================================================
+    
+    
+    
+    
+    
     @Transactional
     public EscrowApplicationStatus payShare(Long applicationId, Long payerId) {
         userApplicationService.requireVerified(payerId);
@@ -494,11 +478,11 @@ public class EscrowApplicationService {
         }
 
         if (expectedShare <= 0) {
-            // 본인 share 가 0 — 결제 의무 없음.
+            
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
         }
 
-        // 포인트 잔액 차감 (atomic UPDATE — 잔액 부족 시 INSUFFICIENT_POINT throw)
+        
         pointApplicationService.deduct(
                 payerId, expectedShare,
                 com.sseulang.domain.point.domain.PointHistoryType.결제,
@@ -507,14 +491,14 @@ public class EscrowApplicationService {
                 "거래대행 결제 — 본인 분담분"
         );
 
-        // paid 마킹
+        
         if (payerId.equals(app.getInitiatorId())) {
             app.markInitiatorPaid();
         } else {
             app.markReceiverPaid();
         }
 
-        // 양쪽 결제 완료 시 EscrowConfirmedEvent 발행 → Delivery 도메인 라이더 자동 매칭
+        
         if (app.getStatus() == EscrowApplicationStatus.결제완료) {
             eventPublisher.publishEvent(new EscrowConfirmedEvent(
                     app.getId(),
@@ -528,15 +512,15 @@ public class EscrowApplicationService {
         return app.getStatus();
     }
 
-    // =============================================================
-    // Use case 4 — 결제 confirm 후 호출 (Payment 도메인이 호출)
-    // =============================================================
+    
+    
+    
     @Transactional
     public EscrowApplicationStatus recordPaymentConfirmed(Long applicationId, Long payerId) {
         EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
         if (app.isPaymentTimedOut()) {
-            // 자동 환불 트리거 — 5/11 시점엔 단순화 — 환불 처리는 Payment 도메인 또는 cron 후속.
+            
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
         }
         if (payerId.equals(app.getInitiatorId())) {
@@ -546,7 +530,7 @@ public class EscrowApplicationService {
         } else {
             throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
         }
-        // 양쪽 결제 완료 시 EscrowConfirmedEvent 발행 → Delivery 도메인 listen
+        
         if (app.getStatus() == EscrowApplicationStatus.결제완료) {
             eventPublisher.publishEvent(new EscrowConfirmedEvent(
                     app.getId(),
@@ -560,9 +544,9 @@ public class EscrowApplicationService {
         return app.getStatus();
     }
 
-    // =============================================================
-    // Use case 5 — 라이더 자동 매칭됐을 때 (Delivery 도메인이 호출)
-    // =============================================================
+    
+    
+    
     @Transactional
     public void markInProgress(Long applicationId) {
         EscrowApplication app = applicationRepository.findById(applicationId)
@@ -570,35 +554,34 @@ public class EscrowApplicationService {
         app.markInProgress();
     }
 
-    // =============================================================
-    // Use case 6 — buyer 수령 확인 (Mode B 만) → 정산
-    // 결정 #4
-    // =============================================================
+    
+    
+    
+    
     @Transactional
     public void confirmReceipt(Long applicationId, Long requesterId) {
         EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
         app.confirmReceipt(requesterId);
-        // 라이더 식별 — Delivery 도메인에서 escrow_application_id 로 조회 (게이트 1 Critical 2).
+        
         Long riderId = deliveryRepository.findByEscrowApplicationId(applicationId)
                 .map(d -> d.getRiderId())
                 .orElse(null);
         if (riderId == null) {
-            // 라이더 매칭 안 된 상태에서 receipt 호출 — 데이터 부정합 (정산 불가).
+            
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
         }
         settle(app, riderId);
     }
 
-    /**
-     * 자동 정산 (Mode A — 배송완료 시 Delivery 도메인이 호출).
-     */
+    
+
     @Transactional
     public void settleAfterDelivery(Long applicationId) {
         EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
         if (app.getTradeMode() == TradeMode.INTERNAL) {
-            // Mode B 는 buyer 수령 확인 별도 endpoint 호출
+            
             return;
         }
         Long riderId = deliveryRepository.findByEscrowApplicationId(applicationId)
@@ -610,10 +593,8 @@ public class EscrowApplicationService {
         settle(app, riderId);
     }
 
-    /**
-     * 정산 — Mode B: seller += itemPrice, rider += deliveryFee.
-     * commissionFee 는 플랫폼 수익 (별도 transfer X — PointHistory 만 기록은 follow-up).
-     */
+    
+
     private void settle(EscrowApplication app, Long riderId) {
         if (app.getTradeMode() == TradeMode.INTERNAL && app.getItemPrice() > 0) {
             pointApplicationService.credit(
@@ -632,9 +613,9 @@ public class EscrowApplicationService {
         app.markSettled();
     }
 
-    // =============================================================
-    // Use case 7 — 취소 (시점별 환불 — 결정 #6)
-    // =============================================================
+    
+    
+    
     @Transactional
     public void cancel(Long applicationId, Long requesterId, String reason) {
         EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
@@ -643,19 +624,19 @@ public class EscrowApplicationService {
             throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
         }
         if (app.getStatus().isAfterMatching()) {
-            // 매칭 후 취소 — 100% 부담 정책 (결정 #6).
-            // 5/11 단순화: 별도 추가 결제 흐름 미구현 — 관리자 분기 처리.
-            // TODO(R1): 자동 추가 결제 + 환불 흐름.
+            
+            
+            
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
         }
-        // 매칭 전 — 양쪽 환불 (결제됐던 양만큼).
-        // 5/11 단순화: 환불 호출은 Payment 도메인이 별도 처리. 여기선 status만 갱신.
+        
+        
         app.cancel(requesterId, reason);
     }
 
-    // =============================================================
-    // Use case 8 — 본인 application 목록 / 단건
-    // =============================================================
+    
+    
+    
     public Page<EscrowApplicationResult> listMine(Long userId, Pageable pageable) {
         return applicationRepository.findMyApplications(userId, pageable)
                 .map(a -> EscrowApplicationResult.from(a, parseImageUrls(a.getImageUrls())));
@@ -670,9 +651,9 @@ public class EscrowApplicationService {
         return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()));
     }
 
-    // =============================================================
-    // Admin 우회 — 참여자 가드 X
-    // =============================================================
+    
+    
+    
     public Page<EscrowApplicationResult> adminListAll(Pageable pageable) {
         return applicationRepository.findAll(pageable)
                 .map(a -> EscrowApplicationResult.from(a, parseImageUrls(a.getImageUrls())));
@@ -684,7 +665,7 @@ public class EscrowApplicationService {
         return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()));
     }
 
-    /** 이미지 URL list 직렬화 (TEXT 컬럼). 5/11 단순화 — JSON 배열. */
+    
     private String serializeImageUrls(List<String> urls) {
         if (urls == null || urls.isEmpty()) return null;
         try {

--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowFeeSettingsApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowFeeSettingsApplicationService.java
@@ -8,12 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 
-/**
- * 거래대행 수수료 정책 운영 (admin). 결정 #9 + #12.
- *
- * <p>변경 흐름: PATCH 호출 → DB UPDATE → 진행 중 application 은 snapshot 으로 영향 X.
- * 변경 시 진행 중 N건 표시 (12-a HH2) 위해 countInProgress 동시 반환.</p>
- */
 @Service
 @Transactional(readOnly = true)
 public class EscrowFeeSettingsApplicationService {
@@ -52,7 +46,7 @@ public class EscrowFeeSettingsApplicationService {
         return repository.save(settings);
     }
 
-    /** admin 변경 시 표시용 — 진행 중 application N건. */
+    
     public long countInProgress() {
         return applicationRepository.countInProgress();
     }

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateCommand.java
@@ -8,9 +8,9 @@ import java.math.BigDecimal;
 import java.util.List;
 
 public record EscrowApplicationCreateCommand(
-        Long receiverId,                // 폼 제출자 = 수신자 후보
+        Long receiverId,                
         String linkToken,
-        long itemPrice,                 // INTERNAL > 0, EXTERNAL = 0
+        long itemPrice,                 
         String itemDescription,
         String pickupAddress,
         BigDecimal pickupLat,
@@ -22,7 +22,7 @@ public record EscrowApplicationCreateCommand(
         Volume volume,
         Fragility fragility,
         String deliveryNotes,
-        // 프론트가 보낸 fee 값 (백엔드 ±10원 검증)
+        
         long submittedDeliveryFee,
         long submittedCommissionFee,
         long submittedTotalFee,

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateInternalCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateInternalCommand.java
@@ -9,20 +9,10 @@ import com.sseulang.domain.escrow.domain.Weight;
 import java.math.BigDecimal;
 import java.util.List;
 
-/**
- * 내부 거래대행 신청 Command (PR-B-2 라운드 12). 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력.
- *
- * <p>외부 link 흐름과 차이:
- * <ul>
- *   <li>{@code linkToken} 미사용 — chatRoomId 로 채팅방 컨텍스트 검증.</li>
- *   <li>{@code requesterId} 는 판매자 (initiator) — 정책상 sellerOnly 라 chat_room.user1/user2 중 sellerId 와 일치 검증.</li>
- *   <li>buyer 는 chat_room 의 상대방에서 도출 (요청자 명시 X).</li>
- * </ul>
- */
 public record EscrowApplicationCreateInternalCommand(
-        Long requesterId,            // 판매자 = initiator
+        Long requesterId,            
         Long chatRoomId,
-        Long itemId,                 // chatRoom 의 item 검증용
+        Long itemId,                 
         TradeMode tradeMode,
         FeePayer feePayer,
         long itemPrice,

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateInternalDraftCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationCreateInternalDraftCommand.java
@@ -9,12 +9,6 @@ import com.sseulang.domain.escrow.domain.Weight;
 import java.math.BigDecimal;
 import java.util.List;
 
-/**
- * 내부 draft 신청 (PR-B-4) — 판매자가 본인 영역만 입력하여 정보입력대기 상태 생성.
- * 구매자 영역 (delivery_*, receiver_phone) 은 buyer-info PATCH 로 별도 입력.
- *
- * <p>fee 산정은 양쪽 입력 완료 후 transitionToReadyForPayment 시점.</p>
- */
 public record EscrowApplicationCreateInternalDraftCommand(
         Long requesterId,
         Long chatRoomId,

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationPreviewCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationPreviewCommand.java
@@ -8,12 +8,6 @@ import com.sseulang.domain.escrow.domain.Weight;
 
 import java.math.BigDecimal;
 
-/**
- * 거래대행 수수료 미리보기 Command — 신청 폼 작성 중 실시간 호출용.
- * 백엔드가 좌표로 거리 계산 + 정책 적용 + share 산정해서 응답.
- *
- * <p>actually persisting 아무것도 안 함 — pure read.</p>
- */
 public record EscrowApplicationPreviewCommand(
         TradeMode tradeMode,
         long itemPrice,

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationPreviewResult.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationPreviewResult.java
@@ -2,17 +2,6 @@ package com.sseulang.domain.escrow.application.dto;
 
 import java.math.BigDecimal;
 
-/**
- * 미리보기 응답. 실제 application 생성 X — 폼 작성 중 실시간 표시용.
- *
- * @param distanceKm     좌표 기반 산정 거리 (소수점 2)
- * @param deliveryFee    라이더 보상 (원)
- * @param commissionFee  플랫폼 수익 (Mode B 만 > 0)
- * @param totalFee       총 fee (deliveryFee + commissionFee + (INTERNAL ? itemPrice : 0))
- * @param buyerPayable   feePayer 별 buyer 부담분 (BOTH=50%, SELLER=0, BUYER=feeTotal)
- * @param sellerPayable  feePayer 별 seller 부담분
- * @param commissionRate snapshot — 정책 변경 시 실신청 시점에 재계산
- */
 public record EscrowApplicationPreviewResult(
         BigDecimal distanceKm,
         long deliveryFee,

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowBuyerInfoPatchCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowBuyerInfoPatchCommand.java
@@ -2,10 +2,6 @@ package com.sseulang.domain.escrow.application.dto;
 
 import java.math.BigDecimal;
 
-/**
- * 구매자 영역 입력 (PR-B-4) — 정보입력대기 상태에서만.
- * 수령지 + 수령자 연락처. 양쪽 filled 시 ApplicationService 가 fee 산정 + 결제대기 전환.
- */
 public record EscrowBuyerInfoPatchCommand(
         String deliveryAddress,
         BigDecimal deliveryLat,

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkResult.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkResult.java
@@ -7,22 +7,6 @@ import com.sseulang.domain.escrow.domain.TradeMode;
 
 import java.time.LocalDateTime;
 
-/**
- * Escrow link 응답.
- *
- * <p>비로그인 GET 응답 시 노출 필드 최소화 (게이트 1 Nit) — 토큰 leak 시 메타데이터 leak 면적 축소.
- * 신청자 본인의 link 생성 응답은 동일 형식이지만 본인 정보라 leak 위험 X.</p>
- *
- * <p>의도적 노출:
- * <ul>
- *   <li>linkToken — 응답으로 받기 위해 필요</li>
- *   <li>initiatorNickname — 수신자가 누가 보낸 건지 식별</li>
- *   <li>initiatorRole / feePayer / tradeMode — 수신자가 본인 부담 결정</li>
- *   <li>expiresAt — 클라가 만료 시각 표시</li>
- * </ul>
- *
- * <p>의도적 비노출 (Nit fix): id, initiatorId, status, createdAt — public 진입 시 leak 면적 축소.</p>
- */
 public record EscrowLinkResult(
         String linkToken,
         String initiatorNickname,

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowSellerInfoPatchCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowSellerInfoPatchCommand.java
@@ -6,10 +6,6 @@ import com.sseulang.domain.escrow.domain.Weight;
 
 import java.math.BigDecimal;
 
-/**
- * 판매자 영역 수정 (PR-B-4) — 정보입력대기 상태에서만.
- * 출발지 / 물품 정보 / 가격을 수정 가능. delivery 좌표는 영향 없음.
- */
 public record EscrowSellerInfoPatchCommand(
         String pickupAddress,
         BigDecimal pickupLat,

--- a/src/main/java/com/sseulang/domain/escrow/domain/EntryType.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EntryType.java
@@ -1,15 +1,5 @@
 package com.sseulang.domain.escrow.domain;
 
-/**
- * 거래대행 신청 진입 경로.
- *
- * <ul>
- *   <li>{@link #EXTERNAL} — 기존 link 토큰 흐름. initiator 가 link 생성, receiver 가 form 제출.
- *       link_id 가 application 에 채워짐.</li>
- *   <li>{@link #INTERNAL} — 채팅방 내 신청 (PR-B-2 라운드 12). 판매자가 채팅방 안에서 신청 + 양쪽 정보 한 번에 입력.
- *       link_id 는 NULL, chat_room_id 가 채워짐.</li>
- * </ul>
- */
 public enum EntryType {
     INTERNAL,
     EXTERNAL

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
@@ -18,15 +18,6 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-/**
- * Escrow Application Aggregate Root. V15 {@code escrow_applications} 매핑.
- *
- * <p>폼 제출 후 단일 row. 결제/정산/취소 라이프사이클 모두 본 Aggregate 이 책임.
- * snapshot (applied_*) — settings 변경 무관 lock (결정 #9, #12).</p>
- *
- * <p>상태머신: 결제대기 → 결제완료 → 진행중 → 완료 / 취소.
- * 양쪽 share 결제 (G2) — initiator/receiver 각자 결제 시점 기록.</p>
- */
 @Entity
 @Table(name = "escrow_applications")
 @Getter
@@ -37,41 +28,34 @@ public class EscrowApplication extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /**
-     * 외부 link 흐름의 link.id. 내부 chatRoom 흐름은 NULL (V20 라운드 12 PR-B-2).
-     */
+    
+
     @Column(name = "link_id", updatable = false)
     private Long linkId;
 
-    /**
-     * 진입 경로 — INTERNAL (채팅방 내 신청) | EXTERNAL (link 토큰 흐름).
-     */
+    
+
     @Enumerated(EnumType.STRING)
     @Column(name = "entry_type", nullable = false, length = 10, updatable = false)
     private EntryType entryType;
 
-    /**
-     * 내부 흐름의 채팅방 ID (V19 컬럼). 외부 link 흐름은 NULL.
-     */
+    
+
     @Column(name = "chat_room_id", updatable = false)
     private Long chatRoomId;
 
-    /**
-     * 판매자 영역 (출발지/물품) 입력 완료 — PR-B-4 라운드 12. 외부 흐름은 항상 TRUE.
-     */
+    
+
     @Column(name = "seller_info_filled", nullable = false)
     private boolean sellerInfoFilled;
 
-    /**
-     * 구매자 영역 (수령지/연락처) 입력 완료. 외부 흐름은 항상 TRUE.
-     * 양쪽 모두 TRUE 가 되면 fee 산정 + status 가 정보입력대기 → 결제대기 로 전환.
-     */
+    
+
     @Column(name = "buyer_info_filled", nullable = false)
     private boolean buyerInfoFilled;
 
-    /**
-     * 수령자 연락처 (구매자 영역) — 내부 흐름의 buyer-info PATCH 시 입력.
-     */
+    
+
     @Column(name = "receiver_phone", length = 20)
     private String receiverPhone;
 
@@ -110,7 +94,7 @@ public class EscrowApplication extends BaseEntity {
     @Column(name = "pickup_lng", nullable = false, precision = 10, scale = 7, updatable = false)
     private BigDecimal pickupLng;
 
-    /** 수령지 — 내부 draft 단계엔 NULL, buyer-info PATCH 시 입력. */
+    
     @Column(name = "delivery_address", length = 255)
     private String deliveryAddress;
 
@@ -135,7 +119,7 @@ public class EscrowApplication extends BaseEntity {
     @Column(name = "delivery_notes", length = 500, updatable = false)
     private String deliveryNotes;
 
-    // ===== snapshot — 양쪽 입력 완료 후 산정. 정보입력대기 단계엔 NULL. =====
+    
     @Column(name = "applied_distance_km", precision = 8, scale = 2)
     private BigDecimal appliedDistanceKm;
 
@@ -151,8 +135,8 @@ public class EscrowApplication extends BaseEntity {
     @Column(name = "applied_commission_rate", precision = 5, scale = 4)
     private BigDecimal appliedCommissionRate;
 
-    // ===== 결제 추적 =====
-    /** 신청자(initiator) 결제 분담분. 양쪽 입력 완료 후 산정. */
+    
+    
     @Column(name = "initiator_share")
     private Long initiatorShare;
 
@@ -168,7 +152,7 @@ public class EscrowApplication extends BaseEntity {
     @Column(name = "payment_due_at")
     private LocalDateTime paymentDueAt;
 
-    // ===== 상태머신 =====
+    
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private EscrowApplicationStatus status;
@@ -188,10 +172,8 @@ public class EscrowApplication extends BaseEntity {
     @Column(name = "image_urls", columnDefinition = "TEXT", updatable = false)
     private String imageUrls;
 
-    /**
-     * 폼 제출 후 application 생성. snapshot 컬럼 모두 채움.
-     * shares 는 feePayer 별 ApplicationService 가 산정 후 주입.
-     */
+    
+
     public static EscrowApplication create(
             Long linkId,
             Long initiatorId, Long receiverId, InitiatorRole initiatorRole,
@@ -210,14 +192,14 @@ public class EscrowApplication extends BaseEntity {
         if (initiatorId.equals(receiverId)) {
             throw new BusinessException(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
         }
-        // role 매핑 — buyer/seller 식별
+        
         Long buyerId = initiatorRole == InitiatorRole.buyer ? initiatorId : receiverId;
         Long sellerId = initiatorRole == InitiatorRole.buyer ? receiverId : initiatorId;
 
         EscrowApplication a = new EscrowApplication();
         a.linkId = linkId;
         a.entryType = EntryType.EXTERNAL;
-        // 외부 link 흐름은 receiver 가 form 제출 시 양쪽 정보 모두 입력 → 양쪽 filled.
+        
         a.sellerInfoFilled = true;
         a.buyerInfoFilled = true;
         a.initiatorId = initiatorId;
@@ -250,16 +232,8 @@ public class EscrowApplication extends BaseEntity {
         return a;
     }
 
-    /**
-     * 내부 chatRoom 흐름 (PR-B-2 라운드 12). 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력.
-     *
-     * <p>특징 (외부 link 흐름과 차이):
-     * <ul>
-     *   <li>{@code linkId = null} — link 미사용</li>
-     *   <li>{@code entryType = INTERNAL}</li>
-     *   <li>initiator = 신청자 (판매자), receiver = 채팅방 상대방 (구매자) — 정책상 sellerOnly 라 initiatorRole=seller 고정</li>
-     * </ul>
-     */
+    
+
     public static EscrowApplication createInternal(
             Long chatRoomId,
             Long initiatorId, Long receiverId,
@@ -278,7 +252,7 @@ public class EscrowApplication extends BaseEntity {
         if (initiatorId.equals(receiverId)) {
             throw new BusinessException(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
         }
-        // 내부 흐름은 판매자만 시작 — initiator = seller, receiver = buyer.
+        
         Long sellerId = initiatorId;
         Long buyerId = receiverId;
 
@@ -289,8 +263,8 @@ public class EscrowApplication extends BaseEntity {
         a.linkId = null;
         a.entryType = EntryType.INTERNAL;
         a.chatRoomId = chatRoomId;
-        // PR-B-3 단순 흐름 — 현재 createInternal 은 양쪽 정보 한 번에 입력. PR-B-4 의 draft 흐름은
-        // 별도 createInternalDraft + patchSellerInfo / patchBuyerInfo 로 분리 (후속 commit).
+        
+        
         a.sellerInfoFilled = true;
         a.buyerInfoFilled = true;
         a.initiatorId = initiatorId;
@@ -323,17 +297,8 @@ public class EscrowApplication extends BaseEntity {
         return a;
     }
 
-    /**
-     * 내부 draft 흐름 (PR-B-4 라운드 12) — 판매자가 본인 영역만 입력하여 application 생성.
-     *
-     * <p>특징:
-     * <ul>
-     *   <li>{@code status = 정보입력대기}, {@code sellerInfoFilled = true}, {@code buyerInfoFilled = false}</li>
-     *   <li>구매자 영역 (delivery_*, receiver_phone) 은 NULL — 구매자가 buyer-info PATCH 시 입력</li>
-     *   <li>fee snapshot / share 는 NULL — 양쪽 입력 완료 후 transitionToReadyForPayment 시점에 산정</li>
-     *   <li>initiator = seller, receiver = buyer (내부 흐름은 sellerOnly 정책)</li>
-     * </ul>
-     */
+    
+
     public static EscrowApplication createInternalDraft(
             Long chatRoomId,
             Long initiatorId, Long receiverId,
@@ -357,7 +322,7 @@ public class EscrowApplication extends BaseEntity {
         a.buyerInfoFilled = false;
         a.initiatorId = initiatorId;
         a.receiverId = receiverId;
-        a.sellerId = initiatorId;   // 판매자만 시작
+        a.sellerId = initiatorId;   
         a.buyerId = receiverId;
         a.tradeMode = tradeMode;
         a.feePayer = feePayer;
@@ -372,14 +337,12 @@ public class EscrowApplication extends BaseEntity {
         a.deliveryNotes = deliveryNotes;
         a.status = EscrowApplicationStatus.정보입력대기;
         a.imageUrls = imageUrls;
-        // delivery_*, receiver_phone, applied_*, share 는 NULL — buyer-info PATCH 시점에 채워짐.
+        
         return a;
     }
 
-    /**
-     * 판매자 영역 수정 (PR-B-4) — 정보입력대기 상태에서만. updatable 컬럼 대상.
-     * delivery 좌표는 영향 없음 (구매자 영역).
-     */
+    
+
     public void patchSellerInfo(
             String pickupAddress, BigDecimal pickupLat, BigDecimal pickupLng,
             Weight weight, Volume volume, Fragility fragility,
@@ -400,10 +363,8 @@ public class EscrowApplication extends BaseEntity {
         this.sellerInfoFilled = true;
     }
 
-    /**
-     * 구매자 영역 입력 (PR-B-4) — 정보입력대기 상태에서만.
-     * buyerInfoFilled=true 로 set. 호출자(ApplicationService)가 양쪽 filled 시 transitionToReadyForPayment 호출.
-     */
+    
+
     public void patchBuyerInfo(
             String deliveryAddress, BigDecimal deliveryLat, BigDecimal deliveryLng,
             String receiverPhone
@@ -418,10 +379,8 @@ public class EscrowApplication extends BaseEntity {
         this.buyerInfoFilled = true;
     }
 
-    /**
-     * 양쪽 입력 완료 — fee 산정 결과 + share 를 set + 결제대기 진입.
-     * ApplicationService 가 EscrowFeeCalculator 로 산정한 snapshot 을 주입.
-     */
+    
+
     public void transitionToReadyForPayment(FeeBreakdown snapshot, long initiatorShare, long receiverShare) {
         if (this.status != EscrowApplicationStatus.정보입력대기) {
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
@@ -439,7 +398,7 @@ public class EscrowApplication extends BaseEntity {
         this.status = EscrowApplicationStatus.결제대기;
     }
 
-    /** 수신자 결제 완료 — 결정 #5 H2 (수신자 먼저). 모든 share 충족 시 결제완료 진입. */
+    
     public void markReceiverPaid() {
         if (this.status != EscrowApplicationStatus.결제대기) {
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
@@ -448,7 +407,7 @@ public class EscrowApplication extends BaseEntity {
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
         }
         this.receiverPaidAt = LocalDateTime.now();
-        // 첫 결제 시점 — payment_due_at = +24h
+        
         if (this.paymentDueAt == null) {
             this.paymentDueAt = this.receiverPaidAt.plusHours(24);
         }
@@ -469,7 +428,7 @@ public class EscrowApplication extends BaseEntity {
         tryAdvanceToConfirmed();
     }
 
-    /** 양쪽 share 모두 충족됐는지 확인 후 결제완료 전진. share=0 인 쪽은 결제 면제. */
+    
     private void tryAdvanceToConfirmed() {
         boolean initiatorOk = this.initiatorShare == 0 || this.initiatorPaidAt != null;
         boolean receiverOk = this.receiverShare == 0 || this.receiverPaidAt != null;
@@ -478,7 +437,7 @@ public class EscrowApplication extends BaseEntity {
         }
     }
 
-    /** 라이더 자동 매칭됐을 때 — 결정 #8 X1. */
+    
     public void markInProgress() {
         if (this.status != EscrowApplicationStatus.결제완료) {
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
@@ -486,7 +445,7 @@ public class EscrowApplication extends BaseEntity {
         this.status = EscrowApplicationStatus.진행중;
     }
 
-    /** Mode B buyer 수령 확인 — 결정 #4. 정산 흐름 트리거. */
+    
     public void confirmReceipt(Long requesterId) {
         if (this.tradeMode != TradeMode.INTERNAL) {
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
@@ -500,7 +459,7 @@ public class EscrowApplication extends BaseEntity {
         this.receiptConfirmedAt = LocalDateTime.now();
     }
 
-    /** 정산 완료 표시 — ApplicationService 가 포인트 이동 후 호출. */
+    
     public void markSettled() {
         if (this.status != EscrowApplicationStatus.진행중) {
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
@@ -509,7 +468,7 @@ public class EscrowApplication extends BaseEntity {
         this.settledAt = LocalDateTime.now();
     }
 
-    /** 취소 — 시점별 환불은 ApplicationService 가 처리. 본 Aggregate 는 상태만 표시. */
+    
     public void cancel(Long cancelledBy, String reason) {
         if (this.status.isTerminal()) {
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
@@ -524,7 +483,7 @@ public class EscrowApplication extends BaseEntity {
                 && this.status == EscrowApplicationStatus.결제대기;
     }
 
-    /** 사용자가 양쪽 당사자인지 확인. */
+    
     public boolean isParticipant(Long userId) {
         return this.initiatorId.equals(userId) || this.receiverId.equals(userId);
     }

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationRepository.java
@@ -12,28 +12,25 @@ public interface EscrowApplicationRepository {
 
     Optional<EscrowApplication> findById(Long id);
 
-    /**
-     * 결제/정산 흐름 비관적 락 — recordPaymentConfirmed / confirmReceipt / cancel race 직렬화
-     * (게이트 1 round 1 — Critical 3: 동시 결제 / receipt 연타 시 paid_at 유실 또는 정산 중복 회귀 차단).
-     */
+    
+
     Optional<EscrowApplication> findByIdForUpdate(Long id);
 
     Optional<EscrowApplication> findByLinkId(Long linkId);
 
-    /** 본인이 참여한 (initiator OR receiver) application 목록. */
+    
     Page<EscrowApplication> findMyApplications(Long userId, Pageable pageable);
 
-    /** Admin — 전체. */
+    
     Page<EscrowApplication> findAll(Pageable pageable);
 
-    /** Admin — 상태 필터. */
+    
     Page<EscrowApplication> findAllByStatus(EscrowApplicationStatus status, Pageable pageable);
 
-    /**
-     * Passive timeout 검증 — 결제대기 + payment_due_at 경과한 것들. 사용자 조회/admin 시점에 사용.
-     */
+    
+
     List<EscrowApplication> findPaymentTimedOut();
 
-    /** 진행 중 N건 (admin fee_settings 변경 시 영향 안내용). 결정 #12 12-a HH2. */
+    
     long countInProgress();
 }

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationStatus.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationStatus.java
@@ -1,18 +1,5 @@
 package com.sseulang.domain.escrow.domain;
 
-/**
- * Escrow application 상태머신.
- *
- * <pre>
- *   [내부 흐름 — PR-B-4]
- *   정보입력대기 → (양쪽 입력 완료) → 결제대기 → 결제완료 → 진행중 → 완료
- *
- *   [외부 link 흐름]
- *   결제대기 → 결제완료 (양쪽 share 결제 — feePayer 별 분기) → 진행중 (라이더 자동 매칭)
- *   진행중   → 완료 (Mode B: buyer 수령 확인 + 정산 / Mode A: 배송완료 + 정산)
- *   any 시점 → 취소 (시점별 환불 정책 — 결정 #6)
- * </pre>
- */
 public enum EscrowApplicationStatus {
     정보입력대기,
     결제대기,
@@ -29,7 +16,7 @@ public enum EscrowApplicationStatus {
         return this != 결제대기 && this != 정보입력대기;
     }
 
-    /** 매칭 후 시점 — 취소 시 fee 100% 부담 정책 (결정 #6 갱신). */
+    
     public boolean isAfterMatching() {
         return this == 진행중 || this == 완료;
     }

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeCalculator.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeCalculator.java
@@ -6,29 +6,14 @@ import com.sseulang.global.exception.ErrorCode;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
-/**
- * 거래대행 수수료 계산 DomainService. 프론트 {@code calcFees} 와 동일 로직 (결정 #9, CC3).
- *
- * <pre>
- * adjustedKmRate = (truck ? truckBaseKmRate : baseKmRate)
- *                  + (fuelPricePerL - baseFuelPrice) * distance / fuelEfficiency
- * baseFee        = (truck ? truckBaseDeliveryFee : baseDeliveryFee)
- * deliveryFee    = baseFee + adjustedKmRate * distance
- * deliveryFee    = max(deliveryFee, truck ? truckMinDeliveryFee : minDeliveryFee)
- * deliveryFee    = round(deliveryFee * weightMul * volumeMul * fragMul)
- * </pre>
- *
- * <p>spring 컴포넌트 X — 순수 도메인 (의존성 없음). 호출자가 settings 주입.</p>
- */
 public final class EscrowFeeCalculator {
 
     private static final double EARTH_RADIUS_KM = 6371.0;
 
     private EscrowFeeCalculator() {}
 
-    /**
-     * 좌표 → distance (haversine). 프론트와 동일 공식.
-     */
+    
+
     public static BigDecimal distanceKm(double lat1, double lng1, double lat2, double lng2) {
         double dLat = Math.toRadians(lat2 - lat1);
         double dLng = Math.toRadians(lng2 - lng1);
@@ -40,14 +25,8 @@ public final class EscrowFeeCalculator {
         return BigDecimal.valueOf(km).setScale(2, RoundingMode.HALF_UP);
     }
 
-    /**
-     * 전체 수수료 산정 (snapshot 용).
-     *
-     * @param settings   현재 운영 정책 (singleton row)
-     * @param tradeMode  INTERNAL/EXTERNAL
-     * @param itemPrice  Mode B 만 > 0
-     * @param distanceKm 좌표로 사전 계산된 거리 (소수점 2)
-     */
+    
+
     public static FeeBreakdown calculate(
             EscrowFeeSettings settings,
             TradeMode tradeMode,
@@ -70,7 +49,7 @@ public final class EscrowFeeCalculator {
         boolean truck = weight.isTruck();
         double dist = distanceKm.doubleValue();
 
-        // 유류비 보정: (현재유가 - 기준유가) * 거리 / 연비 = 거리당 추가비용
+        
         long baseKmRate = truck ? settings.getTruckBaseKmRate() : settings.getBaseKmRate();
         double fuelEff = (truck ? settings.getTruckFuelEfficiency() : settings.getFuelEfficiency()).doubleValue();
         double fuelDiff = settings.getFuelPricePerL() - settings.getBaseFuelPrice();
@@ -100,10 +79,8 @@ public final class EscrowFeeCalculator {
         );
     }
 
-    /**
-     * 프론트가 보낸 fee 값을 ±10원 tolerance 로 검증 (결정 #10, EE2).
-     * mismatch 시 ESCROW_FEE_MISMATCH (race 또는 위변조 의심).
-     */
+    
+
     public static void verifyTolerance(FeeBreakdown calculated, long submittedDeliveryFee, long submittedCommissionFee, long submittedTotalFee) {
         long tolerance = 10L;
         if (Math.abs(calculated.deliveryFee() - submittedDeliveryFee) > tolerance ||

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeSettings.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeSettings.java
@@ -11,14 +11,6 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-/**
- * 거래대행 수수료 정책 — singleton row (id=1).
- *
- * <p>운영 변경은 admin endpoint 로. 변경 시 진행 중 application 영향 X — application 등록 시
- * snapshot 컬럼에 lock (결정 #9, #12).</p>
- *
- * <p>11 fields = 프론트 calcFees 와 동일 (CC3). multiplier 는 enum 코드 상수.</p>
- */
 @Entity
 @Table(name = "escrow_fee_settings")
 @Getter
@@ -70,7 +62,7 @@ public class EscrowFeeSettings {
     @Column(name = "updated_by")
     private Long updatedBy;
 
-    /** 수수료 정책 일괄 변경 — admin endpoint 호출. */
+    
     public void apply(
             BigDecimal commissionRate,
             long fuelPricePerL, long baseFuelPrice,
@@ -90,6 +82,6 @@ public class EscrowFeeSettings {
         this.truckFuelEfficiency = truckFuelEfficiency;
         this.truckMinDeliveryFee = truckMinDeliveryFee;
         this.updatedBy = updatedBy;
-        // updated_at 은 DB ON UPDATE CURRENT_TIMESTAMP — JPA Dirty checking 으로 트리거
+        
     }
 }

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeSettingsRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeSettingsRepository.java
@@ -2,7 +2,7 @@ package com.sseulang.domain.escrow.domain;
 
 public interface EscrowFeeSettingsRepository {
 
-    /** Singleton row (id=1) 조회. 없으면 IllegalStateException — V15 마이그레이션이 default 보장. */
+    
     EscrowFeeSettings findSingleton();
 
     EscrowFeeSettings save(EscrowFeeSettings settings);

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowLink.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowLink.java
@@ -18,12 +18,6 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-/**
- * Escrow Link Aggregate Root. V15 {@code escrow_links} 매핑.
- *
- * <p>신청자가 link 생성 → 수신자에게 공유 → 수신자가 token 으로 진입. 첫 폼 제출자 = 수신자 확정
- * (결정 #2, B3). atomic UPDATE 는 ApplicationService 가 conditional WHERE 로 처리.</p>
- */
 @Entity
 @Table(name = "escrow_links")
 @Getter
@@ -62,7 +56,7 @@ public class EscrowLink extends BaseEntity {
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
 
-    /** 신청자가 link 생성. UUID v4 token + 24h expiry (호출자가 hours 주입). */
+    
     public static EscrowLink create(
             Long initiatorId,
             InitiatorRole initiatorRole,
@@ -87,7 +81,7 @@ public class EscrowLink extends BaseEntity {
         return link;
     }
 
-    /** 수신자 확정 — 결정 #2 B3. 본인 차단 가드는 ApplicationService 가 처리 (DB chk 제약 + 코드 가드). */
+    
     public void claimByReceiver(Long receiverId) {
         if (receiverId == null) {
             throw new IllegalArgumentException("receiverId required");
@@ -107,7 +101,7 @@ public class EscrowLink extends BaseEntity {
         this.receiverId = receiverId;
     }
 
-    /** Application 생성된 후 — link 본 의무 끝. */
+    
     public void markAsCompleted() {
         if (this.status != EscrowLinkStatus.대기) {
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowLinkRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowLinkRepository.java
@@ -5,10 +5,6 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
-/**
- * EscrowLink 도메인 Repository (인터페이스).
- * 구현은 {@code infrastructure/persistence/} 의 JPA Adapter.
- */
 public interface EscrowLinkRepository {
 
     EscrowLink save(EscrowLink link);
@@ -19,11 +15,7 @@ public interface EscrowLinkRepository {
 
     Page<EscrowLink> findByInitiatorId(Long initiatorId, Pageable pageable);
 
-    /**
-     * 첫 폼 제출자 = 수신자 확정 — atomic UPDATE (race-safe).
-     * receiver_id IS NULL && status = 대기 && expires_at > NOW() && initiator_id != receiverId 조건 만족 시만 성공.
-     *
-     * @return 영향 받은 row 수 (0=race lose 또는 만료/본인, 1=성공)
-     */
+    
+
     int claimReceiverIfAvailable(Long linkId, Long receiverId);
 }

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowLinkStatus.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowLinkStatus.java
@@ -1,14 +1,5 @@
 package com.sseulang.domain.escrow.domain;
 
-/**
- * Escrow link 상태머신.
- *
- * <pre>
- *   대기 → 완료 (수신자 확정 + application 생성됨)
- *   대기 → 만료 (expiresAt 경과)
- *   대기 → 취소 (신청자 직접 취소)
- * </pre>
- */
 public enum EscrowLinkStatus {
     대기,
     완료,

--- a/src/main/java/com/sseulang/domain/escrow/domain/FeeBreakdown.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/FeeBreakdown.java
@@ -2,15 +2,6 @@ package com.sseulang.domain.escrow.domain;
 
 import java.math.BigDecimal;
 
-/**
- * 수수료 계산 결과 (snapshot).
- *
- * @param distanceKm        haversine 산정 거리 (소수점 2)
- * @param deliveryFee       라이더 보상 (원)
- * @param commissionFee     플랫폼 수익 (Mode B 만 > 0)
- * @param totalFee          buyer 가 부담할 총액 (Mode B = item + delivery + commission, Mode A = delivery only)
- * @param commissionRate    적용된 수수료율 (snapshot)
- */
 public record FeeBreakdown(
         BigDecimal distanceKm,
         long deliveryFee,

--- a/src/main/java/com/sseulang/domain/escrow/domain/FeePayer.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/FeePayer.java
@@ -1,14 +1,5 @@
 package com.sseulang.domain.escrow.domain;
 
-/**
- * 수수료 부담 정책. 결정 #5 — feePayer=both 는 양쪽 별도 결제 (G2).
- *
- * <ul>
- *   <li>{@code buyer}  : buyer 가 100% 결제</li>
- *   <li>{@code seller} : seller 가 100% 결제</li>
- *   <li>{@code both}   : 50/50 양쪽 별도 결제</li>
- * </ul>
- */
 public enum FeePayer {
     buyer,
     seller,

--- a/src/main/java/com/sseulang/domain/escrow/domain/Fragility.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/Fragility.java
@@ -3,7 +3,6 @@ package com.sseulang.domain.escrow.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** 취급주의 등급 (안전 ~ 매우 높음). multiplier 코드 상수. */
 public enum Fragility {
     F1("f1", 1.0),
     F2("f2", 1.1),

--- a/src/main/java/com/sseulang/domain/escrow/domain/InitiatorRole.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/InitiatorRole.java
@@ -1,6 +1,5 @@
 package com.sseulang.domain.escrow.domain;
 
-/** 신청자 역할 (수신자는 반대 role 자동). 가이드 §5.7 거래대행. */
 public enum InitiatorRole {
     buyer,
     seller;

--- a/src/main/java/com/sseulang/domain/escrow/domain/TradeMode.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/TradeMode.java
@@ -1,13 +1,5 @@
 package com.sseulang.domain.escrow.domain;
 
-/**
- * 거래 모드. 결정 #4 — D-Hybrid.
- *
- * <ul>
- *   <li>{@code INTERNAL}: 쓸랭 내부 거래. itemPrice 까지 escrow hold + buyer 수령 확인 후 정산.</li>
- *   <li>{@code EXTERNAL}: 외부 플랫폼 거래. itemPrice 처리 X — 배달비/수수료만.</li>
- * </ul>
- */
 public enum TradeMode {
     INTERNAL,
     EXTERNAL;

--- a/src/main/java/com/sseulang/domain/escrow/domain/Volume.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/Volume.java
@@ -3,7 +3,6 @@ package com.sseulang.domain.escrow.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** 부피 enum. multiplier 코드 상수 (운영 변경은 follow-up). */
 public enum Volume {
     S("s", 1.0),
     M("m", 1.2),

--- a/src/main/java/com/sseulang/domain/escrow/domain/Weight.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/Weight.java
@@ -3,10 +3,6 @@ package com.sseulang.domain.escrow.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * 물품 무게 enum. 5kg 이상은 용달차 분기 (truck fee 적용).
- * JSON value 는 프론트와 일치 (lt1 / 1to3 / 3to5 / 5to10 / gt10).
- */
 public enum Weight {
     LT1("lt1", 1.0, false),
     R1TO3("1to3", 1.2, false),
@@ -33,7 +29,7 @@ public enum Weight {
         return multiplier;
     }
 
-    /** 5kg 이상이면 용달차 요금 분기 — 결정 #9 (CC3 프론트 schema 와 동일). */
+    
     public boolean isTruck() {
         return truck;
     }

--- a/src/main/java/com/sseulang/domain/escrow/domain/event/EscrowConfirmedEvent.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/event/EscrowConfirmedEvent.java
@@ -1,20 +1,5 @@
 package com.sseulang.domain.escrow.domain.event;
 
-/**
- * 양쪽 결제 완료 → 결제완료 상태 진입 시 발행. Delivery 도메인이 listen 해서 모집중 row 자동 INSERT
- * + 자동 라이더 매칭 (X1, 결정 #8).
- *
- * @param escrowApplicationId 결제완료된 application
- * @param pickupAddress       픽업 주소
- * @param pickupLat           픽업 위도
- * @param pickupLng           픽업 경도
- * @param deliveryAddress     도착 주소
- * @param deliveryLat         도착 위도
- * @param deliveryLng         도착 경도
- * @param itemDescription     물품 설명 (라이더가 보는 이름)
- * @param deliveryFee         라이더 보상 (snapshot)
- * @param requesterId         요청자 = buyer 의 user_id (라이더 fee 차감 X — escrow 가 hold 중)
- */
 public record EscrowConfirmedEvent(
         Long escrowApplicationId,
         String pickupAddress,

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowLinkJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowLinkJpaRepository.java
@@ -17,11 +17,8 @@ public interface EscrowLinkJpaRepository extends JpaRepository<EscrowLink, Long>
 
     Page<EscrowLink> findByInitiatorId(Long initiatorId, Pageable pageable);
 
-    /**
-     * 첫 폼 제출자 = 수신자 확정 atomic UPDATE.
-     * race-safe: receiver_id IS NULL && status = '대기' && expires_at > NOW() && initiator_id != receiverId.
-     * 본인 차단 + race lose 둘 다 영향 0 — 호출자가 분기 처리 (ApplicationService).
-     */
+    
+
     @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE EscrowLink l

--- a/src/main/java/com/sseulang/domain/escrow/presentation/AdminEscrowFeeSettingsController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/AdminEscrowFeeSettingsController.java
@@ -16,11 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
-/**
- * 거래대행 수수료 정책 (admin). 결정 #9 — 프론트 11 fields schema (CC3) + AdminEscrowConfigPage 연동.
- *
- * <p>변경 시 진행 중 N건 표시 (12-a HH2) — PATCH 응답에 inProgressCount 포함.</p>
- */
 @Tag(name = "AdminEscrowFeeSettings", description = "관리자 — 거래대행 수수료 정책 운영")
 @RestController
 @RequestMapping("/api/v1/admin/escrow/fee-settings")

--- a/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
@@ -35,9 +35,9 @@ public class EscrowController {
         this.service = service;
     }
 
-    // =========================================================
-    // Link
-    // =========================================================
+    
+    
+    
     @Operation(summary = "거래대행 link 생성 (신청자)",
             description = "이메일 인증 필수. UUID v4 token + 24h 만료 (env override 가능).")
     @PostMapping("/links")
@@ -56,9 +56,9 @@ public class EscrowController {
         return ApiResponse.ok(service.getByToken(linkToken));
     }
 
-    // =========================================================
-    // Application
-    // =========================================================
+    
+    
+    
     @Operation(summary = "거래대행 수수료 미리보기 (실시간)",
             description = "폼 작성 중 좌표·물품·feePayer 보내면 거리·deliveryFee·commissionFee + buyer/seller 부담분 응답. application 생성 X.")
     @PostMapping("/applications/preview")

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCreateInternalRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCreateInternalRequest.java
@@ -15,11 +15,6 @@ import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.List;
 
-/**
- * 거래대행 내부 신청 요청 (PR-B-3 라운드 12). 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력.
- *
- * <p>권한: 판매자만 (chat_room.itemId 의 sellerId 와 일치). 비참여자 / 미인증 / 비판매자 모두 차단.</p>
- */
 @Schema(description = "내부 거래대행 신청 (채팅방 + 판매자만).")
 public record EscrowApplicationCreateInternalRequest(
         @Schema(example = "7") @NotNull Long chatRoomId,

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationCreateRequest.java
@@ -31,12 +31,12 @@ public record EscrowApplicationCreateRequest(
         @NotNull Volume volume,
         @NotNull Fragility fragility,
         @Size(max = 500) String deliveryNotes,
-        // 프론트 calcFees 결과 — 백엔드 ±10원 검증
+        
         @PositiveOrZero long deliveryFee,
         @PositiveOrZero long commissionFee,
         @PositiveOrZero long totalFee,
         @NotNull BigDecimal distanceKm,
-        // S3 업로드된 이미지 key/url
+        
         List<@Size(max = 500) String> imageUrls
 ) {
     public EscrowApplicationCreateCommand toCommand(Long receiverId) {

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationPreviewRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationPreviewRequest.java
@@ -12,11 +12,6 @@ import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
 
-/**
- * 거래대행 수수료 미리보기 요청 — 폼 작성 중 실시간 호출.
- *
- * <p>actually persisting 아무것도 안 함 — feePayer 별 buyer/seller 부담분만 응답.</p>
- */
 @Schema(description = "거래대행 수수료 미리보기 (실시간) — 좌표·물품 정보·feePayer 받아 buyer/seller 부담분 응답.")
 public record EscrowApplicationPreviewRequest(
         @Schema(example = "INTERNAL", allowableValues = {"INTERNAL", "EXTERNAL"})

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowPayResponse.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowPayResponse.java
@@ -2,11 +2,6 @@ package com.sseulang.domain.escrow.presentation.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * 거래대행 결제 응답 (PR-B-5 라운드 12).
- *
- * @param status 호출 후 application 상태. 한쪽만 paid 면 "결제대기" 유지, 양쪽 paid 시 "결제완료" 또는 그 이후 (라이더 매칭 결과에 따라).
- */
 @Schema(description = "거래대행 본인 share 결제 응답 — 후속 상태 노출.")
 public record EscrowPayResponse(
         @Schema(example = "결제완료", description = "결제대기 | 결제완료 | 진행중") String status

--- a/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
+++ b/src/main/java/com/sseulang/domain/file/application/FileApplicationService.java
@@ -17,26 +17,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-/**
- * 이미지 업로드용 S3 presigned URL 발급. 가이드 §4.5:
- *
- * <ul>
- *   <li>Content-Type: {@code image/*}</li>
- *   <li>Content-Length: ≤ 5MB</li>
- *   <li>만료: 5분</li>
- *   <li>파일명: 백엔드 UUID 강제 (사용자 입력 무시)</li>
- *   <li>key 패턴: {@code {purpose}/{ownerId}/{uuid}.{ext}}</li>
- * </ul>
- *
- * <p><b>일반 사용자 엔드포인트의 화이트리스트</b> — Codex 게이트 2 (2026-04-29) 권한 누수 보강:
- * 일반 사용자는 자기 자원에 해당하는 {@link FilePurpose#PROFILE} / {@link FilePurpose#ITEM} 만 발급 가능.
- * {@code NOTICE} / {@code BANNER} 는 관리자 도메인이, {@code MESSAGE} 는 chat 도메인이 각자
- * 별도 엔드포인트로 직접 호출해야 하며 본 메서드는 거부({@link ErrorCode#FORBIDDEN})한다.</p>
- *
- * <p><b>폴더 구조 후속 정리(TODO)</b>: 가이드 §4.5 는 {@code items/{itemId}/...} 를 명시하지만
- * 등록 전엔 itemId 가 없어 본 PR 에선 {@code items/{userId}/...} 로 임시 보관. 등록 시 백엔드가
- * S3 copy 로 정식 폴더로 이동하는 흐름은 후속 작업.</p>
- */
 @Service
 public class FileApplicationService {
 
@@ -44,7 +24,7 @@ public class FileApplicationService {
     private static final Duration PRESIGN_EXPIRE = Duration.ofMinutes(5);
     private static final int MAX_FILES_PER_REQUEST = 10;
 
-    /** 일반 사용자가 직접 호출 가능한 purpose. 그 외는 도메인 전용 엔드포인트로 분리. */
+    
     private static final Set<FilePurpose> USER_ALLOWED_PURPOSES = EnumSet.of(
             FilePurpose.PROFILE,
             FilePurpose.ITEM,
@@ -71,10 +51,8 @@ public class FileApplicationService {
         this.userService = userService;
     }
 
-    /**
-     * 일반 사용자 진입점. {@link #USER_ALLOWED_PURPOSES} 외 purpose 는 거부한다.
-     * 미인증 이메일 사용자가 비용 큰 S3 업로드를 남용하지 못하도록 verified 가드 (게이트 1 round 2).
-     */
+    
+
     public List<PresignResult> issueForUser(FilePurpose purpose, Long ownerId, List<PresignRequestItem> files) {
         if (purpose == null) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST);
@@ -82,17 +60,16 @@ public class FileApplicationService {
         if (!USER_ALLOWED_PURPOSES.contains(purpose)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
-        // PROFILE 은 미인증 사용자도 허용 — 본인 정보 관리(자금/거래 영향 0). UX 친화 정책 (5/2 합의).
-        // ITEM 은 거래 시작점이라 인증 필수 유지.
+        
+        
         if (purpose != FilePurpose.PROFILE) {
             userService.requireVerified(ownerId);
         }
         return issue(purpose, ownerId, files);
     }
 
-    /**
-     * 도메인 내부(관리자·chat 등)에서 직접 호출 — purpose 화이트리스트 X. 호출자가 권한 검증 책임.
-     */
+    
+
     public List<PresignResult> issue(FilePurpose purpose, Long ownerId, List<PresignRequestItem> files) {
         if (purpose == null) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST);

--- a/src/main/java/com/sseulang/domain/file/domain/FilePurpose.java
+++ b/src/main/java/com/sseulang/domain/file/domain/FilePurpose.java
@@ -1,12 +1,7 @@
 package com.sseulang.domain.file.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 업로드 용도. S3 폴더 구조 1단계 — {@code {purpose}/{ownerId}/{uuid}.{ext}}.
- *
- * <p>가이드 §4.5 폴더 구조와 정합. {@code messages/{roomId}/...} 처럼 owner 의미가 다른 케이스도
- * controller 에서 owner 를 적절히 결정해 전달한다.</p>
- */
+
 @Schema(description = "S3 업로드 용도 — PROFILE/ITEM/SUPPORT/ESCROW 는 일반 사용자 발급 가능. NOTICE/BANNER/MESSAGE 는 도메인 전용.")
 public enum FilePurpose {
     PROFILE("profiles"),

--- a/src/main/java/com/sseulang/domain/file/domain/PresignedUrlGenerator.java
+++ b/src/main/java/com/sseulang/domain/file/domain/PresignedUrlGenerator.java
@@ -2,34 +2,15 @@ package com.sseulang.domain.file.domain;
 
 import java.time.Duration;
 
-/**
- * S3 등 외부 스토리지의 PUT 용 presigned URL 발급 + 키 승격(copy+delete) 인터페이스.
- * 도메인 layer 인터페이스 — 외부 SDK 의존 X. 구현은 {@code domain/file/infrastructure/s3/S3PresignedUrlGenerator}.
- */
 public interface PresignedUrlGenerator {
 
     PresignedUrlResult generate(String key, String contentType, Duration expiresIn);
 
-    /**
-     * 임시 폴더의 객체를 정식 폴더로 복사 + 원본 삭제 (follow-up #12 옵션 A).
-     *
-     * <p>예: {@code items/123/uuid.jpg} → {@code items/4567/uuid.jpg}. URL 변환 책임도 본 메서드가
-     * 가짐 — 호출자는 받은 새 URL 을 그대로 DB 에 저장하면 된다. dst 가 이미 존재하면 덮어쓴다 (idempotent).</p>
-     *
-     * @param sourceUrl  PresignedUrlResult.key 가 path 에 포함된 GET URL (또는 key 자체)
-     * @param fromPrefix 원본 prefix — {@code "items/{userId}/"}
-     * @param toPrefix   목적지 prefix — {@code "items/{itemId}/"}
-     * @return 승격된 정식 GET URL (sourceUrl 의 prefix 만 toPrefix 로 치환). 비매칭 시 sourceUrl 반환.
-     */
+    
+
     String promote(String sourceUrl, String fromPrefix, String toPrefix);
 
-    /**
-     * 단건 객체 삭제 — best-effort. Item 이미지 부분 제거 시 S3 정리용.
-     *
-     * <p>S3 미존재(이미 삭제됨) 또는 네트워크 오류는 예외를 삼키고 로깅만 — DB 트랜잭션은 이미
-     * 커밋되어야 사용자 의도가 보존된다. 잔여 객체는 lifecycle 정책으로 정리.</p>
-     *
-     * @param sourceUrl 정식 폴더 GET URL (또는 key 자체)
-     */
+    
+
     void delete(String sourceUrl);
 }

--- a/src/main/java/com/sseulang/domain/file/infrastructure/s3/S3PresignedUrlGenerator.java
+++ b/src/main/java/com/sseulang/domain/file/infrastructure/s3/S3PresignedUrlGenerator.java
@@ -47,13 +47,8 @@ public class S3PresignedUrlGenerator implements PresignedUrlGenerator {
         return new PresignedUrlResult(presigned.url().toString(), key);
     }
 
-    /**
-     * sourceUrl 안에서 fromPrefix 가 toPrefix 로 치환되는 키를 찾아 S3 copy + 원본 delete.
-     *
-     * <p>실패는 RuntimeException 으로 전파 — 호출 트랜잭션이 롤백되어 DB 상태가 임시 url 에 머문다
-     * (사용자는 재시도하면 된다). copy 만 성공하고 delete 가 실패한 경우는 src 가 garbage 로 남고
-     * dst 는 정상 작동 — lifecycle 정책으로 정리.</p>
-     */
+    
+
     @Override
     public String promote(String sourceUrl, String fromPrefix, String toPrefix) {
         if (sourceUrl == null || fromPrefix == null || toPrefix == null) {
@@ -61,7 +56,7 @@ public class S3PresignedUrlGenerator implements PresignedUrlGenerator {
         }
         int idx = sourceUrl.indexOf(fromPrefix);
         if (idx < 0) {
-            return sourceUrl;  // 이미 승격됐거나 다른 prefix — no-op
+            return sourceUrl;  
         }
         String fromKey = sourceUrl.substring(idx);
         String toKey = toPrefix + fromKey.substring(fromPrefix.length());
@@ -79,17 +74,15 @@ public class S3PresignedUrlGenerator implements PresignedUrlGenerator {
             s3Client.deleteObject(DeleteObjectRequest.builder()
                     .bucket(bucket).key(fromKey).build());
         } catch (S3Exception e) {
-            // delete 실패는 best-effort — copy 는 이미 성공했으므로 dst 사용 가능. 로깅만.
+            
             log.warn("[s3] promote delete 실패 — src={} 잔여, lifecycle 정리 의존", fromKey, e);
         }
 
         return sourceUrl.substring(0, idx) + toPrefix + fromKey.substring(fromPrefix.length());
     }
 
-    /**
-     * 단건 삭제 — best-effort. URL 안의 {@code items/} prefix 부터를 key 로 추출.
-     * S3Exception 은 삼키고 WARN 로깅만 (사용자 흐름은 이미 DB 반영 완료).
-     */
+    
+
     @Override
     public void delete(String sourceUrl) {
         if (sourceUrl == null || sourceUrl.isBlank()) {
@@ -104,12 +97,12 @@ public class S3PresignedUrlGenerator implements PresignedUrlGenerator {
             s3Client.deleteObject(DeleteObjectRequest.builder()
                     .bucket(bucket).key(key).build());
         } catch (S3Exception e) {
-            // best-effort — DB 반영은 이미 끝났음. lifecycle 정책 의존.
+            
             log.warn("[s3] delete 실패 — key={} 잔여, lifecycle 정리 의존", key, e);
         }
     }
 
-    /** URL 에서 {@code items/} 이후를 key 로 사용. 매칭 안 되면 null. */
+    
     private static String extractKey(String url) {
         int idx = url.indexOf("items/");
         if (idx < 0) return null;

--- a/src/main/java/com/sseulang/domain/file/presentation/AdminFileController.java
+++ b/src/main/java/com/sseulang/domain/file/presentation/AdminFileController.java
@@ -17,13 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-/**
- * 관리자 전용 S3 presigned URL 발급. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
- *
- * <p>일반 사용자 endpoint ({@link FileController}) 와 달리 purpose 화이트리스트 X — 관리자 전용
- * NOTICE / BANNER 등 모든 purpose 자유 발급. 일반 사용자가 NOTICE 폴더에 쓰는 누수 차단 목적
- * (게이트 1 의 USER_ALLOWED 정책 유지).</p>
- */
 @Tag(name = "AdminFile", description = "관리자 — S3 presigned URL (모든 purpose)")
 @RestController
 @RequestMapping("/api/v1/admin/files")
@@ -46,7 +39,7 @@ public class AdminFileController {
         List<PresignRequestItem> items = request.files().stream()
                 .map(f -> new PresignRequestItem(f.contentType(), f.contentLength()))
                 .toList();
-        // issue() — USER_ALLOWED 화이트리스트 우회. 권한은 admin chain 이 보장.
+        
         List<PresignResult> results = fileService.issue(request.purpose(), adminId, items);
         return ApiResponse.ok(PresignedUrlResponse.from(results));
     }

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -50,23 +50,25 @@ public class ItemApplicationService {
 
     @Transactional
     public Long register(ItemRegisterCommand cmd) {
-        // Item 등록 — 사기 방지 위해 이메일 인증 필수 (게이트 1).
+        
         userApplicationService.requireVerified(cmd.sellerId());
         categoryApplicationService.requireExists(cmd.categoryId());
-        // presigned URL 발급 시 받은 이미지 키가 본인 ownership prefix(items/{sellerId}/) 인지 검증.
-        // 다른 사용자의 임시 키를 본인 Item 으로 등록하는 위변조 차단 (follow-up #12 옵션 B).
+        
+        
         validateImageOwnership(cmd.sellerId(), cmd.imageUrls());
-        Item item = Item.create(
+        Item item = Item.createMulti(
                 cmd.sellerId(), cmd.categoryId(),
                 cmd.title(), cmd.description(),
-                cmd.price(), cmd.deposit(), cmd.rentalUnit(), cmd.tradeType(),
+                cmd.tradeTypes(),
+                cmd.salePrice(), cmd.rentalPrice(),
+                cmd.deposit(), cmd.rentalUnit(),
                 cmd.region()
         );
         applyHashtags(item, cmd.hashtags());
         Item saved = itemRepository.save(item);
-        // 등록된 itemId 가 생긴 후, 임시 폴더(items/{userId}/) 의 키를 정식 폴더(items/{itemId}/) 로
-        // S3 copy + delete (follow-up #12 옵션 A). 트랜잭션 안에서 실패 시 DB 롤백 + S3 garbage 는
-        // lifecycle 정책으로 정리.
+        
+        
+        
         List<String> promoted = promoteImageUrls(cmd.sellerId(), saved.getId(), cmd.imageUrls());
         applyImages(saved, promoted);
         return saved.getId();
@@ -79,23 +81,19 @@ public class ItemApplicationService {
         return ItemDetailResult.from(item);
     }
 
-    /**
-     * 공개 검색·필터. viewerId 가 null 이면 비로그인 — isWishlisted 는 항상 false.
-     * Page 결과의 itemId 들에 대해 단일 SELECT 로 viewer 의 찜 여부 enrich (N+1 회피).
-     */
+    
+
     public Page<ItemSummaryResult> search(ItemSearchCriteria criteria, Pageable pageable, Long viewerId) {
         return enrich(itemRepository.search(criteria, pageable), viewerId);
     }
 
-    /** viewer 모름 — 비로그인 entry / 시스템 호출용. */
+    
     public Page<ItemSummaryResult> search(ItemSearchCriteria criteria, Pageable pageable) {
         return search(criteria, pageable, null);
     }
 
-    /**
-     * 마이페이지용 본인 물품 목록. status null = 삭제 제외 전체. viewer = sellerId 본인이므로
-     * 본인이 찜한 자기 물품은 표시 (서비스 정책상 가능). viewerId 명시로 isWishlisted 계산.
-     */
+    
+
     public Page<ItemSummaryResult> findMyItems(Long sellerId, ItemStatus status, Pageable pageable) {
         return enrich(itemRepository.findBySellerIdAndStatus(sellerId, status, pageable), sellerId);
     }
@@ -113,9 +111,11 @@ public class ItemApplicationService {
     public void update(Long id, Long requesterId, ItemUpdateCommand cmd) {
         Item item = findOwnedOrThrow(id, requesterId);
 
-        item.updateInfo(
+        item.updateInfoMulti(
                 cmd.title(), cmd.description(),
-                cmd.price(), cmd.deposit(), cmd.rentalUnit(), cmd.region()
+                cmd.tradeTypes(),
+                cmd.salePrice(), cmd.rentalPrice(),
+                cmd.deposit(), cmd.rentalUnit(), cmd.region()
         );
 
         if (cmd.categoryId() != null) {
@@ -123,11 +123,11 @@ public class ItemApplicationService {
             item.assignCategory(cmd.categoryId());
         }
         if (cmd.imageUrls() != null) {
-            // 업데이트 시에도 동일 ownership 검증 — sellerId 임시 폴더 또는 이미 promote 된 itemId
-            // 정식 폴더 prefix 둘 다 허용 (follow-up #12 옵션 A/B 통합).
+            
+            
             validateImageOwnershipForUpdate(item.getSellerId(), item.getId(), cmd.imageUrls());
             item.clearImages();
-            // 새로 업로드된 임시 키는 정식 폴더로 promote, 이미 정식인 키는 promoter 가 no-op.
+            
             List<String> promoted = promoteImageUrls(item.getSellerId(), item.getId(), cmd.imageUrls());
             applyImages(item, promoted);
         }
@@ -143,16 +143,14 @@ public class ItemApplicationService {
         item.markAsDeleted();
     }
 
-    /**
-     * Admin 우회 삭제 (라운드 12 PR-F #6). owner 검증 우회 — admin chain (ROLE_ADMIN) 만 호출.
-     * soft delete (status=삭제). 관련 거래/채팅방은 유지. audit 로그.
-     */
+    
+
     @Transactional
     public void adminDelete(Long id, Long adminId) {
         Item item = itemRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
         if (item.getStatus() == ItemStatus.삭제) {
-            // idempotent — 이미 삭제 상태면 no-op.
+            
             return;
         }
         item.markAsDeleted();
@@ -161,10 +159,8 @@ public class ItemApplicationService {
                         item.getId(), item.getSellerId(), adminId);
     }
 
-    /**
-     * 부분 추가 — 본인 + 이메일 인증 + 5장 한도 체크 (도메인). temp 폴더 url 은 promote, 정식 폴더 url 은
-     * 그대로 재사용 (no-op). 응답으로 반영 후 전체 image url 리스트 반환.
-     */
+    
+
     @Transactional
     public List<String> appendImages(Long itemId, Long requesterId, List<String> imageUrls) {
         userApplicationService.requireVerified(requesterId);
@@ -178,25 +174,21 @@ public class ItemApplicationService {
         return collectImageUrls(item);
     }
 
-    /**
-     * 단건 제거 — 본인 + 미존재 시 404 ITEM_IMAGE_NOT_FOUND. 도메인이 sortOrder/thumbnail 재계산.
-     * 트랜잭션 커밋 시점에 S3 delete 시도 (best-effort). 응답으로 남은 image url 리스트 반환.
-     */
+    
+
     @Transactional
     public List<String> removeImage(Long itemId, Long requesterId, String imageUrl) {
         userApplicationService.requireVerified(requesterId);
         Item item = findOwnedOrThrow(itemId, requesterId);
         item.removeImage(imageUrl);
-        // S3 delete — DB 반영(트랜잭션 커밋) 후에 호출하는 게 정합성 안전. 여기선 best-effort 라
-        // 트랜잭션 안에서 호출해도 무방 (실패해도 삼키므로 롤백 안 됨).
+        
+        
         presignedUrlGenerator.delete(imageUrl);
         return collectImageUrls(item);
     }
 
-    /**
-     * 순서 재배치 — newOrder 가 기존 image url 들과 정확히 같은 set 이어야 함. 다르면 400 ORDER_MISMATCH.
-     * 첫 번째가 새 썸네일.
-     */
+    
+
     @Transactional
     public List<String> reorderImages(Long itemId, Long requesterId, List<String> newOrder) {
         userApplicationService.requireVerified(requesterId);
@@ -211,11 +203,8 @@ public class ItemApplicationService {
                 .toList();
     }
 
-    /**
-     * 다른 도메인 ApplicationService 가 "활성 Item 존재"만 검증할 때 사용 — Wishlist 등.
-     * status=삭제 는 ITEM_NOT_FOUND. CLAUDE.md §3.3 의 다른 도메인 Repository 직접 호출 금지 룰
-     * 정합 — 외부는 본 메서드를 통해서만 Item 검증.
-     */
+    
+
     public void requireActiveItem(Long id) {
         Item item = findOrThrow(id);
         if (item.getStatus() == ItemStatus.삭제) {
@@ -223,10 +212,8 @@ public class ItemApplicationService {
         }
     }
 
-    /**
-     * Chat / 거래 시작 등 다른 도메인이 Item 의 seller 를 알아야 할 때.
-     * 삭제: ITEM_NOT_FOUND, 비공개: ITEM_INVALID_STATE. 판매중/예약/거래완료 는 채팅 가능.
-     */
+    
+
     public Long findSellerOfActiveItem(Long id) {
         Item item = findOrThrow(id);
         if (item.getStatus() == ItemStatus.삭제) {
@@ -238,11 +225,8 @@ public class ItemApplicationService {
         return item.getSellerId();
     }
 
-    /**
-     * 거래 도메인이 거래 생성 시 호출. 비관적 락(PESSIMISTIC_WRITE)으로 Item 행을 잠근 뒤 활성(판매중) 검증.
-     * 가이드 §5.2 — reserve 와 create 동시 시 락 직렬화로 "예약 직후 새 채팅중 거래 저장" 회귀 차단.
-     * Codex 게이트 1 Warning 보강.
-     */
+    
+
     @Transactional
     public ItemForTransactionResult findActiveForTransaction(Long itemId) {
         Item item = itemRepository.findByIdForUpdate(itemId)
@@ -251,14 +235,15 @@ public class ItemApplicationService {
             throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
         }
         return new ItemForTransactionResult(
-                item.getId(), item.getSellerId(), item.getTradeType(), item.getPrice(), item.getDeposit()
+                item.getId(), item.getSellerId(),
+                item.getTradeTypes(),
+                item.getSalePrice(), item.getRentalPrice(),
+                item.getDeposit()
         );
     }
 
-    /**
-     * 거래 도메인이 reserve 시 호출. 비관적 락(PESSIMISTIC_WRITE)으로 Item 행을 잠그고 markAsReserved 호출.
-     * 가이드 §5.2 동시 거래 차단의 핵심 — 같은 트랜잭션 안에서 호출되면 락 유지 + 도메인 invariant 검증.
-     */
+    
+
     @Transactional
     public void markItemAsReserved(Long itemId) {
         Item item = itemRepository.findByIdForUpdate(itemId)
@@ -266,7 +251,7 @@ public class ItemApplicationService {
         item.markAsReserved();
     }
 
-    /** 거래 도메인이 complete 시 호출. 비관적 락 + 예약 → 거래완료. */
+    
     @Transactional
     public void markItemAsSold(Long itemId) {
         Item item = itemRepository.findByIdForUpdate(itemId)
@@ -274,7 +259,7 @@ public class ItemApplicationService {
         item.markAsSold();
     }
 
-    /** 거래 도메인이 cancel 시 호출 (예약 상태였던 거래만). 예약 → 판매중 복원. */
+    
     @Transactional
     public void restoreItemFromReserved(Long itemId) {
         Item item = itemRepository.findByIdForUpdate(itemId)
@@ -282,32 +267,22 @@ public class ItemApplicationService {
         item.restoreFromReserved();
     }
 
-    /**
-     * {@code wishlist_count} 원자 증가. Wishlist 도메인이 찜 추가 성공 직후 호출.
-     *
-     * <p><b>Stale 주의(bulk update)</b>: JPA bulk update 라 persistence context 가 자동 동기화되지
-     * 않는다. 같은 트랜잭션 안에서 후속으로 동일 {@code Item} 을 다시 읽을 경우 stale 값을 받을 수
-     * 있으므로 그때는 {@code EntityManager.refresh} 또는 {@code flush+clear} 필요. 현재 wishlist
-     * add/remove 흐름은 호출 직후 read 가 없어 안전.</p>
-     */
+    
+
     @Transactional
     public void incrementWishlistCount(Long itemId) {
         itemRepository.incrementWishlistCount(itemId);
     }
 
-    /**
-     * {@code wishlist_count} 원자 감소. 음수 방지는 Repository 쪽 SQL 가드.
-     * Stale 주의는 {@link #incrementWishlistCount} 와 동일.
-     */
+    
+
     @Transactional
     public void decrementWishlistCount(Long itemId) {
         itemRepository.decrementWishlistCount(itemId);
     }
 
-    /**
-     * Fresh wishlist_count 조회 — bulk update 직후 호출해도 정확한 DB 값. 본인 토글 응답에 즉시 반영용.
-     * row 가 없으면 ITEM_NOT_FOUND.
-     */
+    
+
     public int getWishlistCount(Long itemId) {
         return itemRepository.getWishlistCount(itemId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
@@ -337,10 +312,8 @@ public class ItemApplicationService {
         }
     }
 
-    /**
-     * 임시 폴더({@code items/{sellerId}/}) 의 객체를 정식 폴더({@code items/{itemId}/}) 로 S3 promote.
-     * 이미 정식 폴더에 있는 url 은 promoter 가 no-op (follow-up #12 옵션 A).
-     */
+    
+
     private List<String> promoteImageUrls(Long sellerId, Long itemId, List<String> sourceUrls) {
         if (sourceUrls == null || sourceUrls.isEmpty()) {
             return sourceUrls;
@@ -354,11 +327,8 @@ public class ItemApplicationService {
         return promoted;
     }
 
-    /**
-     * presigned URL 발급 시 받은 이미지 키가 본인 sellerId 의 prefix 를 가지는지 검증.
-     * key 형식: {@code items/{sellerId}/{uuid}.{ext}} (FileApplicationService.buildKey 참조).
-     * 다른 사용자의 임시 키를 본인 Item 으로 등록하는 위변조 차단 (follow-up #12).
-     */
+    
+
     private static void validateImageOwnership(Long sellerId, List<String> imageUrls) {
         if (imageUrls == null || imageUrls.isEmpty()) {
             return;
@@ -371,10 +341,8 @@ public class ItemApplicationService {
         }
     }
 
-    /**
-     * update 전용 — 임시 폴더({@code items/{sellerId}/}) 또는 정식 폴더({@code items/{itemId}/})
-     * 둘 다 허용. 정식 폴더는 이전 register 단계에서 promote 된 결과 url (사용자가 그대로 다시 보낸 경우).
-     */
+    
+
     private static void validateImageOwnershipForUpdate(Long sellerId, Long itemId, List<String> imageUrls) {
         if (imageUrls == null || imageUrls.isEmpty()) {
             return;

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemDetailResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemDetailResult.java
@@ -8,7 +8,7 @@ import com.sseulang.domain.item.domain.TradeType;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
+import java.util.Set;
 public record ItemDetailResult(
         Long id,
         Long sellerId,
@@ -16,9 +16,12 @@ public record ItemDetailResult(
         String title,
         String description,
         long price,
+        Long salePrice,
+        Long rentalPrice,
         Long deposit,
         RentalUnit rentalUnit,
         TradeType tradeType,
+        Set<TradeType> tradeTypes,
         ItemStatus status,
         String region,
         int viewCount,
@@ -36,9 +39,12 @@ public record ItemDetailResult(
                 item.getTitle(),
                 item.getDescription(),
                 item.getPrice(),
+                item.getSalePrice(),
+                item.getRentalPrice(),
                 item.getDeposit(),
                 item.getRentalUnit(),
                 item.getTradeType(),
+                item.getTradeTypes(),
                 item.getStatus(),
                 item.getRegion(),
                 item.getViewCount(),

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemForTransactionResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemForTransactionResult.java
@@ -2,14 +2,24 @@ package com.sseulang.domain.item.application.dto;
 
 import com.sseulang.domain.item.domain.TradeType;
 
-/**
- * 거래 도메인이 거래 생성 시 필요한 Item 정보. ItemApplicationService 가 활성 Item 만 반환.
- * 다른 도메인이 ItemRepository 를 직접 참조하지 않도록 (CLAUDE.md §3.3).
- */
+import java.util.Set;
+
 public record ItemForTransactionResult(
         Long itemId,
         Long sellerId,
-        TradeType tradeType,
-        long price,
+        Set<TradeType> tradeTypes,
+        Long salePrice,
+        Long rentalPrice,
         Long deposit
-) { }
+) {
+    public Long priceFor(TradeType mode) {
+        if (mode == null || !tradeTypes.contains(mode)) {
+            return null;
+        }
+        return switch (mode) {
+            case 판매 -> salePrice;
+            case 대여 -> rentalPrice;
+            case 나눔 -> 0L;
+        };
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemRegisterCommand.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemRegisterCommand.java
@@ -4,17 +4,34 @@ import com.sseulang.domain.item.domain.RentalUnit;
 import com.sseulang.domain.item.domain.TradeType;
 
 import java.util.List;
+import java.util.Set;
 
 public record ItemRegisterCommand(
         Long sellerId,
         Long categoryId,
         String title,
         String description,
-        long price,
+        Set<TradeType> tradeTypes,
+        Long salePrice,
+        Long rentalPrice,
         Long deposit,
         RentalUnit rentalUnit,
-        TradeType tradeType,
         String region,
         List<String> imageUrls,
         List<String> hashtags
-) { }
+) {
+    public static ItemRegisterCommand legacy(
+            Long sellerId, Long categoryId, String title, String description,
+            long price, Long deposit, RentalUnit rentalUnit, TradeType tradeType,
+            String region, List<String> imageUrls, List<String> hashtags
+    ) {
+        Long salePrice = tradeType == TradeType.판매 ? price : null;
+        Long rentalPrice = tradeType == TradeType.대여 ? price : null;
+        return new ItemRegisterCommand(
+                sellerId, categoryId, title, description,
+                java.util.EnumSet.of(tradeType),
+                salePrice, rentalPrice,
+                deposit, rentalUnit, region, imageUrls, hashtags
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemSearchCriteria.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemSearchCriteria.java
@@ -2,12 +2,6 @@ package com.sseulang.domain.item.application.dto;
 
 import com.sseulang.domain.item.domain.TradeType;
 
-/**
- * Item 검색 조건. null/blank 필드는 무시.
- *
- * <p>키워드 q 는 현재 LIKE 검색 — FULLTEXT(MATCH AGAINST + ngram) 마이그는 issue #10 트래킹.
- * 태그는 단건 매칭 — 다중 AND 는 후속 작업.</p>
- */
 public record ItemSearchCriteria(
         String q,
         Long categoryId,

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemSort.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemSort.java
@@ -1,19 +1,15 @@
 package com.sseulang.domain.item.application.dto;
 
-/**
- * Item 검색 정렬 옵션. URL query param `sort` 의 값과 1:1 매핑.
- * 잘못된 값은 controller 에서 LATEST 로 fallback.
- */
 public enum ItemSort {
-    /** createdAt DESC (default). */
+    
     LATEST,
-    /** price ASC. */
+    
     PRICE_ASC,
-    /** price DESC. */
+    
     PRICE_DESC,
-    /** viewCount DESC — 조회순. 동률은 createdAt DESC. */
+    
     VIEW_DESC,
-    /** wishlistCount DESC — 찜많은순. 동률은 createdAt DESC. */
+    
     WISHLIST_DESC;
 
     public static ItemSort parse(String raw) {

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemSummaryResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemSummaryResult.java
@@ -5,18 +5,18 @@ import com.sseulang.domain.item.domain.ItemStatus;
 import com.sseulang.domain.item.domain.TradeType;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
-/**
- * 목록·검색·찜·내물품 공통 요약. {@code thumbnailUrl} 은 V11 denormalize 컬럼에서 직접,
- * {@code isWishlisted} 는 ApplicationService 가 viewer 기준으로 enrich 단계에서 매핑한다.
- */
 public record ItemSummaryResult(
         Long id,
         Long sellerId,
         Long categoryId,
         String title,
         long price,
+        Long salePrice,
+        Long rentalPrice,
         TradeType tradeType,
+        Set<TradeType> tradeTypes,
         ItemStatus status,
         String region,
         String thumbnailUrl,
@@ -25,7 +25,7 @@ public record ItemSummaryResult(
         int viewCount,
         LocalDateTime createdAt
 ) {
-    /** viewer 가 없거나 비로그인 사용자 — isWishlisted = false. */
+    
     public static ItemSummaryResult from(Item item) {
         return from(item, false);
     }
@@ -37,7 +37,10 @@ public record ItemSummaryResult(
                 item.getCategoryId(),
                 item.getTitle(),
                 item.getPrice(),
+                item.getSalePrice(),
+                item.getRentalPrice(),
                 item.getTradeType(),
+                item.getTradeTypes(),
                 item.getStatus(),
                 item.getRegion(),
                 item.getThumbnailUrl(),

--- a/src/main/java/com/sseulang/domain/item/application/dto/ItemUpdateCommand.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/ItemUpdateCommand.java
@@ -1,21 +1,37 @@
 package com.sseulang.domain.item.application.dto;
 
 import com.sseulang.domain.item.domain.RentalUnit;
+import com.sseulang.domain.item.domain.TradeType;
 
 import java.util.List;
+import java.util.Set;
 
-/**
- * 물품 수정 커맨드. 컬렉션 필드({@code imageUrls}, {@code hashtags})는 {@code null} 이면 변경 없음 —
- * non-null 이면 전체 교체. {@code categoryId} 동일 정책.
- */
 public record ItemUpdateCommand(
         Long categoryId,
         String title,
         String description,
-        long price,
+        Set<TradeType> tradeTypes,
+        Long salePrice,
+        Long rentalPrice,
         Long deposit,
         RentalUnit rentalUnit,
         String region,
         List<String> imageUrls,
         List<String> hashtags
-) { }
+) {
+    public static ItemUpdateCommand legacy(
+            Long categoryId, String title, String description,
+            long price, Long deposit, RentalUnit rentalUnit,
+            String region, List<String> imageUrls, List<String> hashtags
+    ) {
+        TradeType inferred = (deposit != null || rentalUnit != null) ? TradeType.대여 : TradeType.판매;
+        Long salePrice = inferred == TradeType.판매 ? price : null;
+        Long rentalPrice = inferred == TradeType.대여 ? price : null;
+        return new ItemUpdateCommand(
+                categoryId, title, description,
+                java.util.EnumSet.of(inferred),
+                salePrice, rentalPrice,
+                deposit, rentalUnit, region, imageUrls, hashtags
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/domain/Item.java
+++ b/src/main/java/com/sseulang/domain/item/domain/Item.java
@@ -5,6 +5,7 @@ import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -20,20 +21,11 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-/**
- * Item Aggregate Root. V1 스키마 {@code items} 매핑.
- *
- * <p>자식 Entity {@link ItemImage} 는 본 Root 메서드를 통해서만 추가/제거. 외부에서 컬렉션
- * 직접 조작 금지({@link #getImages()} 는 unmodifiable view).</p>
- *
- * <p>거래 진행 상태(예약/거래완료) 전이는 transaction 도메인이 트리거하며, 본 Aggregate 는
- * 판매자 본인이 직접 호출 가능한 {@link #updateInfo}, {@link #markAsHidden}, {@link #markAsDeleted},
- * {@link #restore} 만 노출한다.</p>
- */
 @Entity
 @Table(name = "items")
 @Getter
@@ -63,6 +55,12 @@ public class Item extends BaseEntity {
     @Column(name = "price", nullable = false)
     private long price;
 
+    @Column(name = "sale_price")
+    private Long salePrice;
+
+    @Column(name = "rental_price")
+    private Long rentalPrice;
+
     @Column(name = "deposit")
     private Long deposit;
 
@@ -74,6 +72,10 @@ public class Item extends BaseEntity {
     @Column(name = "trade_type", nullable = false)
     private TradeType tradeType;
 
+    @Convert(converter = TradeTypesConverter.class)
+    @Column(name = "trade_types", nullable = false, length = 64)
+    private Set<TradeType> tradeTypes = EnumSet.noneOf(TradeType.class);
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private ItemStatus status;
@@ -81,10 +83,8 @@ public class Item extends BaseEntity {
     @Column(name = "region", length = REGION_MAX_LENGTH)
     private String region;
 
-    /**
-     * 썸네일 image_url denormalize. {@link #addImage}/{@link #clearImages} 시 자동 갱신 — Aggregate
-     * 외부에서 직접 set 금지. ItemSummary 응답을 N+1 없이 내려주기 위한 V11 컬럼.
-     */
+    
+
     @Column(name = "thumbnail_url", length = 500)
     private String thumbnailUrl;
 
@@ -112,34 +112,70 @@ public class Item extends BaseEntity {
             TradeType tradeType,
             String region
     ) {
-        if (sellerId == null || sellerId <= 0) {
-            throw new IllegalArgumentException("sellerId 는 양수여야 합니다");
-        }
         if (tradeType == null) {
             throw new IllegalArgumentException("tradeType 은 필수입니다");
         }
+        validateRentalFields(tradeType, deposit, rentalUnit);
+        Long salePrice = tradeType == TradeType.판매 ? price : null;
+        Long rentalPrice = tradeType == TradeType.대여 ? price : null;
+        return createMulti(sellerId, categoryId, title, description,
+                EnumSet.of(tradeType), salePrice, rentalPrice, deposit, rentalUnit, region);
+    }
+
+    public static Item createMulti(
+            Long sellerId,
+            Long categoryId,
+            String title,
+            String description,
+            Set<TradeType> tradeTypes,
+            Long salePrice,
+            Long rentalPrice,
+            Long deposit,
+            RentalUnit rentalUnit,
+            String region
+    ) {
+        if (sellerId == null || sellerId <= 0) {
+            throw new IllegalArgumentException("sellerId 는 양수여야 합니다");
+        }
         validateTitle(title);
         validateDescription(description);
-        if (price < 0) {
-            throw new IllegalArgumentException("price 는 0 이상이어야 합니다");
-        }
-        validateRentalFields(tradeType, deposit, rentalUnit);
+        validateTradeTypes(tradeTypes, salePrice, rentalPrice, deposit, rentalUnit);
         validateRegion(region);
+
+        Set<TradeType> typeSet = EnumSet.copyOf(tradeTypes);
+        TradeType primary = primaryOf(typeSet);
 
         Item item = new Item();
         item.sellerId = sellerId;
         item.categoryId = categoryId;
         item.title = title;
         item.description = description;
-        item.price = price;
-        item.deposit = deposit;
-        item.rentalUnit = rentalUnit;
-        item.tradeType = tradeType;
+        item.tradeTypes = typeSet;
+        item.tradeType = primary;
+        item.salePrice = typeSet.contains(TradeType.판매) ? salePrice : null;
+        item.rentalPrice = typeSet.contains(TradeType.대여) ? rentalPrice : null;
+        item.price = derivePrice(primary, item.salePrice, item.rentalPrice);
+        item.deposit = typeSet.contains(TradeType.대여) ? deposit : null;
+        item.rentalUnit = typeSet.contains(TradeType.대여) ? rentalUnit : null;
         item.region = region;
         item.status = ItemStatus.판매중;
         item.viewCount = 0;
         item.wishlistCount = 0;
         return item;
+    }
+
+    private static TradeType primaryOf(Set<TradeType> types) {
+        if (types.contains(TradeType.판매)) return TradeType.판매;
+        if (types.contains(TradeType.대여)) return TradeType.대여;
+        return TradeType.나눔;
+    }
+
+    private static long derivePrice(TradeType primary, Long salePrice, Long rentalPrice) {
+        return switch (primary) {
+            case 판매 -> salePrice != null ? salePrice : 0L;
+            case 대여 -> rentalPrice != null ? rentalPrice : 0L;
+            case 나눔 -> 0L;
+        };
     }
 
     public void addImage(String imageUrl, int sortOrder, boolean thumbnail) {
@@ -157,10 +193,8 @@ public class Item extends BaseEntity {
         this.thumbnailUrl = null;
     }
 
-    /**
-     * 부분 추가 — 기존 이미지 유지하고 imageUrls 순서대로 append. 합산 5장 한도 초과 시 IAE 가 아니라
-     * {@link ErrorCode#ITEM_IMAGE_LIMIT_EXCEEDED}. 기존이 비었으면 첫 번째 새 url 이 썸네일.
-     */
+    
+
     public void appendImages(List<String> imageUrls) {
         if (imageUrls == null || imageUrls.isEmpty()) {
             return;
@@ -180,10 +214,8 @@ public class Item extends BaseEntity {
         }
     }
 
-    /**
-     * 단건 제거 — image_url 기준. 미존재 시 ITEM_IMAGE_NOT_FOUND.
-     * 제거 후 sortOrder 재정렬 (1..N) + 첫 번째를 썸네일로 재지정. 모두 제거되면 thumbnailUrl=null.
-     */
+    
+
     public void removeImage(String imageUrl) {
         if (imageUrl == null) {
             throw new BusinessException(ErrorCode.ITEM_IMAGE_NOT_FOUND);
@@ -192,7 +224,7 @@ public class Item extends BaseEntity {
         if (!removed) {
             throw new BusinessException(ErrorCode.ITEM_IMAGE_NOT_FOUND);
         }
-        // 남은 이미지에 대해 sortOrder + thumbnail 재계산. ItemImage 는 setter 가 없어 교체.
+        
         List<ItemImage> remaining = new ArrayList<>(images);
         images.clear();
         this.thumbnailUrl = null;
@@ -206,10 +238,8 @@ public class Item extends BaseEntity {
         }
     }
 
-    /**
-     * 순서 재배치 — newOrder 가 기존 image url 들과 같은 set (count + elements) 이어야 함. 다르면
-     * ITEM_IMAGE_ORDER_MISMATCH. newOrder 첫 번째가 새 썸네일.
-     */
+    
+
     public void reorderImages(List<String> newOrder) {
         if (newOrder == null || newOrder.size() != images.size()) {
             throw new BusinessException(ErrorCode.ITEM_IMAGE_ORDER_MISMATCH);
@@ -221,7 +251,7 @@ public class Item extends BaseEntity {
             throw new BusinessException(ErrorCode.ITEM_IMAGE_ORDER_MISMATCH);
         }
         if (newUrls.size() != newOrder.size()) {
-            // 중복 url
+            
             throw new BusinessException(ErrorCode.ITEM_IMAGE_ORDER_MISMATCH);
         }
         images.clear();
@@ -236,15 +266,13 @@ public class Item extends BaseEntity {
         }
     }
 
-    /** 외부에 노출되는 이미지 컬렉션은 immutable. 변경은 {@link #addImage} / {@link #clearImages}. */
+    
     public List<ItemImage> getImages() {
         return Collections.unmodifiableList(images);
     }
 
-    /**
-     * 해시태그 추가. 동일 태그(대소문자/공백 정규화 후)는 중복으로 간주해 무시 — DB UNIQUE(item_id, tag)
-     * 와 정합. 태그 자체 검증(blank, 길이)은 {@link ItemHashtag} 생성자에서 IAE.
-     */
+    
+
     public void addHashtag(String tag) {
         ItemHashtag candidate = new ItemHashtag(this, tag);
         Set<String> existing = new HashSet<>();
@@ -261,7 +289,7 @@ public class Item extends BaseEntity {
         hashtags.clear();
     }
 
-    /** 외부에 노출되는 해시태그 컬렉션은 immutable. */
+    
     public List<ItemHashtag> getHashtags() {
         return Collections.unmodifiableList(hashtags);
     }
@@ -274,23 +302,56 @@ public class Item extends BaseEntity {
             RentalUnit rentalUnit,
             String region
     ) {
+        Long salePrice = tradeType == TradeType.판매 ? price : null;
+        Long rentalPrice = tradeType == TradeType.대여 ? price : null;
+        updateInfoMulti(title, description, EnumSet.of(tradeType),
+                salePrice, rentalPrice, deposit, rentalUnit, region);
+    }
+
+    public void updateInfoMulti(
+            String title,
+            String description,
+            Set<TradeType> tradeTypes,
+            Long salePrice,
+            Long rentalPrice,
+            Long deposit,
+            RentalUnit rentalUnit,
+            String region
+    ) {
         if (!status.isEditable()) {
             throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
         }
         validateTitle(title);
         validateDescription(description);
-        if (price < 0) {
-            throw new IllegalArgumentException("price 는 0 이상이어야 합니다");
-        }
-        validateRentalFields(tradeType, deposit, rentalUnit);
+        validateTradeTypes(tradeTypes, salePrice, rentalPrice, deposit, rentalUnit);
         validateRegion(region);
+
+        Set<TradeType> typeSet = EnumSet.copyOf(tradeTypes);
+        TradeType primary = primaryOf(typeSet);
 
         this.title = title;
         this.description = description;
-        this.price = price;
-        this.deposit = deposit;
-        this.rentalUnit = rentalUnit;
+        this.tradeTypes = typeSet;
+        this.tradeType = primary;
+        this.salePrice = typeSet.contains(TradeType.판매) ? salePrice : null;
+        this.rentalPrice = typeSet.contains(TradeType.대여) ? rentalPrice : null;
+        this.price = derivePrice(primary, this.salePrice, this.rentalPrice);
+        this.deposit = typeSet.contains(TradeType.대여) ? deposit : null;
+        this.rentalUnit = typeSet.contains(TradeType.대여) ? rentalUnit : null;
         this.region = region;
+    }
+
+    public Long priceFor(TradeType mode) {
+        if (mode == null) return null;
+        return switch (mode) {
+            case 판매 -> salePrice;
+            case 대여 -> rentalPrice;
+            case 나눔 -> 0L;
+        };
+    }
+
+    public Set<TradeType> getTradeTypes() {
+        return Collections.unmodifiableSet(tradeTypes);
     }
 
     public void assignCategory(Long categoryId) {
@@ -315,11 +376,8 @@ public class Item extends BaseEntity {
         this.status = ItemStatus.판매중;
     }
 
-    /**
-     * 거래 도메인이 reserve 시 호출. 가이드 §5.2 동시 거래 차단의 핵심 — 이미 예약된 Item 에
-     * 다른 거래가 reserve 시도 시 {@link ErrorCode#TRANSACTION_RESERVED_BY_OTHER} 로 거부.
-     * 그 외 비활성 상태(거래완료/비공개/삭제)는 {@link ErrorCode#ITEM_INVALID_STATE}.
-     */
+    
+
     public void markAsReserved() {
         if (status == ItemStatus.예약) {
             throw new BusinessException(ErrorCode.TRANSACTION_RESERVED_BY_OTHER);
@@ -330,7 +388,7 @@ public class Item extends BaseEntity {
         this.status = ItemStatus.예약;
     }
 
-    /** 거래 도메인이 complete 시 호출. 예약 → 거래완료 만 허용. */
+    
     public void markAsSold() {
         if (status != ItemStatus.예약) {
             throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
@@ -338,7 +396,7 @@ public class Item extends BaseEntity {
         this.status = ItemStatus.거래완료;
     }
 
-    /** 거래 도메인이 cancel 시 호출. 예약 → 판매중 복원. 가이드 §5.2 — 채팅 재활성화 효과. */
+    
     public void restoreFromReserved() {
         if (status != ItemStatus.예약) {
             throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
@@ -389,6 +447,34 @@ public class Item extends BaseEntity {
             }
             if (rentalUnit != null) {
                 throw new IllegalArgumentException("대여 외 거래에는 rentalUnit 을 지정할 수 없습니다");
+            }
+        }
+    }
+
+    private static void validateTradeTypes(
+            Set<TradeType> tradeTypes,
+            Long salePrice,
+            Long rentalPrice,
+            Long deposit,
+            RentalUnit rentalUnit
+    ) {
+        if (tradeTypes == null || tradeTypes.isEmpty()) {
+            throw new IllegalArgumentException("tradeTypes 는 최소 1개 이상이어야 합니다");
+        }
+        if (tradeTypes.contains(TradeType.판매)) {
+            if (salePrice == null || salePrice < 0) {
+                throw new IllegalArgumentException("판매 모드는 0 이상의 salePrice 가 필수입니다");
+            }
+        }
+        if (tradeTypes.contains(TradeType.대여)) {
+            if (rentalPrice == null || rentalPrice < 0) {
+                throw new IllegalArgumentException("대여 모드는 0 이상의 rentalPrice 가 필수입니다");
+            }
+            if (rentalUnit == null) {
+                throw new IllegalArgumentException("대여 모드는 rentalUnit 이 필수입니다");
+            }
+            if (deposit == null || deposit < 0) {
+                throw new IllegalArgumentException("대여 모드는 0 이상의 deposit 이 필수입니다");
             }
         }
     }

--- a/src/main/java/com/sseulang/domain/item/domain/ItemHashtag.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemHashtag.java
@@ -13,11 +13,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * Item 자식 엔티티. 외부 직접 생성/조작 금지 — Aggregate Root({@link Item}) 의 메서드를 통해서만.
- *
- * <p>{@code item_hashtags} 테이블은 {@code created_at}/{@code updated_at} 모두 없으므로 BaseEntity 상속 X.</p>
- */
 @Entity
 @Table(name = "item_hashtags")
 @Getter
@@ -37,7 +32,7 @@ public class ItemHashtag {
     @Column(name = "tag", nullable = false, length = TAG_MAX_LENGTH)
     private String tag;
 
-    /** Aggregate Root 만 호출 — package-private. */
+    
     ItemHashtag(Item item, String tag) {
         if (tag == null || tag.isBlank()) {
             throw new IllegalArgumentException("tag 는 비어있을 수 없습니다");

--- a/src/main/java/com/sseulang/domain/item/domain/ItemImage.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemImage.java
@@ -18,12 +18,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-/**
- * Item 자식 엔티티. 외부 직접 생성/조작 금지 — Aggregate Root({@link Item}) 의 메서드를 통해서만.
- *
- * <p>{@code item_images} 테이블엔 {@code created_at} 만 있고 {@code updated_at} 이 없으므로
- * {@link com.sseulang.global.common.BaseEntity} 상속 X.</p>
- */
 @Entity
 @Table(name = "item_images")
 @EntityListeners(AuditingEntityListener.class)
@@ -52,7 +46,7 @@ public class ItemImage {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    /** Aggregate Root 만 호출 — package-private. */
+    
     ItemImage(Item item, String imageUrl, int sortOrder, boolean thumbnail) {
         if (imageUrl == null || imageUrl.isBlank()) {
             throw new IllegalArgumentException("imageUrl 은 비어있을 수 없습니다");

--- a/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
@@ -6,48 +6,34 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
-/**
- * Item Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
- * 검색·필터(QueryDSL) 구현은 {@code infrastructure/persistence/ItemQuerydslRepository}.
- */
 public interface ItemRepository {
 
     Optional<Item> findById(Long id);
 
-    /**
-     * 비관적 쓰기 락(PESSIMISTIC_WRITE)으로 Item 조회. 가이드 §5.2 동시 거래 차단을 위한 핵심 —
-     * Transaction 도메인이 reserve/complete/cancel 시 Item 행을 잠그고 상태 전이.
-     * 첫 호출이 락 점유 → 후속 호출은 대기 → 락 해제 후 status 보고 적절히 거부 (TRANSACTION_RESERVED_BY_OTHER 등).
-     */
+    
+
     Optional<Item> findByIdForUpdate(Long id);
 
-    /** 동적 검색·필터 + 최신순 정렬. criteria 의 모든 필드가 null 이면 전체 (status != 삭제) 최신순. */
+    
     Page<Item> search(ItemSearchCriteria criteria, Pageable pageable);
 
-    /**
-     * 본인 등록 물품 페이징 — 마이페이지 탭 분리용. status 가 null 이면 삭제만 자동 제외하고 전체.
-     * status 명시 시 정확히 일치 (예: 판매중 / 예약 / 거래완료 / 비공개).
-     */
+    
+
     Page<Item> findBySellerIdAndStatus(Long sellerId, ItemStatus status, Pageable pageable);
 
     Item save(Item item);
 
     void delete(Item item);
 
-    /**
-     * {@code wishlist_count} 원자 증가. 영향받은 행 수 반환. 레이스 가능성 있는 카운터를 동시성 안전하게.
-     */
+    
+
     int incrementWishlistCount(Long itemId);
 
-    /**
-     * {@code wishlist_count} 원자 감소. 음수가 되지 않도록 {@code AND wishlist_count > 0} 조건 강제.
-     * 영향받은 행 수 반환.
-     */
+    
+
     int decrementWishlistCount(Long itemId);
 
-    /**
-     * 현재 wishlist_count 값. JPQL 스칼라 projection 으로 fresh DB 조회 — 같은 트랜잭션 내 bulk
-     * update 직후 호출해도 stale 캐시 회피. row 가 없으면 빈 Optional.
-     */
+    
+
     Optional<Integer> getWishlistCount(Long itemId);
 }

--- a/src/main/java/com/sseulang/domain/item/domain/ItemStatus.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemStatus.java
@@ -1,12 +1,7 @@
 package com.sseulang.domain.item.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 물품 상태. DB ENUM('판매중','예약','거래완료','비공개','삭제') 1:1 매핑.
- *
- * <p>거래 관련 상태(예약, 거래완료) 전이는 {@code transaction} 도메인이 트리거 — Item 자체로는
- * markAsHidden / markAsDeleted / restore 만 직접 노출.</p>
- */
+
 @Schema(description = "물품 상태. 판매중→예약→거래완료. 비공개/삭제 는 별도.")
 public enum ItemStatus {
     판매중,

--- a/src/main/java/com/sseulang/domain/item/domain/RentalUnit.java
+++ b/src/main/java/com/sseulang/domain/item/domain/RentalUnit.java
@@ -1,9 +1,7 @@
 package com.sseulang.domain.item.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 대여 단위. DB는 VARCHAR(20) — '시간 | 일 | 주 | 월'. {@code @Enumerated(EnumType.STRING)} 으로 그대로 저장.
- */
+
 @Schema(description = "대여 단위 — 시간 / 일 / 주 / 월. 대여 거래에만 사용 (판매/나눔은 null).")
 public enum RentalUnit {
     시간,

--- a/src/main/java/com/sseulang/domain/item/domain/TradeType.java
+++ b/src/main/java/com/sseulang/domain/item/domain/TradeType.java
@@ -1,9 +1,7 @@
 package com.sseulang.domain.item.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 거래 타입. DB ENUM('대여','판매','나눔') 과 1:1 매핑 — {@code @Enumerated(EnumType.STRING)} 으로 name 그대로 저장.
- */
+
 @Schema(description = "거래 종류 — 판매 / 대여 / 나눔.")
 public enum TradeType {
     대여,

--- a/src/main/java/com/sseulang/domain/item/domain/TradeTypesConverter.java
+++ b/src/main/java/com/sseulang/domain/item/domain/TradeTypesConverter.java
@@ -1,0 +1,38 @@
+package com.sseulang.domain.item.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Converter(autoApply = false)
+public class TradeTypesConverter implements AttributeConverter<Set<TradeType>, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Set<TradeType> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        return attribute.stream()
+                .sorted()
+                .map(Enum::name)
+                .collect(Collectors.joining(","));
+    }
+
+    @Override
+    public Set<TradeType> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return EnumSet.noneOf(TradeType.class);
+        }
+        Set<TradeType> result = new LinkedHashSet<>();
+        for (String token : dbData.split(",")) {
+            String t = token.trim();
+            if (t.isEmpty()) continue;
+            result.add(TradeType.valueOf(t));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/domain/WishlistView.java
+++ b/src/main/java/com/sseulang/domain/item/domain/WishlistView.java
@@ -3,17 +3,9 @@ package com.sseulang.domain.item.domain;
 import java.util.Collection;
 import java.util.Set;
 
-/**
- * Item 도메인이 viewer 의 찜 여부를 알아야 할 때 쓰는 read-only 포트.
- * 구현은 {@code wishlist.infrastructure} 의 어댑터.
- *
- * <p>CLAUDE.md §3.3 — 다른 도메인 Repository 직접 호출 금지. 여기서는 cross-aggregate read 용
- * 포트만 정의하고 wishlist 인프라가 구현 (anti-corruption + 단방향 의존).</p>
- */
 public interface WishlistView {
 
-    /**
-     * 주어진 itemId 들 중 userId 가 찜한 것만 반환. userId / itemIds 가 비어있으면 {@code Set.of()}.
-     */
+    
+
     Set<Long> findWishlistedItemIds(Long userId, Collection<Long> itemIds);
 }

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemJpaRepository.java
@@ -13,7 +13,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-/** Spring Data JPA — {@link ItemRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
 interface ItemJpaRepository extends JpaRepository<Item, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
@@ -28,14 +27,12 @@ interface ItemJpaRepository extends JpaRepository<Item, Long> {
     @Query("UPDATE Item i SET i.wishlistCount = i.wishlistCount - 1 WHERE i.id = :id AND i.wishlistCount > 0")
     int decrementWishlistCount(@Param("id") Long id);
 
-    /** Fresh wishlist_count read — JPQL 스칼라 projection 으로 persistence context 우회. */
+    
     @Query("SELECT i.wishlistCount FROM Item i WHERE i.id = :id")
     Optional<Integer> getWishlistCount(@Param("id") Long id);
 
-    /**
-     * 본인 물품 — status 명시 시 정확 일치, null 이면 삭제 제외 전체.
-     * status 가 null 이면 cross-product 가 안 되므로 두 쿼리로 분기.
-     */
+    
+
     @Query("""
             SELECT i FROM Item i
              WHERE i.sellerId = :sellerId AND i.status = :status

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
@@ -21,19 +21,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/**
- * Item 동적 검색 — QueryDSL BooleanBuilder.
- *
- * <p>q 검색은 V1 스키마의 {@code FULLTEXT KEY ft_items_title_desc (title, description) WITH PARSER ngram}
- * 인덱스를 사용 (follow-up #10). MySQL ngram_token_size=2 + boolean mode + AND 조합:
- * 입력 토큰 중 길이 ≥ 2 만 사용해 {@code +token1 +token2} 형태로 변환 후
- * {@link com.sseulang.global.config.FullTextFunctionContributor#contributeFunctions Hibernate match_against
- * function} 호출. 토큰 길이 1 이거나 sanitization 후 빈 입력은 LIKE 폴백.</p>
- */
 @Repository
 public class ItemQuerydslRepository {
 
-    /** ngram_token_size=2 — 1글자 토큰은 매칭 불가. LIKE 로 폴백. */
+    
     private static final int MIN_NGRAM_TOKEN_LENGTH = 2;
 
     private final JPAQueryFactory queryFactory;
@@ -58,7 +49,7 @@ public class ItemQuerydslRepository {
                 );
                 where.and(matchScore.gt(0));
             } else {
-                // 모든 토큰 길이 < 2 → FULLTEXT 매칭 불가. LIKE 폴백.
+                
                 String pattern = "%" + input + "%";
                 where.and(item.title.like(pattern).or(item.description.like(pattern)));
             }
@@ -104,10 +95,8 @@ public class ItemQuerydslRepository {
         return new PageImpl<>(content, pageable, total == null ? 0L : total);
     }
 
-    /**
-     * sort 옵션 → QueryDSL OrderSpecifier 배열. 동률 시 createdAt DESC 로 안정적 정렬.
-     * default(LATEST) 는 createdAt DESC + id DESC.
-     */
+    
+
     private static OrderSpecifier<?>[] orderBy(ItemSort sort, QItem item) {
         return switch (sort) {
             case PRICE_ASC -> new OrderSpecifier<?>[]{ item.price.asc(), item.id.desc() };
@@ -118,15 +107,8 @@ public class ItemQuerydslRepository {
         };
     }
 
-    /**
-     * 사용자 입력을 MySQL FULLTEXT boolean mode 쿼리로 변환.
-     * <ul>
-     *   <li>boolean mode 메타문자 제거 (injection / 의도치 않은 OR 회피)</li>
-     *   <li>공백으로 split, 길이 ≥ {@value #MIN_NGRAM_TOKEN_LENGTH} 토큰만 채택</li>
-     *   <li>각 토큰에 {@code +} prefix → 모든 토큰 AND 매칭</li>
-     * </ul>
-     * 결과가 빈 문자열이면 호출자가 LIKE 폴백을 사용해야 함.
-     */
+    
+
     static String toBooleanModeQuery(String input) {
         if (input == null) return "";
         String sanitized = input.replaceAll("[+\\-*\"<>()~@]", " ").trim();

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemViewAdapter.java
@@ -8,10 +8,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * {@link ItemView} 어댑터. chat 도메인이 채팅방 응답에 아이템 제목/썸네일을 자동 채울 때 사용.
- * 단일 SELECT IN — N+1 회피.
- */
 @Component
 public class ItemViewAdapter implements ItemView {
 

--- a/src/main/java/com/sseulang/domain/item/presentation/AdminItemController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/AdminItemController.java
@@ -10,11 +10,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * Admin 의 물품 관리. 라운드 12 PR-F #6 — admin 이 본인 아닌 물품도 soft delete 가능.
- *
- * <p>admin chain (ROLE_ADMIN 강제) — user chain 의 {@link ItemController#delete} 와 분리.</p>
- */
 @Tag(name = "AdminItem", description = "관리자 — 물품 관리")
 @RestController
 @RequestMapping("/api/v1/admin/items")

--- a/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/ItemController.java
@@ -81,7 +81,7 @@ public class ItemController {
                 q, categoryId, tradeType, minPrice, maxPrice, tag, sellerId,
                 com.sseulang.domain.item.application.dto.ItemSort.parse(sort));
 
-        // 비로그인 — viewerId null → isWishlisted 항상 false. 로그인 시 단일 SELECT 로 enrich.
+        
         Page<ItemSummaryResponse> result = itemService.search(criteria, pageable, viewerId)
                 .map(ItemSummaryResponse::from);
         return ApiResponse.ok(PageResponse.from(result));

--- a/src/main/java/com/sseulang/domain/item/presentation/MyItemsController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/MyItemsController.java
@@ -16,11 +16,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 마이페이지용 본인 등록 물품 목록. {@link ItemController} 의 공개 검색과 분리 — 본인만 접근.
- *
- * <p>{@code status} 쿼리로 탭 분리 가능: 판매중 / 예약 / 거래완료 / 비공개. 미지정 시 삭제만 자동 제외.</p>
- */
 @Tag(name = "Item", description = "마이페이지 본인 물품 목록")
 @RestController
 @RequestMapping("/api/v1/users/me/items")

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemDetailResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemDetailResponse.java
@@ -8,18 +8,27 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
-@Schema(description = "물품 상세 — 이미지/해시태그 포함. GET /items/{id} 호출 시 viewCount 1 증가.")
+@Schema(description = "물품 상세 — 이미지/해시태그 포함. GET /items/{id} 호출 시 viewCount 1 증가. "
+        + "V25 라운드 12 PR-D 잔여 — salePrice/rentalPrice/tradeTypes 분리.")
 public record ItemDetailResponse(
         @Schema(example = "42") Long id,
         @Schema(example = "100") Long sellerId,
         @Schema(example = "5", description = "카테고리 id (없으면 null)") Long categoryId,
         @Schema(example = "아이폰 14 Pro 미개봉") String title,
         @Schema(example = "박스 미개봉, 색상 딥퍼플") String description,
-        @Schema(example = "1200000") long price,
-        @Schema(example = "100000", description = "대여 시 보증금 (판매/나눔은 null)") Long deposit,
-        @Schema(description = "대여 단위 (판매/나눔은 null)") RentalUnit rentalUnit,
-        TradeType tradeType,
+        @Schema(example = "1200000", description = "[DEPRECATED] primary 가격 — 신규는 salePrice/rentalPrice")
+        long price,
+        @Schema(example = "1200000", description = "판매가 (판매 모드 시)", nullable = true)
+        Long salePrice,
+        @Schema(example = "20000", description = "대여가 (대여 모드 시, rentalUnit 당)", nullable = true)
+        Long rentalPrice,
+        @Schema(example = "100000", description = "보증금 (대여 모드 시 필수)") Long deposit,
+        @Schema(description = "대여 단위 — 시간/일/주/월") RentalUnit rentalUnit,
+        @Schema(description = "[DEPRECATED] primary 모드 — 신규는 tradeTypes 사용") TradeType tradeType,
+        @Schema(description = "거래 모드 set (판매/대여/나눔 복수 가능)", example = "[\"판매\", \"대여\"]")
+        Set<TradeType> tradeTypes,
         ItemStatus status,
         @Schema(example = "서울 강남구") String region,
         @Schema(example = "127") int viewCount,
@@ -33,7 +42,9 @@ public record ItemDetailResponse(
         return new ItemDetailResponse(
                 r.id(), r.sellerId(), r.categoryId(),
                 r.title(), r.description(),
-                r.price(), r.deposit(), r.rentalUnit(), r.tradeType(),
+                r.price(), r.salePrice(), r.rentalPrice(),
+                r.deposit(), r.rentalUnit(),
+                r.tradeType(), r.tradeTypes(),
                 r.status(), r.region(),
                 r.viewCount(), r.wishlistCount(),
                 r.images().stream().map(ItemImageResponse::from).toList(),

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemRegisterRequest.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemRegisterRequest.java
@@ -5,13 +5,16 @@ import com.sseulang.domain.item.domain.RentalUnit;
 import com.sseulang.domain.item.domain.TradeType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
-@Schema(description = "물품 등록 요청. tradeType=대여 인 경우 deposit/rentalUnit 권장.")
+@Schema(description = "물품 등록 요청. tradeTypes 에 판매/대여/나눔 복수 지정 가능 (예: [판매, 대여]).")
 public record ItemRegisterRequest(
         @Schema(description = "카테고리 id (선택)", example = "3")
         Long categoryId,
@@ -22,19 +25,31 @@ public record ItemRegisterRequest(
         @Schema(description = "상세 설명", example = "구매 1년차, 박스/충전기 풀구성. 직거래 선호.")
         @NotBlank String description,
 
-        @Schema(description = "가격 (원). 나눔이면 0", example = "850000")
-        @NotNull @PositiveOrZero Long price,
+        @Schema(description = "거래 유형 set (1개 이상). 판매/대여 동시 등록 가능.",
+                example = "[\"판매\", \"대여\"]")
+        Set<TradeType> tradeTypes,
 
-        @Schema(description = "보증금 (대여 거래 전용, 그 외 null)", example = "100000", nullable = true)
+        @Schema(description = "판매가 (tradeTypes 에 판매 포함 시 필수)", example = "850000", nullable = true)
+        @PositiveOrZero Long salePrice,
+
+        @Schema(description = "대여가 (tradeTypes 에 대여 포함 시 필수, rentalUnit 당)", example = "20000", nullable = true)
+        @PositiveOrZero Long rentalPrice,
+
+        @Schema(description = "보증금 (대여 모드 시 필수)", example = "100000", nullable = true)
         @PositiveOrZero Long deposit,
 
-        @Schema(description = "대여 단위 (대여 거래 전용) — 시간/일/주/월", example = "일",
+        @Schema(description = "대여 단위 — 시간/일/주/월 (대여 모드 시 필수)", example = "일",
                 allowableValues = {"시간", "일", "주", "월"}, nullable = true)
         RentalUnit rentalUnit,
 
-        @Schema(description = "거래 유형", example = "판매",
-                allowableValues = {"판매", "대여", "나눔"})
-        @NotNull TradeType tradeType,
+        
+        @Schema(description = "[DEPRECATED] 단일 가격 — tradeTypes/sale/rental 로 마이그레이션. backwards compat 만.",
+                example = "850000", nullable = true)
+        @PositiveOrZero Long price,
+
+        @Schema(description = "[DEPRECATED] 단일 거래 유형 — tradeTypes 로 마이그레이션. backwards compat 만.",
+                example = "판매", allowableValues = {"판매", "대여", "나눔"}, nullable = true)
+        TradeType tradeType,
 
         @Schema(description = "지역", example = "서울 강남구", maxLength = 100, nullable = true)
         @Size(max = 100) String region,
@@ -47,9 +62,33 @@ public record ItemRegisterRequest(
         List<String> hashtags
 ) {
     public ItemRegisterCommand toCommand(Long sellerId) {
+        Set<TradeType> resolvedTypes = resolveTradeTypes();
+        Long resolvedSale = salePrice != null ? salePrice
+                : (tradeType == TradeType.판매 ? price : null);
+        Long resolvedRental = rentalPrice != null ? rentalPrice
+                : (tradeType == TradeType.대여 ? price : null);
         return new ItemRegisterCommand(
                 sellerId, categoryId, title, description,
-                price, deposit, rentalUnit, tradeType, region, imageUrls, hashtags
+                resolvedTypes, resolvedSale, resolvedRental,
+                deposit, rentalUnit, region, imageUrls, hashtags
         );
+    }
+
+    @jakarta.validation.constraints.AssertTrue(message = "tradeTypes 또는 tradeType 중 하나는 필수입니다")
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    public boolean isModeSpecified() {
+        return (tradeTypes != null && !tradeTypes.isEmpty()) || tradeType != null;
+    }
+
+    private Set<TradeType> resolveTradeTypes() {
+        if (tradeTypes != null && !tradeTypes.isEmpty()) {
+            return EnumSet.copyOf(tradeTypes);
+        }
+        if (tradeType != null) {
+            Set<TradeType> s = new LinkedHashSet<>();
+            s.add(tradeType);
+            return s;
+        }
+        return new LinkedHashSet<>();
     }
 }

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemSummaryResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemSummaryResponse.java
@@ -6,15 +6,24 @@ import com.sseulang.domain.item.domain.TradeType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
-@Schema(description = "물품 목록 row — 검색·찜·내물품 응답 공통.")
+@Schema(description = "물품 목록 row — 검색·찜·내물품 응답 공통. V25 라운드 12 PR-D 잔여 — 판매/대여 가격 분리.")
 public record ItemSummaryResponse(
         @Schema(example = "42") Long id,
         @Schema(example = "100") Long sellerId,
         @Schema(example = "5") Long categoryId,
         @Schema(example = "아이폰 14 Pro 미개봉") String title,
-        @Schema(example = "1200000") long price,
+        @Schema(example = "1200000", description = "[DEPRECATED] primary 모드 가격 — 신규는 salePrice/rentalPrice 사용")
+        long price,
+        @Schema(example = "1200000", description = "판매가 (판매 모드 시)", nullable = true)
+        Long salePrice,
+        @Schema(example = "20000", description = "대여가 (대여 모드 시, rentalUnit 당)", nullable = true)
+        Long rentalPrice,
+        @Schema(description = "[DEPRECATED] primary 모드 — 신규는 tradeTypes 사용")
         TradeType tradeType,
+        @Schema(description = "거래 모드 set (판매/대여/나눔 복수 가능)", example = "[\"판매\", \"대여\"]")
+        Set<TradeType> tradeTypes,
         ItemStatus status,
         @Schema(example = "서울 강남구") String region,
         @Schema(example = "https://cdn.sseulang.com/items/42/abc.jpg",
@@ -33,7 +42,9 @@ public record ItemSummaryResponse(
         return new ItemSummaryResponse(
                 r.id(), r.sellerId(), r.categoryId(),
                 r.title(), r.price(),
-                r.tradeType(), r.status(), r.region(),
+                r.salePrice(), r.rentalPrice(),
+                r.tradeType(), r.tradeTypes(),
+                r.status(), r.region(),
                 r.thumbnailUrl(), r.wishlistCount(), r.isWishlisted(),
                 r.viewCount(),
                 r.createdAt()

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/ItemUpdateRequest.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/ItemUpdateRequest.java
@@ -2,15 +2,18 @@ package com.sseulang.domain.item.presentation.dto;
 
 import com.sseulang.domain.item.application.dto.ItemUpdateCommand;
 import com.sseulang.domain.item.domain.RentalUnit;
+import com.sseulang.domain.item.domain.TradeType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
-@Schema(description = "물품 수정 요청. tradeType 은 변경 불가 — 거래 흐름 일관성 위해 등록 시점에 고정.")
+@Schema(description = "물품 수정 요청. tradeTypes 로 모드 변경 가능.")
 public record ItemUpdateRequest(
         @Schema(description = "카테고리 id", example = "3", nullable = true)
         Long categoryId,
@@ -21,14 +24,26 @@ public record ItemUpdateRequest(
         @Schema(description = "상세 설명", example = "가격 5만원 인하했습니다.")
         @NotBlank String description,
 
-        @Schema(description = "가격", example = "800000")
-        @NotNull @PositiveOrZero Long price,
+        @Schema(description = "거래 유형 set (1개 이상)", example = "[\"판매\", \"대여\"]")
+        Set<TradeType> tradeTypes,
+
+        @Schema(description = "판매가 (tradeTypes 에 판매 포함 시 필수)", example = "800000", nullable = true)
+        @PositiveOrZero Long salePrice,
+
+        @Schema(description = "대여가 (tradeTypes 에 대여 포함 시 필수)", example = "18000", nullable = true)
+        @PositiveOrZero Long rentalPrice,
 
         @Schema(description = "보증금 (대여 거래)", example = "100000", nullable = true)
         @PositiveOrZero Long deposit,
 
-        @Schema(description = "대여 단위", example = "DAY", nullable = true)
+        @Schema(description = "대여 단위", example = "일", nullable = true)
         RentalUnit rentalUnit,
+
+        
+        @Schema(description = "[DEPRECATED] 단일 가격 — backwards compat 만.", example = "800000", nullable = true)
+        @PositiveOrZero Long price,
+        @Schema(description = "[DEPRECATED] 단일 거래 유형 — backwards compat 만.", example = "판매", nullable = true)
+        TradeType tradeType,
 
         @Schema(description = "지역", example = "서울 강남구", maxLength = 100, nullable = true)
         @Size(max = 100) String region,
@@ -40,8 +55,33 @@ public record ItemUpdateRequest(
         List<String> hashtags
 ) {
     public ItemUpdateCommand toCommand() {
+        Set<TradeType> resolvedTypes = resolveTradeTypes();
+        Long resolvedSale = salePrice != null ? salePrice
+                : (tradeType == TradeType.판매 ? price : null);
+        Long resolvedRental = rentalPrice != null ? rentalPrice
+                : (tradeType == TradeType.대여 ? price : null);
         return new ItemUpdateCommand(
-                categoryId, title, description, price, deposit, rentalUnit, region, imageUrls, hashtags
+                categoryId, title, description,
+                resolvedTypes, resolvedSale, resolvedRental,
+                deposit, rentalUnit, region, imageUrls, hashtags
         );
+    }
+
+    @jakarta.validation.constraints.AssertTrue(message = "tradeTypes 또는 tradeType 중 하나는 필수입니다")
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    public boolean isModeSpecified() {
+        return (tradeTypes != null && !tradeTypes.isEmpty()) || tradeType != null;
+    }
+
+    private Set<TradeType> resolveTradeTypes() {
+        if (tradeTypes != null && !tradeTypes.isEmpty()) {
+            return EnumSet.copyOf(tradeTypes);
+        }
+        if (tradeType != null) {
+            Set<TradeType> s = new LinkedHashSet<>();
+            s.add(tradeType);
+            return s;
+        }
+        return new LinkedHashSet<>();
     }
 }

--- a/src/main/java/com/sseulang/domain/message/application/ChatRealtimeEventListener.java
+++ b/src/main/java/com/sseulang/domain/message/application/ChatRealtimeEventListener.java
@@ -8,14 +8,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-/**
- * 채팅 실시간 publish listener — AFTER_COMMIT (follow-up #19).
- *
- * <p>이전: send 트랜잭션 안에서 publish — 트랜잭션 롤백돼도 STOMP 메시지는 이미 발송돼 회수 불가.
- * 이후: 트랜잭션 commit 후 publish — 롤백 시 listener 호출 X 라 정합성 보장.</p>
- *
- * <p>publish 자체 실패는 로깅만 — 채팅방 토픽 broadcast / 알림 push 는 best-effort.</p>
- */
 @Component
 public class ChatRealtimeEventListener {
 

--- a/src/main/java/com/sseulang/domain/message/application/MessageApplicationService.java
+++ b/src/main/java/com/sseulang/domain/message/application/MessageApplicationService.java
@@ -17,20 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-/**
- * 채팅 메시지 도메인. 가이드 §4.10:
- *
- * <ol>
- *   <li>채팅방 참여자 검증 + 상대방 식별</li>
- *   <li>MongoDB Message 저장</li>
- *   <li>MySQL ChatRoom.last_message + unread 원자 갱신 (가이드 §4.10 트랜잭션 분리, 실패 시 로그)</li>
- *   <li>상대방 Notification 생성 + STOMP push</li>
- *   <li>채팅방 토픽 broadcast</li>
- * </ol>
- *
- * <p>각 단계 실패는 다음 단계 진행을 막지 않는다 — 메시지는 잃어도 비즈니스 크리티컬 X.
- * 본 PR(Phase 2) 의 핵심 — WebSocket+STOMP 통합은 가이드 §9.6 즉시 게이트 1 영역.</p>
- */
 @Service
 @Transactional(readOnly = true)
 public class MessageApplicationService {
@@ -38,7 +24,7 @@ public class MessageApplicationService {
     private final MessageRepository messageRepository;
     private final ChatRoomApplicationService chatRoomApplicationService;
     private final NotificationApplicationService notificationApplicationService;
-    private final RealtimePublisher realtimePublisher;  // 단위 테스트 호환용 (deprecated 직접 호출)
+    private final RealtimePublisher realtimePublisher;  
     private final ApplicationEventPublisher eventPublisher;
 
     public MessageApplicationService(
@@ -55,22 +41,15 @@ public class MessageApplicationService {
         this.eventPublisher = eventPublisher;
     }
 
-    /**
-     * 메시지 발신. 텍스트 또는 이미지 (XOR — 한쪽 비어있어야).
-     *
-     * <p>명시 {@code @Transactional} (write) — 클래스 레벨 readOnly 무력화. ChatRoom 메타 갱신은 본 트랜잭션 안.
-     * MongoDB 저장은 트랜잭션 밖, broadcast/notify 는 동기 (가이드 §4.10 — 실패 시 보상 X).</p>
-     *
-     * <p>TODO: broadcast/notify 를 {@code TransactionSynchronization.AFTER_COMMIT} 으로 미루는 정합성 보강은
-     * Codex 게이트 1 검증의 후속 권고 영역.</p>
-     */
+    
+
     @Transactional
     public MessageResult send(MessageSendCommand cmd) {
-        // soft hide 가드 — 본인이 left 한 방에 송신 X / 상대방이 left 한 방도 송신 X (#3.1).
+        
         chatRoomApplicationService.requireSendable(cmd.chatRoomId(), cmd.senderId());
         Long opponentId = chatRoomApplicationService.findOpponent(cmd.chatRoomId(), cmd.senderId());
 
-        // 라운드 12 PR-C #6 — 첫 메시지 발신 시점에 systemCard lazy 생성 (멱등).
+        
         chatRoomApplicationService.ensureSystemCard(cmd.chatRoomId());
 
         Message saved;
@@ -81,12 +60,12 @@ public class MessageApplicationService {
             saved = messageRepository.save(Message.text(cmd.chatRoomId(), cmd.senderId(), cmd.content()));
         }
 
-        // ChatRoom 메타 갱신 — 별도 MySQL 트랜잭션. 실패 시 로그 (가이드 §4.10).
+        
         chatRoomApplicationService.recordIncomingMessage(cmd.chatRoomId(), cmd.senderId(), saved.preview());
 
         MessageResult result = MessageResult.from(saved);
 
-        // 상대방 알림 생성 (트랜잭션 안에서 저장)
+        
         Notification notification = notificationApplicationService.notify(
                 opponentId,
                 NotificationType.메시지,
@@ -96,7 +75,7 @@ public class MessageApplicationService {
                 cmd.chatRoomId()
         );
 
-        // 실시간 publish 는 AFTER_COMMIT 으로 분리 (follow-up #19) — 트랜잭션 롤백 시 발송 X.
+        
         eventPublisher.publishEvent(new ChatRealtimePublishRequestedEvent(
                 cmd.chatRoomId(),
                 opponentId,

--- a/src/main/java/com/sseulang/domain/message/application/event/ChatRealtimePublishRequestedEvent.java
+++ b/src/main/java/com/sseulang/domain/message/application/event/ChatRealtimePublishRequestedEvent.java
@@ -3,12 +3,6 @@ package com.sseulang.domain.message.application.event;
 import com.sseulang.domain.message.application.dto.MessageResult;
 import com.sseulang.domain.notification.application.dto.NotificationResult;
 
-/**
- * 채팅 메시지 / 알림 실시간 publish 요청 이벤트 (follow-up #19 — AFTER_COMMIT 분리).
- *
- * <p>MessageApplicationService.send 가 트랜잭션 안에서 발행, listener 가 commit 후 publish.
- * 트랜잭션 롤백 시 listener 호출 X — 메시지 저장 실패 시 STOMP 메시지 발송 안 됨 (정합성).</p>
- */
 public record ChatRealtimePublishRequestedEvent(
         Long chatRoomId,
         Long opponentId,

--- a/src/main/java/com/sseulang/domain/message/domain/Message.java
+++ b/src/main/java/com/sseulang/domain/message/domain/Message.java
@@ -13,12 +13,6 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Message Aggregate Root — MongoDB {@code messages} 컬렉션 (가이드 §4.10).
- *
- * <p>채팅방의 텍스트/이미지 메시지. 본문은 {@code content} 또는 {@code imageUrls} 둘 중 하나는 필수.
- * 페이징은 커서 기반 — id 의 자연 정렬 (ObjectId 시간순) 활용.</p>
- */
 @Document(collection = "messages")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -91,7 +85,7 @@ public class Message {
         return imageUrls != null && !imageUrls.isEmpty();
     }
 
-    /** 채팅방 last_message 갱신용 미리보기 — 텍스트면 그대로, 이미지면 placeholder. */
+    
     public String preview() {
         if (isImageMessage()) {
             return imageUrls.size() > 1 ? "[사진 " + imageUrls.size() + "장]" : "[사진]";

--- a/src/main/java/com/sseulang/domain/message/domain/MessageRepository.java
+++ b/src/main/java/com/sseulang/domain/message/domain/MessageRepository.java
@@ -6,9 +6,7 @@ public interface MessageRepository {
 
     Message save(Message message);
 
-    /**
-     * 특정 채팅방의 메시지를 커서 페이징으로 조회. 가이드 §6.3 — {@code ?before={messageId}&size=30}.
-     * before 가 null 이면 가장 최근부터. 결과는 최신순 (id desc).
-     */
+    
+
     List<Message> findPage(Long chatRoomId, String beforeId, int size);
 }

--- a/src/main/java/com/sseulang/domain/message/presentation/dto/MessageSendRequest.java
+++ b/src/main/java/com/sseulang/domain/message/presentation/dto/MessageSendRequest.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
-/** content 또는 imageUrls 둘 중 하나는 필수. ApplicationService 가 도메인 invariant 로 검증. */
 @Schema(description = "채팅 메시지 전송 — content 또는 imageUrls 중 최소 1개 필수.")
 public record MessageSendRequest(
         @Schema(description = "텍스트 메시지", example = "안녕하세요, 거래 가능한가요?", maxLength = 2000, nullable = true)

--- a/src/main/java/com/sseulang/domain/notice/application/NoticeApplicationService.java
+++ b/src/main/java/com/sseulang/domain/notice/application/NoticeApplicationService.java
@@ -15,18 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
 
-/**
- * 공지 흐름.
- *
- * <ul>
- *   <li>관리자: CRUD + pin/publish 토글.</li>
- *   <li>사용자: 노출 윈도우 ({@code Notice.isVisibleAt}) 조건 만족하는 공지만 조회.
- *       단건 조회 시 view_count 증가.</li>
- * </ul>
- *
- * <p>관리자 권한 검증은 SecurityConfig admin chain ({@code hasRole("ADMIN")}) 에 위임 — 본
- * 서비스에서는 admin id 만 받아 작성자 정보로 기록.</p>
- */
 @Service
 @Transactional(readOnly = true)
 public class NoticeApplicationService {
@@ -75,7 +63,7 @@ public class NoticeApplicationService {
         noticeRepository.deleteById(noticeId);
     }
 
-    /** 사용자 단건 조회 + 조회수 증가. 미공개·윈도우 외 공지는 NOT_FOUND 로 동일 응답 (존재 leak 차단). */
+    
     @Transactional
     public NoticeResult viewById(Long noticeId) {
         Notice n = findOrThrow(noticeId);

--- a/src/main/java/com/sseulang/domain/notice/application/dto/NoticeResult.java
+++ b/src/main/java/com/sseulang/domain/notice/application/dto/NoticeResult.java
@@ -5,10 +5,6 @@ import com.sseulang.domain.notice.domain.NoticeType;
 
 import java.time.LocalDateTime;
 
-/**
- * 공지 단건 Result — admin / user 공용. user 응답에서는 isPublished 가 항상 true 로 고정되지만
- * 필드는 그대로 노출 (admin 화면 재사용성 + 디버깅 용이).
- */
 public record NoticeResult(
         Long id,
         Long adminId,

--- a/src/main/java/com/sseulang/domain/notice/application/dto/NoticeUpsertCommand.java
+++ b/src/main/java/com/sseulang/domain/notice/application/dto/NoticeUpsertCommand.java
@@ -4,10 +4,6 @@ import com.sseulang.domain.notice.domain.NoticeType;
 
 import java.time.LocalDateTime;
 
-/**
- * 공지 생성·수정 Command. presentation 의 Request DTO 가 변환해 service 로 전달.
- * 검증은 {@link com.sseulang.domain.notice.domain.Notice} 정적 팩토리 / update 가 책임.
- */
 public record NoticeUpsertCommand(
         NoticeType type,
         String title,

--- a/src/main/java/com/sseulang/domain/notice/domain/Notice.java
+++ b/src/main/java/com/sseulang/domain/notice/domain/Notice.java
@@ -15,12 +15,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * Notice Aggregate Root. V1 스키마 {@code notices} 매핑.
- *
- * <p>관리자가 작성하는 공지/이벤트. 게시 윈도우 ({@code startsAt}/{@code endsAt}) 와 게시 여부
- * ({@code isPublished}) 두 축으로 사용자 노출 여부 결정.</p>
- */
 @Entity
 @Table(name = "notices")
 @Getter
@@ -88,12 +82,12 @@ public class Notice extends BaseEntity {
         n.adminId = adminId;
         n.type = type;
         n.title = title.trim();
-        n.content = content;  // 본문은 trim 안 함 — 줄바꿈/공백 의미 보존
+        n.content = content;  
         n.imageUrl = imageUrl;
         n.startsAt = startsAt;
         n.endsAt = endsAt;
         n.pinned = false;
-        n.published = true;  // 기본 게시 — 작성 즉시 노출 가능
+        n.published = true;  
         n.viewCount = 0;
         return n;
     }
@@ -143,9 +137,8 @@ public class Notice extends BaseEntity {
         this.viewCount++;
     }
 
-    /**
-     * 사용자에게 노출되는지: published + 게시 윈도우 안. startsAt/endsAt null 이면 그쪽은 무제한.
-     */
+    
+
     public boolean isVisibleAt(LocalDateTime now) {
         if (!published) {
             return false;
@@ -156,7 +149,7 @@ public class Notice extends BaseEntity {
         if (startsAt != null && now.isBefore(startsAt)) {
             return false;
         }
-        // ends_at 은 exclusive 로 취급 — endsAt == now 이면 종료
+        
         if (endsAt != null && !now.isBefore(endsAt)) {
             return false;
         }

--- a/src/main/java/com/sseulang/domain/notice/domain/NoticeRepository.java
+++ b/src/main/java/com/sseulang/domain/notice/domain/NoticeRepository.java
@@ -6,10 +6,6 @@ import org.springframework.data.domain.Pageable;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-/**
- * Notice Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
- * 구현은 {@code domain/notice/infrastructure/persistence}.
- */
 public interface NoticeRepository {
 
     Notice save(Notice notice);
@@ -18,12 +14,10 @@ public interface NoticeRepository {
 
     void deleteById(Long id);
 
-    /**
-     * 사용자 노출 — published + 게시 윈도우 안 (startsAt 도달 + endsAt 미도달).
-     * is_pinned DESC, created_at DESC 정렬.
-     */
+    
+
     Page<Notice> findVisible(LocalDateTime now, NoticeType type, Pageable pageable);
 
-    /** 관리자 — 전체 또는 type 별 페이징 (created_at DESC). */
+    
     Page<Notice> findAllForAdmin(NoticeType type, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/notice/domain/NoticeType.java
+++ b/src/main/java/com/sseulang/domain/notice/domain/NoticeType.java
@@ -1,10 +1,7 @@
 package com.sseulang.domain.notice.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * V1 schema notices.type ENUM 매핑. 한글 enum 이름은 DB ENUM 값과 동일해야 한다 (Hibernate
- * EnumType.STRING 으로 그대로 매핑).
- */
+
 @Schema(description = "공지 유형 — 공지(일반) / 이벤트 / 새소식.")
 public enum NoticeType {
     공지,

--- a/src/main/java/com/sseulang/domain/notice/infrastructure/persistence/NoticeJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/notice/infrastructure/persistence/NoticeJpaRepository.java
@@ -10,13 +10,10 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 
-/** Spring Data JPA — {@link NoticeRepositoryImpl} 가 wrapping. 외부 직접 import 금지. */
 interface NoticeJpaRepository extends JpaRepository<Notice, Long> {
 
-    /**
-     * 사용자 노출 쿼리. type null 이면 전체 type. 윈도우는 startsAt/endsAt 두 축으로 판정 —
-     * NULL 이면 그쪽 무제한. 정렬은 pinned 우선, 그다음 최신.
-     */
+    
+
     @Query("""
             SELECT n FROM Notice n
              WHERE n.published = true

--- a/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/AdminNoticeController.java
@@ -24,9 +24,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 관리자 공지 CRUD + 상태 토글. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
- */
 @Tag(name = "AdminNotice", description = "관리자 — 공지 작성/관리")
 @RestController
 @RequestMapping("/api/v1/admin/notices")

--- a/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/NoticeController.java
@@ -14,9 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 사용자 공지 조회 — 노출 윈도우 통과한 공지만. SecurityConfig user chain 으로 ROLE_USER 강제.
- */
 @Tag(name = "Notice", description = "공지 조회 (공개)")
 @RestController
 @RequestMapping("/api/v1/notices")

--- a/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeToggleRequest.java
+++ b/src/main/java/com/sseulang/domain/notice/presentation/dto/NoticeToggleRequest.java
@@ -3,7 +3,6 @@ package com.sseulang.domain.notice.presentation.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-/** pin / publish 토글 공용 — 단순 boolean payload. */
 @Schema(description = "공지 pin/publish 토글. 엔드포인트에 따라 의미가 달라짐.")
 public record NoticeToggleRequest(
         @Schema(description = "켜기/끄기", example = "true")

--- a/src/main/java/com/sseulang/domain/notification/application/NotificationApplicationService.java
+++ b/src/main/java/com/sseulang/domain/notification/application/NotificationApplicationService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class NotificationApplicationService {
 
-    /** Admin broadcast 청크 크기 — 활성 사용자 id 청크 페이징 + 배치 INSERT 단위. */
+    
     private static final int BROADCAST_CHUNK_SIZE = 500;
 
     private final NotificationRepository notificationRepository;
@@ -29,9 +29,8 @@ public class NotificationApplicationService {
         this.userRepository = userRepository;
     }
 
-    /**
-     * 시스템 → 사용자 알림 발송. 다른 도메인이 호출 (예: 메시지 발신 시 상대방, 거래 상태 변경 시 등).
-     */
+    
+
     public Notification notify(
             Long userId,
             NotificationType type,
@@ -49,11 +48,8 @@ public class NotificationApplicationService {
         return notificationRepository.findByUserId(userId, pageable).map(NotificationResult::from);
     }
 
-    /**
-     * 알림 읽음 처리. 본인 알림이 아니면 (또는 미존재면) <b>조용히 무시</b> — 다른 사용자 알림 id 가
-     * 우연히 알려진 케이스에서도 실패 응답으로 정보 노출하지 않음. doc/FRONTEND_INTEGRATION.md §10.10 정합.
-     * 본인 본인 알림이 이미 read 면 추가 SAVE 안 함 (멱등).
-     */
+    
+
     public void markAsRead(String notificationId, Long requesterId) {
         Notification n = notificationRepository.findById(notificationId).orElse(null);
         if (n == null || !n.isOwnedBy(requesterId)) {
@@ -65,26 +61,13 @@ public class NotificationApplicationService {
         }
     }
 
-    /** 본인 unread 알림 모두 read 처리 (atomic UPDATE multi). 처리 건수 반환 — 0 도 정상. */
+    
     public long markAllAsRead(Long userId) {
         return notificationRepository.markAllAsReadByUserId(userId);
     }
 
-    /**
-     * Admin broadcast — 활성 사용자(blocked/deleted 제외) 전원에게 동일 알림 발송.
-     *
-     * <p>round 12 멱등성 + bulk:
-     * <ul>
-     *   <li>idempotencyKey null 이면 서버 UUID 자동 생성 → 응답으로 반환</li>
-     *   <li>idempotencyKey 제공 시 그대로 broadcastId — 같은 키 재호출 시 중복 INSERT 차단</li>
-     *   <li>chunk 당 BulkOperations UNORDERED INSERT — Mongo round-trip 1번 (이전엔 chunk 사이즈만큼)</li>
-     *   <li>중간 실패 시 같은 broadcastId 로 재호출 → (broadcastId, userId) UNIQUE 가 dup skip</li>
-     * </ul>
-     *
-     * <p>type {@link NotificationType#공지} 고정. linkType / linkId null.</p>
-     *
-     * @return BroadcastResult — broadcastId + 실제 INSERT 된 건수
-     */
+    
+
     public BroadcastResult broadcast(String title, String content, String idempotencyKey) {
         if (title == null || title.isBlank()) {
             throw new IllegalArgumentException("title 은 필수입니다");
@@ -111,6 +94,6 @@ public class NotificationApplicationService {
         return new BroadcastResult(broadcastId, total);
     }
 
-    /** Round 12 broadcast 결과 — broadcastId 응답으로 반환해 재호출 멱등키로 사용. */
+    
     public record BroadcastResult(String broadcastId, long sent) { }
 }

--- a/src/main/java/com/sseulang/domain/notification/domain/Notification.java
+++ b/src/main/java/com/sseulang/domain/notification/domain/Notification.java
@@ -12,14 +12,9 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.Instant;
 
-/**
- * Notification Aggregate Root — MongoDB {@code notifications} 컬렉션 (가이드 §4.10).
- * 시스템 → 사용자 단방향 알림. 클릭 시 이동할 곳은 {@code linkType + linkId} 조합으로.
- */
 @Document(collection = "notifications")
 @CompoundIndex(name = "user_created", def = "{'userId': 1, 'createdAt': -1}")
-// Round 12 — broadcast 멱등성. 같은 (broadcastId, userId) 중복 INSERT 차단.
-// broadcastId 가 null 인 일반 알림은 sparse=true 로 인덱스 외.
+
 @CompoundIndex(name = "broadcast_user_unique",
         def = "{'broadcastId': 1, 'userId': 1}", unique = true, sparse = true)
 @Getter
@@ -54,17 +49,13 @@ public class Notification {
     @Field("read")
     private boolean read;
 
-    /**
-     * Admin broadcast 멱등키 (round 12). 같은 broadcastId 로 재호출 시 (broadcastId, userId) UNIQUE
-     * 위반으로 중복 INSERT 차단. 일반 알림은 null (sparse 인덱스).
-     */
+    
+
     @Field("broadcastId")
     private String broadcastId;
 
-    /**
-     * 알림 대분류 — PR-F #5 라운드 12. 프론트가 SYSTEM/REPORT/INQUIRY/USER 4가지 카테고리로 분류 노출.
-     * 기존 row 는 default USER (자동 적용).
-     */
+    
+
     @Field("category")
     private NotificationCategory category;
 
@@ -83,7 +74,7 @@ public class Notification {
         return create(userId, type, title, content, linkType, linkId, null, NotificationCategory.USER);
     }
 
-    /** Round 12 broadcast 전용 — broadcastId 동반 INSERT (category=SYSTEM). */
+    
     public static Notification create(
             Long userId,
             NotificationType type,
@@ -93,11 +84,11 @@ public class Notification {
             Long linkId,
             String broadcastId
     ) {
-        // broadcast 는 admin 공지 — SYSTEM 카테고리.
+        
         return create(userId, type, title, content, linkType, linkId, broadcastId, NotificationCategory.SYSTEM);
     }
 
-    /** Round 12 PR-F #5 — 카테고리 명시 INSERT. */
+    
     public static Notification create(
             Long userId,
             NotificationType type,

--- a/src/main/java/com/sseulang/domain/notification/domain/NotificationCategory.java
+++ b/src/main/java/com/sseulang/domain/notification/domain/NotificationCategory.java
@@ -1,17 +1,5 @@
 package com.sseulang.domain.notification.domain;
 
-/**
- * 알림 대분류 (PR-F #5 라운드 12). 프론트가 알림 목록을 시스템/신고/문의/사용자 4가지 카테고리로 분류 노출.
- *
- * <ul>
- *   <li>{@link #SYSTEM} — 관리자 공지/이벤트 broadcast</li>
- *   <li>{@link #REPORT} — 신고 처리 결과</li>
- *   <li>{@link #INQUIRY} — 1:1 문의 답변</li>
- *   <li>{@link #USER} — 일반 사용자 액션 (메시지/거래/결제/정산 등) — default</li>
- * </ul>
- *
- * <p>기존 NotificationType (메시지/거래/결제/...) 와 별도 — type 은 구체 이벤트, category 는 분류 묶음.</p>
- */
 public enum NotificationCategory {
     SYSTEM,
     REPORT,

--- a/src/main/java/com/sseulang/domain/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/sseulang/domain/notification/domain/NotificationRepository.java
@@ -11,20 +11,14 @@ public interface NotificationRepository {
 
     Optional<Notification> findById(String id);
 
-    /** userId 기준 최신순 페이징. */
+    
     Page<Notification> findByUserId(Long userId, Pageable pageable);
 
-    /**
-     * 본인 unread 알림 모두 read 처리 (atomic UPDATE). 처리된 건수 반환 — 0 도 정상.
-     */
+    
+
     long markAllAsReadByUserId(Long userId);
 
-    /**
-     * Round 12 — broadcast 청크 bulk INSERT. (broadcastId, userId) UNIQUE 위반 ({@link
-     * org.springframework.dao.DuplicateKeyException}) 은 silent skip — 중복 알림 생성 차단.
-     * 실제 INSERT 된 건수 반환.
-     *
-     * <p>Mongo unordered insert — 한 chunk 안의 중복 한 건이 나머지 INSERT 를 차단하지 않음.</p>
-     */
+    
+
     int saveAllIgnoreDuplicates(java.util.List<Notification> notifications);
 }

--- a/src/main/java/com/sseulang/domain/notification/domain/NotificationType.java
+++ b/src/main/java/com/sseulang/domain/notification/domain/NotificationType.java
@@ -1,7 +1,7 @@
 package com.sseulang.domain.notification.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/** 알림 유형 — 가이드 §4.10 시스템 → 사용자 단방향. */
+
 @Schema(description = "알림 유형 — 메시지 / 거래 / 리뷰 / 공지 / 시스템.")
 public enum NotificationType {
     메시지,

--- a/src/main/java/com/sseulang/domain/notification/infrastructure/persistence/NotificationRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/notification/infrastructure/persistence/NotificationRepositoryImpl.java
@@ -48,8 +48,8 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     @Override
     public int saveAllIgnoreDuplicates(java.util.List<Notification> notifications) {
         if (notifications == null || notifications.isEmpty()) return 0;
-        // BulkOperations UNORDERED — 같은 chunk 안의 중복 한 건이 나머지 INSERT 를 차단하지 않음.
-        // (broadcastId, userId) UNIQUE 위반은 silent skip — 중복 알림 차단 (round 12 멱등성).
+        
+        
         org.springframework.data.mongodb.core.BulkOperations bulk =
                 mongoTemplate.bulkOps(
                         org.springframework.data.mongodb.core.BulkOperations.BulkMode.UNORDERED,
@@ -61,8 +61,8 @@ public class NotificationRepositoryImpl implements NotificationRepository {
         try {
             return bulk.execute().getInsertedCount();
         } catch (org.springframework.dao.DuplicateKeyException dup) {
-            // 부분 중복 — UNORDERED 라 정상 INSERT 는 이미 적용됨. 정확 카운트 조회 어려워 size 반환.
-            // 운영 정합성에 영향 없음 (이미 적용된 건은 그대로, 중복은 차단).
+            
+            
             return notifications.size();
         }
     }

--- a/src/main/java/com/sseulang/domain/notification/presentation/AdminNotificationController.java
+++ b/src/main/java/com/sseulang/domain/notification/presentation/AdminNotificationController.java
@@ -15,11 +15,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 관리자 공지 broadcast — 활성 사용자 전원에게 시스템 알림 INSERT.
- *
- * <p>SecurityConfig admin chain 으로 ROLE_ADMIN 강제. targetRole 은 현재 ALL 만 — ADMIN/USER 분기는 후속.</p>
- */
 @Tag(name = "AdminNotification", description = "관리자 — 알림 broadcast")
 @RestController
 @RequestMapping("/api/v1/admin/notifications")

--- a/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
@@ -32,18 +32,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-/**
- * 가이드 §4.9 결제 흐름 — 토스페이먼츠 실연동:
- *
- * <ol>
- *   <li>{@link #startCharge}: merchant_uid 발급 + Payment 저장 (status=대기). 클라이언트가 토스 위젯으로 결제 진행.</li>
- *   <li>{@link #confirmCharge}: 토스 redirect 후 백엔드 콜백. Payment 비관적 락 → amount 위변조 검증 →
- *       토스 confirm API 호출 → 응답 재검증 → markAsPaid + 포인트 atomic 적립. 멱등 — 이미 완료면 노op.</li>
- *   <li>{@link #handleWebhook}: 토스 webhook 수신 — 본 PR 에선 로깅만. confirm 으로 처리되므로 보강용.</li>
- * </ol>
- *
- * <p><b>위변조 방지 2중</b>: 클라가 보낸 amount 와 Payment 저장 amount 일치 + 토스 응답 amount 와 Payment amount 일치.</p>
- */
 @Service
 @Transactional(readOnly = true)
 public class PaymentApplicationService {
@@ -85,10 +73,8 @@ public class PaymentApplicationService {
         this.escrowApplicationService = escrowApplicationService;
     }
 
-    /**
-     * 부팅 시점 skipVerify 활성 경고. dev/QA 환경에서 토스 시크릿 키 미발급 상태로 결제 흐름 검증할 때만 사용.
-     * 운영 진입 시 반드시 false 로 복귀해야 함.
-     */
+    
+
     @jakarta.annotation.PostConstruct
     void warnIfSkipVerifyEnabled() {
         if (Boolean.TRUE.equals(tossProperties.skipVerify())) {
@@ -102,10 +88,10 @@ public class PaymentApplicationService {
         if (cmd.amount() <= 0) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST);
         }
-        // 자금 흐름 진입점 — 이메일 인증 미완료 사용자 차단 (게이트 1).
+        
         userApplicationService.requireVerified(cmd.userId());
 
-        // 거래대행 결제면 — Escrow application 검증 (payer / share / status).
+        
         if (cmd.isEscrow()) {
             escrowApplicationService.verifyChargeIntent(cmd.escrowApplicationId(), cmd.userId(), cmd.amount());
         }
@@ -116,9 +102,8 @@ public class PaymentApplicationService {
         return new ChargeStartResult(saved.getId(), merchantUid, cmd.amount(), tossProperties.clientKey());
     }
 
-    /**
-     * 토스 redirect 후 백엔드 confirm. 비관적 락 + 멱등 + 위변조 검증 + 토스 호출 + 포인트 적립.
-     */
+    
+
     @Transactional
     public PaymentResult confirmCharge(ChargeConfirmCommand cmd) {
         Payment payment = paymentRepository.findByMerchantUidForUpdate(cmd.orderId())
@@ -128,7 +113,7 @@ public class PaymentApplicationService {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
-        // 1차 검증 — 클라가 보낸 amount 와 저장 amount 일치 (위변조 방지).
+        
         try {
             payment.verifyAmount(cmd.amount());
         } catch (BusinessException e) {
@@ -141,13 +126,13 @@ public class PaymentApplicationService {
             throw e;
         }
 
-        // 멱등 — 이미 완료된 결제는 토스 호출 없이 그대로 반환.
+        
         if (payment.getStatus().isPaid()) {
             return PaymentResult.from(payment);
         }
 
-        // skip-verify 모드 (dev/QA 한정) — 토스 시크릿 키 없는 환경에서 confirm 흐름 검증용.
-        // 1차 verifyAmount 가드는 통과한 상태 → 클라이언트 amount 그대로 신뢰. 운영 절대 사용 X (부팅 WARN 참고).
+        
+        
         if (Boolean.TRUE.equals(tossProperties.skipVerify())) {
             log.warn("[toss-confirm][SKIP-VERIFY] 토스 검증 우회 — paymentId={} merchantUid={} amount={} requesterId={}",
                     payment.getId(), payment.getMerchantUid(), cmd.amount(), cmd.requesterId());
@@ -163,9 +148,9 @@ public class PaymentApplicationService {
             return PaymentResult.from(payment);
         }
 
-        // 토스 confirm API 호출. 4xx 분기:
-        //   - PAYMENT_ALREADY_PROCESSED → lookup 으로 상태 동기화 (dangling 자동 복구, Codex 게이트 1 ④)
-        //   - 그 외 → 그대로 throw
+        
+        
+        
         PaymentConfirmResult result;
         try {
             result = paymentGateway.confirm(cmd.paymentKey(), cmd.orderId(), cmd.amount());
@@ -177,8 +162,8 @@ public class PaymentApplicationService {
             }
         }
 
-        // 2차 검증 — 토스 응답 orderId / amount 가 저장값과 일치 (confirm 정상 / lookup 복구 양 경로 공통).
-        // orderId 검증은 lookup 복구 시 다른 paymentKey-orderId 페어가 우리 결제와 매칭되는 위변조 차단 (Codex 게이트 1 2차).
+        
+        
         if (!payment.getMerchantUid().equals(result.orderId())) {
             throw new BusinessException(ErrorCode.PAYMENT_VERIFY_FAILED);
         }
@@ -208,24 +193,17 @@ public class PaymentApplicationService {
         return PaymentResult.from(payment);
     }
 
-    /**
-     * Payment 가 newly paid 됐을 때 부수효과 — escrow 결제 / 일반 충전 분기.
-     * confirmCharge / handleWebhook / reconcileStalePayment 가 모두 호출 (게이트 1 Critical 1 회귀 방지).
-     *
-     * <ul>
-     *   <li>escrow 결제 (escrow_application_id NOT NULL): buyer 잔액 변동 X — escrow application paid_at 갱신만</li>
-     *   <li>일반 충전: atomic point_balance + history 적재</li>
-     * </ul>
-     */
+    
+
     private void applyPaymentConfirmedEffects(Payment payment, String chargeDescription) {
         if (payment.getEscrowApplicationId() != null) {
-            // 거래대행 결제 — buyer 잔액 변동 X (escrow hold). 정산 시 seller / rider 한테만 credit.
+            
             escrowApplicationService.recordPaymentConfirmed(
                     payment.getEscrowApplicationId(),
                     payment.getUserId()
             );
         } else {
-            // 일반 충전 — atomic point_balance 증가 + history 적재.
+            
             pointApplicationService.credit(
                     payment.getUserId(),
                     payment.getAmount(),
@@ -237,43 +215,15 @@ public class PaymentApplicationService {
         }
     }
 
-    /**
-     * 토스가 confirm 4xx ALREADY_PROCESSED 응답한 케이스 — 이미 PG 측에서 승인된 상태라
-     * paymentKey 단건 조회로 결과를 복구해서 markAsPaid + 포인트 적립까지 동기화한다.
-     * lookup 결과 amount 가 우리 저장 amount 와 다르면 verifyAmount 가 PAYMENT_AMOUNT_MISMATCH 던짐 (위변조 차단).
-     */
+    
+
     private PaymentConfirmResult recoverByLookup(String paymentKey) {
         log.warn("[toss-recover] confirm ALREADY_PROCESSED → lookup paymentKey={}", paymentKey);
         return paymentGateway.lookup(paymentKey);
     }
 
-    /**
-     * 토스 webhook 처리 — 토스 공식 spec 기반 (게이트 1 round 1 — Codex 피드백 반영 round 2).
-     *
-     * <p>토스 결제 webhook 공식 사항 (https://docs.tosspayments.com/reference/using-api/webhook-events):
-     * <ul>
-     *   <li>결제 이벤트 ({@code PAYMENT_STATUS_CHANGED}) 에는 <b>HMAC 시그니처 헤더가 없음</b> —
-     *       위변조 방지는 webhook payload 자체가 아니라 토스 lookup API 재조회로 한다.</li>
-     *   <li>멱등 키는 헤더 {@code tosspayments-webhook-transmission-id} (body 의 eventId 가 아님).</li>
-     *   <li>HMAC 시그니처 ({@code tosspayments-webhook-signature}) 는 {@code payout.changed},
-     *       {@code seller.changed} 등 일부 이벤트에만 포함 — 본 핸들러는 결제 이벤트만 처리하므로
-     *       시그니처 검증은 위 두 이벤트 도입 시 활성. {@link TossWebhookSignatureVerifier} 는 골격만.</li>
-     * </ul>
-     *
-     * <p>흐름:
-     * <ol>
-     *   <li>transmission-id 헤더 → 멱등 키. WebhookEvent saveAndFlush — UNIQUE 충돌 즉시 catch
-     *       (lazy flush 로 트랜잭션 commit 시점에 터지는 회귀 차단).</li>
-     *   <li>payload 파싱 → {@code eventType / data.paymentKey}. payload 의 status/amount 는 신뢰 X.</li>
-     *   <li>{@code PAYMENT_STATUS_CHANGED} 이면 {@link PaymentGateway#lookup} 으로 토스 서버 재조회.</li>
-     *   <li>lookup 결과의 status=DONE + orderId/amount 일치 검증 → markAsPaid + 포인트 적립.</li>
-     * </ol>
-     *
-     * <p>confirm 콜백과 webhook 모두 markAsPaid 를 호출할 수 있으므로 Payment 비관적 락 + 멱등
-     * (markAsPaid 가 이미 완료면 false 반환) 으로 두 경로 race 차단.</p>
-     *
-     * @param transmissionId 토스 발송 ID (멱등 키, 헤더 누락 시 PAYLOAD_INVALID)
-     */
+    
+
     @Transactional
     public void handleWebhook(String rawPayload, String transmissionId) {
         if (transmissionId == null || transmissionId.isBlank()) {
@@ -282,8 +232,8 @@ public class PaymentApplicationService {
         JsonNode root = parseOrThrow(rawPayload);
         String eventType = textOrThrow(root, "eventType");
 
-        // DoS 차단 (게이트 1 round 2 Critical) — 결제 외 eventType 은 저장도 lookup 도 X.
-        // 공격자가 random eventType + transmission-id 로 webhook_events row 폭증시키는 경로 차단.
+        
+        
         if (!"PAYMENT_STATUS_CHANGED".equals(eventType)) {
             log.debug("[toss-webhook] 비결제 eventType={} — 무시", eventType);
             return;
@@ -296,8 +246,8 @@ public class PaymentApplicationService {
             throw new BusinessException(ErrorCode.PAYMENT_WEBHOOK_PAYLOAD_INVALID);
         }
 
-        // DoS 차단 — 우리 시스템 결제가 아니거나 이미 종결된 결제면 저장 / lookup outbound 모두 X.
-        // 본인 pending 으로 random paymentKey 반복 공격 차단을 위해 status=대기 만 진행 (게이트 1 round 3).
+        
+        
         Payment routed = paymentRepository.findByMerchantUid(orderId).orElse(null);
         if (routed == null) {
             log.warn("[toss-webhook] 알 수 없는 orderId={} (다른 가맹점 결제) — 저장 / lookup 모두 skip", orderId);
@@ -309,14 +259,14 @@ public class PaymentApplicationService {
             return;
         }
 
-        // pending 유지 공격 차단 (게이트 1 round 4) — 같은 pending orderId 에 대해 60초 윈도우
-        // 안 N회만 lookup outbound 허용. 토스 정상 흐름은 같은 transmission-id retry 라
-        // UNIQUE 멱등에 잡혀 lookup 1회만 — 한도에 걸릴 일 없음.
+        
+        
+        
         if (!pendingRateLimiter.tryAcquire(orderId)) {
             return;
         }
 
-        // 1. 멱등 저장 — saveAndFlush 로 즉시 UNIQUE 충돌 감지 (게이트 1 round 1 Critical 4).
+        
         LocalDateTime now = LocalDateTime.now();
         WebhookEvent saved;
         try {
@@ -328,33 +278,23 @@ public class PaymentApplicationService {
             return;
         }
 
-        // 2. state 동기화 — Payment 비관적 락 + lookup 재조회 + payload orderId 와 lookup orderId 일치 검증.
+        
         boolean settled = syncPaidByWebhook(paymentKey, orderId);
         saved.markProcessed(LocalDateTime.now());
-        // 정상 정산된 경우만 카운터 회수 — lookup 실패는 카운터 유지해 공격 누적 차단.
+        
         if (settled) {
             pendingRateLimiter.release(orderId);
         }
     }
 
-    /**
-     * webhook 받은 paymentKey 로 토스 lookup 재조회 → DONE 이고 우리 Payment 와 amount/orderId
-     * 일치하면 markAsPaid + 포인트 적립.
-     *
-     * <p>위변조 방지의 핵심 — webhook payload 의 status/amount 를 그대로 신뢰하지 않고 토스 서버에
-     * 직접 물어 본다 (게이트 1 round 1 Critical 3). lookup 결과 자체가 신뢰원.</p>
-     *
-     * <p>이미 confirm 흐름으로 markAsPaid 됐다면 멱등 (markAsPaid false 반환). lookup orderId 가
-     * 우리 DB 에 없으면 무시 (다른 가맹점 결제 잘못 라우팅 가능성).</p>
-     */
-    /**
-     * @return true = 정상 정산 완료 (또는 confirm 으로 이미 완료된 멱등 케이스),
-     *         false = lookup 실패 / orderId 불일치 등 비정상 — 호출자가 rate limit 카운터 유지.
-     */
+    
+
+    
+
     private boolean syncPaidByWebhook(String paymentKey, String expectedOrderId) {
-        // TossPaymentGateway.lookup 은 status=DONE 만 정상 반환 (DONE 아니면 PAYMENT_VERIFY_FAILED throw).
-        // BusinessException 은 토스 측 의미 있는 응답(미완료/취소 등) 으로 보고 200 + skip.
-        // ExternalApiException (네트워크/5xx/파싱 실패) 은 catch 안 함 → 5xx 던져 토스 retry 유도.
+        
+        
+        
         PaymentConfirmResult lookup;
         try {
             lookup = paymentGateway.lookup(paymentKey);
@@ -362,7 +302,7 @@ public class PaymentApplicationService {
             log.warn("[toss-webhook] lookup 비정상 응답 paymentKey={} code={}", paymentKey, e.getErrorCode());
             return false;
         }
-        // payload orderId 와 lookup orderId 일치 검증 (게이트 1 round 3 — Critical).
+        
         if (!expectedOrderId.equals(lookup.orderId())) {
             log.warn("[toss-webhook] payload orderId={} 와 lookup orderId={} 불일치 — 처리 거부",
                     expectedOrderId, lookup.orderId());
@@ -374,11 +314,11 @@ public class PaymentApplicationService {
             return false;
         }
         if (payment.getStatus() == PaymentStatus.완료) {
-            return true;  // confirm 흐름으로 이미 처리. 멱등 정상.
+            return true;  
         }
-        // amount 위변조 검증 — lookup amount 와 우리 저장 amount 일치 확인.
-        // mismatch 시 명시적 ERROR 로깅 — audit row 는 트랜잭션 롤백되므로 운영 모니터링이
-        // ERROR level 로그를 잡아 알림으로 활용 (follow-up #53 round 1).
+        
+        
+        
         try {
             payment.verifyAmount(lookup.amount());
         } catch (BusinessException e) {
@@ -427,19 +367,15 @@ public class PaymentApplicationService {
         return PaymentResult.from(payment);
     }
 
-    /** 관리자 결제 통계 — 완료 건수 + 누적 금액. 단일 SUM/COUNT 쿼리. */
+    
     public PaymentStatsResult adminGetStats() {
         return new PaymentStatsResult(paymentRepository.countPaid(), paymentRepository.sumPaidAmount());
     }
 
-    // ───────── Reconciliation (follow-up #21) ─────────
+    
 
-    /**
-     * dangling 복구 — orderId 로 토스 lookup 시도 후 일치하면 markAsPaid + 적립.
-     * Reconciliation 스케줄러가 호출. 단일 Payment 단위 트랜잭션.
-     *
-     * @return true = 복구 성공 (markAsPaid), false = 토스 측 미완료 / 위변조 / 매칭 실패 등
-     */
+    
+
     @Transactional
     public boolean reconcileStalePayment(Long paymentId) {
         Payment payment = paymentRepository.findById(paymentId).orElse(null);
@@ -471,7 +407,7 @@ public class PaymentApplicationService {
         return true;
     }
 
-    /** Reconciliation 스케줄러 진입점 — stale Payment id 목록 조회. */
+    
     public java.util.List<Long> findStalePendingIds(java.time.LocalDateTime cutoff, int limit) {
         return paymentRepository.findStalePending(cutoff, limit).stream()
                 .map(Payment::getId)

--- a/src/main/java/com/sseulang/domain/payment/application/PaymentReconciliationScheduler.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentReconciliationScheduler.java
@@ -11,25 +11,12 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
-/**
- * 토스 결제 dangling 복구 스케줄러 (follow-up #21).
- *
- * <p>주기적으로 status=대기 + 일정 시간 경과 Payment 를 토스 lookup 으로 동기화. 시나리오:
- * <ul>
- *   <li>confirm 도중 응답 유실 / 5xx → DB 는 대기, 토스는 DONE</li>
- *   <li>markAsPaid + creditPoint 직전 commit 장애 → 동일</li>
- *   <li>webhook 도 못 받은 케이스 (토스 측 webhook 발송 실패 또는 네트워크)</li>
- * </ul>
- *
- * <p>각 Payment 는 별도 트랜잭션으로 처리 — 한 건 실패해도 다른 건 진행.
- * 스케줄 주기는 {@code app.payment.reconcile.interval-millis} (기본 5분).</p>
- */
 @Component
 public class PaymentReconciliationScheduler {
 
     private static final Logger log = LoggerFactory.getLogger(PaymentReconciliationScheduler.class);
 
-    /** 한 cycle 에 처리할 최대 건수 — Toss API 부하 / 트랜잭션 시간 제어. */
+    
     private static final int BATCH_LIMIT = 50;
 
     private final PaymentApplicationService paymentService;
@@ -39,7 +26,7 @@ public class PaymentReconciliationScheduler {
     public PaymentReconciliationScheduler(
             PaymentApplicationService paymentService,
             Clock clock,
-            @Value("${app.payment.reconcile.stale-after-millis:600000}")  // 기본 10분
+            @Value("${app.payment.reconcile.stale-after-millis:600000}")  
             long staleAfterMillis
     ) {
         this.paymentService = paymentService;
@@ -47,11 +34,8 @@ public class PaymentReconciliationScheduler {
         this.staleAfterMillis = staleAfterMillis;
     }
 
-    /**
-     * 5분마다 실행. fixedDelay — 이전 cycle 끝난 후 5분 (overlap 차단).
-     * 운영 환경에서 주기 변경은 {@code app.payment.reconcile.fixed-delay-millis} (Spring Boot 자동 바인딩 X 라
-     * 본 메서드 변경 필요 — 5/6 이전 단순화).
-     */
+    
+
     @Scheduled(fixedDelayString = "${app.payment.reconcile.fixed-delay-millis:300000}", initialDelayString = "60000")
     public void reconcile() {
         LocalDateTime cutoff = LocalDateTime.now(clock).minus(Duration.ofMillis(staleAfterMillis));

--- a/src/main/java/com/sseulang/domain/payment/application/WebhookPendingRateLimiter.java
+++ b/src/main/java/com/sseulang/domain/payment/application/WebhookPendingRateLimiter.java
@@ -8,31 +8,18 @@ import java.time.Clock;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-/**
- * pending Payment.orderId 당 webhook lookup outbound 시도 제한.
- *
- * <p>게이트 1 round 4 — DoS: 공격자가 본인 pending 만든 후 결제하지 않고 random paymentKey +
- * unique transmission-id 반복 보내면 매번 webhook_events INSERT + Toss lookup outbound 발생.
- * 사전 status=대기 가드는 정상 결제 1회 후엔 막지만, pending 유지 동안은 무방비.</p>
- *
- * <p>한도: orderId 당 60초 윈도우에 {@value #MAX_PER_WINDOW} 회. 초과 시 false 반환 → 호출자가
- * 사전 거부 (저장 / lookup 모두 skip). 정상 흐름은 토스가 같은 transmission-id 로 retry 하므로
- * UNIQUE 멱등 가드에 잡혀 lookup 도 1회만 — 한도에 걸릴 일 없음.</p>
- *
- * <p><b>단일 JVM 한정.</b> 다중 인스턴스 prod 에서는 Redis 카운터로 교체 (follow-up #53).</p>
- */
 @Component
 public class WebhookPendingRateLimiter {
 
     private static final Logger log = LoggerFactory.getLogger(WebhookPendingRateLimiter.class);
 
-    /** orderId 당 윈도우 안 lookup 시도 한도. */
+    
     static final int MAX_PER_WINDOW = 5;
 
-    /** 윈도우 길이 (밀리초). */
+    
     static final long WINDOW_MILLIS = 60_000L;
 
-    /** 자체 청소 임계 — 누적 키 수가 초과하면 만료된 항목 정리 (메모리 누수 차단). */
+    
     private static final int CLEANUP_THRESHOLD = 10_000;
 
     private final ConcurrentMap<String, Slot> slots = new ConcurrentHashMap<>();
@@ -42,14 +29,13 @@ public class WebhookPendingRateLimiter {
         this(Clock.systemUTC());
     }
 
-    /** 테스트용 — Clock 주입. Spring 은 본 생성자 호출 X. */
+    
     public WebhookPendingRateLimiter(Clock clock) {
         this.clock = clock;
     }
 
-    /**
-     * 시도 허용 여부. true = 허용 (호출자가 진행), false = 한도 초과 (호출자가 skip).
-     */
+    
+
     public boolean tryAcquire(String orderId) {
         long now = clock.millis();
         if (slots.size() > CLEANUP_THRESHOLD) {
@@ -72,7 +58,7 @@ public class WebhookPendingRateLimiter {
         return true;
     }
 
-    /** 결제 완료 후 즉시 카운터 비움 — 메모리 빠른 회수. */
+    
     public void release(String orderId) {
         slots.remove(orderId);
     }

--- a/src/main/java/com/sseulang/domain/payment/application/dto/ChargeConfirmCommand.java
+++ b/src/main/java/com/sseulang/domain/payment/application/dto/ChargeConfirmCommand.java
@@ -1,9 +1,5 @@
 package com.sseulang.domain.payment.application.dto;
 
-/**
- * 클라가 토스 redirect 후 백엔드에 확정 요청 시 — paymentKey/orderId/amount 는 토스 응답.
- * requesterId 는 인증된 사용자 (Payment 소유자 검증용).
- */
 public record ChargeConfirmCommand(
         Long requesterId,
         String paymentKey,

--- a/src/main/java/com/sseulang/domain/payment/application/dto/ChargeStartCommand.java
+++ b/src/main/java/com/sseulang/domain/payment/application/dto/ChargeStartCommand.java
@@ -1,14 +1,11 @@
 package com.sseulang.domain.payment.application.dto;
 
-/**
- * 충전 시작 — escrowApplicationId=null 면 일반 충전, NOT NULL 이면 거래대행 결제.
- */
 public record ChargeStartCommand(
         Long userId,
         long amount,
         Long escrowApplicationId
 ) {
-    /** 일반 충전 (Day 7 spec) — 호환 secondary constructor. */
+    
     public ChargeStartCommand(Long userId, long amount) {
         this(userId, amount, null);
     }

--- a/src/main/java/com/sseulang/domain/payment/application/dto/ChargeStartResult.java
+++ b/src/main/java/com/sseulang/domain/payment/application/dto/ChargeStartResult.java
@@ -1,9 +1,5 @@
 package com.sseulang.domain.payment.application.dto;
 
-/**
- * 충전 시작 응답 — 클라이언트가 토스 위젯에 사용. 토스 결제 완료 후 redirect 시
- * {@code orderId == merchantUid}, {@code amount} 그대로 confirm endpoint 에 전달.
- */
 public record ChargeStartResult(
         Long paymentId,
         String merchantUid,

--- a/src/main/java/com/sseulang/domain/payment/application/dto/PaymentStatsResult.java
+++ b/src/main/java/com/sseulang/domain/payment/application/dto/PaymentStatsResult.java
@@ -2,9 +2,6 @@ package com.sseulang.domain.payment.application.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * 결제 통계 — 완료된 결제 건수 + 누적 금액. 미완료/실패/환불 결제는 제외.
- */
 @Schema(description = "관리자 dashboard — 결제 통계 (완료된 결제만).")
 public record PaymentStatsResult(
         @Schema(example = "342", description = "완료(PAID) 상태 결제 수") long paidCount,

--- a/src/main/java/com/sseulang/domain/payment/domain/Payment.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/Payment.java
@@ -17,12 +17,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * Payment Aggregate Root. V1 스키마 {@code payments} — 충전/거래결제/환불 통합.
- *
- * <p>가이드 §4.9 멱등성: {@code merchant_uid} UNIQUE — 우리 측 주문 ID 로 중복 결제 차단.
- * 위변조 방지: 토스 confirm 후 amount 재검증.</p>
- */
 @Entity
 @Table(name = "payments")
 @Getter
@@ -75,10 +69,8 @@ public class Payment extends BaseEntity {
     @Column(name = "raw_response", columnDefinition = "TEXT")
     private String rawResponse;
 
-    /**
-     * 충전 시작 — status=대기. amount 양수 강제.
-     * escrowApplicationId 가 NOT NULL 이면 거래대행 결제 — confirm 시 잔액 차감 + escrow 갱신 트리거.
-     */
+    
+
     public static Payment startCharge(Long userId, String merchantUid, long amount, Long escrowApplicationId) {
         if (userId == null || userId <= 0) {
             throw new IllegalArgumentException("userId 는 양수여야 합니다");
@@ -100,20 +92,16 @@ public class Payment extends BaseEntity {
         return p;
     }
 
-    /** Day 7 호환 (escrowApplicationId 없는 일반 충전). */
+    
     public static Payment startCharge(Long userId, String merchantUid, long amount) {
         return startCharge(userId, merchantUid, amount, null);
     }
 
-    /**
-     * 토스 confirm 응답 받아 완료 처리. 멱등 — 이미 완료면 무시 (true=새로 적용, false=중복).
-     *
-     * <p>paymentKey / paidAt 필수 — 완료 결제인데 paid_at 비는 상태 차단 (게이트 1 round 2 Warning).
-     * method 는 결제수단별 nullable 허용 (예: 일부 가상계좌는 method 없이 응답).</p>
-     */
+    
+
     public boolean markAsPaid(String paymentKey, PaymentMethod method, LocalDateTime paidAt, String rawResponse) {
         if (status == PaymentStatus.완료) {
-            return false;  // 멱등 — 이미 완료
+            return false;  
         }
         if (!status.canConfirm()) {
             throw new BusinessException(ErrorCode.PAYMENT_DUPLICATED);
@@ -140,7 +128,7 @@ public class Payment extends BaseEntity {
         this.failReason = reason;
     }
 
-    /** 토스 응답의 amount 가 우리가 저장한 amount 와 일치하는지 검증 — 위변조 방지. */
+    
     public void verifyAmount(long confirmedAmount) {
         if (confirmedAmount != this.amount) {
             throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentConfirmResult.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentConfirmResult.java
@@ -2,9 +2,6 @@ package com.sseulang.domain.payment.domain;
 
 import java.time.LocalDateTime;
 
-/**
- * PG (토스 등) 의 confirm API 응답 — 도메인이 의존하는 형태. 외부 PG 응답 형식 변경에 대한 anti-corruption.
- */
 public record PaymentConfirmResult(
         String paymentKey,
         String orderId,

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentGateway.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentGateway.java
@@ -1,29 +1,16 @@
 package com.sseulang.domain.payment.domain;
 
-/**
- * 결제 PG 추상화. 도메인 layer 인터페이스 — 외부 SDK / HTTP 의존 X.
- * 구현은 {@code domain/payment/infrastructure/} (TossPaymentGateway). 향후 KakaoPay 등 추가 시 새 구현체.
- */
 public interface PaymentGateway {
 
-    /**
-     * PG 의 confirm API 호출 — paymentKey 와 orderId 로 승인 처리.
-     * <p>실패 시 {@link com.sseulang.global.exception.BusinessException} 또는
-     * {@link com.sseulang.global.exception.ExternalApiException} throw.</p>
-     */
+    
+
     PaymentConfirmResult confirm(String paymentKey, String orderId, long amount);
 
-    /**
-     * paymentKey 로 PG 측 결제 상태 단건 조회. Codex 게이트 1 보강 — confirm 4xx ALREADY_PROCESSED
-     * 응답 시 dangling 자동 복구 분기에서 사용. confirm 과 동일 형태의 결과 반환 (이미 승인된 결제만 호출).
-     * <p>4xx (없는 paymentKey 등) → BusinessException, 5xx → ExternalApiException.</p>
-     */
+    
+
     PaymentConfirmResult lookup(String paymentKey);
 
-    /**
-     * orderId(merchantUid) 로 PG 측 결제 상태 조회. dangling 복구 스케줄러용 (follow-up #21):
-     * confirm 도중 응답 유실로 paymentKey 를 못 받은 status=대기 Payment 를 orderId 만으로 토스 측 상태 동기화.
-     * <p>4xx (없는 orderId 등) → BusinessException, 5xx → ExternalApiException.</p>
-     */
+    
+
     PaymentConfirmResult lookupByOrderId(String orderId);
 }

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentMethod.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentMethod.java
@@ -1,10 +1,7 @@
 package com.sseulang.domain.payment.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 결제 수단. 토스가 응답에 String 으로 반환 (CARD / TRANSFER / VIRTUAL_ACCOUNT 등).
- * DB는 VARCHAR(30) — Java enum 으로는 그대로 영문 식별자 사용.
- */
+
 @Schema(description = "결제 수단 — CARD(카드) / TRANSFER(계좌이체) / VIRTUAL_ACCOUNT(가상계좌) / POINT(포인트). 토스 SDK 응답을 그대로 매핑.")
 public enum PaymentMethod {
     CARD,

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentRepository.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentRepository.java
@@ -8,23 +8,20 @@ public interface PaymentRepository {
 
     Optional<Payment> findByMerchantUid(String merchantUid);
 
-    /** 비관적 락 — confirm/webhook race 직렬화 (가이드 §5.3 동시성). */
+    
     Optional<Payment> findByMerchantUidForUpdate(String merchantUid);
 
     Payment save(Payment payment);
 
-    /**
-     * dangling 복구 스케줄러용 (follow-up #21) — status=대기 + created_at < cutoff 인 Payment 목록.
-     * confirm 도중 응답 유실 / 5xx 등으로 토스는 처리됐지만 우리 DB 는 대기 상태로 남은 결제를
-     * 주기적으로 토스 lookup 으로 동기화.
-     */
+    
+
     java.util.List<Payment> findStalePending(java.time.LocalDateTime cutoff, int limit);
 
-    // ───────── 관리자 통계 ─────────
+    
 
-    /** status=완료 결제의 paid_amount 합계. 미완료 결제는 제외. */
+    
     long sumPaidAmount();
 
-    /** status=완료 결제 건수. */
+    
     long countPaid();
 }

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentStatus.java
@@ -1,16 +1,7 @@
 package com.sseulang.domain.payment.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 결제 상태. DB ENUM('대기','진행중','완료','실패','환불진행중','환불완료','환불실패') 1:1.
- * <p>상태 머신:</p>
- * <pre>
- *   대기 → 진행중 → 완료
- *                ↘ 실패
- *   완료 → 환불진행중 → 환불완료
- *                    ↘ 환불실패
- * </pre>
- */
+
 @Schema(description = "결제 상태. 대기→진행중→완료/실패. 완료→환불진행중→환불완료/환불실패.")
 public enum PaymentStatus {
     대기,

--- a/src/main/java/com/sseulang/domain/payment/domain/PaymentType.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/PaymentType.java
@@ -1,10 +1,7 @@
 package com.sseulang.domain.payment.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 결제 종류. DB ENUM('충전','대여금','보증금','수수료','환불') 1:1.
- * 본 PR(Day 7) 은 {@link #충전} 에 집중. 거래 결제(대여금/보증금)는 Day 8 영역.
- */
+
 @Schema(description = "결제 종류 — 충전(잔액 충전) / 대여금 / 보증금 / 수수료 / 환불.")
 public enum PaymentType {
     충전,

--- a/src/main/java/com/sseulang/domain/payment/domain/WebhookEvent.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/WebhookEvent.java
@@ -14,12 +14,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * 외부 PG webhook 멱등 저장 Aggregate. {@code webhook_events} 매핑.
- *
- * <p>UNIQUE(source, eventId) 가 race 의 마지막 가드 — 동일 이벤트가 두 번 전달돼도 두 번째는
- * INSERT 에서 DataIntegrityViolation. ApplicationService 가 이를 잡아 "이미 처리됨" 으로 응답.</p>
- */
 @Entity
 @Table(name = "webhook_events")
 @Getter

--- a/src/main/java/com/sseulang/domain/payment/domain/WebhookEventRepository.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/WebhookEventRepository.java
@@ -4,10 +4,8 @@ import java.util.Optional;
 
 public interface WebhookEventRepository {
 
-    /**
-     * 저장. UNIQUE(source, eventId) 충돌 시 DataIntegrityViolationException 던짐 — 호출자가
-     * findBy 로 기존 row 조회 후 멱등 응답 처리.
-     */
+    
+
     WebhookEvent save(WebhookEvent event);
 
     Optional<WebhookEvent> findBySourceAndEventId(WebhookEventSource source, String eventId);

--- a/src/main/java/com/sseulang/domain/payment/domain/WebhookEventSource.java
+++ b/src/main/java/com/sseulang/domain/payment/domain/WebhookEventSource.java
@@ -1,6 +1,5 @@
 package com.sseulang.domain.payment.domain;
 
-/** Webhook 발신 PG 식별. {@code webhook_events.source} 컬럼 매핑. */
 public enum WebhookEventSource {
     TOSS,
     KAKAO

--- a/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/PaymentJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/PaymentJpaRepository.java
@@ -20,19 +20,16 @@ interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
     @Query("SELECT p FROM Payment p WHERE p.merchantUid = :merchantUid")
     Optional<Payment> findByMerchantUidForUpdate(@Param("merchantUid") String merchantUid);
 
-    /**
-     * status=완료 결제의 amount 합계. COALESCE 로 빈 결과(완료 0건)에서도 0 반환 — Long null 회피.
-     * payments.status 인덱스 권장 (V1 schema 에 idx_payments_status 있음).
-     */
+    
+
     @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p WHERE p.status = com.sseulang.domain.payment.domain.PaymentStatus.완료")
     long sumPaidAmount();
 
     @Query("SELECT COUNT(p) FROM Payment p WHERE p.status = com.sseulang.domain.payment.domain.PaymentStatus.완료")
     long countPaid();
 
-    /**
-     * dangling 복구 스케줄러용 (follow-up #21) — status=대기 + createdAt < cutoff. 오래된 것부터.
-     */
+    
+
     @Query("""
             SELECT p FROM Payment p
              WHERE p.status = com.sseulang.domain.payment.domain.PaymentStatus.대기

--- a/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/WebhookEventRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/payment/infrastructure/persistence/WebhookEventRepositoryImpl.java
@@ -18,8 +18,8 @@ public class WebhookEventRepositoryImpl implements WebhookEventRepository {
 
     @Override
     public WebhookEvent save(WebhookEvent event) {
-        // saveAndFlush — UNIQUE 충돌이 트랜잭션 commit 시점이 아니라 즉시 발생하도록 강제.
-        // (게이트 1 round 1 — Critical 4: lazy flush 로 try/catch 안 잡히는 회귀 차단)
+        
+        
         return jpa.saveAndFlush(event);
     }
 

--- a/src/main/java/com/sseulang/domain/payment/infrastructure/toss/TossPaymentGateway.java
+++ b/src/main/java/com/sseulang/domain/payment/infrastructure/toss/TossPaymentGateway.java
@@ -20,22 +20,10 @@ import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.Map;
 
-/**
- * 토스페이먼츠 confirm API 어댑터. 가이드 §4.9 — 결제 완료 후 백엔드가 토스 API 로 금액 재검증.
- *
- * <ul>
- *   <li>POST {@code /v1/payments/confirm} — Basic auth (secret_key:)</li>
- *   <li>Body: {paymentKey, orderId, amount}</li>
- *   <li>4xx body.code 가 ALREADY_PROCESSED_PAYMENT 계열 → {@link ErrorCode#PAYMENT_ALREADY_PROCESSED}
- *       (Codex 게이트 1 보강 — dangling 복구 후속 잡이 분기 처리 가능하도록 분리)</li>
- *   <li>그 외 4xx → {@link ErrorCode#PAYMENT_VERIFY_FAILED} (위변조 / 잘못된 결제)</li>
- *   <li>5xx / 네트워크 / 응답 파싱 실패 → {@link ExternalApiException} (재시도 영역)</li>
- * </ul>
- */
 @Component
 public class TossPaymentGateway implements PaymentGateway {
 
-    /** 토스 4xx body.code — 같은 paymentKey/orderId 가 이미 승인된 상태. */
+    
     private static final java.util.Set<String> ALREADY_PROCESSED_CODES = java.util.Set.of(
             "ALREADY_PROCESSED_PAYMENT",
             "ALREADY_COMPLETED_PAYMENT"
@@ -51,7 +39,7 @@ public class TossPaymentGateway implements PaymentGateway {
                 .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                 .build();
         this.objectMapper = objectMapper;
-        // Basic auth — username=secret_key, password=빈문자열. 토스 가이드 패턴.
+        
         String token = Base64.getEncoder().encodeToString(
                 (props.secretKey() + ":").getBytes(StandardCharsets.UTF_8)
         );
@@ -70,16 +58,16 @@ public class TossPaymentGateway implements PaymentGateway {
             response = restClient.post()
                     .uri("/v1/payments/confirm")
                     .header("Authorization", authorizationHeader)
-                    // Idempotency-Key: 같은 paymentKey 로 confirm 재시도 시 토스가 동일 응답 반환 (follow-up #21).
-                    // 응답 유실/네트워크 타임아웃 후 재시도 안전 — paymentKey 자체가 결제 단위 멱등 키.
+                    
+                    
                     .header("Idempotency-Key", paymentKey)
                     .body(body)
                     .retrieve()
                     .body(String.class);
         } catch (RestClientResponseException e) {
-            // 4xx — 토스가 명시 거부. body.code 별로 분기:
-            //   - ALREADY_PROCESSED_PAYMENT 계열 → PAYMENT_ALREADY_PROCESSED (dangling 복구 후속 잡 분기 가능)
-            //   - 그 외 → PAYMENT_VERIFY_FAILED (위변조/잘못된 결제)
+            
+            
+            
             if (e.getStatusCode().is4xxClientError()) {
                 throw new BusinessException(extractErrorCode(e.getResponseBodyAsString()));
             }
@@ -101,7 +89,7 @@ public class TossPaymentGateway implements PaymentGateway {
                     .body(String.class);
         } catch (RestClientResponseException e) {
             if (e.getStatusCode().is4xxClientError()) {
-                // 없는 paymentKey 등 — 위변조/잘못된 요청 취급.
+                
                 throw new BusinessException(ErrorCode.PAYMENT_VERIFY_FAILED);
             }
             throw new ExternalApiException("토스 결제 조회 실패", e);
@@ -131,7 +119,7 @@ public class TossPaymentGateway implements PaymentGateway {
         return parse(response);
     }
 
-    /** package-private — 단위 테스트에서 4xx body 분기 직접 검증. */
+    
     ErrorCode extractErrorCode(String body) {
         if (body == null || body.isBlank()) {
             return ErrorCode.PAYMENT_VERIFY_FAILED;
@@ -146,25 +134,25 @@ public class TossPaymentGateway implements PaymentGateway {
         }
     }
 
-    /** package-private — 단위 테스트에서 응답 파싱/필드 검증 직접 호출. */
+    
     PaymentConfirmResult parse(String response) {
         try {
             JsonNode root = objectMapper.readTree(response);
-            // Codex 게이트 1 보강 — 필수 필드 누락 시 silent fallback 금지.
-            // 빈 paymentKey / orderId 또는 0 amount 가 그대로 저장되면 후속 정합성 검증/조회가 깨진다.
+            
+            
             String paymentKey = requireText(root, "paymentKey");
             String orderId = requireText(root, "orderId");
             long amount = requireLong(root, "totalAmount");
             String status = requireText(root, "status");
-            // 2차 재리뷰 보강 — confirm/lookup 모두 status=DONE 만 정상 승인. READY/IN_PROGRESS/ABORTED/EXPIRED
-            // 등이 도달하면 잘못된 markAsPaid 를 막기 위해 차단 (BusinessException 으로 트랜잭션 롤백).
+            
+            
             if (!"DONE".equals(status)) {
                 throw new BusinessException(ErrorCode.PAYMENT_VERIFY_FAILED);
             }
             String methodRaw = root.path("method").asText("");
             PaymentMethod method = mapMethod(methodRaw);
-            // 2차 재리뷰 보강 — approvedAt 누락 시 LocalDateTime.now() silent fallback 제거.
-            // 승인 시각 없는 응답은 토스 측 비정상 — 명시 실패.
+            
+            
             String approvedAt = root.path("approvedAt").asText(null);
             if (approvedAt == null || approvedAt.isBlank()) {
                 throw new ExternalApiException("toss", "응답 approvedAt 누락");
@@ -198,10 +186,8 @@ public class TossPaymentGateway implements PaymentGateway {
         return node.asLong();
     }
 
-    /**
-     * 토스 method → 도메인 enum 매핑. 미지원 method 는 silent null 금지 — 명시 실패로 운영 알림.
-     * 신규 결제수단 (간편결제, 휴대폰 등) 출시 시 본 매핑을 먼저 확장해야 안전하게 활성화된다.
-     */
+    
+
     private static PaymentMethod mapMethod(String raw) {
         if (raw == null || raw.isBlank()) {
             throw new ExternalApiException("toss", "응답 method 누락");

--- a/src/main/java/com/sseulang/domain/payment/presentation/PaymentController.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/PaymentController.java
@@ -57,21 +57,8 @@ public class PaymentController {
         ));
     }
 
-    /**
-     * 토스 webhook — 토스 공식 spec (PAYMENT_STATUS_CHANGED) 처리.
-     *
-     * <p>Toss 발송 헤더:
-     * <ul>
-     *   <li>{@code tosspayments-webhook-transmission-id} — 멱등 키 (재전송 시 동일)</li>
-     *   <li>{@code tosspayments-webhook-transmission-time} — 발송 시각 (감사용)</li>
-     * </ul>
-     *
-     * <p>결제 이벤트에는 HMAC 시그니처가 없으므로 위변조 방지는 토스 lookup API 재조회로 처리
-     * (게이트 1 round 1). 정상/멱등(중복 transmission-id) 시 200 → 재시도 중단. payload 형식 오류
-     * 또는 transmission-id 누락 시 400 → 토스 재시도.</p>
-     *
-     * <p>SecurityConfig 의 CSRF / auth 면제 이미 적용 (Day 7).</p>
-     */
+    
+
     @Operation(summary = "토스 결제 webhook (외부)",
             description = "토스에서 호출. 인증/CSRF 면제. transmission-id 로 멱등성 보장. "
                     + "위변조 방지는 토스 lookup API 재조회로 검증. 프론트는 호출하지 않음.")

--- a/src/main/java/com/sseulang/domain/payment/presentation/WebhookBodySizeFilter.java
+++ b/src/main/java/com/sseulang/domain/payment/presentation/WebhookBodySizeFilter.java
@@ -14,22 +14,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-/**
- * 토스 결제 webhook 의 body size 제한 필터 (follow-up #53).
- *
- * <p>{@code @RequestBody String} 으로 전체 payload 를 메모리에 적재하는 구조라
- * 외부에서 큰 body 를 던지면 OOM / GC 압박. nginx {@code client_max_body_size} 가 1차 방어,
- * 본 필터는 nginx 우회 / 직결 케이스 (개발/내부 호출) 를 위한 application-단 2차 방어.</p>
- *
- * <p>한도 초과 시 413 Payload Too Large 즉시 응답 — Spring DispatcherServlet 까지 가지 않음.</p>
- *
- * <p>매칭 path: {@code /api/v1/payments/webhook/**}. 다른 endpoint 에는 영향 X.</p>
- */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE + 10)
 public class WebhookBodySizeFilter extends OncePerRequestFilter {
 
-    /** 토스 webhook payload 정상 크기는 ~3KB. 16KB 면 충분히 여유. */
+    
     static final long MAX_BODY_BYTES = 16L * 1024;
 
     private static final String WEBHOOK_PATH_PREFIX = "/api/v1/payments/webhook/";
@@ -46,7 +35,7 @@ public class WebhookBodySizeFilter extends OncePerRequestFilter {
             FilterChain chain
     ) throws ServletException, IOException {
         long contentLength = request.getContentLengthLong();
-        // Content-Length 미주입 (chunked 또는 누락) 도 거부 — webhook 은 Content-Length 명시 의무.
+        
         if (contentLength < 0 || contentLength > MAX_BODY_BYTES) {
             writeRejection(response);
             return;
@@ -54,16 +43,14 @@ public class WebhookBodySizeFilter extends OncePerRequestFilter {
         chain.doFilter(request, response);
     }
 
-    /**
-     * 공통 ApiResponse 형식과 일치하는 413 응답 + traceId 포함. ErrorCode 와 message 도 enum 에서.
-     * GlobalExceptionHandler 를 거치지 않아 traceId 헤더는 TraceIdFilter 에서 이미 세팅됨 — MDC 에서 가져옴.
-     */
+    
+
     private static void writeRejection(HttpServletResponse response) throws IOException {
         ErrorCode code = ErrorCode.PAYLOAD_TOO_LARGE;
         response.setStatus(code.getStatus().value());
         response.setContentType("application/json;charset=UTF-8");
         String traceId = MDC.get(TraceIdFilter.MDC_KEY);
-        // JSON 수동 직렬화 — traceId/message 모두 안전 문자열만이라 escape 안전.
+        
         String body = "{\"success\":false,\"error\":{"
                 + "\"code\":\"" + code.name() + "\","
                 + "\"message\":\"" + code.getDefaultMessage() + "\","

--- a/src/main/java/com/sseulang/domain/point/application/PointApplicationService.java
+++ b/src/main/java/com/sseulang/domain/point/application/PointApplicationService.java
@@ -13,17 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
-/**
- * 가이드 §4.8 — 포인트 잔액 변동 + history 적재 단일 진입점. 모든 잔액 변동 (충전 / 결제 / 판매정산 /
- * 출금 / 환불) 은 본 서비스를 거쳐 user.point_balance UPDATE 와 point_histories INSERT 가 한
- * 트랜잭션으로 묶인다 — 잔액 갱신 직후 history 누락 dangling 방지.
- *
- * <p>거래 정산 (구매자 차감 → 판매자 적립) 은 {@link #transfer} 로 처리. deadlock 방지를 위해
- * 두 user 의 잔액 변동 순서를 <b>userId 오름차순</b> 으로 강제한다 (가이드 §5.3).</p>
- *
- * <p>다른 도메인은 본 서비스만 의존 — UserRepository / PointHistoryRepository 직접 호출 금지
- * (CLAUDE.md §3.3).</p>
- */
 @Service
 @Transactional(readOnly = true)
 public class PointApplicationService {
@@ -39,10 +28,8 @@ public class PointApplicationService {
         this.pointHistoryRepository = pointHistoryRepository;
     }
 
-    /**
-     * 잔액 적립 + history 적재. 충전 / 환불 (적립 방향) 호출.
-     * affected!=1 인 경우 (미존재 userId) 는 UserApplicationService 내부에서 USER_NOT_FOUND 던짐 → 롤백.
-     */
+    
+
     @Transactional
     public void credit(
             Long userId,
@@ -59,10 +46,8 @@ public class PointApplicationService {
         ));
     }
 
-    /**
-     * 잔액 차감 + history 적재. 결제 / 출금 (차감 방향) 호출.
-     * 잔액 부족 시 UserApplicationService 내부에서 INSUFFICIENT_POINT 던짐 → 롤백 (history 미적재).
-     */
+    
+
     @Transactional
     public void deduct(
             Long userId,
@@ -79,11 +64,8 @@ public class PointApplicationService {
         ));
     }
 
-    /**
-     * 거래 정산 — buyer 차감 → seller 적립을 한 트랜잭션으로 묶음.
-     * 가이드 §5.3 deadlock 방지: 두 user 의 잔액 변동 순서를 userId 오름차순으로 강제 (id 작은 user 먼저 락 획득).
-     * <p>buyer 잔액 부족 시 INSUFFICIENT_POINT — seller 의 선행 적립도 같은 트랜잭션 안이라 함께 롤백.</p>
-     */
+    
+
     @Transactional
     public void transfer(
             Long buyerId,
@@ -102,7 +84,7 @@ public class PointApplicationService {
         if (amount <= 0) {
             throw new IllegalArgumentException("amount 는 양수여야 합니다");
         }
-        // userId 오름차순으로 잔액 변동 — deadlock 방지 (역방향 거래가 동시에 일어나도 락 순서 일관)
+        
         if (buyerId < sellerId) {
             deduct(buyerId, amount, PointHistoryType.결제, referenceType, referenceId, description);
             credit(sellerId, amount, PointHistoryType.판매정산, referenceType, referenceId, description);
@@ -112,13 +94,8 @@ public class PointApplicationService {
         }
     }
 
-    /**
-     * 배달 정산 — 요청자 차감 → 라이더 적립. 거래 정산({@link #transfer})과 동일하게 id-asc 순서로 락
-     * 획득 (deadlock 방지). type 은 {@link PointHistoryType#배달결제}/{@link PointHistoryType#배달정산},
-     * referenceType 은 {@link PointReferenceType#DELIVERY} 고정.
-     *
-     * <p>요청자 잔액 부족 시 INSUFFICIENT_POINT — 라이더의 선행 적립도 같은 트랜잭션 안이라 함께 롤백.</p>
-     */
+    
+
     @Transactional
     public void transferForDelivery(
             Long requesterId,
@@ -136,7 +113,7 @@ public class PointApplicationService {
         if (amount <= 0) {
             throw new IllegalArgumentException("amount 는 양수여야 합니다");
         }
-        // 정산 추적 키. point service 진입점에서 막아 history dangling 회귀 차단 (게이트 1 Suggestion).
+        
         if (deliveryId == null || deliveryId <= 0) {
             throw new IllegalArgumentException("deliveryId 는 양수여야 합니다");
         }
@@ -149,12 +126,8 @@ public class PointApplicationService {
         }
     }
 
-    /**
-     * 거래 환불 — 거래완료 상태였던 거래가 취소되는 케이스. 양쪽 잔액 원복 + 환불 history 두 건 적재.
-     * id-asc 락 순서 유지 — buyer 적립 / seller 차감.
-     * <p>seller 가 이미 사용/출금 등으로 잔액이 amount 미만이면 INSUFFICIENT_POINT — 운영 이슈로 escalation
-     * (자동 환불 불가, Day 9 보정 절차 / 관리자 수동 처리).</p>
-     */
+    
+
     @Transactional
     public void refund(
             Long buyerId,
@@ -202,24 +175,17 @@ public class PointApplicationService {
         return userApplicationService.getPointBalance(userId);
     }
 
-    /**
-     * 본인 포인트 히스토리 페이징 — 마이페이지 노출용. type 명시 시 정확 일치, null 이면 전체.
-     * createdAt DESC + id DESC 안정 정렬.
-     */
+    
+
     public Page<PointHistoryResult> findMyHistory(Long userId, PointHistoryType type, Pageable pageable) {
         return pointHistoryRepository.findByUserIdAndType(userId, type, pageable)
                 .map(PointHistoryResult::from);
     }
 
-    // ───────── 라운드 11 — 거래 escrow hold 흐름 (가이드 §5.1) ─────────
+    
 
-    /**
-     * 거래 예약 시 buyer hold — point_balance 차감 + point_hold 적립을 단일 atomic UPDATE.
-     * 거래보관 history 1건 적재 (balance_after = 차감 후 잔액).
-     *
-     * <p>잔액 부족 시 UserApplicationService 가 INSUFFICIENT_POINT throw → 트랜잭션 롤백
-     * (history 미적재).</p>
-     */
+    
+
     @Transactional
     public void escrowHold(Long buyerId, long amount, Long transactionId, String description) {
         if (buyerId == null || buyerId <= 0) {
@@ -239,16 +205,8 @@ public class PointApplicationService {
         ));
     }
 
-    /**
-     * 거래완료 (인수확인) 시 정산 — buyer hold 해제 + seller balance 적립을 한 트랜잭션.
-     *
-     * <p>가이드 §5.3 deadlock 방지: 두 user 의 잔액 변동 순서를 userId 오름차순으로 강제.
-     * buyer 의 hold 해제는 잔액 변화 X 라 history 미적재 (Aggregate 정책 — V16/PointHistoryType 주석 동기).
-     * seller 는 판매정산 history 1건 적재.</p>
-     *
-     * <p>buyer hold 부족 시 UserApplicationService 가 TRANSACTION_HOLD_FAILED throw — 운영 이상,
-     * seller 선행 적립도 롤백.</p>
-     */
+    
+
     @Transactional
     public void escrowRelease(
             Long buyerId,
@@ -278,12 +236,8 @@ public class PointApplicationService {
         }
     }
 
-    /**
-     * 거래 취소 시 buyer 환불 — point_hold 차감 + point_balance 적립을 단일 atomic UPDATE.
-     * 거래환불 history 1건 적재 (balance_after = 적립 후 잔액). seller 잔액 변동 X (정산 전이라).
-     *
-     * <p>buyer hold 부족 시 UserApplicationService 가 TRANSACTION_HOLD_FAILED throw → 운영 이상.</p>
-     */
+    
+
     @Transactional
     public void escrowRefund(Long buyerId, long amount, Long transactionId, String description) {
         if (buyerId == null || buyerId <= 0) {

--- a/src/main/java/com/sseulang/domain/point/application/dto/PointHistoryResult.java
+++ b/src/main/java/com/sseulang/domain/point/application/dto/PointHistoryResult.java
@@ -6,11 +6,6 @@ import com.sseulang.domain.point.domain.PointReferenceType;
 
 import java.time.LocalDateTime;
 
-/**
- * 본인 포인트 히스토리 row — 페이징 응답에 포함. Application/Presentation 경계 DTO.
- *
- * <p>amount 는 부호 포함 (충전/적립 = +, 결제/출금 = -). balanceAfter 는 변동 직후 잔액 스냅샷.</p>
- */
 public record PointHistoryResult(
         Long id,
         PointHistoryType type,

--- a/src/main/java/com/sseulang/domain/point/domain/PointHistory.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointHistory.java
@@ -14,15 +14,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * PointHistory Aggregate Root. V1 스키마 {@code point_histories} 매핑.
- *
- * <p>가이드 §4.8 — 모든 잔액 변동 흐름 (충전 / 결제 / 판매정산 / 출금 / 환불) 에서 적재.
- * amount 는 {@code +} (증가) / {@code -} (감소) 부호 포함. balance_after 는 변동 직후 잔액 스냅샷.</p>
- *
- * <p>Setter 없음. 정적 팩토리 {@link #record} 만 사용. created_at 은 DB DEFAULT CURRENT_TIMESTAMP 가
- * 채우지만 Aggregate 생성 시 명시 설정해 테스트/감사 일관.</p>
- */
 @Entity
 @Table(name = "point_histories")
 @Getter
@@ -40,7 +31,7 @@ public class PointHistory {
     @Column(name = "point_type", nullable = false)
     private PointHistoryType pointType;
 
-    /** + 증가 / - 감소 부호 포함 */
+    
     @Column(name = "amount", nullable = false)
     private long amount;
 
@@ -60,10 +51,8 @@ public class PointHistory {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    /**
-     * 잔액 증가 history. caller 는 양수 amount 만 전달, 저장 amount 도 + 부호로 보존.
-     * 허용 type: 충전 / 판매정산 / 환불 (buyer 환불 적립).
-     */
+    
+
     public static PointHistory recordCredit(
             Long userId,
             PointHistoryType type,
@@ -79,10 +68,8 @@ public class PointHistory {
         return build(userId, type, amount, balanceAfter, referenceType, referenceId, description, now);
     }
 
-    /**
-     * 잔액 감소 history. caller 는 양수 amount 만 전달, 저장 amount 는 - 부호로 보존.
-     * 허용 type: 결제 / 출금 / 환불 (seller 환불 차감).
-     */
+    
+
     public static PointHistory recordDebit(
             Long userId,
             PointHistoryType type,

--- a/src/main/java/com/sseulang/domain/point/domain/PointHistoryRepository.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointHistoryRepository.java
@@ -5,20 +5,14 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
-/**
- * PointHistory Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
- * 구현은 {@code domain/point/infrastructure/persistence}.
- */
 public interface PointHistoryRepository {
 
     PointHistory save(PointHistory history);
 
-    /** 특정 사용자의 history 최신순 조회 (전수). admin/리포팅 용. */
+    
     List<PointHistory> findByUserIdOrderByCreatedAtDesc(Long userId);
 
-    /**
-     * 본인 history 페이징 — 마이페이지 노출용. type 이 null 이면 전체 type, 명시 시 정확 일치.
-     * 정렬: createdAt DESC + id DESC (안정 정렬).
-     */
+    
+
     Page<PointHistory> findByUserIdAndType(Long userId, PointHistoryType type, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/point/domain/PointHistoryType.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointHistoryType.java
@@ -1,23 +1,5 @@
 package com.sseulang.domain.point.domain;
 
-/**
- * point_histories.point_type ENUM 매핑. V1 init schema 의 한글 ENUM 그대로.
- *
- * <ul>
- *   <li>{@link #충전} — 토스 결제로 잔액 증가 (Day 7)</li>
- *   <li>{@link #결제} — 거래 결제 시 구매자 잔액 차감 (Day 8 — 즉시 정산 정책. 라운드 11 부터는 사용 X)</li>
- *   <li>{@link #판매정산} — 거래 정산 시 판매자 잔액 적립 (Day 8 / 라운드 11 인수확인)</li>
- *   <li>{@link #출금} — 출금 신청 시 잔액 차감 (Day 8)</li>
- *   <li>{@link #환불} — Day 8 거래 취소 시 양쪽 잔액 원복 (라운드 11 부터는 거래환불로 분리)</li>
- *   <li>{@link #배달결제} — 배달 정산 시 요청자 잔액 차감 (Day 9)</li>
- *   <li>{@link #배달정산} — 배달 정산 시 라이더 잔액 적립 (Day 9)</li>
- *   <li>{@link #거래보관} — 라운드 11 예약 시 buyer balance↓ + hold↑ (escrow hold). 프론트 라벨 "거래 #N 보관".</li>
- *   <li>{@link #거래환불} — 라운드 11 거래 취소 시 buyer balance↑ + hold↓. 프론트 라벨 "거래 #N 취소 환불".</li>
- * </ul>
- *
- * <p>라운드 11 인수확인 시 buyer 의 hold 해제는 잔액 변화 X 이므로 history 미적재 (Aggregate 정책 — V16 주석 동기).
- * seller 의 정산 적립은 기존 {@link #판매정산} 활용, 프론트 라벨 "거래 #N 정산 수령".</p>
- */
 public enum PointHistoryType {
     충전,
     결제,

--- a/src/main/java/com/sseulang/domain/point/domain/PointReferenceType.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointReferenceType.java
@@ -1,9 +1,5 @@
 package com.sseulang.domain.point.domain;
 
-/**
- * point_histories.reference_type 분류. 잔액 변동의 원인 도메인 식별.
- * VARCHAR(30) 매핑이라 enum 이름 그대로 저장.
- */
 public enum PointReferenceType {
     PAYMENT,
     TRANSACTION,

--- a/src/main/java/com/sseulang/domain/point/infrastructure/persistence/PointHistoryJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/point/infrastructure/persistence/PointHistoryJpaRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-/** Spring Data JPA — {@link PointHistoryRepositoryImpl} 가 wrapping. 외부 직접 import 금지. */
 interface PointHistoryJpaRepository extends JpaRepository<PointHistory, Long> {
 
     List<PointHistory> findByUserIdOrderByCreatedAtDesc(Long userId);

--- a/src/main/java/com/sseulang/domain/point/presentation/PointController.java
+++ b/src/main/java/com/sseulang/domain/point/presentation/PointController.java
@@ -18,10 +18,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 본인 포인트 관련 endpoint. 라운드 11: 잔액 페이지 3분할 표시용 balance endpoint 추가
- * (사용 가능 / 거래 보관 / 합산). 헤더/카드 용도는 GET /users/me 의 pointBalance + pointHold 활용.
- */
 @Tag(name = "Point", description = "본인 포인트 잔액 / 히스토리")
 @RestController
 @RequestMapping("/api/v1/users/me/point")

--- a/src/main/java/com/sseulang/domain/point/presentation/dto/PointBalanceResponse.java
+++ b/src/main/java/com/sseulang/domain/point/presentation/dto/PointBalanceResponse.java
@@ -2,10 +2,6 @@ package com.sseulang.domain.point.presentation.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * 본인 포인트 잔액 응답 — 라운드 11 (B-1 A안 합의). 잔액 페이지에서 3분할 표시:
- * "{balance}P 사용 가능 · {holdAmount}P 거래 보관 중 · 총 {totalBalance}P".
- */
 @Schema(description = "본인 포인트 잔액 — 사용 가능 / 거래 보관 / 합산 3분할.")
 public record PointBalanceResponse(
         @Schema(example = "50000", description = "즉시 사용 가능 (point_balance)") long balance,

--- a/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
+++ b/src/main/java/com/sseulang/domain/report/application/UserReportApplicationService.java
@@ -31,24 +31,22 @@ public class UserReportApplicationService {
         this.clock = clock;
     }
 
-    /**
-     * 사용자 신고. 자기 신고 거부는 도메인 invariant 에서.
-     * 미인증 사용자의 무차별 신고 스팸 방지 — verified 가드 (게이트 1 round 2).
-     */
+    
+
     @Transactional
     public Long reportUser(Long reporterId, Long reportedUserId, String reason, String detail) {
         userService.requireVerified(reporterId);
         return repository.save(UserReport.reportUser(reporterId, reportedUserId, reason, detail)).getId();
     }
 
-    /** 물품 신고. Item 존재 여부는 FK 가 잡음 (RESTRICT/CASCADE) — 별도 검증 생략. */
+    
     @Transactional
     public Long reportItem(Long reporterId, Long itemId, String reason, String detail) {
         userService.requireVerified(reporterId);
         return repository.save(UserReport.reportItem(reporterId, itemId, reason, detail)).getId();
     }
 
-    // ───────── 관리자 처리 흐름 ─────────
+    
 
     @Transactional
     public void adminMarkInProgress(Long reportId, Long adminId, String memo) {
@@ -76,17 +74,17 @@ public class UserReportApplicationService {
         return findOrThrow(reportId);
     }
 
-    /** 차트 dashboard summary — 처리 대기 (접수 + 처리중) 신고 수. */
+    
     public long countPending() {
         return repository.countPending();
     }
 
-    /** 차트 dashboard — 처리 완료 (처리완료 + 반려) 신고 수. */
+    
     public long countResolved() {
         return repository.countResolved();
     }
 
-    /** 차트 dashboard — 특정 시점 이후 생성된 신고 건수 (전체 status). */
+    
     public long countCreatedSince(java.time.LocalDateTime since) {
         return repository.countCreatedSince(since);
     }

--- a/src/main/java/com/sseulang/domain/report/domain/ReportStatus.java
+++ b/src/main/java/com/sseulang/domain/report/domain/ReportStatus.java
@@ -1,10 +1,7 @@
 package com.sseulang.domain.report.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 신고 처리 상태. DB ENUM('접수','처리중','처리완료','반려') 1:1.
- * 상태 전이는 관리자가 트리거 (Day 9 admin 도메인).
- */
+
 @Schema(description = "신고 처리 상태. 접수→처리중→처리완료/반려.")
 public enum ReportStatus {
     접수,

--- a/src/main/java/com/sseulang/domain/report/domain/UserReport.java
+++ b/src/main/java/com/sseulang/domain/report/domain/UserReport.java
@@ -17,10 +17,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * 사용자/물품 신고 Aggregate. {@code user_reports} 테이블 — CHECK reported_id XOR item_id (둘 중 하나는 NOT NULL).
- * 관리자 처리 흐름(상태 전이)은 Day 9 admin 도메인.
- */
 @Entity
 @Table(name = "user_reports")
 @Getter
@@ -101,10 +97,8 @@ public class UserReport extends BaseEntity {
         return r;
     }
 
-    /**
-     * 관리자 처리 시작. 접수 → 처리중. processedAt 은 처리 시작 시점에 기록 (terminal 일 때
-     * 다시 갱신 가능).
-     */
+    
+
     public void markInProgress(Long adminId, String memo, LocalDateTime now) {
         validateAdminAndNow(adminId, now);
         if (status != ReportStatus.접수) {
@@ -116,7 +110,7 @@ public class UserReport extends BaseEntity {
         this.processedAt = now;
     }
 
-    /** 처리 완료 — 처리중 단계에서만 가능. */
+    
     public void complete(Long adminId, String memo, LocalDateTime now) {
         validateAdminAndNow(adminId, now);
         if (status != ReportStatus.처리중) {
@@ -128,7 +122,7 @@ public class UserReport extends BaseEntity {
         this.processedAt = now;
     }
 
-    /** 반려 — 접수 또는 처리중에서만 가능 (terminal 상태 전이는 거부). */
+    
     public void reject(Long adminId, String memo, LocalDateTime now) {
         validateAdminAndNow(adminId, now);
         if (status.isTerminal()) {

--- a/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
+++ b/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
@@ -11,21 +11,19 @@ public interface UserReportRepository {
 
     Optional<UserReport> findById(Long id);
 
-    /** 관리자 — 상태별 페이징 (status null 이면 전체). created_at DESC. */
+    
     Page<UserReport> findByStatus(ReportStatus status, Pageable pageable);
 
-    /**
-     * Admin 회원 카드용 — targetUserIds 가 신고당한 횟수의 (targetUserId → count) 맵.
-     * 빈 입력은 빈 맵. 단일 GROUP BY 쿼리 — N+1 회피.
-     */
+    
+
     java.util.Map<Long, Long> countByTargetUserIds(java.util.Collection<Long> targetUserIds);
 
-    /** 차트 dashboard summary — 처리 대기 신고 수 (status IN (접수, 처리중)). */
+    
     long countPending();
 
-    /** 차트 dashboard — 처리 완료 신고 수 (status IN (처리완료, 반려)). */
+    
     long countResolved();
 
-    /** 차트 dashboard — 특정 시점 이후 생성된 신고 건수 (전체 status). */
+    
     long countCreatedSince(java.time.LocalDateTime since);
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
@@ -17,7 +17,7 @@ interface UserReportJpaRepository extends JpaRepository<UserReport, Long> {
             """)
     Page<UserReport> findByStatusFilter(@Param("status") ReportStatus status, Pageable pageable);
 
-    /** Admin enrich — targetUserIds 의 신고 누적 수 (target_user_id, count). */
+    
     @Query("""
             SELECT r.reportedId AS userId, COUNT(r) AS cnt FROM UserReport r
              WHERE r.reportedId IN :ids
@@ -30,15 +30,15 @@ interface UserReportJpaRepository extends JpaRepository<UserReport, Long> {
         Long getCnt();
     }
 
-    /** 차트 dashboard summary — 처리 대기 (접수 또는 처리중) 신고 수. */
+    
     @Query("SELECT COUNT(r) FROM UserReport r WHERE r.status IN (com.sseulang.domain.report.domain.ReportStatus.접수, com.sseulang.domain.report.domain.ReportStatus.처리중)")
     long countPending();
 
-    /** 차트 dashboard — 처리 완료 (처리완료 또는 반려) 신고 수. */
+    
     @Query("SELECT COUNT(r) FROM UserReport r WHERE r.status IN (com.sseulang.domain.report.domain.ReportStatus.처리완료, com.sseulang.domain.report.domain.ReportStatus.반려)")
     long countResolved();
 
-    /** 차트 dashboard — 특정 시점 이후 생성된 신고 건수 (전체 status). */
+    
     @Query("SELECT COUNT(r) FROM UserReport r WHERE r.createdAt >= :since")
     long countCreatedSince(@org.springframework.data.repository.query.Param("since") java.time.LocalDateTime since);
 }

--- a/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
+++ b/src/main/java/com/sseulang/domain/report/presentation/UserReportController.java
@@ -15,10 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 사용자/물품 신고 진입점. Item 신고는 가이드 §6.1 의 {@code POST /api/v1/items/{id}/report},
- * User 신고는 별도 {@code POST /api/v1/users/{id}/report}.
- */
 @Tag(name = "Report", description = "사용자 신고 등록")
 @RestController
 public class UserReportController {

--- a/src/main/java/com/sseulang/domain/review/application/ReviewApplicationService.java
+++ b/src/main/java/com/sseulang/domain/review/application/ReviewApplicationService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ReviewApplicationService {
 
-    /** V1 스키마 {@code uk_reviews_tx_reviewer} — 동일 reviewer 같은 거래 두 번 작성 시 race 보정. */
+    
     private static final String UNIQUE_TX_REVIEWER = "uk_reviews_tx_reviewer";
 
     private final ReviewRepository reviewRepository;
@@ -38,10 +38,8 @@ public class ReviewApplicationService {
         this.userApplicationService = userApplicationService;
     }
 
-    /**
-     * Review 작성. Transaction 검증(거래완료 + 7일 + 참여자) 은 TransactionApplicationService 가 수행.
-     * UNIQUE(tx, reviewer) race 는 좁은 catch → REVIEW_DUPLICATED. 작성 후 reviewee 의 trust_score atomic 갱신.
-     */
+    
+
     @Transactional
     public Long write(ReviewWriteCommand cmd) {
         ReviewableTransactionResult info = transactionApplicationService
@@ -65,26 +63,23 @@ public class ReviewApplicationService {
             throw violation;
         }
 
-        // 가이드 §4.7 — 작성 시점 review_count / rating_sum 누적 + trust_score atomic 재계산.
-        // 단일 UPDATE 라 race 안전 (Codex 게이트 2 보강).
+        
+        
         userApplicationService.recordReview(info.revieweeId(), cmd.rating());
 
         return savedId;
     }
 
-    /**
-     * 받은 리뷰 페이징. 한줄평은 작성자 본인만 보이도록 마스킹 (가이드 §4.7 "한줄평은 본인만").
-     */
+    
+
     public Page<ReviewResult> listReceived(Long revieweeId, Long requesterId, Pageable pageable) {
         return reviewRepository.findByRevieweeId(revieweeId, pageable)
                 .map(ReviewResult::from)
                 .map(r -> r.masked(requesterId));
     }
 
-    /**
-     * Review 작성 대기 거래 목록 (follow-up #56). 본인이 reviewer 로 아직 작성 안 한 7일 이내 완료 거래.
-     * Cross-aggregate read 는 TransactionApplicationService 가 책임 — 본 서비스는 단순 위임.
-     */
+    
+
     public Page<PendingReviewableResult> listPending(Long requesterId, Pageable pageable) {
         return transactionApplicationService.findPendingReviewable(requesterId, pageable);
     }

--- a/src/main/java/com/sseulang/domain/review/application/dto/ReviewResult.java
+++ b/src/main/java/com/sseulang/domain/review/application/dto/ReviewResult.java
@@ -22,7 +22,7 @@ public record ReviewResult(
         );
     }
 
-    /** 본인 한줄평만 노출 — 가이드 §4.7 "한줄평은 본인만". */
+    
     public ReviewResult masked(Long requesterId) {
         if (reviewerId.equals(requesterId)) {
             return this;

--- a/src/main/java/com/sseulang/domain/review/domain/Review.java
+++ b/src/main/java/com/sseulang/domain/review/domain/Review.java
@@ -17,12 +17,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-/**
- * Review Aggregate Root. {@code reviews} 테이블. 거래 후 양방향 평가 — 가이드 §4.7.
- *
- * <p>UNIQUE(transaction_id, reviewer_id) — 같은 reviewer 같은 거래 두 번 X.
- * CHECK rating 1~5, reviewer != reviewee.</p>
- */
 @Entity
 @Table(name = "reviews")
 @EntityListeners(AuditingEntityListener.class)
@@ -45,7 +39,7 @@ public class Review {
     @Column(name = "reviewee_id", nullable = false)
     private Long revieweeId;
 
-    /** DB {@code rating TINYINT}. Java int 와 매핑 mismatch 방지를 위해 명시 JDBC TINYINT 사용. */
+    
     @Column(name = "rating", nullable = false)
     @JdbcTypeCode(SqlTypes.TINYINT)
     private int rating;

--- a/src/main/java/com/sseulang/domain/review/domain/ReviewRepository.java
+++ b/src/main/java/com/sseulang/domain/review/domain/ReviewRepository.java
@@ -7,6 +7,6 @@ public interface ReviewRepository {
 
     Review save(Review review);
 
-    /** 특정 사용자가 받은 리뷰 페이징 (최신순). */
+    
     Page<Review> findByRevieweeId(Long revieweeId, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/review/presentation/dto/PendingReviewResponse.java
+++ b/src/main/java/com/sseulang/domain/review/presentation/dto/PendingReviewResponse.java
@@ -6,11 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-/**
- * Review 작성 대기 거래 응답 (follow-up #56).
- *
- * <p>{@code deadline = completedAt + 7d} — 클라이언트가 남은 시간 카운트다운 UI 에 직접 사용.</p>
- */
 @Schema(description = "리뷰 작성 대기 거래 — 본인이 reviewer 로 아직 작성 안 한 7일 이내 완료 거래.")
 public record PendingReviewResponse(
         @Schema(example = "12") Long transactionId,

--- a/src/main/java/com/sseulang/domain/stats/application/AdminDashboardChartsResult.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminDashboardChartsResult.java
@@ -3,17 +3,6 @@ package com.sseulang.domain.stats.application;
 import java.time.LocalDate;
 import java.util.List;
 
-/**
- * 관리자 대시보드 차트 데이터 — recharts 친화 (date ASC, 빈 일자 0 채움).
- *
- * <p>프론트 합의 (옵션 A'):
- * <ul>
- *   <li>summary: 카드 4종 + 비교값</li>
- *   <li>signupTrend: 일자별 가입자 (AreaChart)</li>
- *   <li>tradeByType: TradeType 별 (BarChart) — 한국어 enum</li>
- *   <li>tradeByStatus: 진행중/완료/취소 3분류 (PieChart) — 라운드 11 5단계 그룹핑</li>
- * </ul>
- */
 public record AdminDashboardChartsResult(
         Summary summary,
         List<DailyCount> signupTrend,
@@ -28,27 +17,22 @@ public record AdminDashboardChartsResult(
             long pendingReports
     ) { }
 
-    /**
-     * 관리자 대시보드 신고 위젯 (PR-F #9 라운드 12).
-     *
-     * @param pending        처리 대기 (접수 + 처리중)
-     * @param resolved       처리 완료 (처리완료 + 반려)
-     * @param totalLast7Days 최근 7일 (생성 기준, 전체 status)
-     */
+    
+
     public record ReportsSummary(long pending, long resolved, long totalLast7Days) { }
 
     public record UsersSummary(long total, long monthDelta) { }
 
     public record TodaySignupsSummary(long count, long yesterdayDelta) { }
 
-    /** prevMonthRate: 전월 대비 증감률. 전월 0이면 null. */
+    
     public record MonthTradesSummary(long count, Double prevMonthRate) { }
 
     public record DailyCount(LocalDate date, long count) { }
 
-    /** tradeType: 한국어 enum (판매/대여/나눔). */
+    
     public record TradeTypeCount(String type, long count) { }
 
-    /** group: 진행중/완료/취소. */
+    
     public record StatusGroupCount(String status, long count) { }
 }

--- a/src/main/java/com/sseulang/domain/stats/application/AdminDashboardResult.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminDashboardResult.java
@@ -6,7 +6,6 @@ import com.sseulang.domain.transaction.application.dto.TransactionStatsResult;
 import com.sseulang.domain.user.application.dto.UserStatsResult;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
 
-/** 5개 도메인 통계 묶음. 단순 wrapper — 각 도메인 stats result 는 그 도메인 dto 그대로 노출. */
 public record AdminDashboardResult(
         UserStatsResult users,
         TransactionStatsResult transactions,

--- a/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
+++ b/src/main/java/com/sseulang/domain/stats/application/AdminStatsService.java
@@ -28,16 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-/**
- * 관리자 dashboard 통계 — 4개 도메인 ApplicationService 를 호출하여 단순 조립.
- *
- * <p>본 서비스는 자체 상태/도메인 없음 — read-only orchestration. CLAUDE.md §3.3 준수:
- * 다른 도메인 Repository 직접 호출 금지, 각 도메인 ApplicationService 만 의존.</p>
- *
- * <p>각 도메인 stats 호출은 단일 집계 쿼리 (GROUP BY / SUM / COUNT) 라 N+1 없음. 전체 dashboard
- * 한 번 호출 시 SQL 11개 (User 4 [all/blocked/deleted/active] + Transaction 1 + Payment 2 +
- * Withdrawal 2 + Delivery 2). prod 트래픽 스케일 커지면 schedule 캐싱 검토.</p>
- */
 @Service
 @Transactional(readOnly = true)
 public class AdminStatsService {
@@ -77,17 +67,14 @@ public class AdminStatsService {
         return new AdminDashboardResult(users, transactions, payments, withdrawals, deliveries);
     }
 
-    /** 월별 거래완료 집계 — recharts 차트용. month ASC, 빈 월은 0 채움. */
+    
     public java.util.List<com.sseulang.domain.transaction.domain.TransactionMonthlyStat> tradesMonthly(
             java.time.YearMonth from, java.time.YearMonth to) {
         return transactionService.adminMonthlyTrades(from, to);
     }
 
-    /**
-     * 차트 dashboard — summary 카드 + signupTrend + tradeByType + tradeByStatus 한 번에.
-     * 기간 [startDate 00:00, endDate 23:59:59.999) — endDate 도 inclusive day.
-     * default (양쪽 null): 최근 14일 (today-13 ~ today).
-     */
+    
+
     public AdminDashboardChartsResult dashboardCharts(LocalDate startDate, LocalDate endDate) {
         LocalDate today = LocalDate.now(clock);
         LocalDate end = (endDate != null) ? endDate : today;
@@ -108,7 +95,7 @@ public class AdminStatsService {
         );
     }
 
-    /** PR-F #9 라운드 12 — 신고 위젯 (pending / resolved / 최근 7일). */
+    
     private AdminDashboardChartsResult.ReportsSummary buildReportsSummary(LocalDate today) {
         long pending = userReportService.countPending();
         long resolved = userReportService.countResolved();
@@ -118,19 +105,19 @@ public class AdminStatsService {
     }
 
     private AdminDashboardChartsResult.Summary buildSummary(LocalDate today) {
-        // users
+        
         long totalUsers = userService.adminGetStats().total();
         LocalDateTime monthStart = today.withDayOfMonth(1).atStartOfDay();
         LocalDateTime tomorrow = today.plusDays(1).atStartOfDay();
         long monthDelta = userService.countSignupsBetween(monthStart, tomorrow);
 
-        // today signups
+        
         LocalDateTime todayStart = today.atStartOfDay();
         long todayCount = userService.countSignupsBetween(todayStart, tomorrow);
         long yesterdayCount = userService.countSignupsBetween(today.minusDays(1).atStartOfDay(), todayStart);
         long yesterdayDelta = todayCount - yesterdayCount;
 
-        // month trades — TransactionMonthlyStat 활용 (status=거래완료, completed_at 기준)
+        
         YearMonth thisMonth = YearMonth.from(today);
         YearMonth prevMonth = thisMonth.minusMonths(1);
         var monthly = transactionService.adminMonthlyTrades(prevMonth, thisMonth);
@@ -140,7 +127,7 @@ public class AdminStatsService {
                 ? null
                 : (thisMonthTrades - prevMonthTrades) / (double) prevMonthTrades;
 
-        // pending reports
+        
         long pendingReports = userReportService.countPending();
 
         return new AdminDashboardChartsResult.Summary(
@@ -166,7 +153,7 @@ public class AdminStatsService {
     private List<AdminDashboardChartsResult.TradeTypeCount> buildTradeByType(
             LocalDateTime fromTs, LocalDateTime toExclusive) {
         var raw = transactionService.countByTradeTypeBetween(fromTs, toExclusive);
-        // 한국어 enum 이름 그대로 (판매/대여/나눔). 빈 type 은 0 채움 — TradeType 모든 값 포함.
+        
         Map<com.sseulang.domain.item.domain.TradeType, Long> rawMap = new EnumMap<>(com.sseulang.domain.item.domain.TradeType.class);
         for (var r : raw) rawMap.put(r.tradeType(), r.count());
         List<AdminDashboardChartsResult.TradeTypeCount> result = new ArrayList<>();

--- a/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/AdminStatsController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** 관리자 통계 dashboard. SecurityConfig admin chain 으로 ROLE_ADMIN 강제. */
 @Tag(name = "AdminStats", description = "관리자 — dashboard 통계")
 @RestController
 @RequestMapping("/api/v1/admin/stats")

--- a/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardResponse.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/dto/AdminDashboardResponse.java
@@ -8,10 +8,6 @@ import com.sseulang.domain.user.application.dto.UserStatsResult;
 import com.sseulang.domain.withdrawal.application.dto.WithdrawalStatsResult;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * 관리자 dashboard JSON 응답. presentation layer 응답 — application Result 를 그대로 노출하지만
- * 향후 응답 shape 분리(예: 일부 필드 마스킹)에 대비해 wrapper 유지.
- */
 @Schema(description = "관리자 dashboard — 5개 도메인 (User/Transaction/Payment/Withdrawal/Delivery) 통계 묶음.")
 public record AdminDashboardResponse(
         UserStatsResult users,

--- a/src/main/java/com/sseulang/domain/stats/presentation/dto/MonthlyTradeStatResponse.java
+++ b/src/main/java/com/sseulang/domain/stats/presentation/dto/MonthlyTradeStatResponse.java
@@ -3,9 +3,6 @@ package com.sseulang.domain.stats.presentation.dto;
 import com.sseulang.domain.transaction.domain.TransactionMonthlyStat;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * 월별 거래완료 집계 응답. recharts 차트 친화 (month ASC, 빈 월은 count=0/amount=0 으로 채워짐).
- */
 @Schema(description = "월별 거래완료 집계.")
 public record MonthlyTradeStatResponse(
         @Schema(example = "2026-05") String month,

--- a/src/main/java/com/sseulang/domain/support/application/InquiryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/support/application/InquiryApplicationService.java
@@ -20,17 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
 
-/**
- * 1:1 문의 흐름.
- *
- * <ul>
- *   <li>사용자: 작성 / 본인 목록·단건 조회 / PENDING 상태일 때만 본인 삭제.</li>
- *   <li>관리자: 전체 조회 / 답변 작성 (status 동시 갱신) / status 변경 / 삭제.</li>
- * </ul>
- *
- * <p>관리자 권한 강제는 SecurityConfig admin chain ({@code hasRole("ADMIN")}). 본 서비스는
- * 사용자 권한 검증만 — 본인 문의가 아니면 {@link ErrorCode#INQUIRY_FORBIDDEN}.</p>
- */
 @Slf4j
 @Service
 @Transactional(readOnly = true)
@@ -72,7 +61,7 @@ public class InquiryApplicationService {
     public InquiryResult findOwnedById(Long inquiryId, Long viewerId) {
         Inquiry inquiry = findOrThrow(inquiryId);
         if (!inquiry.isOwnedBy(viewerId)) {
-            // 존재 leak 방지를 위해 NOT_FOUND 도 고려했으나 명세상 INQUIRY_FORBIDDEN 으로 분리.
+            
             throw new BusinessException(ErrorCode.INQUIRY_FORBIDDEN);
         }
         return InquiryResult.from(inquiry);
@@ -94,7 +83,7 @@ public class InquiryApplicationService {
         inquiryRepository.deleteById(inquiryId);
     }
 
-    // ===== 관리자 영역 =====
+    
 
     public Page<InquiryResult> adminFindAll(InquiryStatus status, Pageable pageable) {
         return inquiryRepository.findAllForAdmin(status, pageable).map(InquiryResult::from);
@@ -104,16 +93,8 @@ public class InquiryApplicationService {
         return InquiryResult.from(findOrThrow(inquiryId));
     }
 
-    /**
-     * 답변 작성. status null 이면 DONE 으로 자동 — 명세대로. status=PENDING 은 거부 (INVALID_STATE).
-     *
-     * <p><b>알림 흐름</b> (Codex round 9 hotfix):
-     * <ol>
-     *   <li>Inquiry.writeAdminReply — JPA write</li>
-     *   <li>Notification + Email 은 {@code AFTER_COMMIT} 이벤트로 분리 — JPA commit 실패 시 알림/메일도
-     *       함께 롤백 (dangling 차단). Email 은 best-effort (예외는 WARN).</li>
-     * </ol>
-     */
+    
+
     @Transactional
     public void adminReply(Long inquiryId, InquiryReplyCommand cmd) {
         if (cmd.status() == InquiryStatus.PENDING) {
@@ -124,17 +105,17 @@ public class InquiryApplicationService {
         try {
             inquiry.writeAdminReply(cmd.adminReply(), next, LocalDateTime.now(clock));
         } catch (IllegalArgumentException e) {
-            // 도메인 검증 (PENDING 거부 등) 은 비즈니스 예외로 변환 — 500 회귀 차단.
+            
             throw new BusinessException(ErrorCode.INQUIRY_INVALID_STATE);
         }
-        // AFTER_COMMIT 이벤트 등록 — 트랜잭션 commit 후 listener 가 알림/메일 발송.
+        
         eventPublisher.publishEvent(new InquiryRepliedEvent(
                 inquiry.getId(), inquiry.getUserId(), inquiry.getEmail(),
                 inquiry.getTitle(), cmd.adminReply()
         ));
     }
 
-    /** Round 9 hotfix — JPA commit 후 알림/메일 발송 (dangling 차단). */
+    
     @org.springframework.transaction.event.TransactionalEventListener(
             phase = org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT)
     public void onInquiryReplied(InquiryRepliedEvent event) {
@@ -155,7 +136,7 @@ public class InquiryApplicationService {
         }
     }
 
-    /** AFTER_COMMIT 이벤트 payload — Inquiry entity 직접 들고가지 않음 (lazy init / 컨텍스트 밖 회귀 차단). */
+    
     public record InquiryRepliedEvent(Long inquiryId, Long userId, String email, String title, String adminReply) { }
 
     private static String buildReplyEmailHtml(String title, String adminReply) {
@@ -185,7 +166,7 @@ public class InquiryApplicationService {
         try {
             inquiry.changeStatus(newStatus);
         } catch (IllegalArgumentException e) {
-            // 도메인 검증 (역방향 전이 / 답변 없이 DONE 등) 은 비즈니스 예외로 변환 — 500 회귀 차단.
+            
             throw new BusinessException(ErrorCode.INQUIRY_INVALID_STATE);
         }
     }

--- a/src/main/java/com/sseulang/domain/support/application/SupportPostApplicationService.java
+++ b/src/main/java/com/sseulang/domain/support/application/SupportPostApplicationService.java
@@ -13,14 +13,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * FAQ / QNA 게시판 흐름.
- *
- * <ul>
- *   <li>관리자: CRUD 전부.</li>
- *   <li>사용자: 누구나 (비로그인 포함) 조회. 작성·수정·삭제 권한 X — SecurityConfig 가 admin chain 분리.</li>
- * </ul>
- */
 @Service
 @Transactional(readOnly = true)
 public class SupportPostApplicationService {

--- a/src/main/java/com/sseulang/domain/support/application/dto/InquiryCreateCommand.java
+++ b/src/main/java/com/sseulang/domain/support/application/dto/InquiryCreateCommand.java
@@ -4,7 +4,6 @@ import com.sseulang.domain.support.domain.InquiryCategory;
 
 import java.util.List;
 
-/** 1:1 문의 작성 Command. 검증 일부는 Inquiry.create 위임. */
 public record InquiryCreateCommand(
         InquiryCategory category,
         String title,

--- a/src/main/java/com/sseulang/domain/support/application/dto/InquiryReplyCommand.java
+++ b/src/main/java/com/sseulang/domain/support/application/dto/InquiryReplyCommand.java
@@ -2,11 +2,6 @@ package com.sseulang.domain.support.application.dto;
 
 import com.sseulang.domain.support.domain.InquiryStatus;
 
-/**
- * 관리자 답변 Command. status 가 null 이면 기본 DONE 으로 자동 설정 (서비스에서 처리).
- *
- * <p>명세: 클라가 명시하면 그대로 따르고, status 안 보내면 DONE 으로 강제.</p>
- */
 public record InquiryReplyCommand(
         String adminReply,
         InquiryStatus status

--- a/src/main/java/com/sseulang/domain/support/application/dto/InquiryResult.java
+++ b/src/main/java/com/sseulang/domain/support/application/dto/InquiryResult.java
@@ -7,11 +7,6 @@ import com.sseulang.domain.support.domain.InquiryStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
-/**
- * 1:1 문의 단건 결과. 사용자/관리자 공용. presentation Response 가 wrapping.
- *
- * <p>관리자 답변 미작성이면 {@code adminReply}/{@code repliedAt} null. 응답에 그대로 노출.</p>
- */
 public record InquiryResult(
         Long id,
         Long userId,

--- a/src/main/java/com/sseulang/domain/support/application/dto/SupportPostUpsertCommand.java
+++ b/src/main/java/com/sseulang/domain/support/application/dto/SupportPostUpsertCommand.java
@@ -5,7 +5,6 @@ import com.sseulang.domain.support.domain.SupportPostType;
 
 import java.util.List;
 
-/** FAQ/QNA 게시글 생성·수정 Command. 검증은 SupportPost 도메인 위임. */
 public record SupportPostUpsertCommand(
         SupportPostType postType,
         InquiryCategory category,

--- a/src/main/java/com/sseulang/domain/support/domain/Inquiry.java
+++ b/src/main/java/com/sseulang/domain/support/domain/Inquiry.java
@@ -20,17 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Inquiry Aggregate Root — 1:1 비공개 문의. V12 {@code inquiries} 매핑.
- *
- * <p>사용자가 작성, 관리자가 답변. 작성자만 본인 것 조회 가능 (관리자는 전체 조회).</p>
- *
- * <p><b>상태 전이</b>: {@link InquiryStatus} 참조. 본 엔티티는 전이의 유효성만 검증 — 권한은
- * ApplicationService.</p>
- *
- * <p><b>이미지</b>: 최대 5장, presigned 업로드 후 URL 만 받아 보관. JSON 컬럼.
- * 작성·수정 시 통째로 갱신 — 부분 조작 메서드 없음.</p>
- */
 @Entity
 @Table(name = "inquiries")
 @Getter
@@ -101,14 +90,14 @@ public class Inquiry extends BaseEntity {
         i.userId = userId;
         i.category = category;
         i.title = title.trim();
-        i.content = content;            // 본문 줄바꿈/공백 보존
+        i.content = content;            
         i.email = email.trim();
         i.status = InquiryStatus.PENDING;
         i.imageUrls = sanitized;
         return i;
     }
 
-    /** 관리자 답변 작성/수정. status 동시 갱신 (보통 PROCESSING 또는 DONE). */
+    
     public void writeAdminReply(String adminReply, InquiryStatus newStatus, LocalDateTime now) {
         if (adminReply == null || adminReply.isBlank()) {
             throw new IllegalArgumentException("adminReply 는 필수입니다");
@@ -117,7 +106,7 @@ public class Inquiry extends BaseEntity {
             throw new IllegalArgumentException("status 는 필수입니다");
         }
         if (newStatus == InquiryStatus.PENDING) {
-            // 답변을 쓰는 시점에 PENDING 으로 되돌리는 건 의미 없음 — 차단.
+            
             throw new IllegalArgumentException("답변 작성 시 PENDING 으로 되돌릴 수 없습니다");
         }
         if (now == null) {
@@ -128,37 +117,32 @@ public class Inquiry extends BaseEntity {
         this.repliedAt = now;
     }
 
-    /**
-     * 답변 없이 status 만 변경 — 보통 PENDING → PROCESSING.
-     *
-     * <p>전이 룰 (단방향): {@code PENDING → PROCESSING → DONE}. 역방향 (PROCESSING/DONE → PENDING)
-     * 은 거부 — 상태머신 정합 (Codex round 9 hotfix).</p>
-     * <p>DONE 으로 가려면 admin_reply 가 있어야 함.</p>
-     */
+    
+
     public void changeStatus(InquiryStatus newStatus) {
         if (newStatus == null) {
             throw new IllegalArgumentException("status 는 필수입니다");
         }
-        // 역방향 전이 거부 — 정상적인 상태머신은 단방향.
+        
         if (newStatus == InquiryStatus.PENDING && this.status != InquiryStatus.PENDING) {
             throw new IllegalArgumentException("PENDING 으로 되돌릴 수 없습니다");
         }
         if (newStatus == InquiryStatus.PROCESSING && this.status == InquiryStatus.DONE) {
             throw new IllegalArgumentException("DONE 에서 PROCESSING 으로 되돌릴 수 없습니다");
         }
-        // DONE 으로 가려면 admin_reply 가 있어야 함.
+        
         if (newStatus == InquiryStatus.DONE && (adminReply == null || adminReply.isBlank())) {
             throw new IllegalArgumentException("답변 없이 DONE 으로 변경할 수 없습니다");
         }
         this.status = newStatus;
     }
 
-    /** 작성자 본인 검증 — ApplicationService 가 호출. */
+    
     public boolean isOwnedBy(Long candidateUserId) {
         return candidateUserId != null && candidateUserId.equals(userId);
     }
 
-    /** PENDING 상태에서만 본인 삭제 가능 — 관리자 답변 시작 후엔 못 지움 (감사 추적). */
+    
     public boolean isDeletableByOwner() {
         return status == InquiryStatus.PENDING;
     }
@@ -184,7 +168,7 @@ public class Inquiry extends BaseEntity {
         if (trimmed.length() > EMAIL_MAX_LENGTH) {
             throw new IllegalArgumentException("email 은 " + EMAIL_MAX_LENGTH + "자 이하여야 합니다");
         }
-        // 형식 검증은 DTO @Email 레이어에서 — 여기선 길이만.
+        
     }
 
     private static List<String> sanitizeImages(List<String> imageUrls) {

--- a/src/main/java/com/sseulang/domain/support/domain/InquiryCategory.java
+++ b/src/main/java/com/sseulang/domain/support/domain/InquiryCategory.java
@@ -2,11 +2,6 @@ package com.sseulang.domain.support.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * 1:1 문의 카테고리. EnumType.STRING 으로 DB 저장 — 한글 이름 그대로.
- *
- * <p>Notice 와 동일 패턴 (한글 enum). FAQ/QNA 게시글({@link SupportPost}) 도 같은 enum 공유.</p>
- */
 @Schema(description = "고객지원 카테고리 — 계정/거래/결제/배송/기타")
 public enum InquiryCategory {
     계정,

--- a/src/main/java/com/sseulang/domain/support/domain/InquiryRepository.java
+++ b/src/main/java/com/sseulang/domain/support/domain/InquiryRepository.java
@@ -5,11 +5,6 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
-/**
- * Inquiry Aggregate Repository (도메인 인터페이스).
- *
- * <p>JPA 구현은 {@code infrastructure/persistence/}. 도메인 레이어는 Spring/JPA 의존 0.</p>
- */
 public interface InquiryRepository {
 
     Inquiry save(Inquiry inquiry);
@@ -18,9 +13,9 @@ public interface InquiryRepository {
 
     void deleteById(Long id);
 
-    /** 본인 문의 목록. status 필터 nullable. 최신순. */
+    
     Page<Inquiry> findByUserId(Long userId, InquiryStatus status, Pageable pageable);
 
-    /** 관리자 전체 조회. status 필터 nullable. 최신순. */
+    
     Page<Inquiry> findAllForAdmin(InquiryStatus status, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/support/domain/InquiryStatus.java
+++ b/src/main/java/com/sseulang/domain/support/domain/InquiryStatus.java
@@ -2,20 +2,6 @@ package com.sseulang.domain.support.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * 1:1 문의 처리 상태.
- *
- * <ul>
- *   <li>{@link #PENDING} — 사용자가 작성, 관리자 미확인. 사용자가 본인 삭제 가능한 유일한 상태.</li>
- *   <li>{@link #PROCESSING} — 관리자가 확인했으나 답변 미완료.</li>
- *   <li>{@link #DONE} — 관리자 답변 완료 (admin_reply + replied_at 채워짐).</li>
- * </ul>
- *
- * <p>전이 룰: {@code PENDING → PROCESSING → DONE} 단방향. 되돌리는 것 ({@code DONE → PENDING}) 은
- * 명세상 유스케이스 없음 — 관리자가 status 변경하더라도 enum 검증으로 순방향만.</p>
- *
- * <p>FAQ/QNA 게시글은 status 가 없음 — 작성 즉시 노출.</p>
- */
 @Schema(description = "1:1 문의 처리 상태 — PENDING(대기) / PROCESSING(처리중) / DONE(완료)")
 public enum InquiryStatus {
     PENDING,

--- a/src/main/java/com/sseulang/domain/support/domain/SupportPost.java
+++ b/src/main/java/com/sseulang/domain/support/domain/SupportPost.java
@@ -19,13 +19,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * SupportPost Aggregate Root — FAQ / QNA 공개 게시글. V12 {@code support_posts} 매핑.
- *
- * <p>관리자만 작성/수정/삭제. 사용자는 비로그인 포함 누구나 조회. 상태 개념 없음 — 작성 즉시 노출.</p>
- *
- * <p>FAQ 와 QNA 가 컬럼이 동일해 단일 테이블 + {@code post_type} 컬럼으로 구분.</p>
- */
 @Entity
 @Table(name = "support_posts")
 @Getter

--- a/src/main/java/com/sseulang/domain/support/domain/SupportPostRepository.java
+++ b/src/main/java/com/sseulang/domain/support/domain/SupportPostRepository.java
@@ -5,11 +5,6 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
-/**
- * SupportPost Aggregate Repository (도메인 인터페이스).
- *
- * <p>JPA 구현은 {@code infrastructure/persistence/}.</p>
- */
 public interface SupportPostRepository {
 
     SupportPost save(SupportPost post);
@@ -18,6 +13,6 @@ public interface SupportPostRepository {
 
     void deleteById(Long id);
 
-    /** 공개 목록 — type 필수, category nullable. 최신순. */
+    
     Page<SupportPost> findVisible(SupportPostType type, InquiryCategory category, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/support/domain/SupportPostType.java
+++ b/src/main/java/com/sseulang/domain/support/domain/SupportPostType.java
@@ -2,11 +2,6 @@ package com.sseulang.domain.support.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * 고객지원 게시판 글 종류. FAQ(자주 묻는 질문) / QNA(공개 Q&amp;A).
- *
- * <p>구조가 동일해 단일 테이블 + 컬럼 구분. 카드 UI 만 type 별 분기.</p>
- */
 @Schema(description = "FAQ / QNA")
 public enum SupportPostType {
     FAQ,

--- a/src/main/java/com/sseulang/domain/support/infrastructure/persistence/InquiryJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/support/infrastructure/persistence/InquiryJpaRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-/** Spring Data JPA — {@link InquiryRepositoryImpl} 가 wrapping. */
 interface InquiryJpaRepository extends JpaRepository<Inquiry, Long> {
 
     @Query("""

--- a/src/main/java/com/sseulang/domain/support/presentation/AdminInquiryController.java
+++ b/src/main/java/com/sseulang/domain/support/presentation/AdminInquiryController.java
@@ -20,9 +20,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 관리자 — 1:1 문의 전체 조회 / 답변 / 상태 변경 / 삭제. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
- */
 @Tag(name = "AdminInquiry", description = "관리자 — 1:1 문의 답변/관리")
 @RestController
 @RequestMapping("/api/v1/admin/inquiries")

--- a/src/main/java/com/sseulang/domain/support/presentation/AdminSupportPostController.java
+++ b/src/main/java/com/sseulang/domain/support/presentation/AdminSupportPostController.java
@@ -17,9 +17,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 관리자 — FAQ / QNA 게시글 CRUD. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
- */
 @Tag(name = "AdminSupportPost", description = "관리자 — FAQ/QNA 작성")
 @RestController
 @RequestMapping("/api/v1/admin/support/posts")

--- a/src/main/java/com/sseulang/domain/support/presentation/InquiryController.java
+++ b/src/main/java/com/sseulang/domain/support/presentation/InquiryController.java
@@ -22,11 +22,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 1:1 문의 (사용자). 본인 작성 + 본인 조회만. ROLE_USER 강제.
- *
- * <p>관리자용은 {@link AdminInquiryController}.</p>
- */
 @Tag(name = "Inquiry", description = "1:1 문의 — 본인 작성/조회/삭제")
 @RestController
 @RequestMapping("/api/v1/support/inquiries")

--- a/src/main/java/com/sseulang/domain/support/presentation/SupportPostController.java
+++ b/src/main/java/com/sseulang/domain/support/presentation/SupportPostController.java
@@ -15,9 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * FAQ / QNA 게시글 — 누구나 (비로그인 포함) 조회. SecurityConfig 가 GET 만 permitAll.
- */
 @Tag(name = "SupportPost", description = "고객지원 FAQ / QNA — 공개 조회")
 @RestController
 @RequestMapping("/api/v1/support/posts")

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -31,21 +31,6 @@ import java.time.LocalDateTime;
 import java.util.EnumMap;
 import java.util.Map;
 
-/**
- * Transaction 거래 흐름. 가이드 §5.1 / §5.2 정합:
- *
- * <ul>
- *   <li>create: buyer 가 호출. <b>Item 비관적 락</b> + 활성(판매중) 검증 + 자기 거래 거부.
- *       reserve 동시 시 락 직렬화 — "예약 직후 새 채팅중 거래" 회귀 차단.</li>
- *   <li>reserve: seller 가 호출. <b>락 순서 Transaction → Item</b>.
- *       같은 거래에 대한 reserve vs cancel race 도 Transaction 락이 직렬화 (Codex 게이트 1 Critical 1 보강).
- *       다른 거래의 reserve 와는 Item 락이 직렬화 → status=예약 보고 거부.</li>
- *   <li>complete: seller 가 호출. <b>Item 락 → markAsSold</b> 후 PointApplicationService.transfer 로
- *       buyer 차감 → seller 적립 (id-asc 락 순서, 가이드 §5.3) + history 두 건. 정산 실패 시 트랜잭션
- *       롤백으로 Item / Tx / 잔액 / history 모두 원복 (Day 8 합류, SettlementRollbackIT 가드).</li>
- *   <li>cancel: 양쪽 참여자 모두 호출 가능. Transaction 락 → 예약 상태였으면 Item 복원 (예약 → 판매중).</li>
- * </ul>
- */
 @Service
 @Transactional(readOnly = true)
 public class TransactionApplicationService {
@@ -76,57 +61,55 @@ public class TransactionApplicationService {
         this.clock = clock;
     }
 
-    /**
-     * 거래 생성 — 라운드 12 (#3.2 + 판매자만 정책): 판매자가 채팅방 안에서 거래 시작.
-     *
-     * <p>검증 순서 (의도적):</p>
-     * <ol>
-     *   <li>chatRoomId 누락 → TX_CHATROOM_REQUIRED (다른 검증보다 먼저)</li>
-     *   <li>호출자(seller) verified — 자금 영향이라 이메일 인증 필수</li>
-     *   <li>chat_room 참여자 검증 + chatRoom.itemId == cmd.itemId 일치</li>
-     *   <li>호출자 == item.sellerId — 판매자만 거래 시작 가능 (TX_SELLER_ONLY)</li>
-     *   <li>한 채팅방 = 1 active transaction</li>
-     *   <li>buyer 도출 — chatRoom 의 상대방</li>
-     * </ol>
-     */
+    
+
     @Transactional
     public Long create(TransactionCreateCommand cmd) {
         if (cmd.chatRoomId() == null) {
             throw new BusinessException(ErrorCode.TX_CHATROOM_REQUIRED);
         }
-        // 호출자(seller) 인증 — 자금 흐름 진입자라 이메일 인증 필수.
+        
         userApplicationService.requireVerified(cmd.requesterId());
 
-        // Item 조회 먼저 — 미존재면 ITEM_NOT_FOUND (chatRoom 검증보다 우선).
+        
         ItemForTransactionResult info = itemApplicationService.findActiveForTransaction(cmd.itemId());
 
-        // 채팅방 가드 — 참여자 + chatRoom.itemId 일치 검증
+        
         ChatRoomApplicationService.ChatRoomMeta meta =
                 chatRoomApplicationService.findMetaForParticipant(cmd.chatRoomId(), cmd.requesterId());
         if (!meta.itemId().equals(cmd.itemId())) {
             throw new BusinessException(ErrorCode.TX_CHATROOM_ITEM_MISMATCH);
         }
 
-        // 판매자만 거래 시작 가능 (#3.2 round 12 정책 변경)
+        
         if (!info.sellerId().equals(cmd.requesterId())) {
             throw new BusinessException(ErrorCode.TX_SELLER_ONLY);
         }
 
-        // 한 채팅방 = 1 active transaction 가드 (#3.2)
+        
         if (transactionRepository.existsActiveByChatRoomId(cmd.chatRoomId())) {
             throw new BusinessException(ErrorCode.TX_ALREADY_ACTIVE_IN_ROOM);
         }
 
-        // buyer 도출 — chatRoom 참여자 중 seller 가 아닌 쪽
+        
         Long buyerId = chatRoomApplicationService.findOpponent(cmd.chatRoomId(), cmd.requesterId());
+
+        
+        
+        com.sseulang.domain.item.domain.TradeType mode = meta.tradeMode();
+        Long price = info.priceFor(mode);
+        if (price == null) {
+            throw new BusinessException(ErrorCode.ITEM_INVALID_STATE);
+        }
+        Long deposit = mode == com.sseulang.domain.item.domain.TradeType.대여 ? info.deposit() : null;
 
         Transaction tx = Transaction.create(
                 info.itemId(),
                 info.sellerId(),
                 buyerId,
-                info.tradeType(),
-                info.price(),
-                info.deposit(),
+                mode,
+                price,
+                deposit,
                 cmd.rentalStart(),
                 cmd.rentalEnd(),
                 cmd.chatRoomId()
@@ -134,30 +117,15 @@ public class TransactionApplicationService {
         return transactionRepository.save(tx).getId();
     }
 
-    /**
-     * 거래 예약 — seller 가 호출. 라운드 11 흐름:
-     * <ol>
-     *   <li>Transaction 비관적 락 (findByIdForUpdate)</li>
-     *   <li>seller 권한 가드 (TRANSACTION_FORBIDDEN)</li>
-     *   <li>Item 락 + markItemAsReserved (락 순서 Transaction → Item — deadlock 회피)</li>
-     *   <li>Transaction.markAsReserved(now, price) — escrowHoldAmount 동기 set</li>
-     *   <li>price &gt; 0 이면 PointApplicationService.escrowHold — buyer point_balance↓ + point_hold↑
-     *       + 거래보관 history. 잔액 부족 시 INSUFFICIENT_POINT 트랜잭션 롤백 (Item/Tx 도 원복).</li>
-     * </ol>
-     *
-     * <p>락 순서: Transaction → Item → User(buyer). 다른 거래의 reserve 와는 Item 락이, 같은 buyer 의
-     * 다른 거래 reserve 동시 시도는 buyer 행 락이 직렬화. 두 거래 모두 잔액 충분이면 차례로 통과,
-     * 한 쪽만 충분이면 다른 쪽은 INSUFFICIENT_POINT.</p>
-     *
-     * <p>나눔 거래 (price=0) 는 escrowHold 호출 X — escrowHoldAmount 도 0.</p>
-     */
+    
+
     @Transactional
     public void reserve(Long transactionId, Long requesterId) {
         Transaction tx = findOrThrowForUpdate(transactionId);
         if (!tx.isSeller(requesterId)) {
             throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
         }
-        // Item 락 + 상태 전이 — 락 순서 Transaction → Item 고정 (deadlock 회피)
+        
         itemApplicationService.markItemAsReserved(tx.getItemId());
         LocalDateTime now = LocalDateTime.now(clock);
         long holdAmount = tx.getPrice();
@@ -174,17 +142,8 @@ public class TransactionApplicationService {
                 tx.getId(), tx.getBuyerId(), tx.getSellerId(), tx.getPrice()));
     }
 
-    /**
-     * 라운드 11 — seller 인계확인. 예약 → 인계완료 전이.
-     *
-     * <ul>
-     *   <li>seller 가 아니면 TRANSACTION_HANDOVER_NOT_ALLOWED</li>
-     *   <li>이미 인계완료 상태이면 멱등 (no-op) — PATCH 재시도 시 사용자 혼란 방지</li>
-     *   <li>그 외 status (채팅중/거래완료/취소) 에서 호출 시 TRANSACTION_INVALID_STATE</li>
-     * </ul>
-     *
-     * <p>buyer 잔액/hold 변동 X — 단순 status 전이. Item 도 변동 X (markAsSold 는 markReceived 시점).</p>
-     */
+    
+
     @Transactional
     public void markHandover(Long transactionId, Long requesterId) {
         Transaction tx = findOrThrowForUpdate(transactionId);
@@ -192,27 +151,14 @@ public class TransactionApplicationService {
             throw new BusinessException(ErrorCode.TRANSACTION_HANDOVER_NOT_ALLOWED);
         }
         if (tx.getStatus() == TransactionStatus.인계완료) {
-            return;  // 멱등 — 이미 인계완료
+            return;  
         }
         tx.markHandover(LocalDateTime.now(clock));
         eventPublisher.publishEvent(new TransactionHandoverConfirmedEvent(tx.getId(), tx.getBuyerId()));
     }
 
-    /**
-     * 라운드 11 — buyer 인수확인. 인계완료 → 거래완료 자동 전이 + 정산.
-     *
-     * <ol>
-     *   <li>Transaction 락 + buyer 권한 가드 (TRANSACTION_RECEIVE_NOT_ALLOWED)</li>
-     *   <li>이미 거래완료 상태이면 멱등 (no-op)</li>
-     *   <li>Item 락 + markItemAsSold (락 순서 Transaction → Item — reserve 와 동일)</li>
-     *   <li>escrowHoldAmount &gt; 0 이면 PointApplicationService.escrowRelease — buyer hold↓ + seller balance↑
-     *       (id-asc 락 순서, 가이드 §5.3) + 판매정산 history 1건</li>
-     *   <li>Transaction.markReceived — status=거래완료, receiveConfirmedAt + completedAt 동기 set</li>
-     * </ol>
-     *
-     * <p>buyer hold 부족 (운영 이상) → TRANSACTION_HOLD_FAILED. 트랜잭션 롤백으로 Item / Tx / 잔액
-     * 모두 원복. 나눔 거래 (escrowHoldAmount=0) 는 escrowRelease skip.</p>
-     */
+    
+
     @Transactional
     public void markReceived(Long transactionId, Long requesterId) {
         Transaction tx = findOrThrowForUpdate(transactionId);
@@ -220,9 +166,9 @@ public class TransactionApplicationService {
             throw new BusinessException(ErrorCode.TRANSACTION_RECEIVE_NOT_ALLOWED);
         }
         if (tx.getStatus() == TransactionStatus.거래완료) {
-            return;  // 멱등 — 이미 거래완료
+            return;  
         }
-        // Item 락 + markAsSold (락 순서 Transaction → Item)
+        
         itemApplicationService.markItemAsSold(tx.getItemId());
         long settleAmount = tx.getEscrowHoldAmount();
         if (settleAmount > 0) {
@@ -239,19 +185,8 @@ public class TransactionApplicationService {
                 tx.getId(), tx.getSellerId(), settleAmount));
     }
 
-    /**
-     * 거래 취소 — 양쪽 참여자 누구나 호출. 라운드 11 단계별 환불:
-     *
-     * <ul>
-     *   <li>채팅중 단계: hold 없음 → 단순 status 전이만</li>
-     *   <li>예약 단계: Item 판매중 복원 + escrowRefund (buyer hold↓, balance↑) + 거래환불 history</li>
-     *   <li>인계완료 / 거래완료 / 취소 단계: Transaction.cancel 의 canCancel() 가드가 거부 (TRANSACTION_INVALID_STATE).
-     *       라운드 11 합의 (B-3) — 인계 후 환불은 R2 분쟁 endpoint 영역</li>
-     * </ul>
-     *
-     * <p>예약 단계 환불 시 락 순서: Transaction → Item → User(buyer). reserve 와 동일 순서라 deadlock 회피.
-     * 호출 시점에 escrowHoldAmount 를 미리 캡처 — tx.cancel() 후에도 컬럼은 유지되지만 명확성을 위해.</p>
-     */
+    
+
     @Transactional
     public void cancel(Long transactionId, Long requesterId, String reason) {
         Transaction tx = findOrThrowForUpdate(transactionId);
@@ -260,14 +195,14 @@ public class TransactionApplicationService {
         }
         boolean wasReserved = tx.getStatus() == TransactionStatus.예약;
         long holdAmount = tx.getEscrowHoldAmount();
-        // canCancel() 가드 — 인계완료 이후 status 는 TRANSACTION_INVALID_STATE
+        
         tx.cancel(LocalDateTime.now(clock), reason);
         if (wasReserved) {
-            // 예약 상태였던 거래만 Item 을 판매중으로 복원 (가이드 §5.2 채팅 재활성화)
+            
             itemApplicationService.restoreItemFromReserved(tx.getItemId());
             if (holdAmount > 0) {
-                // 라운드 11 — buyer escrow 환불 (hold↓, balance↑) + 거래환불 history.
-                // hold 부족 (운영 이상) → TRANSACTION_HOLD_FAILED 트랜잭션 롤백 (Item/Tx 도 원복).
+                
+                
                 pointApplicationService.escrowRefund(
                         tx.getBuyerId(),
                         holdAmount,
@@ -288,16 +223,8 @@ public class TransactionApplicationService {
         return TransactionResult.from(tx);
     }
 
-    /**
-     * Review 작성 시 호출. 가이드 §4.7:
-     * <ul>
-     *   <li>{@code status == 거래완료} 만 허용</li>
-     *   <li>거래 완료 후 7일 이내</li>
-     *   <li>requester 가 거래 참여자</li>
-     * </ul>
-     * reviewee 는 자동 결정 (seller 가 reviewer 면 buyer, 그 반대도). CLAUDE.md §3.3 — Review 도메인은
-     * 본 메서드만 의존, TransactionRepository 직접 접근 X.
-     */
+    
+
     public ReviewableTransactionResult findCompletedForReview(Long transactionId, Long requesterId) {
         Transaction tx = findOrThrow(transactionId);
         if (!tx.isParticipant(requesterId)) {
@@ -306,7 +233,7 @@ public class TransactionApplicationService {
         if (tx.getStatus() != TransactionStatus.거래완료 || tx.getCompletedAt() == null) {
             throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
         }
-        // 7일 경계 정확 비교 — Duration.toDays() 는 내림이라 7일 23시간도 허용되는 회귀 (Codex 게이트 2).
+        
         if (LocalDateTime.now(clock).isAfter(tx.getCompletedAt().plusDays(7))) {
             throw new BusinessException(ErrorCode.REVIEW_PERIOD_EXPIRED);
         }
@@ -314,26 +241,24 @@ public class TransactionApplicationService {
         return new ReviewableTransactionResult(tx.getId(), requesterId, revieweeId, tx.getCompletedAt());
     }
 
-    /** 차트 dashboard — 기간 [from, to) tradeType 별 카운트 (created_at 기준). */
+    
     public java.util.List<com.sseulang.domain.transaction.domain.TransactionRepository.TradeTypeCount>
             countByTradeTypeBetween(java.time.LocalDateTime from, java.time.LocalDateTime to) {
         return transactionRepository.countByTradeTypeBetween(from, to);
     }
 
-    /** 차트 dashboard — 기간 [from, to) status 별 카운트 (라운드 11 5단계, created_at 기준). */
+    
     public java.util.List<TransactionStatusCount> countByStatusBetween(
             java.time.LocalDateTime from, java.time.LocalDateTime to) {
         return transactionRepository.countByStatusBetween(from, to);
     }
 
-    /**
-     * 관리자 거래 통계 — total + status 별 카운트. byStatus 는 enum 모든 값 포함 (없는 status 는 0L).
-     * 단일 GROUP BY 쿼리 — N+1 없음.
-     */
+    
+
     public TransactionStatsResult adminGetStats() {
         Map<TransactionStatus, Long> byStatus = new EnumMap<>(TransactionStatus.class);
         for (TransactionStatus s : TransactionStatus.values()) {
-            byStatus.put(s, 0L);  // default 0
+            byStatus.put(s, 0L);  
         }
         long total = 0;
         for (TransactionStatusCount row : transactionRepository.countGroupByStatus()) {
@@ -343,10 +268,8 @@ public class TransactionApplicationService {
         return new TransactionStatsResult(total, byStatus);
     }
 
-    /**
-     * 월별 거래완료 집계 (Admin) — completed_at 기준. 거래 0 건 월은 응답에서 0 으로 채워진다.
-     * recharts 친화 — month ASC. (year, month, count, amount).
-     */
+    
+
     public java.util.List<com.sseulang.domain.transaction.domain.TransactionMonthlyStat> adminMonthlyTrades(
             java.time.YearMonth from, java.time.YearMonth to) {
         java.util.Map<java.time.YearMonth, com.sseulang.domain.transaction.domain.TransactionMonthlyStat> byMonth = new java.util.LinkedHashMap<>();
@@ -359,20 +282,11 @@ public class TransactionApplicationService {
         return new java.util.ArrayList<>(byMonth.values());
     }
 
-    /** Admin 거래 keyword LIKE 매칭 시 user IN 절 폭주 방지 — top N user. */
+    
     private static final int KEYWORD_USER_LIMIT = 200;
 
-    /**
-     * Admin 거래 검색 (round 9 + round 10 LIKE).
-     *
-     * <p>keyword 처리 (round 10):
-     * <ul>
-     *   <li>숫자: transactionId 또는 itemId 정확 매칭</li>
-     *   <li>비숫자: UserApplicationService.findUserIdsByKeyword 로 user 매치 (top {@value #KEYWORD_USER_LIMIT}) →
-     *       Transaction.sellerId/buyerId IN. user 매치 0건이면 빈 결과.</li>
-     * </ul>
-     * 모든 필터 nullable, 최신순.</p>
-     */
+    
+
     public Page<TransactionResult> adminSearch(
             java.time.LocalDateTime startDate,
             java.time.LocalDateTime endDate,
@@ -395,16 +309,10 @@ public class TransactionApplicationService {
         try { return Long.parseLong(s.trim()); } catch (NumberFormatException e) { return null; }
     }
 
-    /**
-     * 본인이 reviewer 로 아직 작성하지 않은 거래완료 거래 페이징 (follow-up #56).
-     *
-     * <p>completedAt 이 7일 이내인 것만 — 작성 가능 기간이 지난 거래는 제외 (가이드 §5.5).
-     * 응답 DTO 의 deadline = completedAt + 7d → 클라이언트가 남은 시간 UI 작성에 사용.</p>
-     */
-    /**
-     * 마이페이지 내 거래 목록 — viewer 가 buyer/seller/양쪽 으로 참여한 거래 페이징.
-     * role null = 양쪽, status null = 전체. 정렬: createdAt DESC + id DESC.
-     */
+    
+
+    
+
     public Page<TransactionResult> findMyTransactions(
             Long userId, TransactionRole role, TransactionStatus status, Pageable pageable) {
         return transactionRepository.findMyTransactions(userId, role, status, pageable)

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionNotificationListener.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionNotificationListener.java
@@ -14,15 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-/**
- * 라운드 11 — 거래 단계별 알림 발송. {@code AFTER_COMMIT} phase: TransactionApplicationService 의
- * 트랜잭션 커밋 후 실행 (롤백 시 X). linkType="TRANSACTION" + linkId=거래ID — 프론트가 클릭 시
- * /trades/{id} 이동 (B-4 합의).
- *
- * <p><b>예외 격리</b> (게이트 2 W-1): 각 listener 는 {@code REQUIRES_NEW} 별도 트랜잭션 + try/catch.
- * Mongo 저장 실패가 호출자(HTTP request 처리 스레드) 로 전파되어 거래 응답이 500 으로 끝나는 회귀 방지.
- * 알림 발송 실패는 ERROR 로깅으로만 기록 — 운영 모니터링이 처리.</p>
- */
 @Component
 public class TransactionNotificationListener {
 
@@ -36,7 +27,7 @@ public class TransactionNotificationListener {
         this.notificationService = notificationService;
     }
 
-    /** 예약됨 → buyer 에게. */
+    
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onReserved(TransactionReservedEvent e) {
@@ -54,7 +45,7 @@ public class TransactionNotificationListener {
         }
     }
 
-    /** 인계확인됨 → buyer 에게 인수확인 부탁. */
+    
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onHandoverConfirmed(TransactionHandoverConfirmedEvent e) {
@@ -72,7 +63,7 @@ public class TransactionNotificationListener {
         }
     }
 
-    /** 인수확인됨 / 거래완료 → seller 에게 정산 완료 (+N,000P 표시). */
+    
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onReceiveConfirmed(TransactionReceiveConfirmedEvent e) {
@@ -81,7 +72,7 @@ public class TransactionNotificationListener {
             if (e.settleAmount() > 0) {
                 body = "거래 #" + e.transactionId() + " 정산 완료 (+" + formatKrw(e.settleAmount()) + "P)";
             } else {
-                body = "거래 #" + e.transactionId() + " 가 완료되었습니다.";  // 나눔 거래
+                body = "거래 #" + e.transactionId() + " 가 완료되었습니다.";  
             }
             notificationService.notify(
                     e.sellerId(),
@@ -96,12 +87,12 @@ public class TransactionNotificationListener {
         }
     }
 
-    /** 거래취소됨 → 양쪽 참여자에게. */
+    
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onCanceled(TransactionCanceledEvent e) {
         String body = "거래 #" + e.transactionId() + " 가 취소되었습니다.";
-        // 두 발송을 한 트랜잭션 안에서 — 한 쪽 실패해도 try/catch 격리.
+        
         try {
             notificationService.notify(
                     e.buyerId(), NotificationType.거래,

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/PendingReviewableResult.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/PendingReviewableResult.java
@@ -4,12 +4,6 @@ import com.sseulang.domain.item.domain.TradeType;
 
 import java.time.LocalDateTime;
 
-/**
- * Review 작성 대기 중 거래 — 거래완료된 본인 참여 거래 중 본인이 아직 review 작성 안 한 것.
- *
- * <p>follow-up #56. 7일 작성 가능 기간 안에 들어오는 거래만. 상대방 id(revieweeId) 와
- * 작성 deadline(completedAt + 7d) 을 함께 노출 — 클라이언트가 "남은 시간" UI 만들기 쉽게.</p>
- */
 public record PendingReviewableResult(
         Long transactionId,
         Long itemId,

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/ReviewableTransactionResult.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/ReviewableTransactionResult.java
@@ -2,10 +2,6 @@ package com.sseulang.domain.transaction.application.dto;
 
 import java.time.LocalDateTime;
 
-/**
- * Review 도메인이 거래 후 양방향 평가를 작성할 때 받는 정보. reviewer 권한·기한 검증은
- * Transaction 도메인이 수행하고, reviewee 는 자동 결정 (참여자 중 reviewer 가 아닌 쪽).
- */
 public record ReviewableTransactionResult(
         Long transactionId,
         Long reviewerId,

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionCreateCommand.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionCreateCommand.java
@@ -2,14 +2,6 @@ package com.sseulang.domain.transaction.application.dto;
 
 import java.time.LocalDateTime;
 
-/**
- * 거래 생성 Command. 라운드 12 (#3.2 + 판매자만 정책) — 채팅방 안에서 판매자가 거래 시작.
- *
- * @param requesterId 호출자(판매자) userId. 정책상 item.sellerId 와 일치해야 하며, 그렇지 않으면
- *                    ApplicationService 가 TX_SELLER_ONLY 를 던진다. buyerId 는 chatRoom 의
- *                    상대방에서 도출 (판매자가 거래 시작 시점에 명시 X).
- * @param chatRoomId  채팅방 ID. null 이면 TX_CHATROOM_REQUIRED.
- */
 public record TransactionCreateCommand(
         Long itemId,
         Long requesterId,

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionRole.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionRole.java
@@ -1,16 +1,5 @@
 package com.sseulang.domain.transaction.application.dto;
 
-/**
- * 내 거래 목록 query 의 viewer 역할 필터.
- *
- * <ul>
- *   <li>{@link #BUYER} — viewer 가 buyer 인 거래만</li>
- *   <li>{@link #SELLER} — viewer 가 seller 인 거래만</li>
- *   <li>null — 양쪽 모두 (기본)</li>
- * </ul>
- *
- * <p>잘못된 query 값은 controller 에서 null 로 fallback (= 양쪽).</p>
- */
 public enum TransactionRole {
     BUYER,
     SELLER;

--- a/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionStatsResult.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/dto/TransactionStatsResult.java
@@ -5,9 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 
-/**
- * 거래 통계 — total + status 별 카운트. byStatus 는 모든 enum 값 포함 (0 이면 0L).
- */
 @Schema(description = "관리자 dashboard — 거래 통계. byStatus 는 모든 status 포함 (0 건도 0L).")
 public record TransactionStatsResult(
         @Schema(example = "568", description = "전체 거래 수") long total,

--- a/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
@@ -18,15 +18,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * Transaction Aggregate Root. V1 스키마 {@code transactions} 매핑.
- *
- * <p>가이드 §5.1 거래 상태 머신: {@code 채팅중 → 예약 → 거래완료} (또는 {@code 취소}).
- * 동시 예약 차단은 본 Aggregate 가 아니라 ApplicationService 가 Item 비관적 락 + Item.markAsReserved
- * conditional 전이로 처리. 본 Aggregate 자체는 단일 거래의 상태 머신만 책임.</p>
- *
- * <p>Setter 없음. 상태 변경은 명시 비즈니스 메서드만.</p>
- */
 @Entity
 @Table(name = "transactions")
 @Getter
@@ -46,10 +37,8 @@ public class Transaction extends BaseEntity {
     @Column(name = "buyer_id", nullable = false)
     private Long buyerId;
 
-    /**
-     * 라운드 12 (#3.2) — 거래 시작 채팅방 가드. V19 추가. 거래는 채팅방 안에서만 시작 가능,
-     * 한 채팅방 = 1 active transaction 정책. 이전 라운드 row 는 NULL (legacy).
-     */
+    
+
     @Column(name = "chat_room_id")
     private Long chatRoomId;
 
@@ -76,17 +65,13 @@ public class Transaction extends BaseEntity {
     @Column(name = "reserved_at")
     private LocalDateTime reservedAt;
 
-    /**
-     * 라운드 11 — seller 인계확인 시각 (V16). 예약 → 인계완료 전이 시점.
-     * 본 필드 set 만으로는 의미 없음 — markHandover 가 status 함께 전이.
-     */
+    
+
     @Column(name = "handover_confirmed_at")
     private LocalDateTime handoverConfirmedAt;
 
-    /**
-     * 라운드 11 — buyer 인수확인 시각 (V16). 인계완료 → 거래완료 전이 시점 + 정산 트리거.
-     * 본 필드 set 만으로는 의미 없음 — markReceived 가 status 함께 전이 + completedAt 동기 set.
-     */
+    
+
     @Column(name = "receive_confirmed_at")
     private LocalDateTime receiveConfirmedAt;
 
@@ -99,11 +84,8 @@ public class Transaction extends BaseEntity {
     @Column(name = "cancel_reason", length = 255)
     private String cancelReason;
 
-    /**
-     * 라운드 11 — 예약 시 buyer point_balance 에서 본 컬럼으로 hold 한 금액 (V16). 일반적으로 price 와
-     * 동일하지만, 환불/감사 추적용으로 명시 컬럼화. 채팅중/예약 외 단계에서 cancel 시 환불 금액 결정 키.
-     * 나눔 거래 (price=0) 또는 옛 정책 거래는 0.
-     */
+    
+
     @Column(name = "escrow_hold_amount", nullable = false)
     private long escrowHoldAmount;
 
@@ -155,20 +137,14 @@ public class Transaction extends BaseEntity {
         return t;
     }
 
-    /**
-     * 나눔 거래용 (price=0, hold 0) — 가이드 §4.11. 라운드 11 일반 판매/대여는
-     * {@link #markAsReserved(LocalDateTime, long)} 으로 hold 금액 명시.
-     */
+    
+
     public void markAsReserved(LocalDateTime now) {
         markAsReserved(now, 0L);
     }
 
-    /**
-     * 라운드 11 예약 — status=예약 + reservedAt + escrowHoldAmount 동기 set. ApplicationService 가
-     * 같은 트랜잭션 안에서 PointApplicationService.escrowHold 호출 (buyer balance↓, hold↑).
-     *
-     * @param holdAmount 0 (나눔/옛) 또는 양수 (price 와 동일). 음수는 IllegalArgumentException.
-     */
+    
+
     public void markAsReserved(LocalDateTime now, long holdAmount) {
         if (!status.canReserve()) {
             throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
@@ -181,10 +157,8 @@ public class Transaction extends BaseEntity {
         this.escrowHoldAmount = holdAmount;
     }
 
-    /**
-     * 라운드 11 — seller 인계확인. 예약 → 인계완료 전이. ApplicationService 가 권한 가드 (seller 만)
-     * 후 호출. 잘못된 status 에서 호출 시 TRANSACTION_INVALID_STATE.
-     */
+    
+
     public void markHandover(LocalDateTime now) {
         if (!status.canHandover()) {
             throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
@@ -193,11 +167,8 @@ public class Transaction extends BaseEntity {
         this.handoverConfirmedAt = now;
     }
 
-    /**
-     * 라운드 11 — buyer 인수확인. 인계완료 → 거래완료 자동 전이 + completedAt 동기 set.
-     * ApplicationService 가 같은 트랜잭션 안에서 PointApplicationService.escrowRelease (정산) 호출.
-     * receiveConfirmedAt 과 completedAt 은 같은 시각 (자동 전이 의미).
-     */
+    
+
     public void markReceived(LocalDateTime now) {
         if (!status.canReceive()) {
             throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
@@ -206,7 +177,6 @@ public class Transaction extends BaseEntity {
         this.receiveConfirmedAt = now;
         this.completedAt = now;
     }
-
 
     public void cancel(LocalDateTime now, String reason) {
         if (!status.canCancel()) {

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionMonthlyStat.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionMonthlyStat.java
@@ -2,11 +2,4 @@ package com.sseulang.domain.transaction.domain;
 
 import java.time.YearMonth;
 
-/**
- * 월별 거래 집계 결과 — Admin dashboard 차트(recharts)용.
- *
- * @param month YYYY-MM 단위 (해당 월에 거래완료된 거래)
- * @param count 거래완료 건수
- * @param amount 합계 금액 (KRW)
- */
 public record TransactionMonthlyStat(YearMonth month, long count, long amount) { }

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -8,77 +8,46 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * Transaction Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
- */
 public interface TransactionRepository {
 
     Optional<Transaction> findById(Long id);
 
-    /**
-     * 비관적 쓰기 락(PESSIMISTIC_WRITE)으로 Transaction 조회. 같은 거래에 대한 동시 reserve/cancel/complete
-     * race 직렬화 — Codex 게이트 1 보강 (Critical: tx 행 자체에 락이 없어 reserve vs cancel 가
-     * Transaction=취소, Item=예약 불일치를 만들 수 있던 케이스 차단).
-     *
-     * <p>락 순서: <b>Transaction → Item</b>. 모든 write flow 가 동일 순서를 지켜 deadlock 회피.</p>
-     */
+    
+
     Optional<Transaction> findByIdForUpdate(Long id);
 
     Transaction save(Transaction transaction);
 
-    /**
-     * 라운드 12 (#3.2) — 한 채팅방 = 1 active transaction 정책 가드.
-     *
-     * <p>active 정의: status NOT IN (거래완료, 취소). 즉 채팅중 / 예약 / 인계완료 단계는 모두 active.
-     * legacy chat_room_id IS NULL 거래는 본 쿼리 영향 X (chat_room_id 컬럼 = ? 매칭).</p>
-     */
+    
+
     boolean existsActiveByChatRoomId(Long chatRoomId);
 
-    // ───────── 관리자 통계 ─────────
+    
 
-    /** 단일 GROUP BY 집계 — (status, count) 행 리스트 (가능한 모든 status 행 포함, 0 인 status 는 없음). */
+    
     List<TransactionStatusCount> countGroupByStatus();
 
-    /**
-     * 차트 dashboard — 기간 안 (created_at &gt;= from AND created_at &lt; to) tradeType 별 거래 카운트.
-     * to 는 exclusive. 빈 type 은 결과에 미포함 (호출자가 0 채움).
-     */
+    
+
     List<TradeTypeCount> countByTradeTypeBetween(LocalDateTime from, LocalDateTime to);
 
-    /**
-     * 차트 dashboard — 기간 안 status 별 거래 카운트. 라운드 11 의 5단계 status 그대로 반환.
-     * 그룹핑 (진행중/완료/취소) 은 ApplicationService 가 변환.
-     */
+    
+
     List<TransactionStatusCount> countByStatusBetween(LocalDateTime from, LocalDateTime to);
 
-    /** 차트용 — (tradeType, count) record. */
+    
     record TradeTypeCount(com.sseulang.domain.item.domain.TradeType tradeType, long count) { }
 
-    /**
-     * Admin 회원 카드용 — userId 가 buyer 또는 seller 로 참여한 transaction 의 (userId → count) 맵.
-     * 빈 입력은 빈 맵. 단일 GROUP BY 쿼리 — N+1 회피.
-     */
+    
+
     java.util.Map<Long, Long> countByUserIdsAsParticipant(java.util.Collection<Long> userIds);
 
-    /**
-     * 월별 거래 집계 — completed_at 기준 (status=거래완료 만). [from, to] 월 범위 inclusive.
-     * 결과는 월별 (year, month, count, sumPrice). 거래 0건 월은 응답에 포함되지 않음 (호출자가 0 채움).
-     */
+    
+
     List<TransactionMonthlyStat> countCompletedMonthly(java.time.YearMonth from, java.time.YearMonth to);
 
-    /**
-     * Admin 거래 검색 (round 9 + round 10 LIKE 보강). created_at [start, end] + tradeType / status + keyword.
-     *
-     * <p>keyword 처리 정책 (호출자 ApplicationService 책임):
-     * <ul>
-     *   <li>숫자 → transactionId 또는 itemId 정확 매칭</li>
-     *   <li>비숫자 → ApplicationService 가 UserApplicationService.findUserIdsByKeyword 로 변환 후
-     *       {@code matchedUserIds} 로 전달 (Transaction.sellerId/buyerId IN). 빈 매치는 빈 결과.</li>
-     * </ul>
-     * 모든 필터 nullable. 최신순.</p>
-     *
-     * @param matchedUserIds 비숫자 keyword 의 user 매치 결과. null 또는 empty 면 user 필터 미적용.
-     */
+    
+
     org.springframework.data.domain.Page<Transaction> adminSearch(
             java.time.LocalDateTime startDate,
             java.time.LocalDateTime endDate,
@@ -89,26 +58,14 @@ public interface TransactionRepository {
             org.springframework.data.domain.Pageable pageable
     );
 
-    // ───────── Review pending (follow-up #56) ─────────
+    
 
-    /**
-     * 사용자가 reviewer 로 아직 작성하지 않은 거래완료 transaction 목록 (페이징, completedAt DESC).
-     *
-     * <p>cross-aggregate read query — Review 와 NOT EXISTS 로 join. write flow 는 여전히
-     * 각 aggregate root 가 책임. 본 메서드는 read-only 라 도메인 invariant 를 깨지 않음.</p>
-     *
-     * @param userId    조회 주체 (seller 또는 buyer 중 하나로 참여)
-     * @param since     completedAt 하한 (보통 now - 7일) — 작성 가능 기간 밖은 제외
-     */
+    
+
     Page<Transaction> findPendingReviewable(Long userId, LocalDateTime since, Pageable pageable);
 
-    /**
-     * 마이페이지 거래 목록 — viewer 가 buyer/seller/양쪽 으로 참여한 거래 페이징.
-     *
-     * @param userId 조회 주체
-     * @param role   {@link TransactionRole#BUYER} = buyer 만, {@link TransactionRole#SELLER} = seller 만, null = 양쪽
-     * @param status null = 전체 (취소 포함), 명시 시 정확 일치
-     */
+    
+
     Page<Transaction> findMyTransactions(
             Long userId, TransactionRole role, TransactionStatus status, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatus.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatus.java
@@ -1,13 +1,7 @@
 package com.sseulang.domain.transaction.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 거래 상태. DB ENUM('채팅중','예약','인계완료','거래완료','취소') 1:1 매핑 (V16 라운드 11).
- * 가이드 §5.1: {@code 채팅중 → 예약 → 인계완료 → 거래완료} (또는 {@code 취소}).
- *
- * <p>라운드 11 흐름: 예약 시 buyer escrow hold, 인계확인(seller) → 인계완료, 인수확인(buyer) → 거래완료
- * 자동 전이 + 정산 (buyer hold 해제 + seller credit). 인계완료 이후 단순 취소 차단 — R2 분쟁 흐름.</p>
- */
+
 @Schema(description = "거래 상태 머신. 채팅중→예약→인계완료→거래완료 (또는 취소).")
 public enum TransactionStatus {
     채팅중,
@@ -24,19 +18,18 @@ public enum TransactionStatus {
         return this == 채팅중;
     }
 
-    /** seller 인계확인 — 예약 상태에서만 가능. */
+    
     public boolean canHandover() {
         return this == 예약;
     }
 
-    /** buyer 인수확인 — 인계완료 상태에서만 가능 (자동으로 거래완료 전이 + 정산). */
+    
     public boolean canReceive() {
         return this == 인계완료;
     }
 
-    /**
-     * 라운드 11 합의 (B-3): 채팅중 / 예약 단계만 단순 취소 가능. 인계완료 이후엔 차단 — R2 분쟁 endpoint 영역.
-     */
+    
+
     public boolean canCancel() {
         return this == 채팅중 || this == 예약;
     }

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatusCount.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionStatusCount.java
@@ -1,4 +1,3 @@
 package com.sseulang.domain.transaction.domain;
 
-/** 거래 상태별 집계 결과 — Repository GROUP BY 응답을 받기 위한 record. */
 public record TransactionStatusCount(TransactionStatus status, long count) {}

--- a/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionCanceledEvent.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionCanceledEvent.java
@@ -1,8 +1,5 @@
 package com.sseulang.domain.transaction.domain.event;
 
-/**
- * 거래 취소 시점 — 양쪽 참여자 알림용 (라운드 11). canceledByUserId 는 취소를 누른 사용자 (buyer 또는 seller).
- */
 public record TransactionCanceledEvent(
         Long transactionId,
         Long buyerId,

--- a/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionHandoverConfirmedEvent.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionHandoverConfirmedEvent.java
@@ -1,8 +1,5 @@
 package com.sseulang.domain.transaction.domain.event;
 
-/**
- * seller 인계확인 시점 — buyer 에게 인수확인 부탁 알림용 (라운드 11).
- */
 public record TransactionHandoverConfirmedEvent(
         Long transactionId,
         Long buyerId

--- a/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionReceiveConfirmedEvent.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionReceiveConfirmedEvent.java
@@ -1,8 +1,5 @@
 package com.sseulang.domain.transaction.domain.event;
 
-/**
- * buyer 인수확인 시점 — seller 에게 정산 완료 알림용 (라운드 11). settleAmount 는 seller 에게 적립된 금액.
- */
 public record TransactionReceiveConfirmedEvent(
         Long transactionId,
         Long sellerId,

--- a/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionReservedEvent.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/event/TransactionReservedEvent.java
@@ -1,8 +1,5 @@
 package com.sseulang.domain.transaction.domain.event;
 
-/**
- * 거래 예약 시점 — buyer 알림용 (라운드 11). reserve 트랜잭션 commit 후 listener 가 처리.
- */
 public record TransactionReservedEvent(
         Long transactionId,
         Long buyerId,

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -15,17 +15,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-/** Spring Data JPA — {@link TransactionRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
 interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT t FROM Transaction t WHERE t.id = :id")
     Optional<Transaction> findByIdForUpdate(@Param("id") Long id);
 
-    /**
-     * 라운드 12 (#3.2) — 한 채팅방 = 1 active transaction 가드.
-     * active = status NOT IN (거래완료, 취소). chat_room_id 미지정 (legacy) 거래는 매칭 X.
-     */
+    
+
     @Query("""
             SELECT (COUNT(t) > 0) FROM Transaction t
              WHERE t.chatRoomId = :chatRoomId
@@ -36,10 +33,8 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
             """)
     boolean existsActiveByChatRoomIdJpql(@Param("chatRoomId") Long chatRoomId);
 
-    /**
-     * status 별 거래 건수 집계. 단일 쿼리 — N+1 없음. 결과는 status 가 한 번이라도 등장한 행만 옴
-     * (0 건인 status 는 application 단에서 0 으로 채움). status 컬럼 인덱스 권장.
-     */
+    
+
     @Query("""
             SELECT new com.sseulang.domain.transaction.domain.TransactionStatusCount(t.status, COUNT(t))
               FROM Transaction t
@@ -47,7 +42,7 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
             """)
     List<TransactionStatusCount> countGroupByStatusJpql();
 
-    /** 차트 dashboard — 기간 [from, to) tradeType 별 카운트. created_at 기준. */
+    
     @Query("""
             SELECT new com.sseulang.domain.transaction.domain.TransactionRepository$TradeTypeCount(t.tradeType, COUNT(t))
               FROM Transaction t
@@ -57,7 +52,7 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
     List<com.sseulang.domain.transaction.domain.TransactionRepository.TradeTypeCount> countByTradeTypeBetweenJpql(
             @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 
-    /** 차트 dashboard — 기간 [from, to) status 별 카운트. created_at 기준. */
+    
     @Query("""
             SELECT new com.sseulang.domain.transaction.domain.TransactionStatusCount(t.status, COUNT(t))
               FROM Transaction t
@@ -67,14 +62,8 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
     List<TransactionStatusCount> countByStatusBetweenJpql(
             @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 
-    /**
-     * Admin 거래 검색 (round 9 + round 10). created_at [start, end] + tradeType / status / keywordId / matchedUserIds.
-     * 모두 nullable. 최신순.
-     *
-     * <p>keywordId: t.id 또는 t.itemId 정확 매칭 (숫자 keyword).</p>
-     * <p>matchedUserIds: t.sellerId 또는 t.buyerId 가 IN (cross-aggregate user LIKE 매치 결과).</p>
-     * <p>두 파라미터는 호출자가 mutually exclusive 로 채움 — 동시에 쓰면 OR 로 합쳐짐.</p>
-     */
+    
+
     @Query("""
             SELECT t FROM Transaction t
              WHERE (:start IS NULL OR t.createdAt >= :start)
@@ -99,7 +88,7 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
             Pageable pageable
     );
 
-    /** Admin 회원 카드용 — sellerId 로 참여한 거래 (sellerId, count). */
+    
     @Query("""
             SELECT t.sellerId AS userId, COUNT(t) AS cnt FROM Transaction t
              WHERE t.sellerId IN :ids
@@ -107,7 +96,7 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
             """)
     List<UserCountRow> countAsSellerRaw(@Param("ids") java.util.Collection<Long> ids);
 
-    /** Admin 회원 카드용 — buyerId 로 참여한 거래 (buyerId, count). */
+    
     @Query("""
             SELECT t.buyerId AS userId, COUNT(t) AS cnt FROM Transaction t
              WHERE t.buyerId IN :ids
@@ -120,10 +109,8 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
         Long getCnt();
     }
 
-    /**
-     * 월별 거래완료 집계 — completed_at YEAR/MONTH GROUP BY. native MySQL.
-     * Result projection: (year, month, count, amount). YearMonth 변환은 호출자.
-     */
+    
+
     @Query(value = """
             SELECT YEAR(completed_at) AS y, MONTH(completed_at) AS m,
                    COUNT(*) AS cnt, COALESCE(SUM(price), 0) AS amt
@@ -146,10 +133,8 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
         Long getAmt();
     }
 
-    /**
-     * Review 작성 대기 거래 — completedAt 하한 + 본인 참여 + 본인이 reviewer 인 review 가 아직 없는 것.
-     * Review 와 NOT EXISTS 로 cross-aggregate read (write 가 아니라 도메인 invariant 영향 X).
-     */
+    
+
     @Query(value = """
             SELECT t FROM Transaction t
              WHERE t.status = com.sseulang.domain.transaction.domain.TransactionStatus.거래완료
@@ -177,8 +162,8 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
                                                  @Param("since") LocalDateTime since,
                                                  Pageable pageable);
 
-    // ───────── 내 거래 목록 (마이페이지) ─────────
-    // role 4 분기 × status null/!=null 2 분기 = 6 메서드. role/status 모두 null 이 가장 흔한 케이스.
+    
+    
 
     @Query("""
             SELECT t FROM Transaction t

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -86,19 +86,19 @@ public class TransactionRepositoryImpl implements TransactionRepository {
             java.util.Collection<Long> matchedUserIds,
             Pageable pageable
     ) {
-        // round 10 — keyword 가 숫자면 keywordId 로, 비숫자면 호출자가 미리 LIKE 매치한 userIds 로.
-        // 둘 다 비어있고 keyword 만 있으면 (= 비숫자인데 매치 0건) 빈 결과 즉시 반환.
+        
+        
         boolean hasKeyword = keyword != null && !keyword.isBlank();
         Long keywordId = parseKeywordId(keyword);
         boolean hasUserIds = matchedUserIds != null && !matchedUserIds.isEmpty();
         if (hasKeyword && keywordId == null && !hasUserIds) {
             return new org.springframework.data.domain.PageImpl<>(java.util.Collections.emptyList(), pageable, 0);
         }
-        java.util.Collection<Long> userIdsParam = hasUserIds ? matchedUserIds : java.util.List.of(0L); // dummy IN — JPA 빈 IN 회피
+        java.util.Collection<Long> userIdsParam = hasUserIds ? matchedUserIds : java.util.List.of(0L); 
         return jpa.adminSearchJpql(startDate, endDate, tradeType, status, keywordId, hasUserIds, userIdsParam, pageable);
     }
 
-    /** keyword 가 숫자면 long, 아니면 null. */
+    
     private static Long parseKeywordId(String keyword) {
         if (keyword == null || keyword.isBlank()) return null;
         try {
@@ -118,7 +118,7 @@ public class TransactionRepositoryImpl implements TransactionRepository {
             throw new IllegalArgumentException("from 은 to 이전이어야 합니다");
         }
         java.time.LocalDateTime fromTs = from.atDay(1).atStartOfDay();
-        // toTs 는 (to.다음월 1일 00:00) — exclusive 경계로 to 월 마지막 순간까지 포함.
+        
         java.time.LocalDateTime toTs = to.plusMonths(1).atDay(1).atStartOfDay();
         return jpa.countCompletedMonthlyRaw(fromTs, toTs).stream()
                 .map(r -> new com.sseulang.domain.transaction.domain.TransactionMonthlyStat(

--- a/src/main/java/com/sseulang/domain/transaction/presentation/AdminTransactionController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/AdminTransactionController.java
@@ -17,13 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 
-/**
- * 관리자 거래 검색·관리. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
- *
- * <p>round 9 — AdminTransactionListPanel 의 mock 제거용. created_at 기준 [start, end] 범위 +
- * tradeType / status / keyword 필터. keyword 는 itemId/transactionId 숫자 매칭 (email/nickname
- * LIKE 는 follow-up). 최신순.</p>
- */
 @Tag(name = "AdminTransaction", description = "관리자 — 거래 검색/관리")
 @RestController
 @RequestMapping("/api/v1/admin/transactions")

--- a/src/main/java/com/sseulang/domain/transaction/presentation/MyTransactionsController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/MyTransactionsController.java
@@ -17,12 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 마이페이지 본인 거래 목록 — {@link TransactionController} 의 단건 조회와 별개로 페이징 list 제공.
- *
- * <p>role 쿼리 (buyer/seller) 로 탭 분리, status 쿼리 (한글 enum) 로 상태별 필터.
- * 둘 다 미지정 시 전체 (취소 포함).</p>
- */
 @Tag(name = "Transaction", description = "마이페이지 본인 거래 목록")
 @RestController
 @RequestMapping("/api/v1/users/me/transactions")

--- a/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
@@ -58,15 +58,8 @@ public class TransactionController {
         return ApiResponse.ok(TransactionResponse.from(transactionService.getById(id, requesterId)));
     }
 
-    /**
-     * 거래 상태 전이. action 별 분기 (라운드 11):
-     * <ul>
-     *   <li>{@code 예약}: seller. Item 비관적 락 + buyer escrow hold (잔액 부족 시 INSUFFICIENT_POINT).</li>
-     *   <li>{@code 인계확인}: seller. 예약 → 인계완료. 잔액 변동 X. 멱등.</li>
-     *   <li>{@code 인수확인}: buyer. 인계완료 → 거래완료 자동 전이 + 정산 (buyer hold 해제 + seller credit). 멱등.</li>
-     *   <li>{@code 취소}: 양쪽 참여자. 채팅중/예약 단계만 (인계완료 이후 차단 — R2 분쟁). 예약 단계 취소 시 Item 복원 + escrowRefund.</li>
-     * </ul>
-     */
+    
+
     @Operation(summary = "거래 상태 전이 (예약 / 인계확인 / 인수확인 / 취소)",
             description = "action 분기 — 예약: seller(잔액 부족 시 INSUFFICIENT_POINT), 인계확인: seller, "
                     + "인수확인: buyer(자동 거래완료 + 정산), 취소: 양쪽(채팅중/예약 단계만). "

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchAction.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchAction.java
@@ -2,10 +2,6 @@ package com.sseulang.domain.transaction.presentation.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * PATCH /transactions/{id} body 의 action 값. 라운드 11 합의 (B-2).
- * 사용자 의도 표현 — TransactionStatus enum 과 별도로 둔다 (예: 인계확인 → 인계완료 status 전이).
- */
 @Schema(description = "거래 상태 전이 액션. 예약(seller) / 인계확인(seller) / 인수확인(buyer) / 취소(양쪽).")
 public enum TransactionPatchAction {
     예약,

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchRequest.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchRequest.java
@@ -4,10 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-/**
- * 거래 상태 전이 요청. 라운드 11 — action enum 은 사용자 의도 표현
- * (예약 / 인계확인 / 인수확인 / 취소). cancelReason 은 action=취소 일 때만 의미.
- */
 @Schema(description = "거래 상태 전이. action 별 권한: 예약/인계확인=seller, 인수확인=buyer, 취소=양쪽 참여자.")
 public record TransactionPatchRequest(
         @Schema(description = "전이 액션", example = "예약",

--- a/src/main/java/com/sseulang/domain/user/application/AutoWithdrawalScheduler.java
+++ b/src/main/java/com/sseulang/domain/user/application/AutoWithdrawalScheduler.java
@@ -7,21 +7,12 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-/**
- * 활동 정지 누적 200일 이상 도달 사용자 자동 탈퇴 배치 (라운드 12 PR-F #8).
- *
- * <p>1차 트리거는 {@code UserApplicationService.adminSuspend} 내부 동기 분기 — 보통은 거기서 처리된다.
- * 본 스케줄러는 안전망: DB 수동 수정, 마이그레이션 backfill, 정책 변경 등으로 누락된 사용자를 매일 새벽 1시에
- * 청소한다.</p>
- *
- * <p>각 사용자는 별도 트랜잭션으로 처리 — 한 건 실패해도 다음 건 진행. 메일 발송 실패는 swallow.</p>
- */
 @Component
 public class AutoWithdrawalScheduler {
 
     private static final Logger log = LoggerFactory.getLogger(AutoWithdrawalScheduler.class);
 
-    /** 한 cycle 에 처리할 최대 건수 — 대량 발생 시 다음 cycle 로 자연 분산. */
+    
     private static final int BATCH_LIMIT = 100;
 
     private final UserApplicationService userService;
@@ -30,7 +21,7 @@ public class AutoWithdrawalScheduler {
         this.userService = userService;
     }
 
-    /** 매일 새벽 1시 KST. */
+    
     @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
     public void run() {
         List<Long> targets = userService.findAutoWithdrawTargetIds(BATCH_LIMIT);

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -23,7 +23,7 @@ public class UserApplicationService {
 
     private static final Logger log = LoggerFactory.getLogger(UserApplicationService.class);
 
-    /** 휴면 판정 — 90일 이상 미접속이면 dormant. status derive 와 search 양쪽에서 공유. */
+    
     private static final int DORMANT_THRESHOLD_DAYS = 90;
     private static final String USER_ROLE = "USER";
 
@@ -50,19 +50,8 @@ public class UserApplicationService {
         this.clock = clock;
     }
 
-    /**
-     * 소셜 가입/로그인 흐름 — (provider, providerId) 로 기존 user 조회. 없으면:
-     * <ol>
-     *   <li>같은 email 의 기존 user 가 있으면:
-     *     <ul>
-     *       <li>LOCAL 가입자 → <b>takeover</b>: linkSocial(provider, providerId), 기존 password 무효화 +
-     *           verified=true. 이메일 선점 공격 무력화 (게이트 1).</li>
-     *       <li>다른 provider OAuth 가입자 → AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER 거부</li>
-     *     </ul>
-     *   </li>
-     *   <li>같은 email user 없음 → 신규 OAuth user 생성 (verified=true).</li>
-     * </ol>
-     */
+    
+
     @Transactional
     public User findOrCreateBySocial(
             SocialProvider provider,
@@ -75,19 +64,18 @@ public class UserApplicationService {
                 .orElseGet(() -> linkOrCreate(provider, providerId, email, nickname, profileImage));
     }
 
-    /**
-     * 같은 email user 발견 분기 처리 (linking) + 없으면 신규 생성. {@code create} race 처리도 동일.
-     */
+    
+
     private User linkOrCreate(SocialProvider provider, String providerId, Email email, String nickname, String profileImage) {
         Optional<User> sameEmail = userRepository.findByEmail(email);
         if (sameEmail.isPresent()) {
             User existing = sameEmail.get();
             if (existing.getSocialProvider() == SocialProvider.LOCAL) {
-                // LOCAL 가입자 → OAuth takeover. 기존 password 무효화, social 정보 추가.
+                
                 existing.linkSocial(provider, providerId);
                 return existing;
             }
-            // 다른 OAuth provider — 본 PR scope 에선 multi-provider linking 미지원.
+            
             throw new BusinessException(ErrorCode.AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER);
         }
         return create(provider, providerId, email, nickname, profileImage);
@@ -98,10 +86,8 @@ public class UserApplicationService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
-    /**
-     * 본인 프로필 partial update — null 필드는 변경 X. 미인증 사용자도 호출 가능 (자금/거래 영향 0).
-     * profileImage 빈 문자열 = 이미지 제거.
-     */
+    
+
     @Transactional
     public User updateProfile(Long userId, String profileImage, String nickname) {
         User user = getById(userId);
@@ -109,13 +95,8 @@ public class UserApplicationService {
         return user;
     }
 
-    /**
-     * 민감 기능 진입 가드 — 이메일 인증 미완료 시 {@link ErrorCode#AUTH_EMAIL_NOT_VERIFIED} (FORBIDDEN).
-     * 거래 시작 / 결제 / 출금 / Item 등록 등 자금·신뢰 영향 흐름의 첫 진입점에서 호출.
-     *
-     * <p>Codex round 9 hotfix — blocked / deleted / suspended 도 함께 차단. 정지된 사용자가
-     * 이미 발급된 AT 로 거래/결제/출금 진입하던 회귀 차단.</p>
-     */
+    
+
     public void requireVerified(Long userId) {
         User user = getById(userId);
         if (!user.isAccessibleAt(java.time.LocalDateTime.now(clock))) {
@@ -126,23 +107,15 @@ public class UserApplicationService {
         }
     }
 
-    /**
-     * 가이드 §4.7 — Review 작성 시점에 호출. review_count / rating_sum 누적 + trust_score 재계산.
-     * 단일 native UPDATE 라 동시 review 작성 race 안전 (Codex 게이트 2 보강 — 기존 AVG 서브쿼리
-     * 방식의 REPEATABLE_READ stale view 문제 차단). Review 도메인은 본 메서드만 의존
-     * (UserRepository 직접 호출 금지, CLAUDE.md §3.3).
-     */
+    
+
     @Transactional
     public void recordReview(Long revieweeId, int rating) {
         userRepository.recordReviewFor(revieweeId, rating);
     }
 
-    /**
-     * 가이드 §4.8 — point_balance atomic 증가. 충전(Day 7) / 거래 정산 적립(Day 8) 호출.
-     * Payment 도메인은 본 메서드만 의존 (UserRepository 직접 호출 금지, CLAUDE.md §3.3).
-     * amount 는 양수 강제. UPDATE 영향 행 0 건 → USER_NOT_FOUND 로 트랜잭션 롤백
-     * (Codex 게이트 1 보강 — 결제 완료 상태로 전이됐는데 포인트 미적립 dangling 차단).
-     */
+    
+
     @Transactional
     public void creditPoint(Long userId, long amount) {
         if (amount <= 0) {
@@ -154,11 +127,8 @@ public class UserApplicationService {
         }
     }
 
-    /**
-     * 가이드 §4.8 / §5.3 — point_balance atomic 차감. 거래 결제 (구매자) / 출금 신청에서 호출.
-     * 잔액 부족 시 affected=0 → INSUFFICIENT_POINT 로 트랜잭션 롤백 (음수 방지 가드).
-     * Point 도메인은 본 메서드만 의존 (UserRepository 직접 호출 금지, CLAUDE.md §3.3).
-     */
+    
+
     @Transactional
     public void deductPoint(Long userId, long amount) {
         if (amount <= 0) {
@@ -170,10 +140,8 @@ public class UserApplicationService {
         }
     }
 
-    /**
-     * 잔액 단건 조회 — atomic UPDATE 직후 balance_after 적재용. native scalar 라 영속성 컨텍스트
-     * stale 우회. 미존재 userId 시 USER_NOT_FOUND.
-     */
+    
+
     public long getPointBalance(Long userId) {
         Long balance = userRepository.findPointBalance(userId);
         if (balance == null) {
@@ -182,11 +150,8 @@ public class UserApplicationService {
         return balance;
     }
 
-    /**
-     * 가이드 §5.1 거래 hold (라운드 11) — buyer point_balance 차감 + point_hold 적립을 단일 atomic UPDATE.
-     * 잔액 부족 시 INSUFFICIENT_POINT (음수 방지 가드). amount 양수 강제.
-     * Transaction 도메인은 Point 도메인을 통해 호출, 본 메서드는 UserRepository 위임 단일 진입점.
-     */
+    
+
     @Transactional
     public void holdForEscrow(Long userId, long amount) {
         if (amount <= 0) {
@@ -198,10 +163,8 @@ public class UserApplicationService {
         }
     }
 
-    /**
-     * 거래완료 정산 — buyer point_hold 만 차감 (seller credit 은 creditPoint 별도 호출).
-     * affected=0 = hold 잔액 부족 (운영 이상 — 가드 회귀) → TRANSACTION_HOLD_FAILED.
-     */
+    
+
     @Transactional
     public void releaseHold(Long userId, long amount) {
         if (amount <= 0) {
@@ -213,10 +176,8 @@ public class UserApplicationService {
         }
     }
 
-    /**
-     * 거래 취소 환불 — buyer point_hold 차감 + point_balance 적립을 단일 atomic UPDATE.
-     * affected=0 = hold 잔액 부족 (운영 이상 — 가드 회귀) → TRANSACTION_HOLD_FAILED.
-     */
+    
+
     @Transactional
     public void refundHold(Long userId, long amount) {
         if (amount <= 0) {
@@ -228,18 +189,18 @@ public class UserApplicationService {
         }
     }
 
-    /** 차트 dashboard — 기간 [from, to) 가입자 수. */
+    
     public long countSignupsBetween(java.time.LocalDateTime from, java.time.LocalDateTime to) {
         return userRepository.countSignupsBetween(from, to);
     }
 
-    /** 차트 dashboard — 일자별 가입자 수 (빈 일은 미포함, 호출자가 0 채움). */
+    
     public java.util.List<UserRepository.DailyCount> findDailySignups(
             java.time.LocalDateTime from, java.time.LocalDateTime to) {
         return userRepository.findDailySignups(from, to);
     }
 
-    /** point_hold 단건 scalar 조회 (UI/통계용 + history balance_after 보강용). */
+    
     public long getPointHold(Long userId) {
         Long hold = userRepository.findPointHold(userId);
         if (hold == null) {
@@ -248,26 +209,21 @@ public class UserApplicationService {
         return hold;
     }
 
-    /**
-     * 잔액 + hold 단일 SELECT 스냅샷 — 잔액 페이지 3분할 표시 응답의 race-safe 일관성.
-     * balance / hold 분리 read 시 동시 reserve/cancel/refund 사이에 끼어 합산이 어긋날 수 있어 통합 (게이트 1 W-1).
-     */
+    
+
     public com.sseulang.domain.user.domain.UserRepository.PointSnapshot getPointSnapshot(Long userId) {
         return userRepository.findPointSnapshot(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
-    /**
-     * 관리자 회원 목록 — created_at DESC 페이징. 차단/삭제 상태 모두 포함.
-     */
+    
+
     public Page<User> adminFindAll(Pageable pageable) {
         return userRepository.findAllForAdmin(pageable);
     }
 
-    /**
-     * Admin 회원 검색 + enrich. status/keyword/created_at 범위 필터 후 페이지의 userIds 로 batch
-     * tradeCount / reportCount 집계 (N+1 회피).
-     */
+    
+
     public Page<com.sseulang.domain.user.application.dto.AdminUserResult> adminSearch(
             com.sseulang.domain.user.application.dto.AdminUserSearchCriteria criteria,
             Pageable pageable
@@ -288,7 +244,7 @@ public class UserApplicationService {
         ));
     }
 
-    /** 단건 enrich — 관리자 단건 조회. */
+    
     public com.sseulang.domain.user.application.dto.AdminUserResult adminGetEnriched(Long userId) {
         User u = getById(userId);
         java.time.LocalDateTime now = java.time.LocalDateTime.now(clock);
@@ -298,26 +254,22 @@ public class UserApplicationService {
         return com.sseulang.domain.user.application.dto.AdminUserResult.from(u, now, DORMANT_THRESHOLD_DAYS, trades, reports);
     }
 
-    /**
-     * 관리자 차단/해제 — Aggregate {@code block()/unblock()} 위임. 미존재 userId → USER_NOT_FOUND.
-     * 멱등 (이미 차단된 사용자를 또 차단해도 OK).
-     */
+    
+
     @Transactional
     public void adminSetBlocked(Long userId, boolean blocked) {
         User u = getById(userId);
         if (blocked) {
             u.block();
-            // 즉시 RT 무효화 — 기존 세션이 refresh 로 살아남는 회귀 차단 (Codex round 9 hotfix).
+            
             refreshTokenStore.revokeAll(USER_ROLE, userId);
         } else {
             u.unblock();
         }
     }
 
-    /**
-     * 관리자 시한부 활동정지 — N일 동안. days >= 1. RT 즉시 무효화.
-     * 라운드 12 PR-F #8 — 누적 정지 200일 이상 도달 시 자동 탈퇴 처리 + 안내 메일 발송.
-     */
+    
+
     @Transactional
     public void adminSuspend(Long userId, int days) {
         User u = getById(userId);
@@ -329,7 +281,7 @@ public class UserApplicationService {
         }
     }
 
-    /** 발송 실패는 swallow — soft delete 자체는 트랜잭션 commit 으로 확정. */
+    
     private void sendAutoWithdrawnNotice(User u) {
         try {
             emailSender.sendAutoWithdrawnEmail(u.email().value(), u.getCumulativeSuspendDays());
@@ -338,25 +290,21 @@ public class UserApplicationService {
         }
     }
 
-    /** 관리자 활동정지 즉시 해제. */
+    
     @Transactional
     public void adminUnsuspend(Long userId) {
         User u = getById(userId);
         u.unsuspend();
     }
 
-    /**
-     * 라운드 12 PR-F #8 — 자동 탈퇴 배치 후크. 누적 200일 이상 + 살아있는 사용자 일괄 처리.
-     * adminSuspend 직후 동기 분기는 1차 트리거이고, 이 메서드는 안전망 (DB 수동 변경/마이그레이션 케이스).
-     * 각 user 는 별도 트랜잭션으로 처리 — 한 건 실패해도 다음 건 진행.
-     */
+    
+
     public java.util.List<Long> findAutoWithdrawTargetIds(int limit) {
         return userRepository.findAutoWithdrawTargetIds(200, limit);
     }
 
-    /**
-     * 단건 자동 탈퇴 처리. 이미 deleted 거나 누적 미달이면 no-op. 안내 메일 발송 + RT 무효화.
-     */
+    
+
     @Transactional
     public boolean processAutoWithdrawal(Long userId) {
         User u = userRepository.findById(userId).orElse(null);
@@ -369,27 +317,20 @@ public class UserApplicationService {
         return true;
     }
 
-    /**
-     * Admin 거래 검색 (round 10) — keyword 로 매칭되는 user id 리스트.
-     * cross-aggregate keyword (email/nickname LIKE) 매칭 시 호출자가 IN 절로 사용.
-     * limit 으로 IN 절 폭주 방지.
-     */
+    
+
     public java.util.List<Long> findUserIdsByKeyword(String keyword, int limit) {
         return userRepository.findIdsByKeywordLike(keyword, limit);
     }
 
-    /** 로그인 성공 직후 호출 — 마지막 로그인 시각 기록 (휴면 판정 기준). 미존재 userId 무시. */
+    
     @Transactional
     public void recordLogin(Long userId) {
         userRepository.findById(userId).ifPresent(u -> u.recordLogin(java.time.LocalDateTime.now(clock)));
     }
 
-    /**
-     * 관리자 회원 통계 — total / blocked / deleted / active 모두 직접 집계.
-     * active 는 별도 쿼리(`WHERE blocked=false AND deleted=false`) 로 정확 — 이중 차감(blocked &&
-     * deleted) 시나리오에서도 정확 (게이트 2 보강).
-     * stats 도메인이 본 메서드만 의존하도록 하여 UserRepository 직접 호출 차단 (CLAUDE.md §3.3).
-     */
+    
+
     public UserStatsResult adminGetStats() {
         long total = userRepository.countAll();
         long blocked = userRepository.countBlocked();
@@ -403,8 +344,8 @@ public class UserApplicationService {
         try {
             return userRepository.save(newUser);
         } catch (DataIntegrityViolationException race) {
-            // 본 catch 는 UNIQUE 충돌 race 만 보정. 다른 제약(닉네임 길이 등) 은 그대로 던져
-            // 시스템 에러로 처리한다 — 사용자에게 잘못된 USER_EMAIL_DUPLICATED 응답 방지.
+            
+            
             return resolveRaceOrRethrow(provider, providerId, email, race);
         }
     }
@@ -412,12 +353,12 @@ public class UserApplicationService {
     private User resolveRaceOrRethrow(
             SocialProvider provider, String providerId, Email email, DataIntegrityViolationException race
     ) {
-        // race winner 가 같은 (provider, providerId) 면 그것을 반환
+        
         Optional<User> raceWinner = userRepository.findBySocial(provider, providerId);
         if (raceWinner.isPresent()) {
             return raceWinner.get();
         }
-        // 다른 user 가 같은 email 로 가입했다면 linking 흐름 재진입 (takeover or 거부)
+        
         Optional<User> sameEmail = userRepository.findByEmail(email);
         if (sameEmail.isPresent()) {
             User existing = sameEmail.get();
@@ -427,7 +368,7 @@ public class UserApplicationService {
             }
             throw new BusinessException(ErrorCode.AUTH_EMAIL_ALREADY_LINKED_TO_DIFFERENT_PROVIDER);
         }
-        // UNIQUE 충돌이 아닌 다른 제약 위반 — 시스템 에러로 그대로 노출
+        
         throw race;
     }
 }

--- a/src/main/java/com/sseulang/domain/user/application/dto/AdminUserResult.java
+++ b/src/main/java/com/sseulang/domain/user/application/dto/AdminUserResult.java
@@ -7,11 +7,6 @@ import com.sseulang.domain.user.domain.UserStatus;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-/**
- * Admin 회원 카드용 enriched Result. tradeCount/reportCount 는 다른 도메인에서 batch fetch 후 채움.
- *
- * <p>{@code dormant}/{@code status} 는 User Aggregate 의 derive 결과 — DB 컬럼 X.</p>
- */
 public record AdminUserResult(
         Long id,
         String email,

--- a/src/main/java/com/sseulang/domain/user/application/dto/AdminUserSearchCriteria.java
+++ b/src/main/java/com/sseulang/domain/user/application/dto/AdminUserSearchCriteria.java
@@ -4,15 +4,6 @@ import com.sseulang.domain.user.domain.UserStatus;
 
 import java.time.LocalDateTime;
 
-/**
- * Admin 회원 검색 조건. null/blank 필드는 무시.
- *
- * <ul>
- *   <li>{@code keyword} — 닉네임 또는 이메일 LIKE 검색</li>
- *   <li>{@code status} — ACTIVE / SUSPENDED / WITHDRAWN / DORMANT (derive 기반)</li>
- *   <li>{@code createdAfter} / {@code createdBefore} — created_at 범위 (각 inclusive)</li>
- * </ul>
- */
 public record AdminUserSearchCriteria(
         String keyword,
         UserStatus status,

--- a/src/main/java/com/sseulang/domain/user/application/dto/UserStatsResult.java
+++ b/src/main/java/com/sseulang/domain/user/application/dto/UserStatsResult.java
@@ -2,11 +2,6 @@ package com.sseulang.domain.user.application.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * 회원 통계 — total / blocked / deleted 의 단순 카운트.
- * active = total − (blocked + deleted) 는 derived. 단, blocked && deleted 인 사용자가 있으면
- * active 계산에 음수가 나올 수 있어 service 에서 max(0, ...) 가드.
- */
 @Schema(description = "관리자 dashboard — 회원 통계.")
 public record UserStatsResult(
         @Schema(example = "1234", description = "전체 회원 수 (탈퇴/차단 포함)") long total,

--- a/src/main/java/com/sseulang/domain/user/domain/Email.java
+++ b/src/main/java/com/sseulang/domain/user/domain/Email.java
@@ -2,12 +2,6 @@ package com.sseulang.domain.user.domain;
 
 import java.util.regex.Pattern;
 
-/**
- * 이메일 VO. 불변 + 자가 검증.
- *
- * <p>JPA 매핑은 {@link User} 의 {@code String email} 컬럼이 책임지고, 도메인 layer 는
- * 의미적 wrapper 로 본 record 만 사용한다.</p>
- */
 public record Email(String value) {
 
     private static final int MAX_LENGTH = 100;
@@ -18,7 +12,7 @@ public record Email(String value) {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException("이메일은 필수입니다");
         }
-        // 정규화: provider 별 대소문자 차이로 인한 중복 판단 흔들림 방지
+        
         value = value.trim().toLowerCase();
         if (value.length() > MAX_LENGTH) {
             throw new IllegalArgumentException("이메일은 100자 이하여야 합니다");

--- a/src/main/java/com/sseulang/domain/user/domain/SocialProvider.java
+++ b/src/main/java/com/sseulang/domain/user/domain/SocialProvider.java
@@ -1,14 +1,7 @@
 package com.sseulang.domain.user.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 사용자 가입 출처. V1 스키마의 {@code users.social_provider} 컬럼(VARCHAR(20))과 1:1 매핑.
- * <ul>
- *   <li>{@link #LOCAL} — 이메일/비밀번호 가입 (5/6 이후 영역)</li>
- *   <li>{@link #KAKAO} / {@link #GOOGLE} — 소셜 가입 (Day 3)</li>
- *   <li>{@link #DEV} — 로컬 smoke test 전용 (Codex 게이트 1 보강 — KAKAO provider 의미 오염 차단)</li>
- * </ul>
- */
+
 @Schema(description = "사용자 가입 출처. LOCAL(이메일/비밀번호) / KAKAO / GOOGLE / DEV(로컬 전용).")
 public enum SocialProvider {
     LOCAL,

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -17,15 +17,6 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-/**
- * User Aggregate Root. V1 스키마 {@code users} 매핑.
- *
- * <p>본 PR(Day 3 OAuth) 범위에서 다루는 필드만 매핑. 나머지(point_balance / trust_score /
- * password / address ...) 는 후속 도메인 작업에서 필요 시 추가. JPA validate 는 entity 가 가진
- * 컬럼이 DB 에 있는지만 검사하므로 선택 매핑 가능.</p>
- *
- * <p>Setter 없음. 상태 변경은 명시된 비즈니스 메서드로만.</p>
- */
 @Entity
 @Table(name = "users")
 @Getter
@@ -55,105 +46,71 @@ public class User extends BaseEntity {
     @Column(name = "social_id", length = 100)
     private String socialId;
 
-    /**
-     * BCrypt 해싱된 비밀번호. LOCAL 가입 사용자에게만 채워짐 (소셜 가입은 null).
-     * 평문 비밀번호 검증/해싱은 application layer 의 {@code LocalAuthService} 책임 — 도메인 layer 는
-     * Spring Security 의존 X (CLAUDE.md §3.3).
-     */
+    
+
     @Column(name = "password", length = 255)
     private String password;
 
-    /**
-     * 이메일 소유 검증 여부. OAuth 가입자는 provider 가 검증한 이메일이라 자동 true,
-     * LOCAL 가입자는 인증 메일 클릭 후 true. 민감 기능 (거래/결제/출금/Item 등록) 가드의 기준.
-     * V6 마이그레이션에서 컬럼 추가 + OAuth 사용자 backfill.
-     */
+    
+
     @Column(name = "email_verified", nullable = false)
     private boolean emailVerified;
 
-    /**
-     * 마지막 로그인 시각 (V14). 휴면(dormant) 판정용 — 90일 이상 미접속이면 dormant.
-     * LocalAuthService / OAuthLoginService 가 로그인 성공 시 갱신.
-     */
+    
+
     @Column(name = "last_login_at")
     private LocalDateTime lastLoginAt;
 
     @Column(name = "is_blocked", nullable = false)
     private boolean blocked;
 
-    /**
-     * 시한부 활동정지 (V14). is_blocked(영구) 와 별개. suspended_at + suspend_days 가 만료시각.
-     * 만료 후엔 자동 해제 (status 계산 시점에 derive).
-     */
+    
+
     @Column(name = "suspended_at")
     private LocalDateTime suspendedAt;
 
     @Column(name = "suspend_days")
     private Integer suspendDays;
 
-    /**
-     * 활동 정지 누적 일수 (라운드 12 PR-F #8). 200일 이상 자동 탈퇴 (soft delete).
-     * suspend() 호출 시마다 += days. 기존 row 는 0 (V24 부터 누적 시작).
-     */
+    
+
     @Column(name = "cumulative_suspend_days", nullable = false)
     private int cumulativeSuspendDays;
 
     @Column(name = "is_deleted", nullable = false)
     private boolean deleted;
 
-    /**
-     * 신뢰도(거래 후 받은 리뷰 평균). 가이드 §4.7 — 리뷰 작성 시점에 review_count + rating_sum 을
-     * 단일 atomic UPDATE 로 누적해 race 안전 (Codex 게이트 2 보강).
-     * 리뷰 0건이면 null ("신규" 표시용).
-     */
+    
+
     @Column(name = "trust_score", precision = 3, scale = 2)
     private BigDecimal trustScore;
 
-    /** 누적 리뷰 수. trust_score 정합성을 위해 atomic 갱신 (V3 마이그). */
+    
     @Column(name = "review_count", nullable = false)
     private int reviewCount;
 
-    /** 누적 별점 합계. trust_score = rating_sum / review_count (review_count > 0). */
+    
     @Column(name = "rating_sum", nullable = false)
     private int ratingSum;
 
-    /**
-     * 포인트 잔액(원). 가이드 §4.8 충전식 머니 — 충전/사용/적립/환불은 모두 atomic SQL UPDATE.
-     * 본 필드 setter 없음 — UserRepository.creditPointBalance 등 atomic 메서드만이 갱신.
-     */
+    
+
     @Column(name = "point_balance", nullable = false)
     private long pointBalance;
 
-    /**
-     * 거래 보관 잔액 (escrow hold) — 가이드 §5.1 라운드 11. 예약 시 buyer point_balance 에서
-     * 차감해 본 컬럼에 적립. 거래완료(인수확인) 시 hold 해제 + seller credit, 취소 시 buyer 환불.
-     *
-     * <p>point_balance 와 분리한 이유 (라운드 11 합의 B-3 A안):
-     * <ul>
-     *   <li>잔액 표시 — 즉시 사용 가능(balance) vs 거래 보관(hold) 3분할 UI</li>
-     *   <li>가이드 §5.3 원자 연산 — 단일 SQL UPDATE 로 두 컬럼 동시 변경, race-safe</li>
-     *   <li>잔액 부족 가드 — WHERE point_balance &gt;= :amount 가 hold 무관하게 깔끔</li>
-     * </ul>
-     *
-     * <p>본 필드 setter 없음 — UserRepository.holdForEscrow / releaseHold / refundHold
-     * atomic 메서드만이 갱신. CHECK point_hold &gt;= 0 (V16).</p>
-     */
+    
+
     @Column(name = "point_hold", nullable = false)
     private long pointHold;
 
-    /**
-     * JPA optimistic lock — V7 마이그레이션. LOCAL takeover 처럼 read-modify-write 흐름에서 두
-     * 트랜잭션이 같은 user 를 동시 변경하면 OptimisticLockException 으로 한 쪽이 실패한다 (게이트 1).
-     * 단순 atomic UPDATE (point_balance 등) 는 본 컬럼을 갱신하지 않는다 — JPA dirty-check 시점에만 동작.
-     */
+    
+
     @Version
     @Column(name = "version", nullable = false)
     private long version;
 
-    /**
-     * 소셜 가입 흐름의 정적 팩토리. (provider, providerId) 가 비어있을 수 없으며 LOCAL 은 거부.
-     * 일반 회원가입 흐름은 별도 팩토리(예: {@code createLocalUser})로 분리.
-     */
+    
+
     public static User createSocialUser(
             SocialProvider provider,
             String providerId,
@@ -177,16 +134,14 @@ public class User extends BaseEntity {
         u.profileImage = profileImage;
         u.socialProvider = provider;
         u.socialId = providerId;
-        u.emailVerified = true;  // OAuth provider 가 이메일 소유 검증 — 자동 verified
+        u.emailVerified = true;  
         u.blocked = false;
         u.deleted = false;
         return u;
     }
 
-    /**
-     * LOCAL 가입 정적 팩토리. 비밀번호는 호출자(LocalAuthService) 가 BCrypt 해싱한 결과만 받음 —
-     * 도메인 layer 가 평문/해싱 전환 책임지지 않음 (Spring Security 의존성 회피, CLAUDE.md §3.3).
-     */
+    
+
     public static User createLocalUser(Email email, String hashedPassword, String nickname) {
         if (email == null) {
             throw new IllegalArgumentException("email 은 필수입니다");
@@ -204,29 +159,24 @@ public class User extends BaseEntity {
         u.socialProvider = SocialProvider.LOCAL;
         u.socialId = null;
         u.password = hashedPassword;
-        u.emailVerified = false;  // LOCAL 가입은 인증 메일 클릭 전까지 false
+        u.emailVerified = false;  
         u.blocked = false;
         u.deleted = false;
         return u;
     }
 
-    /** LOCAL 가입 사용자만 비밀번호 보유. 소셜 가입은 null 반환. */
+    
     public boolean hasPassword() {
         return password != null && !password.isBlank();
     }
 
-    /** 이메일 인증 완료. 멱등 호출 가능. */
+    
     public void markEmailVerified() {
         this.emailVerified = true;
     }
 
-    /**
-     * 본인 프로필 partial update. null 인 필드는 변경하지 않음 (PATCH 의미).
-     * 빈 문자열 nickname 은 거부.
-     *
-     * @param newProfileImage S3 GET URL (또는 key). null 이면 변경 X. 빈 문자열은 이미지 제거 의도로 허용 — null 로 설정.
-     * @param newNickname 새 닉네임 (1~50자). null 이면 변경 X.
-     */
+    
+
     public void updateProfile(String newProfileImage, String newNickname) {
         if (newNickname != null) {
             if (newNickname.isBlank() || newNickname.length() > 50) {
@@ -235,18 +185,13 @@ public class User extends BaseEntity {
             this.nickname = newNickname.trim();
         }
         if (newProfileImage != null) {
-            // 빈 문자열 → 이미지 제거 (null 로 저장)
+            
             this.profileImage = newProfileImage.isBlank() ? null : newProfileImage;
         }
     }
 
-    /**
-     * OAuth takeover — 기존 LOCAL user 가 점유한 email 에 진짜 owner 가 OAuth 로 가입 시도.
-     * 기존 user 의 password 무효화 + social 정보 추가 + verified=true. 공격자(LOCAL 가입자)는
-     * 더 이상 비밀번호로 로그인 불가. 게이트 1: 이메일 선점 공격 무력화.
-     *
-     * <p>호출 전제: 같은 user 가 다른 OAuth provider 와 연결되지 않은 상태 — 호출자가 검증.</p>
-     */
+    
+
     public void linkSocial(SocialProvider provider, String socialId) {
         if (provider == null || provider == SocialProvider.LOCAL) {
             throw new IllegalArgumentException("소셜 provider 는 LOCAL 외여야 합니다");
@@ -256,34 +201,33 @@ public class User extends BaseEntity {
         }
         this.socialProvider = provider;
         this.socialId = socialId;
-        // takeover — 기존 LOCAL 비밀번호 무효화 (공격자 차단)
+        
         this.password = null;
         this.emailVerified = true;
     }
 
-    /** 도메인 layer 외부에서 raw String 대신 VO 로 다루도록 의미적 wrapper. */
+    
     public Email email() {
         return new Email(email);
     }
 
-    /** 관리자 차단 — 이미 차단/삭제된 계정도 멱등 호출 가능 (true 보장). */
+    
     public void block() {
         this.blocked = true;
     }
 
-    /** 관리자 차단 해제 — 멱등 호출. */
+    
     public void unblock() {
         this.blocked = false;
     }
 
-    /** 로그인 성공 시점 기록. dormant 판정 기준. */
+    
     public void recordLogin(LocalDateTime now) {
         this.lastLoginAt = now;
     }
 
-    /**
-     * 시한부 활동정지. days >= 1. now 부터 N일 동안. 라운드 12 PR-F #8 — cumulative_suspend_days 누적.
-     */
+    
+
     public void suspend(int days, LocalDateTime now) {
         if (days < 1) {
             throw new IllegalArgumentException("days 는 1 이상이어야 합니다");
@@ -296,23 +240,23 @@ public class User extends BaseEntity {
         this.cumulativeSuspendDays += days;
     }
 
-    /** 라운드 12 PR-F #8 — 누적 정지 200일 이상 도달 시 자동 탈퇴 대상. */
+    
     public boolean isAutoWithdrawTarget() {
         return !this.deleted && this.cumulativeSuspendDays >= 200;
     }
 
-    /** 라운드 12 PR-F #8 — 자동 탈퇴 처리 (soft delete). */
+    
     public void markAutoWithdrawn() {
         this.deleted = true;
     }
 
-    /** 활동정지 즉시 해제. */
+    
     public void unsuspend() {
         this.suspendedAt = null;
         this.suspendDays = null;
     }
 
-    /** 활동정지가 아직 유효 (만료 전). suspendedAt 없거나 만료됐으면 false. */
+    
     public boolean isSuspendedAt(LocalDateTime now) {
         if (suspendedAt == null || suspendDays == null || suspendDays <= 0) {
             return false;
@@ -321,22 +265,16 @@ public class User extends BaseEntity {
         return now != null && now.isBefore(expiresAt);
     }
 
-    /**
-     * 휴면 — lastLoginAt 이 dormantThresholdDays 이상 과거. lastLoginAt 없으면 createdAt 기준.
-     *
-     * <p>경계: 정확히 N일째 (base + N days == now) 도 dormant 로 본다. SQL 의 검색 쿼리
-     * ({@code COALESCE(last_login_at, created_at) <= now - N days}) 와 일관 (round 12 boundary
-     * 통일). 이전엔 Java 만 strict before 라 정확 N일째 ACTIVE / SQL 만 DORMANT 로 분기 → 같은 시점
-     * 같은 user 가 단건 조회와 검색 결과에서 다르게 나오던 회귀.</p>
-     */
+    
+
     public boolean isDormantAt(LocalDateTime now, int dormantThresholdDays) {
         if (now == null) return false;
         LocalDateTime base = lastLoginAt != null ? lastLoginAt : getCreatedAt();
         if (base == null) return false;
-        return !base.plusDays(dormantThresholdDays).isAfter(now);  // <= (inclusive)
+        return !base.plusDays(dormantThresholdDays).isAfter(now);  
     }
 
-    /** Admin 응답용 status derive — WITHDRAWN > SUSPENDED > DORMANT > ACTIVE 우선순위. */
+    
     public UserStatus derivedStatus(LocalDateTime now, int dormantThresholdDays) {
         if (deleted) return UserStatus.WITHDRAWN;
         if (isSuspendedAt(now)) return UserStatus.SUSPENDED;
@@ -344,10 +282,8 @@ public class User extends BaseEntity {
         return UserStatus.ACTIVE;
     }
 
-    /**
-     * 인증/민감 기능 진입 가능한 상태인지. blocked / deleted / suspended (만료 전) 모두 차단.
-     * Codex 게이트 2 (round 9 hotfix) — 정지된 사용자가 기존 AT/RT 로 거래/결제/출금 진입하던 회귀 차단.
-     */
+    
+
     public boolean isAccessibleAt(LocalDateTime now) {
         return !blocked && !deleted && !isSuspendedAt(now);
     }

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -5,10 +5,6 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
-/**
- * User Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
- * 구현은 {@code domain/user/infrastructure/persistence}.
- */
 public interface UserRepository {
 
     Optional<User> findById(Long id);
@@ -19,14 +15,11 @@ public interface UserRepository {
 
     User save(User user);
 
-    /** 관리자 회원 목록 페이징. 차단/삭제 상태 필터는 후속, 일단 전체 노출. created_at DESC. */
+    
     Page<User> findAllForAdmin(Pageable pageable);
 
-    /**
-     * Admin 회원 검색 — keyword(nickname/email LIKE), status filter, created_at 범위.
-     * status 는 derive 기반 — DB 컬럼 직접 매칭 대신 SQL 조건으로 변환.
-     * dormantThresholdDays / now 는 DORMANT/SUSPENDED 계산 기준.
-     */
+    
+
     Page<User> searchForAdmin(
             com.sseulang.domain.user.application.dto.AdminUserSearchCriteria criteria,
             java.time.LocalDateTime now,
@@ -34,114 +27,79 @@ public interface UserRepository {
             Pageable pageable
     );
 
-    /**
-     * 가이드 §4.7 — 리뷰 작성 시점에 review_count / rating_sum 을 단일 원자 UPDATE 로 누적하고
-     * trust_score 를 즉시 재계산. Codex 게이트 2 (2026-04-29) 보강 — REPEATABLE_READ + AVG 서브쿼리
-     * 의 stale read view 회귀를 누적 컬럼으로 차단.
-     */
+    
+
     int recordReviewFor(Long revieweeId, int rating);
 
-    /**
-     * 가이드 §4.8 — 포인트 잔액 atomic 증가 (충전 / 거래 정산 적립). amount 양수 강제.
-     * 단일 SQL UPDATE 라 동시 충전 race 안전. 영향받은 행 수 반환.
-     */
+    
+
     int creditPointBalance(Long userId, long amount);
 
-    /**
-     * 가이드 §4.8 / §5.3 — 포인트 잔액 atomic 차감 (거래 결제 / 출금 신청). amount 양수 강제.
-     * 잔액 부족 시 affected=0 (음수 방지 가드 — WHERE point_balance >= :amount).
-     * 단일 SQL UPDATE + 행 락 직렬화로 동시 차감 race 안전.
-     */
+    
+
     int deductPointBalance(Long userId, long amount);
 
-    /**
-     * 잔액 단건 scalar 조회. atomic UPDATE 직후 balance_after 적재용 — 영속성 컨텍스트 stale 우회.
-     */
+    
+
     Long findPointBalance(Long userId);
 
-    /**
-     * 가이드 §5.1 거래 hold (라운드 11) — point_balance 에서 amount 차감 + point_hold 에 적립.
-     * 단일 원자 UPDATE 로 두 컬럼 동시 변경 → race-safe + buyer 잔액 부족 가드 (WHERE point_balance >= :amount).
-     * 영향 행 0 = 잔액 부족, 1 = 정상.
-     */
+    
+
     int holdForEscrow(Long userId, long amount);
 
-    /**
-     * 거래완료 정산 — buyer point_hold 만 차감 (seller credit 은 creditPointBalance 별도 호출).
-     * 단일 원자 UPDATE. point_hold &lt; amount 이면 affected=0 (가드 회귀 시 호출자 fail-fast).
-     */
+    
+
     int releaseHold(Long userId, long amount);
 
-    /**
-     * 거래 취소 환불 — point_hold 에서 차감 + point_balance 로 적립.
-     * 단일 원자 UPDATE 로 두 컬럼 동시 변경. point_hold &lt; amount 이면 affected=0.
-     */
+    
+
     int refundHold(Long userId, long amount);
 
-    /**
-     * point_hold scalar 조회. atomic UPDATE 직후 history balance_after 적재용 (영속성 컨텍스트 stale 우회).
-     */
+    
+
     Long findPointHold(Long userId);
 
-    /**
-     * (point_balance, point_hold) 단일 SELECT 스냅샷. 잔액 표시 응답 (3분할) 의 race-safe 일관성 보장 —
-     * 두 컬럼을 분리 read 하면 동시 reserve/cancel/refund 사이에 끼어 합산이 어긋날 수 있음 (게이트 1 W-1).
-     */
+    
+
     java.util.Optional<PointSnapshot> findPointSnapshot(Long userId);
 
     record PointSnapshot(long balance, long hold) { }
 
-    // ───────── 관리자 통계 ─────────
+    
 
-    /** 전체 사용자 수 (차단/삭제 포함). */
+    
     long countAll();
 
-    /** is_blocked=true 사용자 수. */
+    
     long countBlocked();
 
-    /** is_deleted=true 사용자 수. */
+    
     long countDeleted();
 
-    /**
-     * 정상(차단 X, 삭제 X) 사용자 수. blocked && deleted 동시 true 인 사용자가 있어도 정확.
-     * 게이트 2 보강 — total - blocked - deleted 의 이중 차감 회피.
-     */
+    
+
     long countActive();
 
-    /**
-     * 차트 dashboard — 기간 안 (created_at &gt;= from AND created_at &lt; to) 가입자 수.
-     * to 는 exclusive. summary.users.monthDelta / todaySignups.* 등 기간 합산용.
-     */
+    
+
     long countSignupsBetween(java.time.LocalDateTime from, java.time.LocalDateTime to);
 
-    /**
-     * 차트 dashboard — 일자별 가입자 수. 빈 일은 결과에 미포함 (호출자가 0으로 채움).
-     * created_at DATE GROUP BY, ASC.
-     */
+    
+
     java.util.List<DailyCount> findDailySignups(java.time.LocalDateTime from, java.time.LocalDateTime to);
 
-    /** {@code (date, count)} record — 일자별 차트 데이터용. */
+    
     record DailyCount(java.time.LocalDate date, long count) { }
 
-    /**
-     * Admin broadcast 용 — 활성 사용자 id 청크 페이징. blocked/deleted 제외.
-     * 큰 사용자 수에서 OOM 방지를 위해 호출자가 청크 단위로 호출. id ASC 안정 정렬.
-     *
-     * @param afterId 이전 호출의 마지막 id (처음 호출은 0)
-     * @param limit   페이지 크기
-     */
+    
+
     java.util.List<Long> findActiveIdsAfter(long afterId, int limit);
 
-    /**
-     * Admin 거래 검색 (round 10) cross-aggregate keyword 매칭용 — email/nickname LIKE.
-     * 결과 id 만 반환 → 호출자가 IN 절로 사용. limit 으로 IN 절 폭주 방지.
-     * keyword null/blank → 빈 리스트.
-     */
+    
+
     java.util.List<Long> findIdsByKeywordLike(String keyword, int limit);
 
-    /**
-     * 라운드 12 PR-F #8 — 누적 정지 일수가 {@code threshold} 이상이면서 아직 soft delete 되지 않은
-     * 사용자 id 청크. id ASC. 배치 자동 탈퇴 처리용.
-     */
+    
+
     java.util.List<Long> findAutoWithdrawTargetIds(int threshold, int limit);
 }

--- a/src/main/java/com/sseulang/domain/user/domain/UserStatus.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserStatus.java
@@ -2,18 +2,6 @@ package com.sseulang.domain.user.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * Admin 응답에서 derive 되는 회원 상태. DB 컬럼 X — {@link User#derivedStatus} 가 시점마다 계산.
- *
- * <p>우선순위: {@link #WITHDRAWN} &gt; {@link #SUSPENDED} &gt; {@link #DORMANT} &gt; {@link #ACTIVE}.</p>
- *
- * <ul>
- *   <li>{@link #ACTIVE} — 정상</li>
- *   <li>{@link #SUSPENDED} — 시한부 활동정지 중 (suspended_at + suspend_days 만료 전)</li>
- *   <li>{@link #WITHDRAWN} — 탈퇴 (is_deleted=true)</li>
- *   <li>{@link #DORMANT} — 휴면 (90일 이상 미접속)</li>
- * </ul>
- */
 @Schema(description = "회원 상태 (derived) — ACTIVE / SUSPENDED / WITHDRAWN / DORMANT")
 public enum UserStatus {
     ACTIVE,

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -11,20 +11,14 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-/** Spring Data JPA — {@link UserRepositoryImpl} 가 wrapping. 외부에서 직접 import 금지. */
 interface UserJpaRepository extends JpaRepository<User, Long> {
 
     Optional<User> findBySocialProviderAndSocialId(SocialProvider provider, String socialId);
 
     Optional<User> findByEmail(String email);
 
-    /**
-     * 단일 atomic UPDATE — review_count / rating_sum 누적 + trust_score 즉시 재계산.
-     * 같은 reviewee 에 대한 동시 review 작성 race 안전 (각 트랜잭션은 본인 행 락 점유 시 직렬화 + 누적).
-     * 가이드 §5.3 동시성 처리 정합. Codex 게이트 2 보강.
-     *
-     * <p>trust_score 정밀도: DECIMAL(3,2) → CAST 로 분수 결과 보존.</p>
-     */
+    
+
     @Modifying
     @Query(value = """
         UPDATE users
@@ -35,40 +29,25 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
     """, nativeQuery = true)
     int recordReviewFor(@Param("userId") Long userId, @Param("rating") int rating);
 
-    /**
-     * 가이드 §4.8 — point_balance 단일 atomic UPDATE 증가. 충전·정산 적립 시 호출.
-     * 동시 충전 / 동시 적립 race 안전 (단일 SQL).
-     */
+    
+
     @Modifying
     @Query("UPDATE User u SET u.pointBalance = u.pointBalance + :amount WHERE u.id = :userId")
     int creditPointBalance(@Param("userId") Long userId, @Param("amount") long amount);
 
-    /**
-     * 가이드 §4.8 / §5.3 — point_balance 단일 atomic UPDATE 차감. 잔액 부족 시 affected=0 (음수 방지 가드).
-     * 거래 결제 (구매자 차감) / 출금 신청에서 호출. 동시 차감 race 안전 (행 락 직렬화).
-     */
+    
+
     @Modifying
     @Query("UPDATE User u SET u.pointBalance = u.pointBalance - :amount WHERE u.id = :userId AND u.pointBalance >= :amount")
     int deductPointBalance(@Param("userId") Long userId, @Param("amount") long amount);
 
-    /**
-     * point_balance scalar 조회. 영속성 컨텍스트의 stale entity 캐시 우회 — atomic UPDATE 직후
-     * balance_after 적재용으로 호출 (Hibernate scalar projection 은 entity 캐시 거치지 않음).
-     */
+    
+
     @Query("SELECT u.pointBalance FROM User u WHERE u.id = :userId")
     Long findPointBalanceById(@Param("userId") Long userId);
 
-    /**
-     * 가이드 §5.1 거래 hold (라운드 11) — point_balance 차감 + point_hold 적립을 단일 원자 UPDATE.
-     * 잔액 부족 시 affected=0 (WHERE point_balance >= :amount 가드 — 음수 방지).
-     * 동시 hold race 안전 (행 락 직렬화 + 단일 SQL).
-     *
-     * <p><b>@Version 정책</b>: 본 메서드 + creditPointBalance / deductPointBalance / releaseHold /
-     * refundHold / recordReviewFor 는 모두 가이드 §5.3 패턴 (원자 SQL 로 직접 컬럼 변경) — JPA dirty-check
-     * 경로를 우회하므로 {@code @Version} 을 의도적으로 갱신하지 않는다. race-safety 는 SQL 자체의
-     * 행 락 + WHERE 가드가 보장. 단, 같은 트랜잭션 안에서 다른 managed write (profile / block / suspend
-     * 등 entity dirty-check 경로) 와 섞이면 별도 optimistic-lock 방어가 필요 — Day 5 takeover 패턴 참고.</p>
-     */
+    
+
     @Modifying
     @Query("""
             UPDATE User u
@@ -79,18 +58,14 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
             """)
     int holdForEscrow(@Param("userId") Long userId, @Param("amount") long amount);
 
-    /**
-     * 거래완료 정산 — buyer point_hold 만 차감. seller credit 은 별도 호출 (양 사용자 id-asc 락 순서).
-     * point_hold &lt; amount 면 affected=0 — 호출자가 fail-fast.
-     */
+    
+
     @Modifying
     @Query("UPDATE User u SET u.pointHold = u.pointHold - :amount WHERE u.id = :userId AND u.pointHold >= :amount")
     int releaseHold(@Param("userId") Long userId, @Param("amount") long amount);
 
-    /**
-     * 거래 취소 환불 — point_hold 차감 + point_balance 적립을 단일 원자 UPDATE.
-     * point_hold &lt; amount 면 affected=0.
-     */
+    
+
     @Modifying
     @Query("""
             UPDATE User u
@@ -101,19 +76,17 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
             """)
     int refundHold(@Param("userId") Long userId, @Param("amount") long amount);
 
-    /** point_hold scalar 조회. atomic UPDATE 직후 history balance_after 적재용. */
+    
     @Query("SELECT u.pointHold FROM User u WHERE u.id = :userId")
     Long findPointHoldById(@Param("userId") Long userId);
 
-    /**
-     * 잔액 + hold 단일 SELECT 스냅샷 — 게이트 1 W-1 보강 (race-safe 일관성).
-     * native projection 으로 영속성 컨텍스트 stale 우회.
-     */
+    
+
     @Query(value = "SELECT point_balance AS balance, point_hold AS hold FROM users WHERE id = :userId",
            nativeQuery = true)
     java.util.Optional<PointSnapshotRow> findPointSnapshotById(@Param("userId") Long userId);
 
-    /** native projection — UserRepository.PointSnapshot 으로 매핑 (Spring Data 인터페이스 projection). */
+    
     interface PointSnapshotRow {
         long getBalance();
         long getHold();
@@ -121,21 +94,8 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
 
     Page<User> findAllByOrderByIdDesc(Pageable pageable);
 
-    /**
-     * Admin 회원 검색 — keyword(nickname/email LIKE), created_at 범위, derive status.
-     *
-     * <p>NATIVE query 사용 이유: SUSPENDED 판정에 {@code suspended_at + INTERVAL suspend_days DAY > now}
-     * 가 필요한데 JPQL TIMESTAMPADD 가 DB 별 호환성 이슈가 큼. MySQL DATE_ADD 직접 사용.</p>
-     *
-     * <p>status 파라미터:
-     * <ul>
-     *   <li>{@code 'WITHDRAWN'} — is_deleted=TRUE</li>
-     *   <li>{@code 'SUSPENDED'} — 시한부 정지 만료 전</li>
-     *   <li>{@code 'DORMANT'} — deleted/suspended 아니고 마지막 로그인이 dormantThreshold 이전</li>
-     *   <li>{@code 'ACTIVE'} — 그 외 (탈퇴/정지/휴면 아님)</li>
-     *   <li>{@code NULL} — 필터 안 함 (전체)</li>
-     * </ul>
-     */
+    
+
     @Query(value = """
             SELECT * FROM users u
              WHERE (:kw IS NULL OR LOWER(u.email) LIKE LOWER(CONCAT('%', :kw, '%'))
@@ -206,10 +166,8 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
     @Query("SELECT COUNT(u) FROM User u WHERE u.createdAt >= :from AND u.createdAt < :to")
     long countSignupsBetween(@Param("from") java.time.LocalDateTime from, @Param("to") java.time.LocalDateTime to);
 
-    /**
-     * 일자별 가입자 — DATE(created_at) GROUP BY. native query (JPQL DATE 함수 호환성 회피).
-     * 결과 row: (date, count). 빈 일자는 결과에 미포함 (호출자가 fill).
-     */
+    
+
     @Query(value = """
             SELECT DATE(u.created_at) AS d, COUNT(*) AS c
               FROM users u
@@ -221,7 +179,7 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
             @Param("from") java.time.LocalDateTime from,
             @Param("to") java.time.LocalDateTime to);
 
-    /** native projection — UserRepository.DailyCount 으로 매핑. */
+    
     interface DailySignupRow {
         java.sql.Date getD();
         long getC();
@@ -230,18 +188,16 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
     @Query("SELECT COUNT(u) FROM User u WHERE u.deleted = true")
     long countDeleted();
 
-    /**
-     * 정상 사용자 수 — blocked && deleted 동시 true 도 active 에서 제외. 복합 인덱스
-     * users(is_blocked, is_deleted) 사용 (V5 마이그레이션).
-     */
+    
+
     @Query("SELECT COUNT(u) FROM User u WHERE u.blocked = false AND u.deleted = false")
     long countActive();
 
-    /** Admin broadcast — 활성 사용자 id 만 청크 페이징. id ASC. */
+    
     @Query("SELECT u.id FROM User u WHERE u.blocked = false AND u.deleted = false AND u.id > :afterId ORDER BY u.id ASC")
     java.util.List<Long> findActiveIdsAfter(@Param("afterId") long afterId, org.springframework.data.domain.Pageable pageable);
 
-    /** Admin 거래 검색 (round 10) — email/nickname LIKE 매칭 user id. limit 으로 IN 절 폭주 방지. */
+    
     @Query("""
             SELECT u.id FROM User u
              WHERE LOWER(u.email)    LIKE LOWER(CONCAT('%', :kw, '%'))
@@ -250,10 +206,8 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
             """)
     java.util.List<Long> findIdsByKeywordLike(@Param("kw") String kw, org.springframework.data.domain.Pageable pageable);
 
-    /**
-     * 라운드 12 PR-F #8 — 누적 정지 일수 ≥ threshold 이면서 아직 살아있는 사용자 id.
-     * 자동 탈퇴 배치 처리용. id ASC.
-     */
+    
+
     @Query("""
             SELECT u.id FROM User u
              WHERE u.cumulativeSuspendDays >= :threshold

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserViewAdapter.java
@@ -8,10 +8,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * {@link UserView} 어댑터. chat 도메인이 채팅방 응답에 상대방 닉네임/프로필을 자동 채울 때 사용.
- * 단일 SELECT IN — N+1 회피.
- */
 @Component
 public class UserViewAdapter implements UserView {
 

--- a/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/AdminUserController.java
@@ -24,11 +24,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 
-/**
- * 관리자 회원 관리. SecurityConfig admin chain 으로 ROLE_ADMIN 강제.
- *
- * <p>v8b: keyword/status/createdAfter/createdBefore 검색·필터, suspend/unsuspend, enriched response.</p>
- */
 @Tag(name = "AdminUser", description = "관리자 — 사용자 목록/검색/차단/정지")
 @RestController
 @RequestMapping("/api/v1/admin/users")

--- a/src/main/java/com/sseulang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
         ));
     }
 
-    /** Spring Security Authentication 의 GrantedAuthority 에서 ROLE_ prefix 제거한 role 문자열. */
+    
     private static String roleFrom(Authentication auth) {
         if (auth == null) return "USER";
         return auth.getAuthorities().stream()

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-/** 관리자용 회원 응답. v8b: tradeCount/reportCount/dormant/status/suspended* 추가. */
 @Schema(description = "관리자 — 회원 단건 (민감 정보 제외).")
 public record AdminUserResponse(
         @Schema(example = "100") Long id,
@@ -43,10 +42,8 @@ public record AdminUserResponse(
         );
     }
 
-    /**
-     * @deprecated 호환용 — 도메인 enrich 정보 없이 entity 만으로 변환. 새 코드는 {@link AdminUserResult} 경유 권장.
-     * Codex 리뷰 + 테스트 갱신 끝나면 제거 예정.
-     */
+    
+
     @Deprecated
     public static AdminUserResponse from(User u) {
         return new AdminUserResponse(

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/MeResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/MeResponse.java
@@ -6,12 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.math.BigDecimal;
 
-/**
- * 본인 사용자 정보 응답 — 로그인/가입/oauth/refresh 응답 + GET /api/v1/users/me 의 표준 본문.
- *
- * <p>비밀번호 / social_id / address 등 민감 정보는 제외. 프론트가 헤더 사용자 영역, store 초기화에
- * 필요한 최소 필드만.</p>
- */
 @Schema(description = "본인 사용자 정보 (헤더/스토어 초기화용).")
 public record MeResponse(
         @Schema(example = "42") Long id,
@@ -30,9 +24,8 @@ public record MeResponse(
                 allowableValues = {"USER", "ADMIN"})
         String role
 ) {
-    /**
-     * @param role 현재 세션의 role ("USER" / "ADMIN"). 호출자가 Authentication 또는 JwtClaims 에서 추출해 전달.
-     */
+    
+
     public static MeResponse from(User u, String role) {
         return new MeResponse(
                 u.getId(),

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/UserProfileResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/UserProfileResponse.java
@@ -7,12 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-/**
- * 다른 사용자(판매자/구매자/리뷰어 등) 의 공개 프로필 — {@code GET /api/v1/users/{id}/profile} 응답.
- *
- * <p>이메일 / 잔액 / emailVerified 등 민감 정보는 노출 X. ItemDetail 화면에서 sellerId 로 호출해
- * 카드 렌더링하는 용도. 비로그인도 접근 가능 (공개).</p>
- */
 @Schema(description = "다른 사용자의 공개 프로필 — 닉네임 + 신뢰도 정보. 비로그인 접근 가능.")
 public record UserProfileResponse(
         @Schema(example = "100") Long id,

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/UserUpdateRequest.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/UserUpdateRequest.java
@@ -3,12 +3,6 @@ package com.sseulang.domain.user.presentation.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
-/**
- * 본인 프로필 partial update. 모든 필드 optional — null 은 변경 안 함.
- *
- * <p>profileImage 빈 문자열은 "이미지 제거" 의도로 처리 (null 저장). 이미지 등록은 미인증 사용자도
- * 허용 — 5/2 합의 (자금/거래만 차단).</p>
- */
 @Schema(description = "본인 프로필 partial update — null 필드는 변경 X.")
 public record UserUpdateRequest(
         @Schema(description = "프로필 이미지 URL/key. null=변경 X, 빈 문자열=제거",

--- a/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
+++ b/src/main/java/com/sseulang/domain/wishlist/application/WishlistApplicationService.java
@@ -16,10 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class WishlistApplicationService {
 
-    /**
-     * V1 스키마({@code uk_wishlists_user_item}) 의 UNIQUE 제약 이름. 동시 add race 만 멱등 처리하고
-     * 그 외 무결성 위반(FK / 다른 제약)은 그대로 던져 시스템 에러로 노출한다 — Codex 게이트 2 보정.
-     */
+    
+
     private static final String UNIQUE_USER_ITEM = "uk_wishlists_user_item";
 
     private final WishlistRepository wishlistRepository;
@@ -33,13 +31,8 @@ public class WishlistApplicationService {
         this.itemApplicationService = itemApplicationService;
     }
 
-    /**
-     * 찜 추가. Item 존재 검증은 {@link ItemApplicationService#requireActiveItem} 위임 (CLAUDE.md
-     * §3.3 — 다른 도메인 Repository 직접 호출 금지). 이미 있으면 멱등하게 무시.
-     * UNIQUE(user_id, item_id) race 는 catch 후 무시 — 그 외 무결성 위반은 재던지기.
-     *
-     * <p>응답으로 fresh wishlistCount 를 반환 — 프론트가 detail 재조회 없이 즉시 UI 갱신.</p>
-     */
+    
+
     @Transactional
     public WishlistToggleResult add(Long userId, Long itemId) {
         itemApplicationService.requireActiveItem(itemId);
@@ -53,24 +46,20 @@ public class WishlistApplicationService {
             if (!isUniqueUserItemConflict(violation)) {
                 throw violation;
             }
-            // race — 다른 트랜잭션이 먼저 추가. 멱등 처리하고 fresh count 만 응답.
+            
         }
         return new WishlistToggleResult(true, itemApplicationService.getWishlistCount(itemId));
     }
 
-    /**
-     * 본인이 찜한 Item 목록 페이징 — 삭제된 Item 자동 제외. 찜한 시간 최신순.
-     * 본인 찜 목록이라 isWishlisted 는 모두 true — DB 조회 없이 ItemSummaryResult 직접 매핑.
-     */
+    
+
     public Page<ItemSummaryResult> listMyWishlistedItems(Long userId, Pageable pageable) {
         return wishlistRepository.findWishlistedItemsByUserId(userId, pageable)
                 .map(item -> ItemSummaryResult.from(item, true));
     }
 
-    /**
-     * 멱등 삭제. 실제 삭제된 row 가 1 건일 때만 wishlist_count 감소 — 동시 remove 시 underflow 방지.
-     * 응답으로 fresh wishlistCount 반환 — 호출 후 상태는 wishlisted=false.
-     */
+    
+
     @Transactional
     public WishlistToggleResult remove(Long userId, Long itemId) {
         int deleted = wishlistRepository.deleteByUserIdAndItemId(userId, itemId);
@@ -80,12 +69,8 @@ public class WishlistApplicationService {
         return new WishlistToggleResult(false, itemApplicationService.getWishlistCount(itemId));
     }
 
-    /**
-     * cause chain 을 끝까지 따라가며 {@code uk_wishlists_user_item} 제약 위반인지 판별.
-     * 단순 {@code violation.getCause()} 만 보면 드물게 wrapper 가 한 겹 더 끼는 경우(예:
-     * {@code DataIntegrityViolationException → JpaSystemException → ConstraintViolationException})
-     * race 가 500 으로 잘못 떨어질 수 있어 traversal 로 보강 (Codex 게이트 2 검증 권고).
-     */
+    
+
     private static boolean isUniqueUserItemConflict(DataIntegrityViolationException violation) {
         Throwable cause = violation;
         while (cause != null) {
@@ -95,7 +80,7 @@ public class WishlistApplicationService {
             }
             Throwable next = cause.getCause();
             if (next == cause) {
-                return false; // 자기참조 방어
+                return false; 
             }
             cause = next;
         }

--- a/src/main/java/com/sseulang/domain/wishlist/application/dto/WishlistToggleResult.java
+++ b/src/main/java/com/sseulang/domain/wishlist/application/dto/WishlistToggleResult.java
@@ -1,9 +1,3 @@
 package com.sseulang.domain.wishlist.application.dto;
 
-/**
- * 찜 추가/해제 직후 응답 — 프론트가 detail 재조회 없이 카드 UI 즉시 갱신할 수 있도록.
- *
- * @param wishlisted 호출 후 viewer 가 해당 item 을 찜하고 있는 상태인지
- * @param wishlistCount 호출 후 item 의 누적 찜 수 (fresh DB 값)
- */
 public record WishlistToggleResult(boolean wishlisted, int wishlistCount) { }

--- a/src/main/java/com/sseulang/domain/wishlist/domain/Wishlist.java
+++ b/src/main/java/com/sseulang/domain/wishlist/domain/Wishlist.java
@@ -15,10 +15,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-/**
- * Wishlist Aggregate Root. {@code wishlists} 테이블 — UNIQUE(user_id, item_id).
- * BaseEntity 미사용 (updated_at 컬럼 없음).
- */
 @Entity
 @Table(name = "wishlists")
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/sseulang/domain/wishlist/domain/WishlistRepository.java
+++ b/src/main/java/com/sseulang/domain/wishlist/domain/WishlistRepository.java
@@ -10,15 +10,11 @@ public interface WishlistRepository {
 
     Wishlist save(Wishlist wishlist);
 
-    /**
-     * 멱등 삭제. 존재하지 않아도 예외 없이 0 건 처리. 영향받은 행 수를 반환 — 호출자가 후속 액션
-     * (예: items.wishlist_count 감소)을 결정할 때 사용.
-     */
+    
+
     int deleteByUserIdAndItemId(Long userId, Long itemId);
 
-    /**
-     * 내 찜 목록 — 삭제된 Item 은 제외, Wishlist.createdAt DESC 로 페이징.
-     * Cross-aggregate read (Wishlist join Item) — write 흐름은 분리되어 있어 read 만 허용.
-     */
+    
+
     Page<Item> findWishlistedItemsByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistJpaRepository.java
@@ -17,19 +17,15 @@ interface WishlistJpaRepository extends JpaRepository<Wishlist, Long> {
     @Query("DELETE FROM Wishlist w WHERE w.userId = :userId AND w.itemId = :itemId")
     int deleteByUserAndItem(@Param("userId") Long userId, @Param("itemId") Long itemId);
 
-    /**
-     * Item 도메인의 {@link com.sseulang.domain.item.domain.WishlistView} 어댑터 백킹 쿼리.
-     * userId 가 itemIds 중 어느 것을 찜했는지 단일 SELECT 로 반환 — N+1 회피용.
-     */
+    
+
     @Query("SELECT w.itemId FROM Wishlist w WHERE w.userId = :userId AND w.itemId IN :itemIds")
     java.util.List<Long> findItemIdsByUserIdAndItemIds(
             @Param("userId") Long userId,
             @Param("itemIds") java.util.Collection<Long> itemIds);
 
-    /**
-     * 본인이 찜한 Item 목록 — 삭제된 Item 은 자동 필터. Wishlist 의 createdAt 기준 최신순.
-     * cross-aggregate read JPQL.
-     */
+    
+
     @Query(value = """
             SELECT i FROM Item i
              WHERE i.id IN (SELECT w.itemId FROM Wishlist w WHERE w.userId = :userId)

--- a/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/wishlist/infrastructure/persistence/WishlistViewAdapter.java
@@ -6,12 +6,6 @@ import org.springframework.stereotype.Component;
 import java.util.Collection;
 import java.util.Set;
 
-/**
- * {@link WishlistView} 어댑터. {@code item} 도메인이 viewer 의 찜한 itemId 집합을 알아야 할 때
- * (목록·검색·내물품 응답의 isWishlisted 매핑) 단일 SELECT 로 응답.
- *
- * <p>userId 가 null 또는 itemIds 가 비면 즉시 {@code Set.of()} — DB 호출 안 함.</p>
- */
 @Component
 class WishlistViewAdapter implements WishlistView {
 

--- a/src/main/java/com/sseulang/domain/wishlist/presentation/MyWishlistController.java
+++ b/src/main/java/com/sseulang/domain/wishlist/presentation/MyWishlistController.java
@@ -15,10 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 본인 찜 목록 조회 — {@link WishlistController} 의 add/remove 와 분리. path prefix 가 다름
- * ({@code /api/v1/users/me/wishlist}).
- */
 @Tag(name = "Wishlist", description = "물품 찜 추가/해제 + 본인 목록")
 @RestController
 @RequestMapping("/api/v1/users/me/wishlist")

--- a/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
+++ b/src/main/java/com/sseulang/domain/wishlist/presentation/WishlistController.java
@@ -12,12 +12,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * Wishlist 진입점은 Item 자원 하위로 둔다 (가이드 §6.1):
- * {@code POST /api/v1/items/{id}/wishlist}, {@code DELETE /api/v1/items/{id}/wishlist}.
- *
- * <p>응답에 fresh {@code wishlisted + wishlistCount} 동봉 — 프론트가 detail 재조회 없이 즉시 UI 갱신.</p>
- */
 @Tag(name = "Wishlist", description = "물품 찜 추가/해제")
 @RestController
 @RequestMapping("/api/v1/items/{itemId}/wishlist")

--- a/src/main/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationService.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/application/WithdrawalApplicationService.java
@@ -29,20 +29,6 @@ import java.time.LocalDateTime;
 import java.util.EnumMap;
 import java.util.Map;
 
-/**
- * 가이드 §4.8 출금 흐름:
- *
- * <ol>
- *   <li>{@link #request} — 사용자 신청. 잔액 차감 ({@code PointApplicationService.deduct(type=출금, refType=WITHDRAWAL)})
- *       + Withdrawal 저장 (status=신청). 잔액 부족 → INSUFFICIENT_POINT 트랜잭션 롤백.</li>
- *   <li>{@link #cancel} — 사용자 본인 취소. 신청 상태만 허용. 잔액 원복 (환불 history 적재).</li>
- *   <li>{@link #adminApprove} — 관리자 승인. 신청 → 승인. 외부 이체는 후속 {@link #adminComplete} 가 처리.</li>
- *   <li>{@link #adminReject} — 관리자 거부. 잔액 원복.</li>
- *   <li>{@link #adminComplete} — 관리자 외부 이체 완료. 승인 → 완료.</li>
- * </ol>
- *
- * <p>모든 상태 전이는 {@code findByIdForUpdate} 비관적 락으로 직렬화 (가이드 §5.3).</p>
- */
 @Service
 @Transactional(readOnly = true)
 public class WithdrawalApplicationService {
@@ -52,11 +38,8 @@ public class WithdrawalApplicationService {
     private final WithdrawalRepository withdrawalRepository;
     private final PointApplicationService pointApplicationService;
     private final UserApplicationService userApplicationService;
-    /**
-     * 자기 자신 proxy — {@link #request} 가 {@link #insertWithDeduct} 를 별도 트랜잭션으로 호출하기 위해
-     * 사용한다. 직접 {@code this.insertWithDeduct(...)} 로 호출하면 Spring AOP 가 가로채지 못해
-     * REQUIRES_NEW 의미가 깨진다. {@code @Lazy} 로 순환 의존 회피.
-     */
+    
+
     private final WithdrawalApplicationService self;
 
     @Autowired
@@ -72,54 +55,39 @@ public class WithdrawalApplicationService {
         this.self = self;
     }
 
-    /**
-     * 출금 신청 — 멱등성 보장.
-     *
-     * <p>흐름:
-     * <ol>
-     *   <li>같은 (userId, idempotencyKey) 가 이미 있으면 그 id 즉시 반환 (no-op).</li>
-     *   <li>없으면 {@link #insertWithDeduct} 를 REQUIRES_NEW 로 호출. INSERT 가 동시 race 로
-     *       실패(unique 위반 / deadlock)하면 그 트랜잭션만 롤백되고 본 readonly 외부 tx 는 영향 없음.</li>
-     *   <li>패배자 경로: 다시 조회 → winner 가 commit 한 row 의 id 반환.</li>
-     * </ol>
-     *
-     * <p>왜 REQUIRES_NEW 인가: 같은 tx 안에서 INSERT 실패를 catch 하면 Hibernate persistence
-     * context 가 dirty 상태로 남아 후속 flush 가 깨진다 (AssertionFailure: don't flush after exception).
-     * 별도 tx 로 격리해 winner 와 loser 각자 깔끔하게 commit/rollback 하도록 처리.</p>
-     */
+    
+
     public Long request(WithdrawalRequestCommand cmd) {
         if (cmd.amount() <= 0) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST);
         }
-        // 자금 인출 — 이메일 인증 필수 (게이트 1).
+        
         userApplicationService.requireVerified(cmd.userId());
 
-        // 1) Fast path — 기존 신청 dedup. payload 가 다르면 클라이언트 버그 시그널 → 명시 거부.
+        
         var existing = withdrawalRepository.findByUserIdAndIdempotencyKey(cmd.userId(), cmd.idempotencyKey());
         if (existing.isPresent()) {
             assertSamePayload(existing.get(), cmd);
             return existing.get().getId();
         }
 
-        // 2) 새 행 + 차감을 별 tx 에서. 동시 INSERT 가 UNIQUE 제약을 노릴 때 던질 수 있는 모든
-        //    예외를 dedup 시그널로 처리:
-        //    - DataIntegrityViolationException: duplicate-key (가장 일반)
-        //    - PessimisticLockingFailureException 계열 (CannotAcquireLockException /
-        //      DeadlockLoserDataAccessException 포함): InnoDB gap lock + deadlock 패턴
+        
+        
+        
+        
+        
         try {
             return self.insertWithDeduct(cmd);
         } catch (DataIntegrityViolationException | PessimisticLockingFailureException race) {
-            // 3) 패배자 — winner 가 commit 한 상태에서 재조회. 단, 본 outer tx 가 REPEATABLE_READ
-            //    snapshot 을 쥐고 있으면 winner 의 새 row 가 보이지 않으므로 REQUIRES_NEW 로 fresh
-            //    스냅샷을 받아서 조회 (fix #2).
+            
+            
+            
             return self.findIdempotentInFreshTx(cmd, race);
         }
     }
 
-    /**
-     * race 패배자 보정 — outer tx 의 snapshot 으로는 winner 의 새 row 가 보이지 않을 수 있어
-     * 새 트랜잭션으로 재조회한다 (REPEATABLE_READ 환경에서도 안전).
-     */
+    
+
     @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
     public Long findIdempotentInFreshTx(WithdrawalRequestCommand cmd, RuntimeException original) {
         Withdrawal w = withdrawalRepository.findByUserIdAndIdempotencyKey(cmd.userId(), cmd.idempotencyKey())
@@ -128,10 +96,8 @@ public class WithdrawalApplicationService {
         return w.getId();
     }
 
-    /**
-     * 같은 idempotencyKey 로 다른 내용(amount/계좌)이 들어오면 클라이언트 버그 가능성 — 조용히
-     * 기존 id 반환하는 대신 명시적으로 거부 (게이트 2: silent pass 방지).
-     */
+    
+
     private static void assertSamePayload(Withdrawal existing, WithdrawalRequestCommand cmd) {
         if (existing.getAmount() != cmd.amount()
                 || !existing.getBankName().equals(cmd.bankName())
@@ -141,12 +107,8 @@ public class WithdrawalApplicationService {
         }
     }
 
-    /**
-     * 신규 INSERT + 잔액 차감을 한 트랜잭션으로 묶는다. 잔액 부족 시 INSUFFICIENT_POINT → 본 tx 만
-     * 롤백 (Withdrawal save 도 함께 원복). UNIQUE race 패배 시도 본 tx 만 롤백되어 외부에 영향 없음.
-     *
-     * <p>Spring AOP 통과를 위해 반드시 {@link #self} 경유로만 호출.</p>
-     */
+    
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Long insertWithDeduct(WithdrawalRequestCommand cmd) {
         Withdrawal saved = withdrawalRepository.save(Withdrawal.request(
@@ -166,11 +128,11 @@ public class WithdrawalApplicationService {
 
     @Transactional
     public void cancel(Long withdrawalId, Long requesterId) {
-        // 본인 자원만 락 + 권한 검증을 한 쿼리로 — 타인 id 로는 락이 잡히지 않아 lock-DoS 차단 (게이트 1).
-        // 행이 존재하지만 소유자가 다른 경우와, 행 자체가 없는 경우를 클라이언트에 동일하게 응답 (존재 여부 leak X).
+        
+        
         Withdrawal w = withdrawalRepository.findByIdAndUserIdForUpdate(withdrawalId, requesterId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.WITHDRAWAL_NOT_FOUND));
-        // 신청 상태만 허용 (Aggregate 가 가드). 신청 → 취소 + 잔액 원복.
+        
         w.cancel(LocalDateTime.now());
         refund(w, "출금 신청 취소");
     }
@@ -179,7 +141,7 @@ public class WithdrawalApplicationService {
     public void adminApprove(Long withdrawalId, Long adminId, String memo) {
         Withdrawal w = findOrThrowForUpdate(withdrawalId);
         w.approve(adminId, memo, LocalDateTime.now());
-        // 잔액은 신청 시점에 이미 차감되어 있으므로 별도 변동 X. 외부 이체는 adminComplete 단계.
+        
     }
 
     @Transactional
@@ -189,10 +151,8 @@ public class WithdrawalApplicationService {
         refund(w, "출금 신청 거부");
     }
 
-    /**
-     * 관리자 외부 이체 완료 처리. 본 PR 에선 이체 자체는 mock — 외부 은행 API 연동은 5/6 이후 후속.
-     * 승인 → 완료 단순 상태 전이.
-     */
+    
+
     @Transactional
     public void adminComplete(Long withdrawalId, Long adminId) {
         Withdrawal w = findOrThrowForUpdate(withdrawalId);
@@ -218,7 +178,7 @@ public class WithdrawalApplicationService {
         return withdrawalRepository.findByStatus(status, pageable).map(WithdrawalResult::from);
     }
 
-    /** 관리자 출금 통계 — total + byStatus + 완료된 출금 누적 금액. 단일 GROUP BY + 단일 SUM. */
+    
     public WithdrawalStatsResult adminGetStats() {
         Map<WithdrawalStatus, Long> byStatus = new EnumMap<>(WithdrawalStatus.class);
         for (WithdrawalStatus s : WithdrawalStatus.values()) {
@@ -234,7 +194,7 @@ public class WithdrawalApplicationService {
     }
 
     private void refund(Withdrawal w, String description) {
-        // 신청 시점 차감과 동일 트랜잭션 안에서 환불. 잔액 변경 + history 적재 (type=환불, refType=WITHDRAWAL).
+        
         pointApplicationService.credit(
                 w.getUserId(), w.getAmount(),
                 PointHistoryType.환불,

--- a/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalRequestCommand.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalRequestCommand.java
@@ -1,10 +1,5 @@
 package com.sseulang.domain.withdrawal.application.dto;
 
-/**
- * 출금 신청 Command. 모든 문자열 필드(idempotencyKey + 계좌 정보)는 compact constructor 에서
- * 한 번만 정규화 (trim) — Withdrawal 저장 / 멱등성 비교 / 복구 조회 모두 동일 값을 보고
- * trim 위치 불일치로 dedup 이 거짓 거부되는 회귀 차단 (게이트 2 round 2).
- */
 public record WithdrawalRequestCommand(
         Long userId,
         String idempotencyKey,

--- a/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalStatsResult.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/application/dto/WithdrawalStatsResult.java
@@ -5,9 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 
-/**
- * 출금 통계 — total + status 별 카운트 + 완료된 출금 누적 금액.
- */
 @Schema(description = "관리자 dashboard — 출금 통계.")
 public record WithdrawalStatsResult(
         @Schema(example = "87", description = "전체 출금 신청 수") long total,

--- a/src/main/java/com/sseulang/domain/withdrawal/domain/Withdrawal.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/domain/Withdrawal.java
@@ -17,15 +17,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * Withdrawal Aggregate Root. V1 스키마 {@code withdrawals} 매핑.
- *
- * <p>가이드 §4.8 출금: 사용자 신청 → 관리자 승인 → 외부 계좌 이체 (시뮬). 잔액 정합성은
- * ApplicationService 가 PointApplicationService 와 한 트랜잭션으로 묶어 처리. 본 Aggregate 는
- * 상태 머신만 책임.</p>
- *
- * <p>Setter 없음. 상태 변경은 명시 비즈니스 메서드만.</p>
- */
 @Entity
 @Table(name = "withdrawals")
 @Getter
@@ -39,11 +30,8 @@ public class Withdrawal extends BaseEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    /**
-     * 멱등성 키 — 클라이언트가 신청 단위마다 발급. 동일 (user_id, idempotency_key) 재요청 시
-     * ApplicationService 가 기존 row 를 그대로 반환 (DB UNIQUE 가 race 의 마지막 가드).
-     * nullable — V4 마이그레이션 이전 데이터(없음) 호환 여지지만 실제로는 항상 채워서 들어옴.
-     */
+    
+
     @Column(name = "idempotency_key", length = 64)
     private String idempotencyKey;
 
@@ -100,8 +88,8 @@ public class Withdrawal extends BaseEntity {
 
         Withdrawal w = new Withdrawal();
         w.userId = userId;
-        // 모든 문자열 필드는 Command compact constructor 에서 이미 trim/검증됨 — 여기서 다시 trim 하면
-        // 조회/저장 값 불일치로 멱등성 dedup 이 거짓 거부될 수 있어 그대로 저장 (게이트 2 round 2).
+        
+        
         w.idempotencyKey = idempotencyKey;
         w.amount = amount;
         w.bankName = bankName;
@@ -112,9 +100,8 @@ public class Withdrawal extends BaseEntity {
         return w;
     }
 
-    /**
-     * 사용자가 직접 취소. 신청 상태만 허용. 호출자가 잔액 원복 적용.
-     */
+    
+
     public void cancel(LocalDateTime now) {
         if (!status.canUserCancel()) {
             throw new BusinessException(ErrorCode.WITHDRAWAL_NOT_CANCELABLE);
@@ -123,9 +110,8 @@ public class Withdrawal extends BaseEntity {
         this.processedAt = now;
     }
 
-    /**
-     * 관리자 승인 — 신청 → 승인. 외부 이체는 후속 {@link #markAsCompleted} 가 처리.
-     */
+    
+
     public void approve(Long adminId, String memo, LocalDateTime now) {
         if (adminId == null || adminId <= 0) {
             throw new IllegalArgumentException("adminId 는 양수여야 합니다");
@@ -139,9 +125,8 @@ public class Withdrawal extends BaseEntity {
         this.processedAt = now;
     }
 
-    /**
-     * 관리자 거부 — 신청 → 거부. 호출자가 잔액 원복 적용.
-     */
+    
+
     public void reject(Long adminId, String memo, LocalDateTime now) {
         if (adminId == null || adminId <= 0) {
             throw new IllegalArgumentException("adminId 는 양수여야 합니다");
@@ -155,9 +140,8 @@ public class Withdrawal extends BaseEntity {
         this.processedAt = now;
     }
 
-    /**
-     * 관리자 외부 이체 완료 처리 — 승인 → 완료. 외부 이체 mock 후 호출.
-     */
+    
+
     public void markAsCompleted(LocalDateTime now) {
         if (!status.canComplete()) {
             throw new BusinessException(ErrorCode.WITHDRAWAL_INVALID_STATE);

--- a/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalRepository.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalRepository.java
@@ -6,42 +6,33 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * Withdrawal Aggregate Repository. 도메인 layer 인터페이스 — Spring/JPA 의존 X.
- * 구현은 {@code domain/withdrawal/infrastructure/persistence}.
- */
 public interface WithdrawalRepository {
 
     Withdrawal save(Withdrawal withdrawal);
 
     Optional<Withdrawal> findById(Long id);
 
-    /**
-     * 가이드 §5.3 — 출금 처리 시 비관적 락. 동시 승인/거부/취소 race 차단.
-     */
+    
+
     Optional<Withdrawal> findByIdForUpdate(Long id);
 
-    /**
-     * 권한 검증 + 락을 한 번에. 사용자 본인 자원만 락을 잡는다 — 타인 id 로 시도하면 빈 결과만 받고
-     * 락은 획득되지 않음. 게이트 1: cancel 흐름의 lock-DoS 방지.
-     */
+    
+
     Optional<Withdrawal> findByIdAndUserIdForUpdate(Long id, Long userId);
 
-    /**
-     * 멱등성 — 동일 (userId, idempotencyKey) 의 기존 신청 조회. 같은 key 재요청 시 새 행 만들지 않고
-     * 기존 행을 그대로 반환하기 위해 사용. UNIQUE(user_id, idempotency_key) 와 짝.
-     */
+    
+
     Optional<Withdrawal> findByUserIdAndIdempotencyKey(Long userId, String idempotencyKey);
 
     Page<Withdrawal> findByUserId(Long userId, Pageable pageable);
 
-    /** 관리자 — 상태별 페이징 (status null 이면 전체). */
+    
     Page<Withdrawal> findByStatus(WithdrawalStatus status, Pageable pageable);
 
-    // ───────── 관리자 통계 ─────────
+    
 
     List<WithdrawalStatusCount> countGroupByStatus();
 
-    /** status=완료 출금의 amount 합계 (실제 외부 이체된 금액). */
+    
     long sumCompletedAmount();
 }

--- a/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalStatus.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalStatus.java
@@ -1,15 +1,7 @@
 package com.sseulang.domain.withdrawal.domain;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-/**
- * 출금 상태. V1 스키마 ENUM 1:1 매핑. 가이드 §4.8 출금 흐름.
- *
- * <pre>
- *   신청 → 승인 → 완료
- *     ├── 거부 (관리자)
- *     └── 취소 (사용자, 신청 상태만)
- * </pre>
- */
+
 @Schema(description = "출금 상태. 신청→승인→완료 또는 거부(잔액 자동 환불).")
 public enum WithdrawalStatus {
     신청,
@@ -22,22 +14,22 @@ public enum WithdrawalStatus {
         return this == 거부 || this == 완료 || this == 취소;
     }
 
-    /** 관리자가 처리할 수 있는 상태 (승인/거부의 진입). */
+    
     public boolean canAdminProcess() {
         return this == 신청;
     }
 
-    /** 외부 이체 완료 처리 가능한 상태 (승인 → 완료). */
+    
     public boolean canComplete() {
         return this == 승인;
     }
 
-    /** 사용자가 직접 취소 가능한 상태 (신청 상태만). */
+    
     public boolean canUserCancel() {
         return this == 신청;
     }
 
-    /** 잔액 원복이 필요한 상태 (거부/취소 진입 시 호출). */
+    
     public boolean requiresRefundOnExit() {
         return this == 신청;
     }

--- a/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalStatusCount.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/domain/WithdrawalStatusCount.java
@@ -1,4 +1,3 @@
 package com.sseulang.domain.withdrawal.domain;
 
-/** 출금 상태별 집계 결과. */
 public record WithdrawalStatusCount(WithdrawalStatus status, long count) {}

--- a/src/main/java/com/sseulang/domain/withdrawal/infrastructure/persistence/WithdrawalJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/infrastructure/persistence/WithdrawalJpaRepository.java
@@ -14,17 +14,15 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-/** Spring Data JPA — {@link WithdrawalRepositoryImpl} 가 wrapping. 외부 직접 import 금지. */
 interface WithdrawalJpaRepository extends JpaRepository<Withdrawal, Long> {
 
-    /** 가이드 §5.3 — 비관적 락 (SELECT FOR UPDATE) 으로 동시 승인/거부/취소 직렬화. */
+    
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT w FROM Withdrawal w WHERE w.id = :id")
     Optional<Withdrawal> findByIdForUpdate(@Param("id") Long id);
 
-    /**
-     * 본인 소유 + 락 동시 획득. 타인 id 로 시도 시 빈 결과 → 락 미획득 (cancel 의 lock-DoS 방지).
-     */
+    
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT w FROM Withdrawal w WHERE w.id = :id AND w.userId = :userId")
     Optional<Withdrawal> findByIdAndUserIdForUpdate(@Param("id") Long id, @Param("userId") Long userId);
@@ -37,9 +35,8 @@ interface WithdrawalJpaRepository extends JpaRepository<Withdrawal, Long> {
 
     Page<Withdrawal> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
-    /**
-     * status 별 출금 건수 집계. 단일 쿼리. withdrawals.status 인덱스 사용 (V1 idx_withdrawals_status).
-     */
+    
+
     @Query("""
             SELECT new com.sseulang.domain.withdrawal.domain.WithdrawalStatusCount(w.status, COUNT(w))
               FROM Withdrawal w

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/AdminWithdrawalController.java
@@ -19,10 +19,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 관리자 출금 처리 — SecurityConfig 의 admin chain 이 ROLE_ADMIN 강제. AuthenticationPrincipal 은
- * adminId (현재 SecurityFilter 정책 그대로 사용).
- */
 @Tag(name = "AdminWithdrawal", description = "관리자 — 출금 신청 승인/거부")
 @RestController
 @RequestMapping("/api/v1/admin/withdrawals")

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/AdminWithdrawalDecisionRequest.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/AdminWithdrawalDecisionRequest.java
@@ -4,9 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-/**
- * 관리자 출금 처리 요청 — action: APPROVE / REJECT / COMPLETE.
- */
 @Schema(description = "관리자 출금 처리. APPROVE(신청→승인) / REJECT(신청→거부, 잔액 환불) / COMPLETE(승인→완료, 외부 이체).")
 public record AdminWithdrawalDecisionRequest(
         @Schema(description = "처리 액션", example = "APPROVE", allowableValues = {"APPROVE", "REJECT", "COMPLETE"})

--- a/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalRequest.java
+++ b/src/main/java/com/sseulang/domain/withdrawal/presentation/dto/WithdrawalRequest.java
@@ -8,10 +8,8 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "포인트 출금 신청. 신청 시점에 즉시 잔액 차감 + 관리자 승인 후 외부 이체.")
 public record WithdrawalRequest(
-        /**
-         * 클라이언트 발급 멱등성 키 (UUID 권장). 같은 (사용자, 키) 재요청 시 새 출금 행 생성하지 않고
-         * 기존 행을 그대로 반환 — 더블클릭/네트워크 재시도로 잔액 중복 차감 방지 (게이트 1).
-         */
+        
+
         @Schema(description = "클라이언트 발급 멱등성 키 (UUID 권장)", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479", maxLength = 64)
         @NotBlank(message = "idempotencyKey 는 필수입니다")
         @Size(max = 64)

--- a/src/main/resources/db/migration/V25__item_sale_rental_dual.sql
+++ b/src/main/resources/db/migration/V25__item_sale_rental_dual.sql
@@ -1,0 +1,25 @@
+-- V25: 물품 판매/대여 이중 등록 (라운드 12 PR-D 잔여)
+--
+-- 정책:
+--   * 한 Item 이 판매 / 대여 / 나눔 중 복수 모드 동시 등록 가능.
+--   * 새 컬럼 sale_price / rental_price / trade_types 가 authoritative.
+--   * 기존 price / trade_type 은 single-mode 호환용으로 유지 (DEPRECATED — 추후 V30 대 제거).
+--   * trade_types 는 ',' separated VARCHAR — JPA 측에서 Set<TradeType> 으로 변환.
+--
+-- backfill: 기존 row 는 단일 모드 — sale_price/rental_price/trade_types 가 trade_type 기반으로 채워짐.
+
+ALTER TABLE items
+    ADD COLUMN sale_price   BIGINT NULL COMMENT '판매가 (판매 모드 시 필수)',
+    ADD COLUMN rental_price BIGINT NULL COMMENT '대여가 (대여 모드 시 필수, rental_unit 당)',
+    ADD COLUMN trade_types  VARCHAR(64) NULL COMMENT '거래 모드 set (예: "판매,대여")';
+
+UPDATE items
+   SET sale_price   = CASE WHEN trade_type = '판매' THEN price ELSE NULL END,
+       rental_price = CASE WHEN trade_type = '대여' THEN price ELSE NULL END,
+       trade_types  = trade_type
+ WHERE trade_types IS NULL;
+
+ALTER TABLE items
+    MODIFY COLUMN trade_types VARCHAR(64) NOT NULL;
+
+CREATE INDEX idx_items_trade_types ON items (trade_types);

--- a/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
@@ -43,7 +43,7 @@ class ItemApplicationServiceTest {
     @Test
     @DisplayName("register 정상_id 발급되고 이미지+해시태그 add + 이미지 url promote (follow-up #12)")
     void register_정상() {
-        Long id = service.register(new ItemRegisterCommand(
+        Long id = service.register(ItemRegisterCommand.legacy(
                 SELLER, categoryId, "title", "desc", 10_000L, null, null, TradeType.판매,
                 "서울",
                 List.of("https://cdn.test/items/" + SELLER + "/img1.jpg", "https://cdn.test/items/" + SELLER + "/img2.jpg"),
@@ -64,7 +64,7 @@ class ItemApplicationServiceTest {
     @Test
     @DisplayName("register 없는 카테고리_CATEGORY_NOT_FOUND")
     void register_없는_카테고리_거부() {
-        assertThatThrownBy(() -> service.register(new ItemRegisterCommand(
+        assertThatThrownBy(() -> service.register(ItemRegisterCommand.legacy(
                 SELLER, 9999L, "t", "d", 1L, null, null, TradeType.판매, null, null, null
         )))
                 .isInstanceOf(BusinessException.class)
@@ -75,7 +75,7 @@ class ItemApplicationServiceTest {
     @Test
     @DisplayName("register null 카테고리_허용")
     void register_null_카테고리_허용() {
-        Long id = service.register(new ItemRegisterCommand(
+        Long id = service.register(ItemRegisterCommand.legacy(
                 SELLER, null, "t", "d", 1L, null, null, TradeType.판매, null, null, null
         ));
         assertThat(service.getById(id).categoryId()).isNull();
@@ -106,7 +106,7 @@ class ItemApplicationServiceTest {
     void update_본인() {
         Long id = registerSimple();
 
-        service.update(id, SELLER, new ItemUpdateCommand(
+        service.update(id, SELLER, ItemUpdateCommand.legacy(
                 null, "new title", "new desc", 50_000L, null, null, "부산", null, null
         ));
 
@@ -121,7 +121,7 @@ class ItemApplicationServiceTest {
     void update_타인_거부() {
         Long id = registerSimple();
 
-        assertThatThrownBy(() -> service.update(id, OTHER, new ItemUpdateCommand(
+        assertThatThrownBy(() -> service.update(id, OTHER, ItemUpdateCommand.legacy(
                 null, "x", "y", 1L, null, null, null, null, null
         )))
                 .isInstanceOf(BusinessException.class)
@@ -132,12 +132,12 @@ class ItemApplicationServiceTest {
     @Test
     @DisplayName("update imageUrls non-null_전체 교체 + 임시 prefix 자동 promote (follow-up #12)")
     void update_이미지_전체교체() {
-        Long id = service.register(new ItemRegisterCommand(
+        Long id = service.register(ItemRegisterCommand.legacy(
                 SELLER, categoryId, "t", "d", 1L, null, null, TradeType.판매, null,
                 List.of("https://cdn.test/items/" + SELLER + "/old1.jpg", "https://cdn.test/items/" + SELLER + "/old2.jpg"), null
         ));
 
-        service.update(id, SELLER, new ItemUpdateCommand(
+        service.update(id, SELLER, ItemUpdateCommand.legacy(
                 null, "t", "d", 1L, null, null, null, List.of("https://cdn.test/items/" + SELLER + "/new1.jpg"), null
         ));
 
@@ -150,12 +150,12 @@ class ItemApplicationServiceTest {
     @Test
     @DisplayName("update hashtags non-null_전체 교체")
     void update_해시태그_전체교체() {
-        Long id = service.register(new ItemRegisterCommand(
+        Long id = service.register(ItemRegisterCommand.legacy(
                 SELLER, categoryId, "t", "d", 1L, null, null, TradeType.판매, null,
                 null, List.of("old1", "old2")
         ));
 
-        service.update(id, SELLER, new ItemUpdateCommand(
+        service.update(id, SELLER, ItemUpdateCommand.legacy(
                 null, "t", "d", 1L, null, null, null, null, List.of("new1")
         ));
 
@@ -166,12 +166,12 @@ class ItemApplicationServiceTest {
     @Test
     @DisplayName("update hashtags null_변경 없음")
     void update_해시태그_null_유지() {
-        Long id = service.register(new ItemRegisterCommand(
+        Long id = service.register(ItemRegisterCommand.legacy(
                 SELLER, categoryId, "t", "d", 1L, null, null, TradeType.판매, null,
                 null, List.of("keep1", "keep2")
         ));
 
-        service.update(id, SELLER, new ItemUpdateCommand(
+        service.update(id, SELLER, ItemUpdateCommand.legacy(
                 null, "t", "d", 1L, null, null, null, null, null
         ));
 
@@ -204,12 +204,12 @@ class ItemApplicationServiceTest {
     @Test
     @DisplayName("update 대여_정상_deposit/rentalUnit 박힘")
     void update_대여() {
-        Long id = service.register(new ItemRegisterCommand(
+        Long id = service.register(ItemRegisterCommand.legacy(
                 SELLER, categoryId, "t", "d", 1L, 10_000L, RentalUnit.일, TradeType.대여, null,
                 null, null
         ));
 
-        service.update(id, SELLER, new ItemUpdateCommand(
+        service.update(id, SELLER, ItemUpdateCommand.legacy(
                 null, "t", "d", 1L, 20_000L, RentalUnit.주, null, null, null
         ));
 
@@ -219,7 +219,7 @@ class ItemApplicationServiceTest {
     }
 
     private Long registerSimple() {
-        return service.register(new ItemRegisterCommand(
+        return service.register(ItemRegisterCommand.legacy(
                 SELLER, categoryId, "t", "d", 1_000L, null, null, TradeType.판매, null, null, null
         ));
     }

--- a/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
@@ -127,11 +127,11 @@ class ItemSearchTest {
     @Test
     @DisplayName("search tag 필터")
     void search_tag() {
-        Long id1 = service.register(new ItemRegisterCommand(
+        Long id1 = service.register(ItemRegisterCommand.legacy(
                 SELLER, catA, "i1", "d", 1L, null, null, TradeType.판매, null,
                 null, List.of("아이폰", "미개봉")
         ));
-        Long id2 = service.register(new ItemRegisterCommand(
+        Long id2 = service.register(ItemRegisterCommand.legacy(
                 SELLER, catA, "i2", "d", 1L, null, null, TradeType.판매, null,
                 null, List.of("갤럭시")
         ));
@@ -189,13 +189,13 @@ class ItemSearchTest {
 
     private Long register(String title, String desc, Long categoryId, TradeType type, long price, RentalUnit unit) {
         Long deposit = type.requiresDeposit() ? 10_000L : null;
-        return service.register(new ItemRegisterCommand(
+        return service.register(ItemRegisterCommand.legacy(
                 SELLER, categoryId, title, desc, price, deposit, unit, type, null, null, null
         ));
     }
 
     private Long registerSimple() {
-        return service.register(new ItemRegisterCommand(
+        return service.register(ItemRegisterCommand.legacy(
                 SELLER, catA, "t" + System.nanoTime(), "d", 1L, null, null, TradeType.판매, null, null, null
         ));
     }

--- a/src/test/java/com/sseulang/domain/item/domain/ItemTest.java
+++ b/src/test/java/com/sseulang/domain/item/domain/ItemTest.java
@@ -322,4 +322,113 @@ class ItemTest {
     private static Item saleItem() {
         return Item.create(SELLER, CATEGORY, "t", "d", 10_000L, null, null, TradeType.판매, "서울");
     }
+
+    // ───────── V25 라운드 12 PR-D 잔여 — 판매/대여 이중 등록 ─────────
+
+    @Test
+    @DisplayName("createMulti 판매+대여_정상_salePrice/rentalPrice/deposit 모두 박힘")
+    void createMulti_판매대여_정상() {
+        Item item = Item.createMulti(
+                SELLER, CATEGORY, "t", "d",
+                java.util.EnumSet.of(TradeType.판매, TradeType.대여),
+                100_000L, 5_000L, 30_000L, RentalUnit.일, "서울"
+        );
+
+        assertThat(item.getTradeTypes()).containsExactlyInAnyOrder(TradeType.판매, TradeType.대여);
+        assertThat(item.getTradeType()).isEqualTo(TradeType.판매);  // primary
+        assertThat(item.getSalePrice()).isEqualTo(100_000L);
+        assertThat(item.getRentalPrice()).isEqualTo(5_000L);
+        assertThat(item.getDeposit()).isEqualTo(30_000L);
+        assertThat(item.getRentalUnit()).isEqualTo(RentalUnit.일);
+        // legacy price = primary 모드 가격
+        assertThat(item.getPrice()).isEqualTo(100_000L);
+    }
+
+    @Test
+    @DisplayName("createMulti 대여 단독_salePrice null")
+    void createMulti_대여만() {
+        Item item = Item.createMulti(
+                SELLER, CATEGORY, "t", "d",
+                java.util.EnumSet.of(TradeType.대여),
+                null, 5_000L, 30_000L, RentalUnit.일, null
+        );
+        assertThat(item.getSalePrice()).isNull();
+        assertThat(item.getRentalPrice()).isEqualTo(5_000L);
+        assertThat(item.getTradeType()).isEqualTo(TradeType.대여);
+    }
+
+    @Test
+    @DisplayName("createMulti 판매 모드인데 salePrice null_거부")
+    void createMulti_판매_salePrice_없으면_거부() {
+        assertThatThrownBy(() -> Item.createMulti(
+                SELLER, CATEGORY, "t", "d",
+                java.util.EnumSet.of(TradeType.판매),
+                null, null, null, null, null
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("createMulti 대여 모드인데 rentalUnit 누락_거부")
+    void createMulti_대여_rentalUnit_없으면_거부() {
+        assertThatThrownBy(() -> Item.createMulti(
+                SELLER, CATEGORY, "t", "d",
+                java.util.EnumSet.of(TradeType.대여),
+                null, 5_000L, 30_000L, null, null
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("createMulti 대여 모드인데 deposit 누락_거부")
+    void createMulti_대여_deposit_없으면_거부() {
+        assertThatThrownBy(() -> Item.createMulti(
+                SELLER, CATEGORY, "t", "d",
+                java.util.EnumSet.of(TradeType.대여),
+                null, 5_000L, null, RentalUnit.일, null
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("createMulti tradeTypes 비어있으면_거부")
+    void createMulti_빈tradeTypes_거부() {
+        assertThatThrownBy(() -> Item.createMulti(
+                SELLER, CATEGORY, "t", "d",
+                java.util.EnumSet.noneOf(TradeType.class),
+                100L, null, null, null, null
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("priceFor 판매+대여 모드_모드별 정확한 가격 반환")
+    void priceFor_정확() {
+        Item item = Item.createMulti(
+                SELLER, CATEGORY, "t", "d",
+                java.util.EnumSet.of(TradeType.판매, TradeType.대여),
+                100_000L, 5_000L, 30_000L, RentalUnit.일, null
+        );
+        assertThat(item.priceFor(TradeType.판매)).isEqualTo(100_000L);
+        assertThat(item.priceFor(TradeType.대여)).isEqualTo(5_000L);
+        assertThat(item.priceFor(TradeType.나눔)).isZero();
+        assertThat(item.priceFor(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("updateInfoMulti 판매→판매+대여 변경_가격 모두 박힘")
+    void updateInfoMulti_변경() {
+        Item item = Item.createMulti(
+                SELLER, CATEGORY, "t", "d",
+                java.util.EnumSet.of(TradeType.판매), 50_000L, null, null, null, null
+        );
+
+        item.updateInfoMulti(
+                "new", "new desc",
+                java.util.EnumSet.of(TradeType.판매, TradeType.대여),
+                60_000L, 3_000L, 10_000L, RentalUnit.시간, null
+        );
+
+        assertThat(item.getSalePrice()).isEqualTo(60_000L);
+        assertThat(item.getRentalPrice()).isEqualTo(3_000L);
+        assertThat(item.getDeposit()).isEqualTo(10_000L);
+        assertThat(item.getRentalUnit()).isEqualTo(RentalUnit.시간);
+        assertThat(item.getTradeTypes()).containsExactlyInAnyOrder(TradeType.판매, TradeType.대여);
+    }
 }

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -158,7 +158,7 @@ class SettlementRollbackIT {
             return null;
         });
 
-        Long itemId = txTemplate.execute(s -> itemService.register(new ItemRegisterCommand(
+        Long itemId = txTemplate.execute(s -> itemService.register(ItemRegisterCommand.legacy(
                 sellerId, null, "물건", "설명", 50_000L, null, null, TradeType.판매,
                 "서울", null, null
         )));

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -152,7 +152,7 @@ class TransactionConcurrencyIT {
                     .setParameter(2, buyer2Id)
                     .executeUpdate();
 
-            itemId = itemService.register(new ItemRegisterCommand(
+            itemId = itemService.register(ItemRegisterCommand.legacy(
                     sellerId, null, "물건", "설명", 50_000L, null, null, TradeType.판매,
                     "서울", null, null
             ));
@@ -226,7 +226,7 @@ class TransactionConcurrencyIT {
     @DisplayName("라운드 11 — 같은 buyer 두 거래 동시 reserve_잔액 한건만 충당_정확히 1건만 성공")
     void buyer_hold_race() throws Exception {
         // 별도 두 Item + 두 거래 (buyer 동일, 잔액 50000 한 건만 가능). 라운드 12 — 거래는 채팅방 안에서만 (판매자만).
-        Long item2Id = txTemplate.execute(status -> itemService.register(new ItemRegisterCommand(
+        Long item2Id = txTemplate.execute(status -> itemService.register(ItemRegisterCommand.legacy(
                 sellerId, null, "물건2", "설명", 50_000L, null, null, TradeType.판매, "서울", null, null
         )));
         // setUp 의 tx1Id (item1+buyer1, chatRoom1) 그대로 사용 — buyer1 의 첫 번째 거래.


### PR DESCRIPTION
## Summary
- V25: \`items.sale_price\` + \`rental_price\` + \`trade_types\` 컬럼 (이중 모드 동시 등록)
- \`Item.createMulti / updateInfoMulti\` — \`tradeTypes\` Set + 모드별 가격 분리, \`priceFor(mode)\` lookup
- \`ChatRoomMeta.tradeMode\` 추가 — \`Transaction.create\` 가 채팅방 모드로 정확한 가격/보증금 선택
- DTO 확장 — \`salePrice\`/\`rentalPrice\`/\`tradeTypes\` (legacy \`price\`/\`tradeType\` 도 backwards compat)
- 전체 코드베이스 한국어 Javadoc/inline 주석 일괄 제거

## 모드별 필수 필드
- 판매 ∈ tradeTypes → salePrice 필수
- 대여 ∈ tradeTypes → rentalPrice + rentalUnit + deposit 필수
- 나눔 ∈ tradeTypes → 가격 필드 무시

## Backwards compat
- 클라이언트가 기존 \`tradeType\` + \`price\` 만 보내도 controller 가 변환해서 매핑
- 응답에는 새 필드 + legacy 필드 둘 다 노출 (프론트 점진 마이그레이션)
- \`ItemRegisterCommand.legacy()\` / \`ItemUpdateCommand.legacy()\` 헬퍼로 테스트 코드 호환

## Test plan
- [x] Item Aggregate 단위 — createMulti 판매+대여 / 단독 / 빈 set 거부 / priceFor 정확도
- [x] updateInfoMulti — 판매→판매+대여 모드 변경
- [x] 전체 테스트 SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)