### PR TITLE
feat: round 12 PR-E — 거래대행 share 결제 미리보기

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -448,6 +448,36 @@ public class EscrowApplicationService {
     
     
     
+    public com.sseulang.domain.escrow.application.dto.EscrowPaymentPreviewResult previewPayShare(Long applicationId, Long viewerId) {
+        EscrowApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        if (!app.isParticipant(viewerId)) {
+            throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
+        }
+
+        long myShare;
+        boolean alreadyPaid;
+        if (viewerId.equals(app.getInitiatorId())) {
+            myShare = app.getInitiatorShare() == null ? 0L : app.getInitiatorShare();
+            alreadyPaid = app.getInitiatorPaidAt() != null;
+        } else {
+            myShare = app.getReceiverShare() == null ? 0L : app.getReceiverShare();
+            alreadyPaid = app.getReceiverPaidAt() != null;
+        }
+
+        long balance = userApplicationService.getPointSnapshot(viewerId).balance();
+        long deficit = Math.max(0L, myShare - balance);
+        boolean canPay = !alreadyPaid
+                && app.getStatus() == EscrowApplicationStatus.결제대기
+                && !app.isPaymentTimedOut()
+                && myShare > 0
+                && deficit == 0;
+
+        return new com.sseulang.domain.escrow.application.dto.EscrowPaymentPreviewResult(
+                app.getId(), myShare, balance, deficit, canPay, alreadyPaid, app.getPaymentDueAt()
+        );
+    }
+
     @Transactional
     public EscrowApplicationStatus payShare(Long applicationId, Long payerId) {
         userApplicationService.requireVerified(payerId);

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowPaymentPreviewResult.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowPaymentPreviewResult.java
@@ -1,0 +1,13 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import java.time.LocalDateTime;
+
+public record EscrowPaymentPreviewResult(
+        Long applicationId,
+        long myShare,
+        long myBalance,
+        long deficit,
+        boolean canPay,
+        boolean alreadyPaid,
+        LocalDateTime paymentDueAt
+) { }

--- a/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
@@ -133,6 +133,18 @@ public class EscrowController {
         return ApiResponse.ok(service.patchBuyerInfo(id, userId, request.toCommand()));
     }
 
+    @Operation(summary = "본인 share 결제 미리보기 (PR-E)",
+            description = "본인 분담 + 현재 포인트 잔액 + 부족분 + 즉시 결제 가능 여부. 부족 시 프론트가 충전 UI 트리거. 참여자만 접근.")
+    @GetMapping("/applications/{id}/payment-preview")
+    public ApiResponse<com.sseulang.domain.escrow.presentation.dto.EscrowPaymentPreviewResponse> previewPayment(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        return ApiResponse.ok(com.sseulang.domain.escrow.presentation.dto.EscrowPaymentPreviewResponse.from(
+                service.previewPayShare(id, userId)
+        ));
+    }
+
     @Operation(summary = "본인 share 포인트 결제 (PR-B-5)",
             description = "결제대기 상태에서 본인 share 만큼 포인트 잔액 차감. 양쪽 결제 완료 시 자동 결제완료 + 라이더 매칭. "
                     + "에러: 400 INSUFFICIENT_POINT (잔액 부족), 400 ESCROW_INVALID_STATE (상태/시점/이미 결제됨), 403 ESCROW_FORBIDDEN (참여자 아님).")

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowPaymentPreviewResponse.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowPaymentPreviewResponse.java
@@ -1,0 +1,25 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.application.dto.EscrowPaymentPreviewResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "거래대행 본인 share 결제 미리보기 — 부족분/잔액/결제 가능 여부.")
+public record EscrowPaymentPreviewResponse(
+        @Schema(example = "42") Long applicationId,
+        @Schema(example = "15000", description = "본인 분담 금액") long myShare,
+        @Schema(example = "9000", description = "현재 포인트 잔액") long myBalance,
+        @Schema(example = "6000", description = "부족분 = max(0, myShare - myBalance). 0 이면 즉시 결제 가능")
+        long deficit,
+        @Schema(example = "false", description = "즉시 결제 가능 여부 — 상태/시점/잔액/이미 결제 여부 모두 통과") boolean canPay,
+        @Schema(example = "false", description = "이미 본인 share 결제 완료") boolean alreadyPaid,
+        @Schema(description = "결제 마감 시각 — null 이면 마감 없음") LocalDateTime paymentDueAt
+) {
+    public static EscrowPaymentPreviewResponse from(EscrowPaymentPreviewResult r) {
+        return new EscrowPaymentPreviewResponse(
+                r.applicationId(), r.myShare(), r.myBalance(), r.deficit(),
+                r.canPay(), r.alreadyPaid(), r.paymentDueAt()
+        );
+    }
+}

--- a/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
@@ -387,4 +387,92 @@ class EscrowApplicationServiceTest {
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.ESCROW_FORBIDDEN);
     }
+
+    // ------------------------------- previewPayShare (PR-E) -------------------------------
+
+    @Test
+    @DisplayName("previewPayShare_잔액_충분_canPay=true_deficit=0")
+    void previewPayShare_canPay() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult app = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        long receiverShare = app.receiverShare();
+        when(userService.getPointSnapshot(20L))
+                .thenReturn(new com.sseulang.domain.user.domain.UserRepository.PointSnapshot(receiverShare + 1000, 0));
+
+        var preview = service.previewPayShare(app.id(), 20L);
+
+        assertThat(preview.myShare()).isEqualTo(receiverShare);
+        assertThat(preview.myBalance()).isEqualTo(receiverShare + 1000);
+        assertThat(preview.deficit()).isZero();
+        assertThat(preview.canPay()).isTrue();
+        assertThat(preview.alreadyPaid()).isFalse();
+    }
+
+    @Test
+    @DisplayName("previewPayShare_잔액_부족_deficit_정확_canPay=false")
+    void previewPayShare_deficit() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult app = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        long initiatorShare = app.initiatorShare();
+        when(userService.getPointSnapshot(11L))
+                .thenReturn(new com.sseulang.domain.user.domain.UserRepository.PointSnapshot(initiatorShare - 500, 0));
+
+        var preview = service.previewPayShare(app.id(), 11L);
+
+        assertThat(preview.myShare()).isEqualTo(initiatorShare);
+        assertThat(preview.deficit()).isEqualTo(500L);
+        assertThat(preview.canPay()).isFalse();
+    }
+
+    @Test
+    @DisplayName("previewPayShare_제3자_FORBIDDEN")
+    void previewPayShare_third_party_rejected() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult app = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        assertThatThrownBy(() -> service.previewPayShare(app.id(), 99L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ESCROW_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("previewPayShare_이미_본인_share_결제_완료_alreadyPaid=true_canPay=false")
+    void previewPayShare_already_paid() {
+        cacheExpectedFees();
+        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+                11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
+        ));
+        EscrowApplicationResult app = service.createApplication(validForm(
+                20L, link.linkToken(), 1_800_000L,
+                expectedDeliveryFee, expectedCommissionFee, expectedTotalFee
+        ));
+        service.recordPaymentConfirmed(app.id(), 20L);
+
+        long receiverShare = app.receiverShare();
+        when(userService.getPointSnapshot(20L))
+                .thenReturn(new com.sseulang.domain.user.domain.UserRepository.PointSnapshot(receiverShare * 10, 0));
+
+        var preview = service.previewPayShare(app.id(), 20L);
+
+        assertThat(preview.alreadyPaid()).isTrue();
+        assertThat(preview.canPay()).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary
- 새 endpoint: \`GET /api/v1/escrow/applications/{id}/payment-preview\`
- 응답 필드:
  - \`myShare\`: 본인 분담 금액
  - \`myBalance\`: 현재 포인트 잔액
  - \`deficit\`: 부족분 = max(0, myShare - myBalance)
  - \`canPay\`: 결제대기 + 미만료 + 미결제 + share>0 + 잔액 충분 모두 만족 시 true
  - \`alreadyPaid\`: 본인 share 이미 결제 완료
  - \`paymentDueAt\`: 결제 마감 시각 (null = 마감 없음)

## 사용 시나리오
외부 link 를 받은 사용자가 회원가입/로그인 후 본인 share 결제 직전에 호출 →
포인트 부족하면 프론트가 \`deficit\` 금액 충전 UI 띄우고, 충전 완료 후 \`POST /applications/{id}/pay\` 호출.

## 보안 가드
- 참여자(initiator / receiver) 만 접근 가능. 제3자는 \`ESCROW_FORBIDDEN\` (403).
- read-only — 잔액/상태 변경 X.

## Test plan
- [x] previewPayShare 잔액 충분 → canPay=true, deficit=0
- [x] 잔액 부족 → deficit 정확 계산, canPay=false
- [x] 제3자 호출 → ESCROW_FORBIDDEN
- [x] 이미 본인 share 결제 완료 → alreadyPaid=true, canPay=false
- [x] 전체 테스트 BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)