### PR TITLE
fix: 프론트 spec 정합 — systemCard rename + escrow deliveryId

### DIFF
--- a/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
+++ b/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
@@ -29,15 +29,15 @@ public record ChatRoomResult(
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         
-        SystemCard systemCard
+        SystemCard card
 ) {
-    
+
 
     public record SystemCard(
             com.sseulang.domain.item.domain.TradeType tradeMode,
             Long itemId,
             String itemTitle,
-            String thumbnailUrl,
+            String itemThumbnailUrl,
             Long price
     ) {
         public static SystemCard from(com.sseulang.domain.chat.domain.ChatRoomCard c) {
@@ -81,7 +81,7 @@ public record ChatRoomResult(
             String itemTitle,
             String itemThumbnailUrl,
             Long itemSellerId,
-            SystemCard systemCard
+            SystemCard card
     ) {
         Long opponentId;
         int myUnread;
@@ -108,7 +108,7 @@ public record ChatRoomResult(
                 c.getLastMessage(), c.getLastMessageAt(),
                 c.isActive(),
                 c.getCreatedAt(), c.getUpdatedAt(),
-                systemCard
+                card
         );
     }
 }

--- a/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
+++ b/src/main/java/com/sseulang/domain/chat/presentation/dto/ChatRoomResponse.java
@@ -1,15 +1,16 @@
 package com.sseulang.domain.chat.presentation.dto;
 
 import com.sseulang.domain.chat.application.dto.ChatRoomResult;
+import com.sseulang.domain.item.domain.TradeType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(description = "1:1 채팅방. viewer 기준 enrich — opponent* / myUnread / item* 자동 join. raw user1/user2 필드는 호환용 유지.")
+@Schema(description = "1:1 채팅방. viewer 기준 enrich — opponent* / myUnread / item* 자동 join.")
 public record ChatRoomResponse(
         @Schema(example = "8") Long id,
         @Schema(example = "42") Long itemId,
-        
+
         @Schema(example = "200", description = "viewer 의 상대방 사용자 id") Long opponentId,
         @Schema(example = "쓸랭이", description = "상대방 닉네임") String opponentNickname,
         @Schema(description = "상대방 프로필 이미지 URL (없으면 null)") String opponentProfileImage,
@@ -19,18 +20,35 @@ public record ChatRoomResponse(
         @Schema(example = "true", description = "viewer 가 이 채팅방의 아이템 판매자인지") boolean isSeller,
         @Schema(example = "false", description = "본인이 채팅방을 나갔는지 (soft hide). true 면 본인 목록에서 제외됨") boolean iLeft,
         @Schema(example = "false", description = "상대방이 채팅방을 나갔는지. true 면 메시지 send 차단 + 시스템 메시지 노출") boolean opponentLeft,
-        
+
         @Schema(example = "안녕하세요...", description = "최근 메시지 미리보기") String lastMessage,
         LocalDateTime lastMessageAt,
         @Schema(description = "false 면 차단/예약 등으로 비활성") boolean active,
-        
+
         @Schema(description = "정규화 raw — user1Id < user2Id. 호환용 유지, 신규 코드는 opponentId 사용 권장") Long user1Id,
         @Schema(description = "정규화 raw — 호환용 유지") Long user2Id,
         @Schema(description = "raw — user1 미읽음. 호환용 유지, 신규 코드는 myUnread 사용 권장") int user1Unread,
         @Schema(description = "raw — user2 미읽음. 호환용 유지") int user2Unread,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+
+        @Schema(description = "채팅방 시스템 카드 — 첫 메시지 도착 시 lazy 생성. 없으면 null.")
+        SystemCard card
 ) {
+    @Schema(description = "거래 모드 + 아이템 요약 카드.")
+    public record SystemCard(
+            @Schema(example = "대여") TradeType tradeMode,
+            @Schema(example = "42") Long itemId,
+            @Schema(example = "맥북 프로") String itemTitle,
+            @Schema(description = "아이템 썸네일 URL") String itemThumbnailUrl,
+            @Schema(example = "30000") Long price
+    ) {
+        public static SystemCard from(ChatRoomResult.SystemCard c) {
+            if (c == null) return null;
+            return new SystemCard(c.tradeMode(), c.itemId(), c.itemTitle(), c.itemThumbnailUrl(), c.price());
+        }
+    }
+
     public static ChatRoomResponse from(ChatRoomResult r) {
         return new ChatRoomResponse(
                 r.id(), r.itemId(),
@@ -40,7 +58,8 @@ public record ChatRoomResponse(
                 r.iLeft(), r.opponentLeft(),
                 r.lastMessage(), r.lastMessageAt(), r.active(),
                 r.user1Id(), r.user2Id(), r.user1Unread(), r.user2Unread(),
-                r.createdAt(), r.updatedAt()
+                r.createdAt(), r.updatedAt(),
+                SystemCard.from(r.card())
         );
     }
 }

--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -678,7 +678,10 @@ public class EscrowApplicationService {
         if (!app.isParticipant(requesterId)) {
             throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
         }
-        return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()));
+        Long deliveryId = deliveryRepository.findByEscrowApplicationId(id)
+                .map(d -> d.getId())
+                .orElse(null);
+        return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()), deliveryId);
     }
 
     
@@ -692,7 +695,10 @@ public class EscrowApplicationService {
     public EscrowApplicationResult adminGetById(Long id) {
         EscrowApplication app = applicationRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
-        return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()));
+        Long deliveryId = deliveryRepository.findByEscrowApplicationId(id)
+                .map(d -> d.getId())
+                .orElse(null);
+        return EscrowApplicationResult.from(app, parseImageUrls(app.getImageUrls()), deliveryId);
     }
 
     

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationResult.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationResult.java
@@ -49,10 +49,15 @@ public record EscrowApplicationResult(
         LocalDateTime receiptConfirmedAt,
         LocalDateTime settledAt,
         List<String> imageUrls,
+        Long deliveryId,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
     public static EscrowApplicationResult from(EscrowApplication a, List<String> imageUrls) {
+        return from(a, imageUrls, null);
+    }
+
+    public static EscrowApplicationResult from(EscrowApplication a, List<String> imageUrls, Long deliveryId) {
         return new EscrowApplicationResult(
                 a.getId(), a.getLinkId(),
                 a.getInitiatorId(), a.getReceiverId(),
@@ -69,6 +74,7 @@ public record EscrowApplicationResult(
                 a.getStatus(), a.getCancelReason(), a.getCancelledBy(),
                 a.getReceiptConfirmedAt(), a.getSettledAt(),
                 imageUrls,
+                deliveryId,
                 a.getCreatedAt(), a.getUpdatedAt()
         );
     }


### PR DESCRIPTION
## Summary
- ChatRoom 응답: \`systemCard\` → \`card\`, 내부 \`thumbnailUrl\` → \`itemThumbnailUrl\` 로 rename (프론트 이미 맞춘 형태)
- ChatRoomResponse 에 SystemCard inner record 추가 — 그동안 응답 직렬화에서 누락돼 있던 필드 정식 노출
- EscrowApplicationResult 에 \`deliveryId\` 필드 추가 — 매칭 후 GET /deliveries/{id} 로 sub-status 조회 가능

## 변경 영향
- \`GET /chat-rooms/{id}\`, \`GET /chat-rooms\`, \`POST /chat-rooms\` 응답 body 에 \`card\` 필드 노출 (없으면 null)
- \`GET /escrow/applications/{id}\`, \`GET /escrow/applications/me\` 응답 body 에 \`deliveryId\` 필드 노출 (없으면 null)
- listMine 페이징 deliveryId 는 N+1 회피 위해 항상 null — 단건 조회로 lookup. batch 가 필요해지면 후속.

## Test plan
- [x] 컴파일 + 전체 테스트 PASS (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)