### PR TITLE
fix: PATCH /items/{id} hashtag/image UNIQUE 위반 (Hibernate flush 순서)

### DIFF
--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -123,16 +123,18 @@ public class ItemApplicationService {
             item.assignCategory(cmd.categoryId());
         }
         if (cmd.imageUrls() != null) {
-            
-            
+
+
             validateImageOwnershipForUpdate(item.getSellerId(), item.getId(), cmd.imageUrls());
             item.clearImages();
-            
+            itemRepository.flush();
+
             List<String> promoted = promoteImageUrls(item.getSellerId(), item.getId(), cmd.imageUrls());
             applyImages(item, promoted);
         }
         if (cmd.hashtags() != null) {
             item.clearHashtags();
+            itemRepository.flush();
             applyHashtags(item, cmd.hashtags());
         }
     }

--- a/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
@@ -25,6 +25,8 @@ public interface ItemRepository {
 
     void delete(Item item);
 
+    void flush();
+
     
 
     int incrementWishlistCount(Long itemId);

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
@@ -55,6 +55,11 @@ public class ItemRepositoryImpl implements ItemRepository {
     }
 
     @Override
+    public void flush() {
+        jpa.flush();
+    }
+
+    @Override
     public int incrementWishlistCount(Long itemId) {
         return jpa.incrementWishlistCount(itemId);
     }

--- a/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
+++ b/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
@@ -93,6 +93,11 @@ public class InMemoryFakeItemRepository implements ItemRepository {
     }
 
     @Override
+    public void flush() {
+        // in-memory — no-op
+    }
+
+    @Override
     public int incrementWishlistCount(Long itemId) {
         Item item = store.get(itemId);
         if (item == null) return 0;


### PR DESCRIPTION
## 증상
- prod 500 — traceId \`3a36e587-fe69-4ba0-947e-ae390b0af991\`
- \`PATCH /api/v1/items/23\` 호출 시 \`Duplicate entry '23-16' for key 'item_hashtags.uk_item_hashtags_item_tag'\`

## 원인
\`ItemApplicationService.update\` 의 흐름:
\`\`\`
item.clearHashtags();
applyHashtags(item, cmd.hashtags());
\`\`\`
같은 트랜잭션에서 collection clear → add 가 발생하면, Hibernate flush 순서가 **INSERT 먼저 → DELETE 나중** 이라 같은 (item_id, tag) 가 이미 DB 에 있는 상태로 INSERT 시도 → UNIQUE 충돌. 이미지(item_images) 도 동일 위험.

## 수정
- \`ItemRepository\` 인터페이스에 \`flush()\` 추가 + JPA Impl + InMemoryFake 구현
- \`update()\` 에서 \`clearHashtags() / clearImages()\` 직후 \`itemRepository.flush()\` 강제 → DELETE 가 INSERT 보다 먼저 commit 됨

## Test plan
- [x] 컴파일 + 전체 테스트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)