### PR TITLE
fix: 채팅방 응답에 systemCard (card) 항상 포함

### DIFF
--- a/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
+++ b/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
@@ -75,17 +75,20 @@ public class ChatRoomApplicationService {
     public Page<ChatRoomResult> listMine(Long userId, Pageable pageable) {
         Page<ChatRoom> page = chatRoomRepository.findMine(userId, pageable);
         if (page.isEmpty()) {
-            return page.map(c -> ChatRoomResult.from(c, userId, null, null, null, null, null));
+            return page.map(c -> ChatRoomResult.from(c, userId, null, null, null, null, null, null));
         }
         Set<Long> opponentIds = new HashSet<>();
         Set<Long> itemIds = new HashSet<>();
+        Set<Long> roomIds = new HashSet<>();
         for (ChatRoom c : page.getContent()) {
             opponentIds.add(userId.equals(c.getUser1Id()) ? c.getUser2Id() : c.getUser1Id());
             itemIds.add(c.getItemId());
+            roomIds.add(c.getId());
         }
         Map<Long, UserView.UserProjection> userMap = userView.findByIds(opponentIds);
         Map<Long, ItemView.ItemProjection> itemMap = itemView.findByIds(itemIds);
-        return page.map(c -> enrichWithMaps(c, userId, userMap, itemMap));
+        Map<Long, ChatRoomResult.SystemCard> cardMap = loadCards(roomIds);
+        return page.map(c -> enrichWithMaps(c, userId, userMap, itemMap, cardMap));
     }
 
     public ChatRoomResult getOne(Long id, Long requesterId) {
@@ -94,22 +97,7 @@ public class ChatRoomApplicationService {
         if (!room.isParticipant(requesterId)) {
             throw new BusinessException(ErrorCode.CHAT_FORBIDDEN);
         }
-        ChatRoomResult base = enrichOne(room, requesterId);
-        
-        ChatRoomResult.SystemCard card = chatRoomCardRepository.findByChatRoomId(id)
-                .map(ChatRoomResult.SystemCard::from)
-                .orElse(null);
-        return new ChatRoomResult(
-                base.id(), base.itemId(),
-                base.user1Id(), base.user2Id(),
-                base.user1Unread(), base.user2Unread(),
-                base.opponentId(), base.opponentNickname(), base.opponentProfileImage(), base.myUnread(),
-                base.itemTitle(), base.itemThumbnailUrl(), base.isSeller(),
-                base.iLeft(), base.opponentLeft(),
-                base.lastMessage(), base.lastMessageAt(),
-                base.active(), base.createdAt(), base.updatedAt(),
-                card
-        );
+        return enrichOne(room, requesterId);
     }
 
     
@@ -231,25 +219,38 @@ public class ChatRoomApplicationService {
         Long opponentId = viewerId.equals(room.getUser1Id()) ? room.getUser2Id() : room.getUser1Id();
         Map<Long, UserView.UserProjection> userMap = userView.findByIds(List.of(opponentId));
         Map<Long, ItemView.ItemProjection> itemMap = itemView.findByIds(List.of(room.getItemId()));
-        return enrichWithMaps(room, viewerId, userMap, itemMap);
+        Map<Long, ChatRoomResult.SystemCard> cardMap = loadCards(List.of(room.getId()));
+        return enrichWithMaps(room, viewerId, userMap, itemMap, cardMap);
+    }
+
+    private Map<Long, ChatRoomResult.SystemCard> loadCards(java.util.Collection<Long> roomIds) {
+        if (roomIds == null || roomIds.isEmpty()) return Map.of();
+        Map<Long, ChatRoomResult.SystemCard> map = new java.util.HashMap<>();
+        for (var c : chatRoomCardRepository.findByChatRoomIdIn(roomIds)) {
+            map.put(c.getChatRoomId(), ChatRoomResult.SystemCard.from(c));
+        }
+        return map;
     }
 
     private static ChatRoomResult enrichWithMaps(
             ChatRoom c,
             Long viewerId,
             Map<Long, UserView.UserProjection> userMap,
-            Map<Long, ItemView.ItemProjection> itemMap
+            Map<Long, ItemView.ItemProjection> itemMap,
+            Map<Long, ChatRoomResult.SystemCard> cardMap
     ) {
         Long opponentId = viewerId.equals(c.getUser1Id()) ? c.getUser2Id() : c.getUser1Id();
         UserView.UserProjection u = userMap.get(opponentId);
         ItemView.ItemProjection i = itemMap.get(c.getItemId());
+        ChatRoomResult.SystemCard card = cardMap != null ? cardMap.get(c.getId()) : null;
         return ChatRoomResult.from(
                 c, viewerId,
                 u != null ? u.nickname() : null,
                 u != null ? u.profileImage() : null,
                 i != null ? i.title() : null,
                 i != null ? i.thumbnailUrl() : null,
-                i != null ? i.sellerId() : null
+                i != null ? i.sellerId() : null,
+                card
         );
     }
 

--- a/src/main/java/com/sseulang/domain/chat/domain/ChatRoomCardRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/ChatRoomCardRepository.java
@@ -1,10 +1,14 @@
 package com.sseulang.domain.chat.domain;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomCardRepository {
 
     Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId);
+
+    List<ChatRoomCard> findByChatRoomIdIn(Collection<Long> chatRoomIds);
 
     ChatRoomCard save(ChatRoomCard card);
 }

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomCardMongoRepository.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomCardMongoRepository.java
@@ -3,8 +3,12 @@ package com.sseulang.domain.chat.infrastructure.persistence;
 import com.sseulang.domain.chat.domain.ChatRoomCard;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 interface ChatRoomCardMongoRepository extends MongoRepository<ChatRoomCard, String> {
     Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId);
+
+    List<ChatRoomCard> findByChatRoomIdIn(Collection<Long> chatRoomIds);
 }

--- a/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomCardRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/chat/infrastructure/persistence/ChatRoomCardRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.sseulang.domain.chat.domain.ChatRoomCard;
 import com.sseulang.domain.chat.domain.ChatRoomCardRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,6 +20,12 @@ class ChatRoomCardRepositoryImpl implements ChatRoomCardRepository {
     @Override
     public Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId) {
         return mongo.findByChatRoomId(chatRoomId);
+    }
+
+    @Override
+    public List<ChatRoomCard> findByChatRoomIdIn(Collection<Long> chatRoomIds) {
+        if (chatRoomIds == null || chatRoomIds.isEmpty()) return List.of();
+        return mongo.findByChatRoomIdIn(chatRoomIds);
     }
 
     @Override

--- a/src/test/java/com/sseulang/domain/chat/application/InMemoryFakeChatRoomCardRepository.java
+++ b/src/test/java/com/sseulang/domain/chat/application/InMemoryFakeChatRoomCardRepository.java
@@ -3,7 +3,9 @@ package com.sseulang.domain.chat.application;
 import com.sseulang.domain.chat.domain.ChatRoomCard;
 import com.sseulang.domain.chat.domain.ChatRoomCardRepository;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -14,6 +16,14 @@ public class InMemoryFakeChatRoomCardRepository implements ChatRoomCardRepositor
     @Override
     public Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId) {
         return Optional.ofNullable(store.get(chatRoomId));
+    }
+
+    @Override
+    public List<ChatRoomCard> findByChatRoomIdIn(Collection<Long> chatRoomIds) {
+        if (chatRoomIds == null || chatRoomIds.isEmpty()) return List.of();
+        return store.values().stream()
+                .filter(c -> chatRoomIds.contains(c.getChatRoomId()))
+                .toList();
     }
 
     @Override

--- a/src/test/java/com/sseulang/domain/chat/application/NoOpChatRoomCardRepository.java
+++ b/src/test/java/com/sseulang/domain/chat/application/NoOpChatRoomCardRepository.java
@@ -2,20 +2,20 @@ package com.sseulang.domain.chat.application;
 
 import com.sseulang.domain.chat.domain.ChatRoomCard;
 import com.sseulang.domain.chat.domain.ChatRoomCardRepository;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
-/**
- * MongoDB 없는 슬라이스 테스트 (예: SettlementRollbackIT 등 @DataJpaTest)에서 @Import 로 명시 등록.
- * 항상 빈 결과 — 시스템 카드 fetch 가 빠짐.
- *
- * <p>@Component 제거 — SpringBootTest 자동 스캔 시 ChatRoomCardRepositoryImpl 과 충돌 방지.
- * @Import 가 클래스 import 시 Spring 이 빈 등록 (no-arg 생성자 활용).</p>
- */
 public class NoOpChatRoomCardRepository implements ChatRoomCardRepository {
 
     @Override
     public Optional<ChatRoomCard> findByChatRoomId(Long chatRoomId) {
         return Optional.empty();
+    }
+
+    @Override
+    public List<ChatRoomCard> findByChatRoomIdIn(Collection<Long> chatRoomIds) {
+        return List.of();
     }
 
     @Override


### PR DESCRIPTION
## 증상
- 메시지 보내면 mongo \`chat_room_cards\` 에 카드는 정상 생성됨 (ensureSystemCard 동작)
- 그런데 \`POST /chat-rooms\`, \`GET /chat-rooms\` (listMine), \`PATCH /chat-rooms/{id}/read\` 응답의 \`card\` 가 항상 \`null\`
- \`GET /chat-rooms/{id}\` (단건) 호출해야만 카드가 보임 → 프론트가 새 채팅방 진입 시 카드 못 받음

## 원인
\`enrichOne\` / \`enrichWithMaps\` 가 SystemCard 를 fetch 하지 않았음. \`getOne\` 에서만 별도 lookup 했고 다른 경로엔 누락.

## 수정
- \`ChatRoomCardRepository.findByChatRoomIdIn(...)\` batch 메서드 추가 (N+1 회피)
- \`enrichOne\` 단건 + \`listMine\` 페이징 batch 둘 다 \`loadCards\` 로 카드 lookup
- \`enrichWithMaps\` 시그니처에 \`cardMap\` 추가 → 모든 응답에 일관 노출
- \`getOne\` 의 별도 카드 lookup 로직 삭제 (enrichOne 이 처리)

## Test plan
- [x] 컴파일 + 전체 테스트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)