### PR TITLE
fix: enum @JsonCreator DELEGATING mode 명시

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/domain/Fragility.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/Fragility.java
@@ -27,7 +27,7 @@ public enum Fragility {
         return multiplier;
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static Fragility fromCode(String code) {
         for (Fragility f : values()) if (f.code.equals(code)) return f;
         throw new IllegalArgumentException("Unknown Fragility: " + code);

--- a/src/main/java/com/sseulang/domain/escrow/domain/Volume.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/Volume.java
@@ -25,7 +25,7 @@ public enum Volume {
         return multiplier;
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static Volume fromCode(String code) {
         for (Volume v : values()) if (v.code.equals(code)) return v;
         throw new IllegalArgumentException("Unknown Volume: " + code);

--- a/src/main/java/com/sseulang/domain/escrow/domain/Weight.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/Weight.java
@@ -34,7 +34,7 @@ public enum Weight {
         return truck;
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static Weight fromCode(String code) {
         for (Weight w : values()) if (w.code.equals(code)) return w;
         throw new IllegalArgumentException("Unknown Weight: " + code);


### PR DESCRIPTION
Jackson 2.17+ 에서 @JsonCreator 추론이 엄격해져 properties-based 로 잡힘. mode=DELEGATING 명시로 단일 문자열 deserialize 복구.