### PR TITLE
fix: 나눔 거래대행 itemPrice=0 허용

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeCalculator.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowFeeCalculator.java
@@ -39,7 +39,7 @@ public final class EscrowFeeCalculator {
         if (settings == null || tradeMode == null || weight == null || volume == null || fragility == null) {
             throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
         }
-        if (tradeMode == TradeMode.INTERNAL && itemPrice <= 0) {
+        if (tradeMode == TradeMode.INTERNAL && itemPrice < 0) {
             throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
         }
         if (tradeMode == TradeMode.EXTERNAL && itemPrice != 0) {


### PR DESCRIPTION
INTERNAL 모드에서 itemPrice<=0 거부 → 나눔 케이스 통과 못함. <0 로 완화 (음수만 거부, 0 허용).