### PR TITLE
feat(escrow): 외부 link 분리 입력 흐름 (round 12 후속)

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -3,6 +3,7 @@ package com.sseulang.domain.escrow.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationByLinkCommand;
 import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateCommand;
 import com.sseulang.domain.escrow.application.dto.EscrowApplicationCreateInternalCommand;
 import com.sseulang.domain.escrow.application.dto.EscrowApplicationPreviewCommand;
@@ -288,21 +289,33 @@ public class EscrowApplicationService {
     @Transactional
     public EscrowLinkResult createLink(EscrowLinkCreateCommand cmd) {
         userApplicationService.requireVerified(cmd.initiatorId());
-        EscrowLink link = EscrowLink.create(
-                cmd.initiatorId(),
-                cmd.initiatorRole(),
-                cmd.feePayer(),
-                cmd.tradeMode(),
-                linkExpiryHours
-        );
+        boolean hasInitiatorInfo =
+                cmd.initiatorPickupAddress() != null || cmd.initiatorDeliveryAddress() != null
+                        || cmd.initiatorItemPrice() != null || cmd.initiatorReceiverPhone() != null;
+        EscrowLink link;
+        if (hasInitiatorInfo) {
+            link = EscrowLink.createWithInitiatorInfo(
+                    cmd.initiatorId(), cmd.initiatorRole(), cmd.feePayer(), cmd.tradeMode(), linkExpiryHours,
+                    cmd.initiatorPickupAddress(), cmd.initiatorPickupLat(), cmd.initiatorPickupLng(),
+                    cmd.initiatorItemPrice(), cmd.initiatorItemDescription(),
+                    cmd.initiatorWeight(), cmd.initiatorVolume(), cmd.initiatorFragility(),
+                    cmd.initiatorDeliveryNotes(), serializeImageUrls(cmd.initiatorImageUrls()),
+                    cmd.initiatorDeliveryAddress(), cmd.initiatorDeliveryLat(), cmd.initiatorDeliveryLng(),
+                    cmd.initiatorReceiverPhone()
+            );
+        } else {
+            link = EscrowLink.create(
+                    cmd.initiatorId(), cmd.initiatorRole(), cmd.feePayer(), cmd.tradeMode(), linkExpiryHours
+            );
+        }
         EscrowLink saved = linkRepository.save(link);
         User initiator = userApplicationService.getById(cmd.initiatorId());
-        return EscrowLinkResult.from(saved, initiator.getNickname());
+        return EscrowLinkResult.from(saved, initiator.getNickname(), parseImageUrls(saved.getInitiatorImageUrls()));
     }
 
-    
-    
-    
+
+
+
     public EscrowLinkResult getByToken(String linkToken) {
         EscrowLink link = linkRepository.findByLinkToken(linkToken)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_LINK_NOT_FOUND));
@@ -316,7 +329,7 @@ public class EscrowApplicationService {
             throw new BusinessException(ErrorCode.ESCROW_LINK_ALREADY_TAKEN);
         }
         User initiator = userApplicationService.getById(link.getInitiatorId());
-        return EscrowLinkResult.from(link, initiator.getNickname());
+        return EscrowLinkResult.from(link, initiator.getNickname(), parseImageUrls(link.getInitiatorImageUrls()));
     }
 
     
@@ -383,12 +396,139 @@ public class EscrowApplicationService {
                 serializeImageUrls(cmd.imageUrls())
         );
         EscrowApplication saved = applicationRepository.save(app);
-        
+
         link.markAsCompleted();
         return EscrowApplicationResult.from(saved, parseImageUrls(saved.getImageUrls()));
     }
 
-    
+    // 라운드 12 — 분리 입력 흐름. 발급자가 link 발급 시 본인 영역을 미리 입력했고
+    // 수신자는 본인 영역만 채워서 by-link 신청. 양쪽 정보 합쳐 application 생성.
+    @Transactional
+    public EscrowApplicationResult createByLinkApplication(EscrowApplicationByLinkCommand cmd) {
+        userApplicationService.requireVerified(cmd.receiverId());
+
+        EscrowLink link = linkRepository.findByLinkToken(cmd.linkToken())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_LINK_NOT_FOUND));
+
+        // 멱등 — 동일 수신자 재제출 시 기존 application 반환
+        if (cmd.receiverId().equals(link.getReceiverId())) {
+            return applicationRepository.findByLinkId(link.getId())
+                    .map(a -> EscrowApplicationResult.from(a, parseImageUrls(a.getImageUrls())))
+                    .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_INVALID_STATE));
+        }
+
+        int affected = linkRepository.claimReceiverIfAvailable(link.getId(), cmd.receiverId());
+        if (affected == 0) {
+            if (link.getInitiatorId().equals(cmd.receiverId())) {
+                throw new BusinessException(ErrorCode.ESCROW_SELF_NOT_ALLOWED);
+            }
+            if (link.isExpired() || link.getStatus() == EscrowLinkStatus.만료) {
+                throw new BusinessException(ErrorCode.ESCROW_LINK_EXPIRED);
+            }
+            throw new BusinessException(ErrorCode.ESCROW_LINK_ALREADY_TAKEN);
+        }
+
+        // role 별 영역 머지 — 발급자 영역은 link 에서, 수신자 영역은 cmd 에서
+        String pickupAddress;
+        BigDecimal pickupLat;
+        BigDecimal pickupLng;
+        long itemPrice;
+        String itemDescription;
+        com.sseulang.domain.escrow.domain.Weight weight;
+        com.sseulang.domain.escrow.domain.Volume volume;
+        com.sseulang.domain.escrow.domain.Fragility fragility;
+        String deliveryNotes;
+        String imageUrlsJson;
+        String deliveryAddress;
+        BigDecimal deliveryLat;
+        BigDecimal deliveryLng;
+        String receiverPhone;
+
+        if (link.getInitiatorRole() == InitiatorRole.seller) {
+            // 발급자(seller) = pickup + 물품, 수신자(buyer) = delivery + receiverPhone
+            if (link.getInitiatorPickupAddress() == null || link.getInitiatorItemPrice() == null) {
+                throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+            }
+            if (cmd.deliveryAddress() == null || cmd.deliveryLat() == null || cmd.deliveryLng() == null
+                    || cmd.receiverPhone() == null || cmd.receiverPhone().isBlank()) {
+                throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+            }
+            pickupAddress = link.getInitiatorPickupAddress();
+            pickupLat = link.getInitiatorPickupLat();
+            pickupLng = link.getInitiatorPickupLng();
+            itemPrice = link.getInitiatorItemPrice();
+            itemDescription = link.getInitiatorItemDescription();
+            weight = link.getInitiatorWeight();
+            volume = link.getInitiatorVolume();
+            fragility = link.getInitiatorFragility();
+            deliveryNotes = link.getInitiatorDeliveryNotes();
+            imageUrlsJson = link.getInitiatorImageUrls();
+            deliveryAddress = cmd.deliveryAddress();
+            deliveryLat = cmd.deliveryLat();
+            deliveryLng = cmd.deliveryLng();
+            receiverPhone = cmd.receiverPhone();
+        } else {
+            // 발급자(buyer) = delivery + receiverPhone, 수신자(seller) = pickup + 물품
+            if (link.getInitiatorDeliveryAddress() == null || link.getInitiatorReceiverPhone() == null) {
+                throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+            }
+            if (cmd.pickupAddress() == null || cmd.pickupLat() == null || cmd.pickupLng() == null
+                    || cmd.itemPrice() == null || cmd.itemDescription() == null
+                    || cmd.weight() == null || cmd.volume() == null || cmd.fragility() == null) {
+                throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+            }
+            pickupAddress = cmd.pickupAddress();
+            pickupLat = cmd.pickupLat();
+            pickupLng = cmd.pickupLng();
+            itemPrice = cmd.itemPrice();
+            itemDescription = cmd.itemDescription();
+            weight = cmd.weight();
+            volume = cmd.volume();
+            fragility = cmd.fragility();
+            deliveryNotes = cmd.deliveryNotes();
+            imageUrlsJson = serializeImageUrls(cmd.imageUrls());
+            deliveryAddress = link.getInitiatorDeliveryAddress();
+            deliveryLat = link.getInitiatorDeliveryLat();
+            deliveryLng = link.getInitiatorDeliveryLng();
+            receiverPhone = link.getInitiatorReceiverPhone();
+        }
+
+        EscrowFeeSettings settings = feeSettingsRepository.findSingleton();
+        BigDecimal calculatedDistance = EscrowFeeCalculator.distanceKm(
+                pickupLat.doubleValue(), pickupLng.doubleValue(),
+                deliveryLat.doubleValue(), deliveryLng.doubleValue()
+        );
+        FeeBreakdown calculated = EscrowFeeCalculator.calculate(
+                settings, link.getTradeMode(), itemPrice, calculatedDistance,
+                weight, volume, fragility
+        );
+        EscrowFeeCalculator.verifyTolerance(
+                calculated, cmd.submittedDeliveryFee(), cmd.submittedCommissionFee(), cmd.submittedTotalFee()
+        );
+
+        long buyerOwed = computeBuyerOwed(link.getTradeMode(), itemPrice, calculated, link.getFeePayer());
+        long sellerOwed = computeSellerOwed(calculated, link.getFeePayer());
+        long initiatorShare = link.getInitiatorRole() == InitiatorRole.buyer ? buyerOwed : sellerOwed;
+        long receiverShare = link.getInitiatorRole() == InitiatorRole.buyer ? sellerOwed : buyerOwed;
+
+        EscrowApplication app = EscrowApplication.create(
+                link.getId(),
+                link.getInitiatorId(), cmd.receiverId(), link.getInitiatorRole(),
+                link.getTradeMode(), link.getFeePayer(),
+                itemPrice, itemDescription,
+                pickupAddress, pickupLat, pickupLng,
+                deliveryAddress, deliveryLat, deliveryLng,
+                weight, volume, fragility, deliveryNotes,
+                calculated, initiatorShare, receiverShare,
+                imageUrlsJson
+        );
+        EscrowApplication saved = applicationRepository.save(app);
+        saved.attachReceiverPhone(receiverPhone);
+        link.markAsCompleted();
+        return EscrowApplicationResult.from(saved, parseImageUrls(saved.getImageUrls()));
+    }
+
+
 
     private long computeBuyerOwed(TradeMode mode, long itemPrice, FeeBreakdown fee, FeePayer payer) {
         long feeTotal = fee.deliveryFee() + fee.commissionFee();

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationByLinkCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowApplicationByLinkCommand.java
@@ -1,0 +1,37 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+// 라운드 12 분리 입력 — 수신자가 본인 영역만 채워서 link 매칭 → application 생성.
+// role 따라 수신자가 채우는 영역이 달라지므로 모두 nullable. 서비스에서 link.role 보고 검증.
+public record EscrowApplicationByLinkCommand(
+        Long receiverId,
+        String linkToken,
+        // seller 가 발급한 link → 수신자(buyer) 가 delivery + receiverPhone 입력
+        String deliveryAddress,
+        BigDecimal deliveryLat,
+        BigDecimal deliveryLng,
+        String receiverPhone,
+        // buyer 가 발급한 link → 수신자(seller) 가 pickup + 물품 정보 입력
+        String pickupAddress,
+        BigDecimal pickupLat,
+        BigDecimal pickupLng,
+        Long itemPrice,
+        String itemDescription,
+        Weight weight,
+        Volume volume,
+        Fragility fragility,
+        String deliveryNotes,
+        List<String> imageUrls,
+        // preview 단계 fee snapshot — ±10원 검증
+        long submittedDeliveryFee,
+        long submittedCommissionFee,
+        long submittedTotalFee,
+        BigDecimal submittedDistanceKm
+) {
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkCreateCommand.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkCreateCommand.java
@@ -1,13 +1,44 @@
 package com.sseulang.domain.escrow.application.dto;
 
 import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
 import com.sseulang.domain.escrow.domain.InitiatorRole;
 import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 public record EscrowLinkCreateCommand(
         Long initiatorId,
         InitiatorRole initiatorRole,
         FeePayer feePayer,
-        TradeMode tradeMode
+        TradeMode tradeMode,
+        // seller 발급 시
+        String initiatorPickupAddress,
+        BigDecimal initiatorPickupLat,
+        BigDecimal initiatorPickupLng,
+        Long initiatorItemPrice,
+        String initiatorItemDescription,
+        Weight initiatorWeight,
+        Volume initiatorVolume,
+        Fragility initiatorFragility,
+        String initiatorDeliveryNotes,
+        List<String> initiatorImageUrls,
+        // buyer 발급 시
+        String initiatorDeliveryAddress,
+        BigDecimal initiatorDeliveryLat,
+        BigDecimal initiatorDeliveryLng,
+        String initiatorReceiverPhone
 ) {
+    public static EscrowLinkCreateCommand legacy(
+            Long initiatorId, InitiatorRole role, FeePayer feePayer, TradeMode tradeMode
+    ) {
+        return new EscrowLinkCreateCommand(
+                initiatorId, role, feePayer, tradeMode,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null
+        );
+    }
 }

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkResult.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowLinkResult.java
@@ -2,10 +2,15 @@ package com.sseulang.domain.escrow.application.dto;
 
 import com.sseulang.domain.escrow.domain.EscrowLink;
 import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
 import com.sseulang.domain.escrow.domain.InitiatorRole;
 import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record EscrowLinkResult(
         String linkToken,
@@ -13,16 +18,45 @@ public record EscrowLinkResult(
         InitiatorRole initiatorRole,
         FeePayer feePayer,
         TradeMode tradeMode,
-        LocalDateTime expiresAt
+        LocalDateTime expiresAt,
+        // 발급자 본인 영역 — 수신자가 자기 영역 채울 때 참고 (role 따라 일부 필드만 채워짐)
+        String initiatorPickupAddress,
+        BigDecimal initiatorPickupLat,
+        BigDecimal initiatorPickupLng,
+        Long initiatorItemPrice,
+        String initiatorItemDescription,
+        Weight initiatorWeight,
+        Volume initiatorVolume,
+        Fragility initiatorFragility,
+        String initiatorDeliveryNotes,
+        List<String> initiatorImageUrls,
+        String initiatorDeliveryAddress,
+        BigDecimal initiatorDeliveryLat,
+        BigDecimal initiatorDeliveryLng,
+        String initiatorReceiverPhone
 ) {
-    public static EscrowLinkResult from(EscrowLink link, String initiatorNickname) {
+    public static EscrowLinkResult from(EscrowLink link, String initiatorNickname, List<String> initiatorImageUrls) {
         return new EscrowLinkResult(
                 link.getLinkToken(),
                 initiatorNickname,
                 link.getInitiatorRole(),
                 link.getFeePayer(),
                 link.getTradeMode(),
-                link.getExpiresAt()
+                link.getExpiresAt(),
+                link.getInitiatorPickupAddress(),
+                link.getInitiatorPickupLat(),
+                link.getInitiatorPickupLng(),
+                link.getInitiatorItemPrice(),
+                link.getInitiatorItemDescription(),
+                link.getInitiatorWeight(),
+                link.getInitiatorVolume(),
+                link.getInitiatorFragility(),
+                link.getInitiatorDeliveryNotes(),
+                initiatorImageUrls,
+                link.getInitiatorDeliveryAddress(),
+                link.getInitiatorDeliveryLat(),
+                link.getInitiatorDeliveryLng(),
+                link.getInitiatorReceiverPhone()
         );
     }
 }

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
@@ -363,7 +363,12 @@ public class EscrowApplication extends BaseEntity {
         this.sellerInfoFilled = true;
     }
 
-    
+    // 라운드 12 — 분리 입력 by-link 신청용. 생성 직후 receiverPhone 만 추가로 셋팅 (deliveryAddress 는 이미 create 시점에 셋팅됨).
+    public void attachReceiverPhone(String receiverPhone) {
+        if (receiverPhone != null && !receiverPhone.isBlank()) {
+            this.receiverPhone = receiverPhone;
+        }
+    }
 
     public void patchBuyerInfo(
             String deliveryAddress, BigDecimal deliveryLat, BigDecimal deliveryLng,

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowLink.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowLink.java
@@ -15,6 +15,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -56,7 +57,53 @@ public class EscrowLink extends BaseEntity {
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
 
-    
+    // ---- 발급자 본인 영역 (V27) — role 따라 nullable ----
+    @Column(name = "initiator_pickup_address", length = 255, updatable = false)
+    private String initiatorPickupAddress;
+
+    @Column(name = "initiator_pickup_lat", precision = 10, scale = 7, updatable = false)
+    private BigDecimal initiatorPickupLat;
+
+    @Column(name = "initiator_pickup_lng", precision = 10, scale = 7, updatable = false)
+    private BigDecimal initiatorPickupLng;
+
+    @Column(name = "initiator_delivery_address", length = 255, updatable = false)
+    private String initiatorDeliveryAddress;
+
+    @Column(name = "initiator_delivery_lat", precision = 10, scale = 7, updatable = false)
+    private BigDecimal initiatorDeliveryLat;
+
+    @Column(name = "initiator_delivery_lng", precision = 10, scale = 7, updatable = false)
+    private BigDecimal initiatorDeliveryLng;
+
+    @Column(name = "initiator_receiver_phone", length = 20, updatable = false)
+    private String initiatorReceiverPhone;
+
+    @Column(name = "initiator_item_price", updatable = false)
+    private Long initiatorItemPrice;
+
+    @Column(name = "initiator_item_description", length = 500, updatable = false)
+    private String initiatorItemDescription;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "initiator_weight", length = 10, updatable = false)
+    private Weight initiatorWeight;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "initiator_volume", length = 5, updatable = false)
+    private Volume initiatorVolume;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "initiator_fragility", length = 5, updatable = false)
+    private Fragility initiatorFragility;
+
+    @Column(name = "initiator_delivery_notes", length = 500, updatable = false)
+    private String initiatorDeliveryNotes;
+
+    @Column(name = "initiator_image_urls", columnDefinition = "TEXT", updatable = false)
+    private String initiatorImageUrls;
+
+
     public static EscrowLink create(
             Long initiatorId,
             InitiatorRole initiatorRole,
@@ -81,7 +128,53 @@ public class EscrowLink extends BaseEntity {
         return link;
     }
 
-    
+    // V27 — 발급자 본인 영역까지 한 번에 입력하는 분리 입력 흐름.
+    public static EscrowLink createWithInitiatorInfo(
+            Long initiatorId,
+            InitiatorRole initiatorRole,
+            FeePayer feePayer,
+            TradeMode tradeMode,
+            int expiryHours,
+            // seller 가 발급할 때만 채워짐 — pickup + 물품
+            String initiatorPickupAddress, BigDecimal initiatorPickupLat, BigDecimal initiatorPickupLng,
+            Long initiatorItemPrice, String initiatorItemDescription,
+            Weight initiatorWeight, Volume initiatorVolume, Fragility initiatorFragility,
+            String initiatorDeliveryNotes, String initiatorImageUrls,
+            // buyer 가 발급할 때만 채워짐 — delivery + receiverPhone
+            String initiatorDeliveryAddress, BigDecimal initiatorDeliveryLat, BigDecimal initiatorDeliveryLng,
+            String initiatorReceiverPhone
+    ) {
+        EscrowLink link = create(initiatorId, initiatorRole, feePayer, tradeMode, expiryHours);
+
+        if (initiatorRole == InitiatorRole.seller) {
+            if (initiatorPickupAddress == null || initiatorPickupLat == null || initiatorPickupLng == null
+                    || initiatorItemPrice == null || initiatorItemDescription == null
+                    || initiatorWeight == null || initiatorVolume == null || initiatorFragility == null) {
+                throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+            }
+            link.initiatorPickupAddress = initiatorPickupAddress;
+            link.initiatorPickupLat = initiatorPickupLat;
+            link.initiatorPickupLng = initiatorPickupLng;
+            link.initiatorItemPrice = initiatorItemPrice;
+            link.initiatorItemDescription = initiatorItemDescription;
+            link.initiatorWeight = initiatorWeight;
+            link.initiatorVolume = initiatorVolume;
+            link.initiatorFragility = initiatorFragility;
+            link.initiatorDeliveryNotes = initiatorDeliveryNotes;
+            link.initiatorImageUrls = initiatorImageUrls;
+        } else {
+            if (initiatorDeliveryAddress == null || initiatorDeliveryLat == null || initiatorDeliveryLng == null
+                    || initiatorReceiverPhone == null || initiatorReceiverPhone.isBlank()) {
+                throw new BusinessException(ErrorCode.ESCROW_FORM_INVALID);
+            }
+            link.initiatorDeliveryAddress = initiatorDeliveryAddress;
+            link.initiatorDeliveryLat = initiatorDeliveryLat;
+            link.initiatorDeliveryLng = initiatorDeliveryLng;
+            link.initiatorReceiverPhone = initiatorReceiverPhone;
+        }
+        return link;
+    }
+
     public void claimByReceiver(Long receiverId) {
         if (receiverId == null) {
             throw new IllegalArgumentException("receiverId required");
@@ -101,7 +194,7 @@ public class EscrowLink extends BaseEntity {
         this.receiverId = receiverId;
     }
 
-    
+
     public void markAsCompleted() {
         if (this.status != EscrowLinkStatus.대기) {
             throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);

--- a/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
@@ -84,6 +84,19 @@ public class EscrowController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result));
     }
 
+    @Operation(summary = "거래대행 by-link 신청 (분리 입력 흐름)",
+            description = "라운드 12 추가. 발급자가 link 발급 시 본인 영역(pickup+물품 / delivery+연락처)을 미리 입력한 경우, "
+                    + "수신자는 본인 영역만 채워서 신청. role=seller link → buyer 가 delivery+receiverPhone, "
+                    + "role=buyer link → seller 가 pickup+물품 정보. 양쪽 합쳐 application 생성 + ±10원 fee 검증.")
+    @PostMapping("/applications/by-link")
+    public ResponseEntity<ApiResponse<EscrowApplicationResult>> createByLinkApplication(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody com.sseulang.domain.escrow.presentation.dto.EscrowApplicationByLinkRequest request
+    ) {
+        EscrowApplicationResult result = service.createByLinkApplication(request.toCommand(userId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result));
+    }
+
     @Operation(summary = "거래대행 내부 신청 (판매자가 채팅방에서)",
             description = "PR-B-3 라운드 12. 채팅방 안에서 판매자가 한 번에 양쪽 정보 입력. link 토큰 미사용. "
                     + "검증: chatRoom 참여자 + chatRoom.itemId == cmd.itemId + 본인 == item.sellerId. "

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationByLinkRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowApplicationByLinkRequest.java
@@ -1,0 +1,58 @@
+package com.sseulang.domain.escrow.presentation.dto;
+
+import com.sseulang.domain.escrow.application.dto.EscrowApplicationByLinkCommand;
+import com.sseulang.domain.escrow.domain.Fragility;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Schema(description = "거래대행 by-link 신청 (수신자). 발급자가 link 발급 시 본인 영역을 미리 입력했고, "
+        + "수신자는 본인 영역만 채움. link.role=seller → buyer 가 delivery+receiverPhone, "
+        + "link.role=buyer → seller 가 pickup+물품. 서비스 단에서 role 검증.")
+public record EscrowApplicationByLinkRequest(
+        @NotBlank @Size(min = 36, max = 36) String linkToken,
+
+        // role=seller link 일 때 수신자(buyer) 입력
+        @Size(max = 255) String deliveryAddress,
+        @DecimalMin("33") @DecimalMax("39") BigDecimal deliveryLat,
+        @DecimalMin("124") @DecimalMax("132") BigDecimal deliveryLng,
+        @Size(max = 20) String receiverPhone,
+
+        // role=buyer link 일 때 수신자(seller) 입력
+        @Size(max = 255) String pickupAddress,
+        @DecimalMin("33") @DecimalMax("39") BigDecimal pickupLat,
+        @DecimalMin("124") @DecimalMax("132") BigDecimal pickupLng,
+        @PositiveOrZero Long itemPrice,
+        @Size(max = 500) String itemDescription,
+        Weight weight,
+        Volume volume,
+        Fragility fragility,
+        @Size(max = 500) String deliveryNotes,
+        List<@Size(max = 500) String> imageUrls,
+
+        // preview fee snapshot — ±10원 검증
+        @PositiveOrZero long deliveryFee,
+        @PositiveOrZero long commissionFee,
+        @PositiveOrZero long totalFee,
+        @NotNull BigDecimal distanceKm
+) {
+    public EscrowApplicationByLinkCommand toCommand(Long receiverId) {
+        return new EscrowApplicationByLinkCommand(
+                receiverId, linkToken,
+                deliveryAddress, deliveryLat, deliveryLng, receiverPhone,
+                pickupAddress, pickupLat, pickupLng,
+                itemPrice, itemDescription,
+                weight, volume, fragility, deliveryNotes, imageUrls,
+                deliveryFee, commissionFee, totalFee, distanceKm
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowLinkCreateRequest.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/dto/EscrowLinkCreateRequest.java
@@ -2,12 +2,23 @@ package com.sseulang.domain.escrow.presentation.dto;
 
 import com.sseulang.domain.escrow.application.dto.EscrowLinkCreateCommand;
 import com.sseulang.domain.escrow.domain.FeePayer;
+import com.sseulang.domain.escrow.domain.Fragility;
 import com.sseulang.domain.escrow.domain.InitiatorRole;
 import com.sseulang.domain.escrow.domain.TradeMode;
+import com.sseulang.domain.escrow.domain.Volume;
+import com.sseulang.domain.escrow.domain.Weight;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 
-@Schema(description = "거래대행 link 생성 (신청자). role + feePayer + tradeMode 결정.")
+import java.math.BigDecimal;
+import java.util.List;
+
+@Schema(description = "거래대행 link 생성 (신청자). role + feePayer + tradeMode 결정. "
+        + "라운드 12 분리 입력 흐름: role=seller 면 pickup/물품 영역, role=buyer 면 delivery/연락처 영역도 함께 전달.")
 public record EscrowLinkCreateRequest(
         @Schema(description = "신청자 역할 (수신자는 반대)", example = "buyer", allowableValues = {"buyer", "seller"})
         @NotNull InitiatorRole role,
@@ -17,9 +28,35 @@ public record EscrowLinkCreateRequest(
 
         @Schema(description = "거래 모드 — INTERNAL (쓸랭 내) / EXTERNAL (외부 거래 + 배달만)",
                 example = "INTERNAL", allowableValues = {"INTERNAL", "EXTERNAL"})
-        @NotNull TradeMode tradeMode
+        @NotNull TradeMode tradeMode,
+
+        // role=seller 일 때 — pickup + 물품 정보
+        @Size(max = 255) String initiatorPickupAddress,
+        @DecimalMin("33") @DecimalMax("39") BigDecimal initiatorPickupLat,
+        @DecimalMin("124") @DecimalMax("132") BigDecimal initiatorPickupLng,
+        @PositiveOrZero Long initiatorItemPrice,
+        @Size(max = 500) String initiatorItemDescription,
+        Weight initiatorWeight,
+        Volume initiatorVolume,
+        Fragility initiatorFragility,
+        @Size(max = 500) String initiatorDeliveryNotes,
+        List<@Size(max = 500) String> initiatorImageUrls,
+
+        // role=buyer 일 때 — delivery + 수령인 연락처
+        @Size(max = 255) String initiatorDeliveryAddress,
+        @DecimalMin("33") @DecimalMax("39") BigDecimal initiatorDeliveryLat,
+        @DecimalMin("124") @DecimalMax("132") BigDecimal initiatorDeliveryLng,
+        @Size(max = 20) String initiatorReceiverPhone
 ) {
     public EscrowLinkCreateCommand toCommand(Long initiatorId) {
-        return new EscrowLinkCreateCommand(initiatorId, role, feePayer, tradeMode);
+        return new EscrowLinkCreateCommand(
+                initiatorId, role, feePayer, tradeMode,
+                initiatorPickupAddress, initiatorPickupLat, initiatorPickupLng,
+                initiatorItemPrice, initiatorItemDescription,
+                initiatorWeight, initiatorVolume, initiatorFragility,
+                initiatorDeliveryNotes, initiatorImageUrls,
+                initiatorDeliveryAddress, initiatorDeliveryLat, initiatorDeliveryLng,
+                initiatorReceiverPhone
+        );
     }
 }

--- a/src/main/resources/db/migration/V27__escrow_link_initiator_info.sql
+++ b/src/main/resources/db/migration/V27__escrow_link_initiator_info.sql
@@ -1,0 +1,19 @@
+-- 외부 link 분리 입력 흐름 (round 12 후속)
+-- 발급자(initiator) 가 link 발급 시 본인 영역 미리 입력, 수신자는 자기 영역만 채워서 by-link 신청.
+-- role 별 사용 컬럼이 달라 모두 nullable. 발급자 role 에 해당하지 않는 필드는 application 시 수신자가 채움.
+
+ALTER TABLE escrow_links
+    ADD COLUMN initiator_pickup_address VARCHAR(255) NULL,
+    ADD COLUMN initiator_pickup_lat DECIMAL(10, 7) NULL,
+    ADD COLUMN initiator_pickup_lng DECIMAL(10, 7) NULL,
+    ADD COLUMN initiator_delivery_address VARCHAR(255) NULL,
+    ADD COLUMN initiator_delivery_lat DECIMAL(10, 7) NULL,
+    ADD COLUMN initiator_delivery_lng DECIMAL(10, 7) NULL,
+    ADD COLUMN initiator_receiver_phone VARCHAR(20) NULL,
+    ADD COLUMN initiator_item_price BIGINT NULL,
+    ADD COLUMN initiator_item_description VARCHAR(500) NULL,
+    ADD COLUMN initiator_weight VARCHAR(10) NULL,
+    ADD COLUMN initiator_volume VARCHAR(5) NULL,
+    ADD COLUMN initiator_fragility VARCHAR(5) NULL,
+    ADD COLUMN initiator_delivery_notes VARCHAR(500) NULL,
+    ADD COLUMN initiator_image_urls TEXT NULL;

--- a/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
@@ -94,7 +94,7 @@ class EscrowApplicationServiceTest {
     @Test
     @DisplayName("createLink_정상_token+expiresAt_발급")
     void createLink_normal() {
-        EscrowLinkResult r = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult r = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         assertThat(r.linkToken()).hasSize(36);
@@ -107,7 +107,7 @@ class EscrowApplicationServiceTest {
     void createLink_unverified_blocked() {
         doThrow(new BusinessException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED))
                 .when(userService).requireVerified(99L);
-        assertThatThrownBy(() -> service.createLink(new EscrowLinkCreateCommand(
+        assertThatThrownBy(() -> service.createLink(EscrowLinkCreateCommand.legacy(
                 99L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ))).isInstanceOf(BusinessException.class);
     }
@@ -189,7 +189,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("createApplication_정상_status_결제대기_+_share_산정")
     void createApplication_normal() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult r = service.createApplication(validForm(
@@ -209,7 +209,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("createApplication_본인_SELF_NOT_ALLOWED")
     void createApplication_self_rejected() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         assertThatThrownBy(() -> service.createApplication(validForm(
@@ -224,7 +224,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("createApplication_idempotent_본인_더블클릭_같은application")
     void createApplication_idempotent() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult first = service.createApplication(validForm(
@@ -242,7 +242,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("createApplication_race_다른receiver_ALREADY_TAKEN")
     void createApplication_race_other_receiver() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         // 첫 수신자 확정
@@ -263,7 +263,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("createApplication_fee_위변조_FEE_MISMATCH")
     void createApplication_fee_tampering_rejected() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         // 100원 차이 — tolerance 초과
@@ -281,7 +281,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("recordPaymentConfirmed_양쪽결제완료_EscrowConfirmedEvent_발행")
     void recordPaymentConfirmed_event_published() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult app = service.createApplication(validForm(
@@ -305,7 +305,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("verifyChargeIntent_본인_share_일치_통과")
     void verifyChargeIntent_match_pass() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult app = service.createApplication(validForm(
@@ -322,7 +322,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("verifyChargeIntent_share_불일치_FEE_MISMATCH")
     void verifyChargeIntent_amount_mismatch() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult app = service.createApplication(validForm(
@@ -339,7 +339,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("verifyChargeIntent_제3자_FORBIDDEN")
     void verifyChargeIntent_other_user_rejected() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult app = service.createApplication(validForm(
@@ -358,7 +358,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("cancel_매칭전_status_취소")
     void cancel_before_match() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult app = service.createApplication(validForm(
@@ -375,7 +375,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("cancel_제3자_FORBIDDEN")
     void cancel_third_party_rejected() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult app = service.createApplication(validForm(
@@ -394,7 +394,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("previewPayShare_잔액_충분_canPay=true_deficit=0")
     void previewPayShare_canPay() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult app = service.createApplication(validForm(
@@ -418,7 +418,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("previewPayShare_잔액_부족_deficit_정확_canPay=false")
     void previewPayShare_deficit() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult app = service.createApplication(validForm(
@@ -440,7 +440,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("previewPayShare_제3자_FORBIDDEN")
     void previewPayShare_third_party_rejected() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult app = service.createApplication(validForm(
@@ -457,7 +457,7 @@ class EscrowApplicationServiceTest {
     @DisplayName("previewPayShare_이미_본인_share_결제_완료_alreadyPaid=true_canPay=false")
     void previewPayShare_already_paid() {
         cacheExpectedFees();
-        EscrowLinkResult link = service.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = service.createLink(EscrowLinkCreateCommand.legacy(
                 11L, InitiatorRole.buyer, FeePayer.both, TradeMode.INTERNAL
         ));
         EscrowApplicationResult app = service.createApplication(validForm(

--- a/src/test/java/com/sseulang/domain/escrow/domain/EscrowFeeCalculatorTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/domain/EscrowFeeCalculatorTest.java
@@ -106,11 +106,24 @@ class EscrowFeeCalculatorTest {
     }
 
     @Test
-    @DisplayName("calculate_INTERNAL_itemPrice0_FORM_INVALID")
-    void calculate_internal_zero_item_rejected() {
+    @DisplayName("calculate_INTERNAL_itemPrice0_나눔허용")
+    void calculate_internal_zero_item_allowed() {
+        EscrowFeeSettings s = defaultSettings();
+        // 5/11 변경: 나눔(0원) INTERNAL 거래대행 허용. 음수만 거부.
+        FeeBreakdown fb = EscrowFeeCalculator.calculate(
+                s, TradeMode.INTERNAL, 0L,
+                new BigDecimal("5.00"),
+                Weight.LT1, Volume.S, Fragility.F1
+        );
+        assertThat(fb.deliveryFee()).isGreaterThan(0L);
+    }
+
+    @Test
+    @DisplayName("calculate_INTERNAL_itemPrice음수_FORM_INVALID")
+    void calculate_internal_negative_item_rejected() {
         EscrowFeeSettings s = defaultSettings();
         assertThatThrownBy(() -> EscrowFeeCalculator.calculate(
-                s, TradeMode.INTERNAL, 0L,
+                s, TradeMode.INTERNAL, -1L,
                 new BigDecimal("5.00"),
                 Weight.LT1, Volume.S, Fragility.F1
         )).isInstanceOf(BusinessException.class)

--- a/src/test/java/com/sseulang/integration/EscrowFlowE2EIT.java
+++ b/src/test/java/com/sseulang/integration/EscrowFlowE2EIT.java
@@ -176,7 +176,7 @@ class EscrowFlowE2EIT {
     @DisplayName("Mode B INTERNAL feePayer=buyer e2e — buyer 잔액 변동 X + seller 정산 + rider 정산")
     void mode_b_internal_full_flow() {
         // 1) link 생성 (buyer initiator, feePayer=buyer)
-        EscrowLinkResult link = escrowService.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = escrowService.createLink(EscrowLinkCreateCommand.legacy(
                 buyerId, InitiatorRole.buyer, FeePayer.buyer, TradeMode.INTERNAL
         ));
 
@@ -235,7 +235,7 @@ class EscrowFlowE2EIT {
     @Test
     @DisplayName("createApplication race — 두 수신자 중 한 명만 성공")
     void claim_race() {
-        EscrowLinkResult link = escrowService.createLink(new EscrowLinkCreateCommand(
+        EscrowLinkResult link = escrowService.createLink(EscrowLinkCreateCommand.legacy(
                 buyerId, InitiatorRole.buyer, FeePayer.buyer, TradeMode.INTERNAL
         ));
         // seller 가 첫 폼 제출


### PR DESCRIPTION
## Summary
- 발급자가 link 발급 시 본인 영역(role 따라 pickup+물품 / delivery+연락처)을 미리 입력
- 수신자는 본인 영역만 채워서 \`POST /escrow/applications/by-link\` 로 신청 → 양쪽 합쳐 application 생성
- 기존 \`POST /escrow/applications\` (한 번에 양쪽) 유지 (backwards compat)

## Changes
- V27 마이그레이션: \`escrow_links\` 에 발급자 본인 영역 컬럼 14개 추가 (모두 nullable)
- \`EscrowLink.createWithInitiatorInfo\` 팩토리 + role 별 필수 필드 검증
- 새 endpoint \`POST /escrow/applications/by-link\` + Command/Request DTO
- \`POST /escrow/links\` 와 \`GET /escrow/links/{token}\` 가 발급자 본인 영역 누적/노출
- \`EscrowApplication.attachReceiverPhone\` — by-link 흐름에서 receiverPhone 셋팅
- \`EscrowFeeCalculator\` 0원 INTERNAL 허용 변경에 맞춰 fee calculator 테스트 갱신

## Test plan
- [x] \`./gradlew test\` 전체 통과 (739 tests)
- [x] EscrowLink/EscrowApplication 단위 테스트 통과
- [x] EscrowApplicationService 단위 테스트 통과
- [x] EscrowFlowE2EIT 통합 테스트 통과
- [ ] prod 배포 후 by-link 흐름 수동 검증 (시연 직전)

🤖 Generated with [Claude Code](https://claude.com/claude-code)