### PR TITLE
feat(tx/escrow): 직거래 hold 제거 + complete 버튼 + escrow handover + deposit 기준 변경

### DIFF
--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -728,6 +728,14 @@ public class EscrowApplicationService {
     
     
     
+    // 라운드 12 — seller 가 [물품 인계] 확인. 상태 머신 영향 X, 타임스탬프 + buyer 알림.
+    @Transactional
+    public void confirmHandoverBySeller(Long applicationId, Long requesterId) {
+        EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        app.confirmHandoverBySeller(requesterId);
+    }
+
     @Transactional
     public void confirmReceipt(Long applicationId, Long requesterId) {
         EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplication.java
@@ -172,6 +172,10 @@ public class EscrowApplication extends BaseEntity {
     @Column(name = "image_urls", columnDefinition = "TEXT", updatable = false)
     private String imageUrls;
 
+    // 라운드 12 — seller 가 [물품 인계] 확인한 시점. 상태 머신 영향 X, UX 용 audit.
+    @Column(name = "handover_confirmed_by_seller_at")
+    private LocalDateTime handoverConfirmedBySellerAt;
+
     
 
     public static EscrowApplication create(
@@ -368,6 +372,20 @@ public class EscrowApplication extends BaseEntity {
         if (receiverPhone != null && !receiverPhone.isBlank()) {
             this.receiverPhone = receiverPhone;
         }
+    }
+
+    // 라운드 12 — seller 가 [물품 인계] 확인. 진행중 상태에서만 호출. 상태 영향 X, 타임스탬프 + 알림용.
+    public void confirmHandoverBySeller(Long sellerId) {
+        if (this.status != EscrowApplicationStatus.진행중) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+        if (!this.sellerId.equals(sellerId)) {
+            throw new BusinessException(ErrorCode.ESCROW_FORBIDDEN);
+        }
+        if (this.handoverConfirmedBySellerAt != null) {
+            return; // idempotent
+        }
+        this.handoverConfirmedBySellerAt = LocalDateTime.now();
     }
 
     public void patchBuyerInfo(

--- a/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
+++ b/src/main/java/com/sseulang/domain/escrow/presentation/EscrowController.java
@@ -210,4 +210,16 @@ public class EscrowController {
         service.confirmReceipt(id, userId);
         return ApiResponse.ok();
     }
+
+    @Operation(summary = "seller 물품 인계 확인 (라운드 12)",
+            description = "진행중 상태에서 seller 만 호출. 상태 머신 영향 X — UX 용 audit 타임스탬프. "
+                    + "에러: ESCROW_INVALID_STATE (진행중 외 상태), ESCROW_FORBIDDEN (seller 아님).")
+    @PostMapping("/applications/{id}/confirm-handover")
+    public ApiResponse<Void> confirmHandover(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        service.confirmHandoverBySeller(id, userId);
+        return ApiResponse.ok();
+    }
 }

--- a/src/main/java/com/sseulang/domain/item/domain/Item.java
+++ b/src/main/java/com/sseulang/domain/item/domain/Item.java
@@ -424,7 +424,9 @@ public class Item extends BaseEntity {
             return null;
         }
         if (depositType == DepositType.PERCENT) {
-            return (long) Math.ceil(rentalPrice * deposit / 100.0);
+            // 라운드 12 — 물품 가격(salePrice) 기준. 판매 모드가 없으면 rentalPrice fallback.
+            long base = (salePrice != null) ? salePrice : rentalPrice;
+            return (long) Math.ceil(base * deposit / 100.0);
         }
         return deposit;
     }

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -119,25 +119,16 @@ public class TransactionApplicationService {
 
     
 
+    // 직거래는 사이트 포인트 거래 없음(외부 결제). reserve 는 Item 잠금 + 상태 마킹만.
     @Transactional
     public void reserve(Long transactionId, Long requesterId) {
         Transaction tx = findOrThrowForUpdate(transactionId);
         if (!tx.isSeller(requesterId)) {
             throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
         }
-        
         itemApplicationService.markItemAsReserved(tx.getItemId());
         LocalDateTime now = LocalDateTime.now(clock);
-        long holdAmount = tx.getPrice();
-        tx.markAsReserved(now, holdAmount);
-        if (holdAmount > 0) {
-            pointApplicationService.escrowHold(
-                    tx.getBuyerId(),
-                    holdAmount,
-                    tx.getId(),
-                    "거래 #" + tx.getId() + " 보관"
-            );
-        }
+        tx.markAsReserved(now, 0L);
         eventPublisher.publishEvent(new TransactionReservedEvent(
                 tx.getId(), tx.getBuyerId(), tx.getSellerId(), tx.getPrice()));
     }
@@ -166,26 +157,34 @@ public class TransactionApplicationService {
             throw new BusinessException(ErrorCode.TRANSACTION_RECEIVE_NOT_ALLOWED);
         }
         if (tx.getStatus() == TransactionStatus.거래완료) {
-            return;  
+            return;
         }
-        
         itemApplicationService.markItemAsSold(tx.getItemId());
-        long settleAmount = tx.getEscrowHoldAmount();
-        if (settleAmount > 0) {
-            pointApplicationService.escrowRelease(
-                    tx.getBuyerId(),
-                    tx.getSellerId(),
-                    settleAmount,
-                    tx.getId(),
-                    "거래 #" + tx.getId() + " 정산 수령"
-            );
-        }
         tx.markReceived(LocalDateTime.now(clock));
         eventPublisher.publishEvent(new TransactionReceiveConfirmedEvent(
-                tx.getId(), tx.getSellerId(), settleAmount));
+                tx.getId(), tx.getSellerId(), 0L));
     }
 
-    
+    // 라운드 12 — 판매자가 한 번에 거래완료. 직거래는 사이트 포인트 거래 없음.
+    @Transactional
+    public void completeBySeller(Long transactionId, Long requesterId) {
+        Transaction tx = findOrThrowForUpdate(transactionId);
+        if (!tx.isSeller(requesterId)) {
+            throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
+        }
+        if (tx.getStatus() == TransactionStatus.거래완료) {
+            return;
+        }
+        // Item 잠금 / 판매완료 전이
+        if (tx.getStatus() == TransactionStatus.채팅중) {
+            itemApplicationService.markItemAsReserved(tx.getItemId());
+        }
+        itemApplicationService.markItemAsSold(tx.getItemId());
+        tx.completeBySeller(LocalDateTime.now(clock));
+        eventPublisher.publishEvent(new TransactionReceiveConfirmedEvent(
+                tx.getId(), tx.getSellerId(), 0L));
+    }
+
 
     @Transactional
     public void cancel(Long transactionId, Long requesterId, String reason) {
@@ -193,23 +192,11 @@ public class TransactionApplicationService {
         if (!tx.isParticipant(requesterId)) {
             throw new BusinessException(ErrorCode.TRANSACTION_FORBIDDEN);
         }
-        boolean wasReserved = tx.getStatus() == TransactionStatus.예약;
-        long holdAmount = tx.getEscrowHoldAmount();
-        
+        boolean wasReserved = tx.getStatus() == TransactionStatus.예약
+                || tx.getStatus() == TransactionStatus.인계완료;
         tx.cancel(LocalDateTime.now(clock), reason);
         if (wasReserved) {
-            
             itemApplicationService.restoreItemFromReserved(tx.getItemId());
-            if (holdAmount > 0) {
-                
-                
-                pointApplicationService.escrowRefund(
-                        tx.getBuyerId(),
-                        holdAmount,
-                        tx.getId(),
-                        "거래 #" + tx.getId() + " 취소 환불"
-                );
-            }
         }
         eventPublisher.publishEvent(new TransactionCanceledEvent(
                 tx.getId(), tx.getBuyerId(), tx.getSellerId(), requesterId));

--- a/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
@@ -178,6 +178,23 @@ public class Transaction extends BaseEntity {
         this.completedAt = now;
     }
 
+    // 라운드 12 — 직거래 단순 완료. 사이트 포인트 거래 없음(외부 결제).
+    // 채팅중/예약/인계완료 어떤 상태에서든 거래완료로 전이. 판매자 호출 가정.
+    public void completeBySeller(LocalDateTime now) {
+        if (status == TransactionStatus.거래완료 || status == TransactionStatus.취소) {
+            throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);
+        }
+        if (this.reservedAt == null) {
+            this.reservedAt = now;
+        }
+        if (this.handoverConfirmedAt == null) {
+            this.handoverConfirmedAt = now;
+        }
+        this.receiveConfirmedAt = now;
+        this.completedAt = now;
+        this.status = TransactionStatus.거래완료;
+    }
+
     public void cancel(LocalDateTime now, String reason) {
         if (!status.canCancel()) {
             throw new BusinessException(ErrorCode.TRANSACTION_INVALID_STATE);

--- a/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/TransactionController.java
@@ -60,10 +60,10 @@ public class TransactionController {
 
     
 
-    @Operation(summary = "거래 상태 전이 (예약 / 인계확인 / 인수확인 / 취소)",
-            description = "action 분기 — 예약: seller(잔액 부족 시 INSUFFICIENT_POINT), 인계확인: seller, "
-                    + "인수확인: buyer(자동 거래완료 + 정산), 취소: 양쪽(채팅중/예약 단계만). "
-                    + "동시 reserve 는 한 건만 성공(409 TRANSACTION_RESERVED_BY_OTHER).")
+    @Operation(summary = "거래 상태 전이 (예약 / 인계확인 / 인수확인 / 완료 / 취소)",
+            description = "action 분기 — 예약: seller, 인계확인: seller, 인수확인: buyer, "
+                    + "완료: seller (한 번에 거래완료, 라운드 12 단순화), 취소: 양쪽(채팅중/예약/인계완료 단계). "
+                    + "직거래는 사이트 포인트 거래 없음(외부 결제). 동시 reserve 는 한 건만 성공.")
     @PatchMapping("/{id}")
     public ApiResponse<Void> patch(
             @AuthenticationPrincipal Long requesterId,
@@ -76,6 +76,8 @@ public class TransactionController {
             transactionService.markHandover(id, requesterId);
         } else if (request.isReceive()) {
             transactionService.markReceived(id, requesterId);
+        } else if (request.isComplete()) {
+            transactionService.completeBySeller(id, requesterId);
         } else if (request.isCancel()) {
             transactionService.cancel(id, requesterId, request.cancelReason());
         } else {

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchAction.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchAction.java
@@ -7,5 +7,6 @@ public enum TransactionPatchAction {
     예약,
     인계확인,
     인수확인,
+    완료,
     취소
 }

--- a/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchRequest.java
+++ b/src/main/java/com/sseulang/domain/transaction/presentation/dto/TransactionPatchRequest.java
@@ -25,6 +25,10 @@ public record TransactionPatchRequest(
         return action == TransactionPatchAction.인수확인;
     }
 
+    public boolean isComplete() {
+        return action == TransactionPatchAction.완료;
+    }
+
     public boolean isCancel() {
         return action == TransactionPatchAction.취소;
     }

--- a/src/main/resources/db/migration/V28__escrow_handover_confirmed.sql
+++ b/src/main/resources/db/migration/V28__escrow_handover_confirmed.sql
@@ -1,0 +1,3 @@
+-- 거래대행 판매자 [물품 인계] 확인 시점 — UX 용 audit 타임스탬프 (정산 영향 X)
+ALTER TABLE escrow_applications
+    ADD COLUMN handover_confirmed_by_seller_at TIMESTAMP NULL;

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -113,8 +113,9 @@ class TransactionApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("create dual item 대여 PERCENT deposit_대여가 기준 환산 금액 저장")
+    @DisplayName("create dual item 대여 PERCENT deposit_물품가(salePrice) 기준 환산")
     void create_dual_item_대여_percent_deposit_환산() {
+        // 라운드 12 — salePrice 기준 환산. 120_000 × 30% = 36_000.
         Item rental = itemRepo.save(Item.createMulti(
                 SELLER, null, "대여물건", "설명", java.util.EnumSet.of(TradeType.판매, TradeType.대여),
                 120_000L, 99_997L, 30L, DepositType.PERCENT, RentalUnit.일, "서울"
@@ -131,7 +132,7 @@ class TransactionApplicationServiceTest {
 
         TransactionResult r = service.getById(txId, BUYER);
         assertThat(r.price()).isEqualTo(99_997L);
-        assertThat(r.deposit()).isEqualTo(30_000L);
+        assertThat(r.deposit()).isEqualTo(36_000L);
     }
 
     @Test
@@ -171,35 +172,33 @@ class TransactionApplicationServiceTest {
     // ───────── reserve (hold 흐름) ─────────
 
     @Test
-    @DisplayName("reserve 정상_buyer balance↓ + hold↑ + escrowHoldAmount + 거래보관 history + ReservedEvent")
+    @DisplayName("reserve 정상_Item 예약 + escrowHoldAmount=0 + ReservedEvent (라운드 12 — 직거래 hold 제거)")
     void reserve_정상_hold() {
         Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
-        userRepo.creditPointBalance(BUYER, 50_000L);  // 잔액 충전
 
         service.reserve(txId, SELLER);
 
         TransactionResult r = service.getById(txId, SELLER);
         assertThat(r.status()).isEqualTo(TransactionStatus.예약);
-        assertThat(r.escrowHoldAmount()).isEqualTo(50_000L);
+        assertThat(r.escrowHoldAmount()).isZero();   // 직거래 = 사이트 포인트 거래 X
         assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.예약);
         assertThat(userRepo.findPointBalance(BUYER)).isZero();
-        assertThat(userRepo.findPointHold(BUYER)).isEqualTo(50_000L);
-        assertThat(pointHistoryRepo.size()).isEqualTo(1);  // 거래보관 1건
+        assertThat(userRepo.findPointHold(BUYER)).isZero();
+        assertThat(pointHistoryRepo.size()).isZero();  // history 안 남음
         assertThat(publishedEvents)
                 .hasSize(1)
                 .first().isInstanceOf(com.sseulang.domain.transaction.domain.event.TransactionReservedEvent.class);
     }
 
     @Test
-    @DisplayName("reserve 잔액 부족_INSUFFICIENT_POINT")
+    @DisplayName("reserve 잔액 0_정상 동작 (라운드 12 — hold 없음)")
     void reserve_잔액부족_거부() {
         Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
-        userRepo.creditPointBalance(BUYER, 10_000L);  // 부족
+        // 잔액 0 이어도 hold 가 없으니 정상 reserve.
+        service.reserve(txId, SELLER);
 
-        assertThatThrownBy(() -> service.reserve(txId, SELLER))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.INSUFFICIENT_POINT);
+        assertThat(service.getById(txId, SELLER).status()).isEqualTo(TransactionStatus.예약);
+        assertThat(userRepo.findPointBalance(BUYER)).isZero();
     }
 
     @Test
@@ -251,7 +250,7 @@ class TransactionApplicationServiceTest {
     // ───────── markHandover (라운드 11) ─────────
 
     @Test
-    @DisplayName("markHandover seller 정상_status=인계완료 + HandoverEvent")
+    @DisplayName("markHandover seller 정상_status=인계완료 + HandoverEvent (라운드 12 — hold 없음)")
     void handover_정상() {
         Long txId = reservedTxByBuyer();
 
@@ -260,9 +259,9 @@ class TransactionApplicationServiceTest {
         TransactionResult r = service.getById(txId, SELLER);
         assertThat(r.status()).isEqualTo(TransactionStatus.인계완료);
         assertThat(r.handoverConfirmedAt()).isNotNull();
-        assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.예약);  // 아직 sold X
-        assertThat(userRepo.findPointBalance(BUYER)).isZero();  // hold 유지
-        assertThat(userRepo.findPointHold(BUYER)).isEqualTo(50_000L);
+        assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.예약);
+        assertThat(userRepo.findPointBalance(BUYER)).isZero();
+        assertThat(userRepo.findPointHold(BUYER)).isZero();
         assertThat(eventTypes()).contains("TransactionHandoverConfirmedEvent");
     }
 
@@ -293,7 +292,7 @@ class TransactionApplicationServiceTest {
     // ───────── markReceived (라운드 11) ─────────
 
     @Test
-    @DisplayName("markReceived buyer 정상_정산_buyer hold↓ + seller balance↑ + 판매정산 history + ReceiveEvent")
+    @DisplayName("markReceived buyer 정상_단순 마킹 + Item 거래완료 + ReceiveEvent (라운드 12 — 정산 없음)")
     void receive_정상() {
         Long txId = reservedTxByBuyer();
         service.markHandover(txId, SELLER);
@@ -305,11 +304,11 @@ class TransactionApplicationServiceTest {
         assertThat(r.receiveConfirmedAt()).isNotNull();
         assertThat(r.completedAt()).isEqualTo(r.receiveConfirmedAt());
         assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.거래완료);
+        // 직거래 = 사이트 포인트 거래 X
         assertThat(userRepo.findPointBalance(BUYER)).isZero();
-        assertThat(userRepo.findPointHold(BUYER)).isZero();  // 해제됨
-        assertThat(userRepo.findPointBalance(SELLER)).isEqualTo(50_000L);
-        // history: 거래보관(buyer, reserve) + 판매정산(seller, receive) = 2건
-        assertThat(pointHistoryRepo.size()).isEqualTo(2);
+        assertThat(userRepo.findPointHold(BUYER)).isZero();
+        assertThat(userRepo.findPointBalance(SELLER)).isZero();
+        assertThat(pointHistoryRepo.size()).isZero();
         assertThat(eventTypes()).contains("TransactionReceiveConfirmedEvent");
     }
 
@@ -367,21 +366,18 @@ class TransactionApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("cancel 예약 상태_Item 복원 + buyer hold 환불 + 거래환불 history + CancelEvent")
+    @DisplayName("cancel 예약 상태_Item 복원 + CancelEvent (라운드 12 — 환불 없음)")
     void cancel_예약_환불() {
         Long txId = reservedTxByBuyer();
-        int historyBefore = pointHistoryRepo.size();
 
         service.cancel(txId, SELLER, "물건 파손");
 
         assertThat(service.getById(txId, SELLER).status()).isEqualTo(TransactionStatus.취소);
         assertThat(itemRepo.findById(itemId).orElseThrow().getStatus()).isEqualTo(ItemStatus.판매중);
-        assertThat(userRepo.findPointBalance(BUYER)).isEqualTo(50_000L);  // 환불
+        // 직거래 = 사이트 포인트 거래 X
+        assertThat(userRepo.findPointBalance(BUYER)).isZero();
         assertThat(userRepo.findPointHold(BUYER)).isZero();
-        assertThat(pointHistoryRepo.size()).isEqualTo(historyBefore + 1);
-        assertThat(pointHistoryRepo.findByUserIdOrderByCreatedAtDesc(BUYER))
-                .extracting("pointType")
-                .contains(PointHistoryType.거래보관, PointHistoryType.거래환불);
+        assertThat(pointHistoryRepo.size()).isZero();
         assertThat(eventTypes()).contains("TransactionCanceledEvent");
     }
 
@@ -426,13 +422,12 @@ class TransactionApplicationServiceTest {
                 SocialProvider.KAKAO, "k-buyer2-" + System.nanoTime(),
                 new Email("buyer2-" + System.nanoTime() + "@x.com"), "buyer2", null
         )).getId();
-        userRepo.creditPointBalance(BUYER, 50_000L);
-        userRepo.creditPointBalance(buyer2, 50_000L);
 
         Long tx1 = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
         service.reserve(tx1, SELLER);
         service.cancel(tx1, SELLER, "재예약 가능");
-        assertThat(userRepo.findPointBalance(BUYER)).isEqualTo(50_000L);  // 환불 OK
+        // 라운드 12 — 직거래 hold 없음. cancel 후 잔액 변동 X.
+        assertThat(userRepo.findPointBalance(BUYER)).isZero();
 
         // 라운드 12 — buyer2 와 SELLER 의 새 chatRoom 필요 (한 채팅방=1 active 정책 + 거래 시작은 판매자만).
         com.sseulang.domain.chat.domain.ChatRoom room2 =
@@ -446,9 +441,8 @@ class TransactionApplicationServiceTest {
 
     // ───────── helpers ─────────
 
-    /** buyer 충전 + 거래 생성 + reserve 까지 진행한 trasaction id 반환. */
+    /** 거래 생성 + reserve 까지 진행한 transaction id 반환. 라운드 12 — 직거래 hold 제거 후 잔액 충전 불필요. */
     private Long reservedTxByBuyer() {
-        userRepo.creditPointBalance(BUYER, 50_000L);
         Long txId = service.create(new TransactionCreateCommand(itemId, SELLER, chatRoomId, null, null));
         service.reserve(txId, SELLER);
         return txId;

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -148,6 +148,7 @@ class SettlementRollbackIT {
     }
 
     @Test
+    @org.junit.jupiter.api.Disabled("라운드 12 — 직거래는 사이트 포인트 거래 없음. reserve 시 hold 안 함 → 잔액 부족 시나리오 자체가 무의미.")
     @DisplayName("라운드 11 — reserve 시 buyer 잔액 부족_INSUFFICIENT_POINT + Item/Tx/잔액/history 모두 원복")
     void reserve_hold_실패_롤백() {
         Long sellerId = txTemplate.execute(s -> persistUser("seller"));

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -223,6 +223,7 @@ class TransactionConcurrencyIT {
      * (WHERE point_balance >= :amount) 가 두 번째 호출을 INSUFFICIENT_POINT 로 차단.
      */
     @Test
+    @org.junit.jupiter.api.Disabled("라운드 12 — 직거래는 사이트 포인트 거래 없음. buyer hold race 시나리오 무의미.")
     @DisplayName("라운드 11 — 같은 buyer 두 거래 동시 reserve_잔액 한건만 충당_정확히 1건만 성공")
     void buyer_hold_race() throws Exception {
         // 별도 두 Item + 두 거래 (buyer 동일, 잔액 50000 한 건만 가능). 라운드 12 — 거래는 채팅방 안에서만 (판매자만).

--- a/src/test/java/com/sseulang/integration/EndToEndGuardScenariosIT.java
+++ b/src/test/java/com/sseulang/integration/EndToEndGuardScenariosIT.java
@@ -198,6 +198,7 @@ class EndToEndGuardScenariosIT {
     // ───────── 시나리오 2: 잔액 부족 정산 실패 ─────────
 
     @Test
+    @org.junit.jupiter.api.Disabled("라운드 12 — 직거래는 사이트 포인트 거래 없음. 예약 시 INSUFFICIENT_POINT 발생 안함.")
     @DisplayName("라운드 11 — buyer 충전 안 한 상태_예약 시점에 INSUFFICIENT_POINT + Item/Tx 모두 롤백")
     void scenario_잔액부족_롤백() throws Exception {
         // Seller — OAuth (verified=true). Item 등록.


### PR DESCRIPTION
## Summary
라운드 12 후속 — 사용자 정정 반영 (직거래는 사이트 포인트 거래 없음, 외부 결제).

## #6-A 직거래 단순화
- Transaction.reserve / markReceived / cancel 의 PointApplicationService hold/release/refund 호출 모두 제거
- escrowHoldAmount 는 항상 0 (DB 컬럼 V16 유지, 향후 거래대행 정합성용으로만)
- 새 action '완료' (TransactionPatchAction.완료) → 판매자가 한 번에 거래완료
- 채팅중/예약/인계완료 어느 상태에서든 호출 가능 → 자동으로 timestamp 채우고 Item 거래완료 전이
- 기존 예약/인계확인/인수확인 action 유지 (backwards compat)

## #6-B 거래대행 판매자 인계
- V28 마이그레이션: escrow_applications.handover_confirmed_by_seller_at TIMESTAMP NULL
- EscrowApplication.confirmHandoverBySeller — 진행중 상태 + seller 만, audit 타임스탬프 (정산/상태 영향 X)
- 신규 endpoint: POST /escrow/applications/{id}/confirm-handover
- 멱등 — 이미 확인됨이면 no-op

## #4-4 보증금 % 환산
- Item.computeDepositAmount: \`rentalPrice × pct\` → \`salePrice × pct\`
- salePrice null 시 rentalPrice fallback
- 기존 PERCENT deposit 테스트 — 36_000 (120_000 × 30%) 으로 갱신

## Test plan
- [x] 컴파일 통과
- [x] \`./gradlew test\` 전체 통과 (사이트 포인트 hold 시나리오 IT 3건 @Disabled)
- [ ] prod 배포 후 직거래 \`PATCH /transactions/{id}\` action=완료 수동 검증
- [ ] prod 배포 후 거래대행 \`POST /escrow/applications/{id}/confirm-handover\` 수동 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)