### PR TITLE
feat(escrow/tx): 거래대행 완료 시 paired Transaction 자동 생성 (어드민/리뷰 통합)

### DIFF
--- a/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
+++ b/src/main/java/com/sseulang/domain/chat/application/ChatRoomApplicationService.java
@@ -243,7 +243,7 @@ public class ChatRoomApplicationService {
             if (base == null) continue;
             var e = escrowMap.get(roomId);
             if (e != null) {
-                map.put(roomId, base.withEscrow(e.escrowApplicationId(), e.status(), e.deliveryId()));
+                map.put(roomId, base.withEscrow(e.escrowApplicationId(), e.status(), e.deliveryId(), e.transactionId()));
                 continue;
             }
             var t = txMap.get(roomId);

--- a/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
+++ b/src/main/java/com/sseulang/domain/chat/application/dto/ChatRoomResult.java
@@ -60,9 +60,9 @@ public record ChatRoomResult(
                     txId, status, null, null, null);
         }
 
-        public SystemCard withEscrow(Long escrowId, String status, Long deliveryId) {
+        public SystemCard withEscrow(Long escrowId, String status, Long deliveryId, Long pairedTransactionId) {
             return new SystemCard("EscrowApplication", tradeMode, itemId, itemTitle, itemThumbnailUrl, price,
-                    null, null, escrowId, status, deliveryId);
+                    pairedTransactionId, status, escrowId, status, deliveryId);
         }
     }
     

--- a/src/main/java/com/sseulang/domain/chat/domain/EscrowApplicationView.java
+++ b/src/main/java/com/sseulang/domain/chat/domain/EscrowApplicationView.java
@@ -8,5 +8,6 @@ public interface EscrowApplicationView {
 
     Map<Long, EscrowApplicationProjection> findActiveByChatRoomIds(Collection<Long> chatRoomIds);
 
-    record EscrowApplicationProjection(Long escrowApplicationId, String status, Long deliveryId) { }
+    // 라운드 12 — 거래대행 완료 시 paired Transaction 생성. card 에서 리뷰용으로 transactionId 함께 노출.
+    record EscrowApplicationProjection(Long escrowApplicationId, String status, Long deliveryId, Long transactionId) { }
 }

--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -59,6 +59,7 @@ public class EscrowApplicationService {
     private final ApplicationEventPublisher eventPublisher;
     private final com.sseulang.domain.chat.application.ChatRoomApplicationService chatRoomApplicationService;
     private final com.sseulang.domain.item.application.ItemApplicationService itemApplicationService;
+    private final com.sseulang.domain.transaction.application.TransactionApplicationService transactionApplicationService;
     private final int linkExpiryHours;
 
     public EscrowApplicationService(
@@ -71,6 +72,7 @@ public class EscrowApplicationService {
             ApplicationEventPublisher eventPublisher,
             com.sseulang.domain.chat.application.ChatRoomApplicationService chatRoomApplicationService,
             com.sseulang.domain.item.application.ItemApplicationService itemApplicationService,
+            com.sseulang.domain.transaction.application.TransactionApplicationService transactionApplicationService,
             @Value("${app.escrow.link.expiry-hours:24}") int linkExpiryHours
     ) {
         this.linkRepository = linkRepository;
@@ -82,6 +84,7 @@ public class EscrowApplicationService {
         this.eventPublisher = eventPublisher;
         this.chatRoomApplicationService = chatRoomApplicationService;
         this.itemApplicationService = itemApplicationService;
+        this.transactionApplicationService = transactionApplicationService;
         this.linkExpiryHours = linkExpiryHours;
     }
 
@@ -789,6 +792,15 @@ public class EscrowApplicationService {
             );
         }
         app.markSettled();
+        // 라운드 12 — paired Transaction 자동 생성. 어드민/리뷰가 직거래와 동일 모델로 통합.
+        transactionApplicationService.createFromEscrow(
+                app.getId(),
+                null,            // 거래대행은 Item 미연결 (INTERNAL 도 chatRoom.itemId 와 별개 트랙)
+                app.getSellerId(), app.getBuyerId(),
+                app.getItemPrice(),
+                app.getChatRoomId(),
+                app.getSettledAt() != null ? app.getSettledAt() : java.time.LocalDateTime.now()
+        );
     }
 
     

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/EscrowApplicationViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/EscrowApplicationViewAdapter.java
@@ -5,6 +5,8 @@ import com.sseulang.domain.delivery.domain.DeliveryRepository;
 import com.sseulang.domain.delivery.domain.DeliveryRequest;
 import com.sseulang.domain.escrow.domain.EscrowApplication;
 import com.sseulang.domain.escrow.domain.EscrowApplicationRepository;
+import com.sseulang.domain.transaction.domain.Transaction;
+import com.sseulang.domain.transaction.domain.TransactionRepository;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -17,13 +19,16 @@ public class EscrowApplicationViewAdapter implements EscrowApplicationView {
 
     private final EscrowApplicationRepository applicationRepository;
     private final DeliveryRepository deliveryRepository;
+    private final TransactionRepository transactionRepository;
 
     public EscrowApplicationViewAdapter(
             EscrowApplicationRepository applicationRepository,
-            DeliveryRepository deliveryRepository
+            DeliveryRepository deliveryRepository,
+            TransactionRepository transactionRepository
     ) {
         this.applicationRepository = applicationRepository;
         this.deliveryRepository = deliveryRepository;
+        this.transactionRepository = transactionRepository;
     }
 
     @Override
@@ -37,11 +42,17 @@ public class EscrowApplicationViewAdapter implements EscrowApplicationView {
         for (DeliveryRequest d : deliveryRepository.findByEscrowApplicationIdIn(appIds)) {
             deliveryByApp.put(d.getEscrowApplicationId(), d.getId());
         }
+        // 라운드 12 — escrow 완료 시 paired Transaction 매핑. card 에서 리뷰용 transactionId 노출.
+        Map<Long, Long> txByApp = new HashMap<>();
+        for (Transaction t : transactionRepository.findByEscrowApplicationIdIn(appIds)) {
+            txByApp.put(t.getEscrowApplicationId(), t.getId());
+        }
 
         Map<Long, EscrowApplicationProjection> map = new HashMap<>();
         for (EscrowApplication a : apps) {
             map.put(a.getChatRoomId(),
-                    new EscrowApplicationProjection(a.getId(), a.getStatus().name(), deliveryByApp.get(a.getId())));
+                    new EscrowApplicationProjection(a.getId(), a.getStatus().name(),
+                            deliveryByApp.get(a.getId()), txByApp.get(a.getId())));
         }
         return map;
     }

--- a/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
+++ b/src/main/java/com/sseulang/domain/transaction/application/TransactionApplicationService.java
@@ -165,6 +165,24 @@ public class TransactionApplicationService {
                 tx.getId(), tx.getSellerId(), 0L));
     }
 
+    // 라운드 12 — 거래대행 정산 시 paired Transaction 자동 생성.
+    // 이미 paired Tx 있으면 (UNIQUE 가드) idempotent — 기존 id 반환.
+    @Transactional
+    public Long createFromEscrow(
+            Long escrowApplicationId,
+            Long itemId,
+            Long sellerId, Long buyerId,
+            long itemPrice,
+            Long chatRoomId,
+            LocalDateTime settledAt
+    ) {
+        return transactionRepository.findByEscrowApplicationId(escrowApplicationId)
+                .map(Transaction::getId)
+                .orElseGet(() -> transactionRepository.save(Transaction.createFromEscrow(
+                        escrowApplicationId, itemId, sellerId, buyerId, itemPrice, chatRoomId, settledAt
+                )).getId());
+    }
+
     // 라운드 12 — 판매자가 한 번에 거래완료. 직거래는 사이트 포인트 거래 없음.
     @Transactional
     public void completeBySeller(Long transactionId, Long requesterId) {

--- a/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/Transaction.java
@@ -28,8 +28,13 @@ public class Transaction extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "item_id", nullable = false)
+    // 라운드 12 — 거래대행 paired Transaction 은 Item 없을 수 있음(EXTERNAL).
+    @Column(name = "item_id")
     private Long itemId;
+
+    // 라운드 12 — 거래대행 paired Transaction 의 1:1 역참조. UNIQUE 가드로 중복 paired 방지.
+    @Column(name = "escrow_application_id", updatable = false)
+    private Long escrowApplicationId;
 
     @Column(name = "seller_id", nullable = false)
     private Long sellerId;
@@ -103,6 +108,7 @@ public class Transaction extends BaseEntity {
         if (itemId == null || itemId <= 0) {
             throw new IllegalArgumentException("itemId 는 양수여야 합니다");
         }
+        // 직거래는 Item 필수. paired-from-escrow 는 createFromEscrow 팩토리 사용.
         if (sellerId == null || sellerId <= 0) {
             throw new IllegalArgumentException("sellerId 는 양수여야 합니다");
         }
@@ -193,6 +199,51 @@ public class Transaction extends BaseEntity {
         this.receiveConfirmedAt = now;
         this.completedAt = now;
         this.status = TransactionStatus.거래완료;
+    }
+
+    // 라운드 12 — 거래대행 정산 시점에 paired Transaction 자동 생성.
+    // tradeType 매핑: itemPrice==0(나눔) → 나눔, 그 외 → 판매. (대여는 거래대행 흐름에 안 들어옴)
+    // Item 은 INTERNAL escrow 면 linkedItem, EXTERNAL 이면 null.
+    public static Transaction createFromEscrow(
+            Long escrowApplicationId,
+            Long itemId,
+            Long sellerId, Long buyerId,
+            long itemPrice,
+            Long chatRoomId,
+            LocalDateTime settledAt
+    ) {
+        if (escrowApplicationId == null || escrowApplicationId <= 0) {
+            throw new IllegalArgumentException("escrowApplicationId 는 양수여야 합니다");
+        }
+        if (sellerId == null || sellerId <= 0 || buyerId == null || buyerId <= 0) {
+            throw new IllegalArgumentException("seller/buyerId 양수 필수");
+        }
+        if (sellerId.equals(buyerId)) {
+            throw new IllegalArgumentException("seller 와 buyer 는 같을 수 없습니다");
+        }
+        if (itemPrice < 0) {
+            throw new IllegalArgumentException("itemPrice 는 0 이상이어야 합니다");
+        }
+        if (settledAt == null) {
+            throw new IllegalArgumentException("settledAt 필수");
+        }
+        Transaction t = new Transaction();
+        t.escrowApplicationId = escrowApplicationId;
+        t.itemId = itemId;   // nullable
+        t.sellerId = sellerId;
+        t.buyerId = buyerId;
+        t.tradeType = itemPrice == 0 ? TradeType.나눔 : TradeType.판매;
+        t.price = itemPrice;
+        t.deposit = null;
+        t.rentalStart = null;
+        t.rentalEnd = null;
+        t.chatRoomId = chatRoomId;
+        t.status = TransactionStatus.거래완료;
+        t.reservedAt = settledAt;
+        t.handoverConfirmedAt = settledAt;
+        t.receiveConfirmedAt = settledAt;
+        t.completedAt = settledAt;
+        return t;
     }
 
     public void cancel(LocalDateTime now, String reason) {

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -22,6 +22,11 @@ public interface TransactionRepository {
 
     boolean existsActiveByChatRoomId(Long chatRoomId);
 
+    // 라운드 12 — 거래대행 paired 매핑 (1:1, UNIQUE).
+    Optional<Transaction> findByEscrowApplicationId(Long escrowApplicationId);
+
+    java.util.List<Transaction> findByEscrowApplicationIdIn(java.util.Collection<Long> escrowApplicationIds);
+
     // 라운드 12 — 채팅방 카드용. 비취소 최신 1건 (취소 제외, 거래완료까지 포함).
     Optional<Transaction> findLatestNonCanceledByChatRoomId(Long chatRoomId);
 

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -33,6 +33,11 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
             """)
     boolean existsActiveByChatRoomIdJpql(@Param("chatRoomId") Long chatRoomId);
 
+    // 라운드 12 — 거래대행 paired Transaction (1:1).
+    Optional<Transaction> findByEscrowApplicationId(Long escrowApplicationId);
+
+    List<Transaction> findByEscrowApplicationIdIn(java.util.Collection<Long> escrowApplicationIds);
+
     // 라운드 12 — 채팅방 카드용. 비취소 최신 1건 (id desc).
     @Query("""
             SELECT t FROM Transaction t

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -46,6 +46,18 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     }
 
     @Override
+    public Optional<Transaction> findByEscrowApplicationId(Long escrowApplicationId) {
+        if (escrowApplicationId == null) return Optional.empty();
+        return jpa.findByEscrowApplicationId(escrowApplicationId);
+    }
+
+    @Override
+    public List<Transaction> findByEscrowApplicationIdIn(java.util.Collection<Long> escrowApplicationIds) {
+        if (escrowApplicationIds == null || escrowApplicationIds.isEmpty()) return List.of();
+        return jpa.findByEscrowApplicationIdIn(escrowApplicationIds);
+    }
+
+    @Override
     public Optional<Transaction> findLatestNonCanceledByChatRoomId(Long chatRoomId) {
         if (chatRoomId == null) return Optional.empty();
         List<Transaction> rows = jpa.findLatestNonCanceledByChatRoomIdJpql(

--- a/src/main/resources/db/migration/V29__transactions_escrow_link.sql
+++ b/src/main/resources/db/migration/V29__transactions_escrow_link.sql
@@ -1,0 +1,8 @@
+-- 거래대행 완료 시 paired Transaction 자동 생성 — 어드민/리뷰가 직거래와 동일 모델로 통합.
+-- escrow_application_id 1:1 UNIQUE. EXTERNAL 거래대행은 Item 이 없으니 item_id nullable.
+
+ALTER TABLE transactions
+    MODIFY COLUMN item_id BIGINT NULL,
+    ADD COLUMN escrow_application_id BIGINT NULL,
+    ADD CONSTRAINT uk_tx_escrow UNIQUE (escrow_application_id),
+    ADD CONSTRAINT fk_tx_escrow FOREIGN KEY (escrow_application_id) REFERENCES escrow_applications(id);

--- a/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
@@ -68,10 +68,12 @@ class EscrowApplicationServiceTest {
                 mock(com.sseulang.domain.chat.application.ChatRoomApplicationService.class);
         com.sseulang.domain.item.application.ItemApplicationService itemAppService =
                 mock(com.sseulang.domain.item.application.ItemApplicationService.class);
+        com.sseulang.domain.transaction.application.TransactionApplicationService txAppService =
+                mock(com.sseulang.domain.transaction.application.TransactionApplicationService.class);
         service = new EscrowApplicationService(
                 linkRepo, appRepo, settingsRepo,
                 userService, pointService, deliveryRepo, eventPublisher,
-                chatRoomService, itemAppService,
+                chatRoomService, itemAppService, txAppService,
                 24
         );
     }

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -55,6 +55,22 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
     }
 
     @Override
+    public java.util.Optional<Transaction> findByEscrowApplicationId(Long escrowApplicationId) {
+        if (escrowApplicationId == null) return java.util.Optional.empty();
+        return store.values().stream()
+                .filter(t -> escrowApplicationId.equals(t.getEscrowApplicationId()))
+                .findFirst();
+    }
+
+    @Override
+    public java.util.List<Transaction> findByEscrowApplicationIdIn(java.util.Collection<Long> ids) {
+        if (ids == null || ids.isEmpty()) return java.util.List.of();
+        return store.values().stream()
+                .filter(t -> t.getEscrowApplicationId() != null && ids.contains(t.getEscrowApplicationId()))
+                .toList();
+    }
+
+    @Override
     public java.util.Optional<Transaction> findLatestNonCanceledByChatRoomId(Long chatRoomId) {
         if (chatRoomId == null) return java.util.Optional.empty();
         return store.values().stream()


### PR DESCRIPTION
## Summary
거래대행도 직거래와 동일 모델로 리뷰/통계 통합. EscrowApplication 정산 시점에 paired Transaction 1건 자동 생성.

## Changes
- V29: \`transactions.escrow_application_id\` UNIQUE FK + \`item_id\` NULL 허용
- \`Transaction.createFromEscrow\` 팩토리 — 거래완료 즉시 (settledAt 으로 모든 타임스탬프)
  - \`tradeType\`: itemPrice=0 → 나눔, 아니면 판매
  - \`chatRoomId\`: INTERNAL escrow.chatRoomId, EXTERNAL 은 null
- \`EscrowApplicationService.settle()\` 끝에 \`TransactionApplicationService.createFromEscrow\` 호출 (UNIQUE 가드로 idempotent)
- \`EscrowApplicationView.Projection\` 에 paired \`transactionId\` 추가
- \`ChatRoom.card\` 의 EscrowApplication 분기에서 \`transactionId\` 도 노출 → 프론트가 그 값으로 \`POST /reviews\`

## Test plan
- [x] \`./gradlew test\` 전체 통과
- [ ] prod 배포 후 거래대행 정산 → \`transactions\` 에 paired row 자동 생성 확인
- [ ] 채팅방 응답 \`card\` 에 \`transactionId\` + \`escrowApplicationId\` 둘 다 채워짐 확인
- [ ] \`POST /reviews { transactionId }\` 로 거래대행 리뷰 작성 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)