### PR TITLE
feat(admin): 물품/배달 관리 endpoint 4종

### DIFF
--- a/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/DeliveryApplicationService.java
@@ -231,6 +231,44 @@ public class DeliveryApplicationService {
 
     
 
+    // 라운드 12 — admin delivery 검색.
+    public org.springframework.data.domain.Page<com.sseulang.domain.delivery.application.dto.AdminDeliveryResult> adminSearch(
+            DeliveryStatus status, Long riderId, Long requesterId,
+            java.time.LocalDateTime createdAfter, java.time.LocalDateTime createdBefore,
+            String sort, Pageable pageable
+    ) {
+        Page<DeliveryRequest> page = deliveryRepository.adminSearch(
+                status, riderId, requesterId, createdAfter, createdBefore, sort, pageable);
+        if (page.isEmpty()) return org.springframework.data.domain.Page.empty(pageable);
+        java.util.Set<Long> userIds = new java.util.HashSet<>();
+        for (DeliveryRequest d : page.getContent()) {
+            userIds.add(d.getRequesterId());
+            if (d.getRiderId() != null) userIds.add(d.getRiderId());
+        }
+        java.util.Map<Long, UserApplicationService.UserProjection> userMap =
+                userApplicationService.findProjectionsByIds(userIds);
+        return page.map(d -> com.sseulang.domain.delivery.application.dto.AdminDeliveryResult.from(
+                d,
+                java.util.Optional.ofNullable(userMap.get(d.getRequesterId()))
+                        .map(UserApplicationService.UserProjection::nickname).orElse(null),
+                d.getRiderId() == null ? null : java.util.Optional.ofNullable(userMap.get(d.getRiderId()))
+                        .map(UserApplicationService.UserProjection::nickname).orElse(null)
+        ));
+    }
+
+    public com.sseulang.domain.delivery.application.dto.AdminDeliveryStatsResult adminGetStatsV2() {
+        Map<DeliveryStatus, Long> byStatus = new EnumMap<>(DeliveryStatus.class);
+        for (DeliveryStatus s : DeliveryStatus.values()) byStatus.put(s, 0L);
+        long total = 0;
+        for (DeliveryStatusCount row : deliveryRepository.countGroupByStatus()) {
+            byStatus.put(row.status(), row.count());
+            total += row.count();
+        }
+        long todayNew = deliveryRepository.countCreatedSince(
+                java.time.LocalDate.now().atStartOfDay());
+        return new com.sseulang.domain.delivery.application.dto.AdminDeliveryStatsResult(byStatus, total, todayNew);
+    }
+
     public DeliveryStatsResult adminGetStats() {
         Map<DeliveryStatus, Long> byStatus = new EnumMap<>(DeliveryStatus.class);
         for (DeliveryStatus s : DeliveryStatus.values()) {

--- a/src/main/java/com/sseulang/domain/delivery/application/dto/AdminDeliveryResult.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/dto/AdminDeliveryResult.java
@@ -1,0 +1,40 @@
+package com.sseulang.domain.delivery.application.dto;
+
+import com.sseulang.domain.delivery.domain.DeliveryRequest;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+
+import java.time.LocalDateTime;
+
+public record AdminDeliveryResult(
+        Long id,
+        Long requesterId,
+        String requesterNickname,
+        Long riderId,
+        String riderNickname,
+        String pickupAddress,
+        String dropoffAddress,
+        String itemDescription,
+        long fee,
+        DeliveryStatus status,
+        LocalDateTime requestedAt,
+        LocalDateTime acceptedAt,
+        LocalDateTime pickedUpAt,
+        LocalDateTime deliveredAt,
+        LocalDateTime completedAt,
+        LocalDateTime canceledAt,
+        String cancelReason,
+        Long escrowApplicationId
+) {
+    public static AdminDeliveryResult from(DeliveryRequest d, String requesterNickname, String riderNickname) {
+        return new AdminDeliveryResult(
+                d.getId(), d.getRequesterId(), requesterNickname,
+                d.getRiderId(), riderNickname,
+                d.getPickupAddress(), d.getDropoffAddress(),
+                d.getItemDescription(), d.getFee(), d.getStatus(),
+                d.getRequestedAt(), d.getAcceptedAt(), d.getPickedUpAt(),
+                d.getDeliveredAt(), d.getCompletedAt(),
+                d.getCanceledAt(), d.getCancelReason(),
+                d.getEscrowApplicationId()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/application/dto/AdminDeliveryStatsResult.java
+++ b/src/main/java/com/sseulang/domain/delivery/application/dto/AdminDeliveryStatsResult.java
@@ -1,0 +1,12 @@
+package com.sseulang.domain.delivery.application.dto;
+
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+
+import java.util.Map;
+
+public record AdminDeliveryStatsResult(
+        Map<DeliveryStatus, Long> byStatus,
+        long total,
+        long todayNew
+) {
+}

--- a/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/domain/DeliveryRepository.java
@@ -41,4 +41,14 @@ public interface DeliveryRepository {
     Optional<DeliveryRequest> findByEscrowApplicationId(Long escrowApplicationId);
 
     java.util.List<DeliveryRequest> findByEscrowApplicationIdIn(java.util.Collection<Long> escrowApplicationIds);
+
+    // 라운드 12 — admin delivery 검색.
+    Page<DeliveryRequest> adminSearch(
+            DeliveryStatus status, Long riderId, Long requesterId,
+            LocalDateTime createdAfter, LocalDateTime createdBefore,
+            String sort,   // "latest" | "picked_up_desc"
+            Pageable pageable
+    );
+
+    long countCreatedSince(LocalDateTime since);
 }

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryJpaRepository.java
@@ -86,4 +86,24 @@ interface DeliveryJpaRepository extends JpaRepository<DeliveryRequest, Long> {
     java.util.Optional<DeliveryRequest> findByEscrowApplicationId(Long escrowApplicationId);
 
     java.util.List<DeliveryRequest> findByEscrowApplicationIdIn(java.util.Collection<Long> escrowApplicationIds);
+
+    @Query("""
+            SELECT d FROM DeliveryRequest d
+             WHERE (:status IS NULL OR d.status = :status)
+               AND (:riderId IS NULL OR d.riderId = :riderId)
+               AND (:requesterId IS NULL OR d.requesterId = :requesterId)
+               AND (:createdAfter IS NULL OR d.requestedAt >= :createdAfter)
+               AND (:createdBefore IS NULL OR d.requestedAt < :createdBefore)
+            """)
+    Page<DeliveryRequest> adminSearch(
+            @Param("status") DeliveryStatus status,
+            @Param("riderId") Long riderId,
+            @Param("requesterId") Long requesterId,
+            @Param("createdAfter") LocalDateTime createdAfter,
+            @Param("createdBefore") LocalDateTime createdBefore,
+            Pageable pageable
+    );
+
+    @Query("SELECT COUNT(d) FROM DeliveryRequest d WHERE d.requestedAt >= :since")
+    long countCreatedSince(@Param("since") LocalDateTime since);
 }

--- a/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/delivery/infrastructure/persistence/DeliveryRepositoryImpl.java
@@ -77,4 +77,25 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
         if (escrowApplicationIds == null || escrowApplicationIds.isEmpty()) return java.util.List.of();
         return jpa.findByEscrowApplicationIdIn(escrowApplicationIds);
     }
+
+    @Override
+    public Page<DeliveryRequest> adminSearch(
+            DeliveryStatus status, Long riderId, Long requesterId,
+            LocalDateTime createdAfter, LocalDateTime createdBefore,
+            String sort, Pageable pageable
+    ) {
+        org.springframework.data.domain.Sort order = "picked_up_desc".equals(sort)
+                ? org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Order.desc("pickedUpAt").nullsLast(),
+                        org.springframework.data.domain.Sort.Order.desc("id"))
+                : org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Order.desc("requestedAt"),
+                        org.springframework.data.domain.Sort.Order.desc("id"));
+        org.springframework.data.domain.PageRequest pr = org.springframework.data.domain.PageRequest.of(
+                pageable.getPageNumber(), pageable.getPageSize(), order);
+        return jpa.adminSearch(status, riderId, requesterId, createdAfter, createdBefore, pr);
+    }
+
+    @Override
+    public long countCreatedSince(LocalDateTime since) {
+        return jpa.countCreatedSince(since);
+    }
 }

--- a/src/main/java/com/sseulang/domain/delivery/presentation/AdminDeliveryController.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/AdminDeliveryController.java
@@ -1,0 +1,60 @@
+package com.sseulang.domain.delivery.presentation;
+
+import com.sseulang.domain.delivery.application.DeliveryApplicationService;
+import com.sseulang.domain.delivery.application.dto.AdminDeliveryResult;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+import com.sseulang.domain.delivery.presentation.dto.AdminDeliveryResponse;
+import com.sseulang.domain.delivery.presentation.dto.AdminDeliveryStatsResponse;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "AdminDelivery", description = "관리자 — 배달 이력 / 통계")
+@RestController
+@RequestMapping("/api/v1/admin/deliveries")
+public class AdminDeliveryController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final DeliveryApplicationService service;
+
+    public AdminDeliveryController(DeliveryApplicationService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "[관리자] 전체 배달 이력",
+            description = "status/riderId/requesterId 필터, createdAfter/Before 기간, sort=latest|picked_up_desc.")
+    @GetMapping
+    public ApiResponse<PageResponse<AdminDeliveryResponse>> list(
+            @RequestParam(required = false) DeliveryStatus status,
+            @RequestParam(required = false) Long riderId,
+            @RequestParam(required = false) Long requesterId,
+            @RequestParam(required = false) LocalDateTime createdAfter,
+            @RequestParam(required = false) LocalDateTime createdBefore,
+            @RequestParam(required = false, defaultValue = "latest") String sort,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(Math.max(page, 0), Math.min(Math.max(size, 1), MAX_PAGE_SIZE));
+        Page<AdminDeliveryResult> result = service.adminSearch(
+                status, riderId, requesterId, createdAfter, createdBefore, sort, pageable);
+        return ApiResponse.ok(PageResponse.from(result.map(AdminDeliveryResponse::from)));
+    }
+
+    @Operation(summary = "[관리자] 배달 상태별 카운트",
+            description = "byStatus 맵, total 합계, todayNew (오늘 신규 신청 수).")
+    @GetMapping("/stats")
+    public ApiResponse<AdminDeliveryStatsResponse> stats() {
+        return ApiResponse.ok(AdminDeliveryStatsResponse.from(service.adminGetStatsV2()));
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/AdminDeliveryResponse.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/AdminDeliveryResponse.java
@@ -1,0 +1,33 @@
+package com.sseulang.domain.delivery.presentation.dto;
+
+import com.sseulang.domain.delivery.application.dto.AdminDeliveryResult;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+
+import java.time.LocalDateTime;
+
+public record AdminDeliveryResponse(
+        Long id,
+        Long requesterId, String requesterNickname,
+        Long riderId, String riderNickname,
+        String pickupAddress, String dropoffAddress,
+        String itemDescription,
+        long fee, DeliveryStatus status,
+        LocalDateTime requestedAt, LocalDateTime acceptedAt,
+        LocalDateTime pickedUpAt, LocalDateTime deliveredAt,
+        LocalDateTime completedAt, LocalDateTime canceledAt,
+        String cancelReason,
+        Long escrowApplicationId
+) {
+    public static AdminDeliveryResponse from(AdminDeliveryResult r) {
+        return new AdminDeliveryResponse(
+                r.id(), r.requesterId(), r.requesterNickname(),
+                r.riderId(), r.riderNickname(),
+                r.pickupAddress(), r.dropoffAddress(), r.itemDescription(),
+                r.fee(), r.status(),
+                r.requestedAt(), r.acceptedAt(), r.pickedUpAt(),
+                r.deliveredAt(), r.completedAt(),
+                r.canceledAt(), r.cancelReason(),
+                r.escrowApplicationId()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/delivery/presentation/dto/AdminDeliveryStatsResponse.java
+++ b/src/main/java/com/sseulang/domain/delivery/presentation/dto/AdminDeliveryStatsResponse.java
@@ -1,0 +1,21 @@
+package com.sseulang.domain.delivery.presentation.dto;
+
+import com.sseulang.domain.delivery.application.dto.AdminDeliveryStatsResult;
+import com.sseulang.domain.delivery.domain.DeliveryStatus;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public record AdminDeliveryStatsResponse(
+        Map<String, Long> byStatus,
+        long total,
+        long todayNew
+) {
+    public static AdminDeliveryStatsResponse from(AdminDeliveryStatsResult r) {
+        Map<String, Long> map = new LinkedHashMap<>();
+        for (Map.Entry<DeliveryStatus, Long> e : r.byStatus().entrySet()) {
+            map.put(e.getKey().name(), e.getValue());
+        }
+        return new AdminDeliveryStatsResponse(map, r.total(), r.todayNew());
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
+++ b/src/main/java/com/sseulang/domain/item/application/ItemApplicationService.java
@@ -33,19 +33,22 @@ public class ItemApplicationService {
     private final UserApplicationService userApplicationService;
     private final PresignedUrlGenerator presignedUrlGenerator;
     private final WishlistView wishlistView;
+    private final com.sseulang.domain.item.domain.ItemReportView itemReportView;
 
     public ItemApplicationService(
             ItemRepository itemRepository,
             CategoryApplicationService categoryApplicationService,
             UserApplicationService userApplicationService,
             PresignedUrlGenerator presignedUrlGenerator,
-            WishlistView wishlistView
+            WishlistView wishlistView,
+            com.sseulang.domain.item.domain.ItemReportView itemReportView
     ) {
         this.itemRepository = itemRepository;
         this.categoryApplicationService = categoryApplicationService;
         this.userApplicationService = userApplicationService;
         this.presignedUrlGenerator = presignedUrlGenerator;
         this.wishlistView = wishlistView;
+        this.itemReportView = itemReportView;
     }
 
     @Transactional
@@ -146,6 +149,89 @@ public class ItemApplicationService {
     }
 
     
+
+    // 라운드 12 — admin item 목록. q 키워드는 title or sellerId IN matchedUsers, status/tradeType/category 필터.
+    public Page<com.sseulang.domain.item.application.dto.AdminItemSummaryResult> adminSearch(
+            com.sseulang.domain.item.application.dto.AdminItemSearchCriteria criteria,
+            Pageable pageable
+    ) {
+        java.util.List<Long> matchedSellerIds = java.util.Collections.emptyList();
+        if (criteria.q() != null && !criteria.q().isBlank()) {
+            matchedSellerIds = userApplicationService.findUserIdsByKeyword(criteria.q().strip(), 200);
+        }
+        Page<Item> page = itemRepository.adminSearch(criteria, matchedSellerIds, pageable);
+        if (page.isEmpty()) return Page.empty(pageable);
+
+        java.util.List<Long> sellerIds = page.getContent().stream().map(Item::getSellerId).distinct().toList();
+        java.util.Map<Long, com.sseulang.domain.user.application.UserApplicationService.UserProjection> userMap =
+                userApplicationService.findProjectionsByIds(sellerIds);
+        java.util.List<Long> itemIds = page.getContent().stream().map(Item::getId).toList();
+        java.util.Map<Long, Long> reportMap = itemReportView.countByItemIds(itemIds);
+
+        java.util.List<com.sseulang.domain.item.application.dto.AdminItemSummaryResult> rows = page.getContent().stream()
+                .map(it -> com.sseulang.domain.item.application.dto.AdminItemSummaryResult.from(
+                        it,
+                        java.util.Optional.ofNullable(userMap.get(it.getSellerId()))
+                                .map(com.sseulang.domain.user.application.UserApplicationService.UserProjection::nickname).orElse(null),
+                        reportMap.getOrDefault(it.getId(), 0L)
+                ))
+                .toList();
+
+        if (criteria.sort() == com.sseulang.domain.item.application.dto.AdminItemSort.REPORT_DESC) {
+            rows = new java.util.ArrayList<>(rows);
+            rows.sort(java.util.Comparator.comparingLong(
+                    com.sseulang.domain.item.application.dto.AdminItemSummaryResult::reportCount).reversed());
+        }
+        return new org.springframework.data.domain.PageImpl<>(rows, pageable, page.getTotalElements());
+    }
+
+    // 라운드 12 — admin item 상세.
+    public com.sseulang.domain.item.application.dto.AdminItemDetailResult adminGetDetail(
+            Long itemId,
+            java.util.List<com.sseulang.domain.report.domain.UserReport> reports,
+            java.util.List<com.sseulang.domain.transaction.domain.Transaction> transactions
+    ) {
+        Item item = findOrThrow(itemId);
+        com.sseulang.domain.item.application.dto.ItemDetailResult detail =
+                com.sseulang.domain.item.application.dto.ItemDetailResult.from(item);
+
+        com.sseulang.domain.user.application.UserApplicationService.UserProjection seller =
+                userApplicationService.findProjectionsByIds(java.util.List.of(item.getSellerId()))
+                        .get(item.getSellerId());
+
+        java.util.List<Long> buyerIds = transactions.stream()
+                .map(com.sseulang.domain.transaction.domain.Transaction::getBuyerId)
+                .distinct().toList();
+        java.util.Map<Long, com.sseulang.domain.user.application.UserApplicationService.UserProjection> buyerMap =
+                userApplicationService.findProjectionsByIds(buyerIds);
+
+        java.util.List<com.sseulang.domain.item.application.dto.AdminItemDetailResult.ReportHistoryItem> reportRows =
+                reports.stream()
+                        .map(r -> new com.sseulang.domain.item.application.dto.AdminItemDetailResult.ReportHistoryItem(
+                                r.getId(), r.getReporterId(), r.getReason(),
+                                r.getStatus().name(), r.getCreatedAt()
+                        ))
+                        .toList();
+
+        java.util.List<com.sseulang.domain.item.application.dto.AdminItemDetailResult.TransactionHistoryItem> txRows =
+                transactions.stream()
+                        .map(t -> new com.sseulang.domain.item.application.dto.AdminItemDetailResult.TransactionHistoryItem(
+                                t.getId(), t.getBuyerId(),
+                                java.util.Optional.ofNullable(buyerMap.get(t.getBuyerId()))
+                                        .map(com.sseulang.domain.user.application.UserApplicationService.UserProjection::nickname)
+                                        .orElse(null),
+                                t.getStatus().name(), t.getPrice(), t.getCompletedAt()
+                        ))
+                        .toList();
+
+        return new com.sseulang.domain.item.application.dto.AdminItemDetailResult(
+                detail,
+                seller != null ? seller.nickname() : null,
+                reportRows.size(),
+                reportRows,
+                txRows
+        );
+    }
 
     @Transactional
     public void adminDelete(Long id, Long adminId) {

--- a/src/main/java/com/sseulang/domain/item/application/dto/AdminItemDetailResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/AdminItemDetailResult.java
@@ -1,0 +1,30 @@
+package com.sseulang.domain.item.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 라운드 12 — admin item 상세. ItemDetail + 신고 이력 + 거래 이력.
+public record AdminItemDetailResult(
+        ItemDetailResult item,
+        String sellerNickname,
+        long reportCount,
+        List<ReportHistoryItem> reportHistory,
+        List<TransactionHistoryItem> transactionHistory
+) {
+    public record ReportHistoryItem(
+            Long id,
+            Long reporterId,
+            String reason,
+            String status,            // 접수/처리중/처리완료/반려
+            LocalDateTime createdAt
+    ) { }
+
+    public record TransactionHistoryItem(
+            Long id,
+            Long buyerId,
+            String buyerNickname,
+            String status,            // 채팅중/예약/인계완료/거래완료/취소
+            long price,
+            LocalDateTime completedAt
+    ) { }
+}

--- a/src/main/java/com/sseulang/domain/item/application/dto/AdminItemSearchCriteria.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/AdminItemSearchCriteria.java
@@ -1,0 +1,20 @@
+package com.sseulang.domain.item.application.dto;
+
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.TradeType;
+
+import java.time.LocalDateTime;
+
+public record AdminItemSearchCriteria(
+        String q,                       // title 또는 seller nickname 키워드
+        ItemStatus status,
+        TradeType tradeType,
+        Long categoryId,
+        LocalDateTime createdAfter,
+        LocalDateTime createdBefore,
+        AdminItemSort sort              // LATEST / VIEW_DESC / REPORT_DESC
+) {
+    public AdminItemSearchCriteria {
+        if (sort == null) sort = AdminItemSort.LATEST;
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/application/dto/AdminItemSort.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/AdminItemSort.java
@@ -1,0 +1,7 @@
+package com.sseulang.domain.item.application.dto;
+
+public enum AdminItemSort {
+    LATEST,
+    VIEW_DESC,
+    REPORT_DESC
+}

--- a/src/main/java/com/sseulang/domain/item/application/dto/AdminItemSummaryResult.java
+++ b/src/main/java/com/sseulang/domain/item/application/dto/AdminItemSummaryResult.java
@@ -1,0 +1,51 @@
+package com.sseulang.domain.item.application.dto;
+
+import com.sseulang.domain.item.domain.Item;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.TradeType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+// 라운드 12 — admin item 목록용. 일반 ItemSummary 에 reportCount 추가 + sellerNickname 노출.
+public record AdminItemSummaryResult(
+        Long id,
+        Long sellerId,
+        String sellerNickname,
+        String title,
+        String thumbnailUrl,
+        Set<TradeType> tradeTypes,
+        Long salePrice,
+        Long rentalPrice,
+        TradeType tradeType,           // legacy
+        long price,                    // legacy
+        Long categoryId,
+        ItemStatus status,
+        String region,
+        int viewCount,
+        int wishlistCount,
+        long reportCount,
+        LocalDateTime createdAt
+) {
+    public static AdminItemSummaryResult from(Item item, String sellerNickname, long reportCount) {
+        return new AdminItemSummaryResult(
+                item.getId(),
+                item.getSellerId(),
+                sellerNickname,
+                item.getTitle(),
+                item.getThumbnailUrl(),
+                item.getTradeTypes(),
+                item.getSalePrice(),
+                item.getRentalPrice(),
+                item.getTradeType(),
+                item.getPrice(),
+                item.getCategoryId(),
+                item.getStatus(),
+                item.getRegion(),
+                item.getViewCount(),
+                item.getWishlistCount(),
+                reportCount,
+                item.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/domain/ItemReportView.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemReportView.java
@@ -1,0 +1,10 @@
+package com.sseulang.domain.item.domain;
+
+import java.util.Collection;
+import java.util.Map;
+
+// 라운드 12 — admin item 화면용 신고 카운트 view 포트. 어댑터는 report/infrastructure 에 위치.
+public interface ItemReportView {
+
+    Map<Long, Long> countByItemIds(Collection<Long> itemIds);
+}

--- a/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
+++ b/src/main/java/com/sseulang/domain/item/domain/ItemRepository.java
@@ -21,6 +21,13 @@ public interface ItemRepository {
 
     Page<Item> findBySellerIdAndStatus(Long sellerId, ItemStatus status, Pageable pageable);
 
+    // 라운드 12 — admin item 검색. 삭제 포함 모든 상태 + 키워드(title or sellerId IN matched users)
+    Page<Item> adminSearch(
+            com.sseulang.domain.item.application.dto.AdminItemSearchCriteria criteria,
+            java.util.Collection<Long> matchedSellerIds,
+            Pageable pageable
+    );
+
     Item save(Item item);
 
     void delete(Item item);

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemQuerydslRepository.java
@@ -118,4 +118,38 @@ public class ItemQuerydslRepository {
                 .map(s -> "+" + s)
                 .collect(Collectors.joining(" "));
     }
+
+    // 라운드 12 — admin item 검색. 삭제 포함 모든 상태, REPORT_DESC 정렬은 service 후처리.
+    public Page<Item> adminSearch(
+            com.sseulang.domain.item.application.dto.AdminItemSearchCriteria criteria,
+            java.util.Collection<Long> matchedSellerIds,
+            Pageable pageable
+    ) {
+        QItem item = QItem.item;
+        BooleanBuilder where = new BooleanBuilder();
+        if (criteria.q() != null && !criteria.q().isBlank()) {
+            String pattern = "%" + criteria.q().strip() + "%";
+            BooleanBuilder kw = new BooleanBuilder(item.title.like(pattern));
+            if (matchedSellerIds != null && !matchedSellerIds.isEmpty()) {
+                kw.or(item.sellerId.in(matchedSellerIds));
+            }
+            where.and(kw);
+        }
+        if (criteria.status() != null) where.and(item.status.eq(criteria.status()));
+        if (criteria.tradeType() != null) where.and(item.tradeType.eq(criteria.tradeType()));
+        if (criteria.categoryId() != null) where.and(item.categoryId.eq(criteria.categoryId()));
+        if (criteria.createdAfter() != null) where.and(item.createdAt.goe(criteria.createdAfter()));
+        if (criteria.createdBefore() != null) where.and(item.createdAt.lt(criteria.createdBefore()));
+
+        OrderSpecifier<?>[] orders = switch (criteria.sort()) {
+            case VIEW_DESC -> new OrderSpecifier<?>[]{ item.viewCount.desc(), item.id.desc() };
+            case REPORT_DESC, LATEST -> new OrderSpecifier<?>[]{ item.createdAt.desc(), item.id.desc() };
+        };
+
+        List<Item> content = queryFactory
+                .selectFrom(item).where(where).orderBy(orders)
+                .offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
+        Long total = queryFactory.select(item.count()).from(item).where(where).fetchOne();
+        return new PageImpl<>(content, pageable, total == null ? 0L : total);
+    }
 }

--- a/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/item/infrastructure/persistence/ItemRepositoryImpl.java
@@ -37,6 +37,15 @@ public class ItemRepositoryImpl implements ItemRepository {
     }
 
     @Override
+    public Page<Item> adminSearch(
+            com.sseulang.domain.item.application.dto.AdminItemSearchCriteria criteria,
+            java.util.Collection<Long> matchedSellerIds,
+            Pageable pageable
+    ) {
+        return querydsl.adminSearch(criteria, matchedSellerIds, pageable);
+    }
+
+    @Override
     public Page<Item> findBySellerIdAndStatus(Long sellerId, ItemStatus status, Pageable pageable) {
         if (status == null) {
             return jpa.findBySellerIdExcludingDeleted(sellerId, pageable);

--- a/src/main/java/com/sseulang/domain/item/presentation/AdminItemController.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/AdminItemController.java
@@ -1,24 +1,91 @@
 package com.sseulang.domain.item.presentation;
 
 import com.sseulang.domain.item.application.ItemApplicationService;
+import com.sseulang.domain.item.application.dto.AdminItemSearchCriteria;
+import com.sseulang.domain.item.application.dto.AdminItemSort;
+import com.sseulang.domain.item.application.dto.AdminItemSummaryResult;
+import com.sseulang.domain.item.application.dto.AdminItemDetailResult;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.TradeType;
+import com.sseulang.domain.item.presentation.dto.AdminItemDetailResponse;
+import com.sseulang.domain.item.presentation.dto.AdminItemSummaryResponse;
+import com.sseulang.domain.report.domain.UserReportRepository;
+import com.sseulang.domain.transaction.domain.TransactionRepository;
 import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
 
 @Tag(name = "AdminItem", description = "관리자 — 물품 관리")
 @RestController
 @RequestMapping("/api/v1/admin/items")
 public class AdminItemController {
 
-    private final ItemApplicationService itemService;
+    private static final int MAX_PAGE_SIZE = 100;
 
-    public AdminItemController(ItemApplicationService itemService) {
+    private final ItemApplicationService itemService;
+    private final UserReportRepository userReportRepository;
+    private final TransactionRepository transactionRepository;
+
+    public AdminItemController(
+            ItemApplicationService itemService,
+            UserReportRepository userReportRepository,
+            TransactionRepository transactionRepository
+    ) {
         this.itemService = itemService;
+        this.userReportRepository = userReportRepository;
+        this.transactionRepository = transactionRepository;
+    }
+
+    @Operation(summary = "[관리자] 전체 물품 목록",
+            description = "q=title or seller nickname, status/tradeType/category 필터, "
+                    + "createdAfter/Before 기간, sort=latest|view_desc|report_desc.")
+    @GetMapping
+    public ApiResponse<PageResponse<AdminItemSummaryResponse>> list(
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) ItemStatus status,
+            @RequestParam(required = false) TradeType tradeType,
+            @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) LocalDateTime createdAfter,
+            @RequestParam(required = false) LocalDateTime createdBefore,
+            @RequestParam(required = false, defaultValue = "latest") String sort,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        AdminItemSort sortEnum = switch (sort) {
+            case "view_desc" -> AdminItemSort.VIEW_DESC;
+            case "report_desc" -> AdminItemSort.REPORT_DESC;
+            default -> AdminItemSort.LATEST;
+        };
+        Pageable pageable = PageRequest.of(Math.max(page, 0), Math.min(Math.max(size, 1), MAX_PAGE_SIZE));
+        Page<AdminItemSummaryResult> result = itemService.adminSearch(
+                new AdminItemSearchCriteria(q, status, tradeType, categoryId, createdAfter, createdBefore, sortEnum),
+                pageable
+        );
+        return ApiResponse.ok(PageResponse.from(result.map(AdminItemSummaryResponse::from)));
+    }
+
+    @Operation(summary = "[관리자] 물품 상세 + 신고 이력 + 거래 이력")
+    @GetMapping("/{id}")
+    public ApiResponse<AdminItemDetailResponse> getOne(@PathVariable("id") Long id) {
+        AdminItemDetailResult result = itemService.adminGetDetail(
+                id,
+                userReportRepository.findByItemIdOrderByCreatedAtDesc(id),
+                transactionRepository.findByItemIdOrderByIdDesc(id)
+        );
+        return ApiResponse.ok(AdminItemDetailResponse.from(result));
     }
 
     @Operation(summary = "[관리자] 물품 강제 삭제 (soft delete)",

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/AdminItemDetailResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/AdminItemDetailResponse.java
@@ -1,0 +1,39 @@
+package com.sseulang.domain.item.presentation.dto;
+
+import com.sseulang.domain.item.application.dto.AdminItemDetailResult;
+import com.sseulang.domain.item.application.dto.ItemDetailResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AdminItemDetailResponse(
+        ItemDetailResult item,
+        String sellerNickname,
+        long reportCount,
+        List<ReportHistoryItem> reportHistory,
+        List<TransactionHistoryItem> transactionHistory
+) {
+    public record ReportHistoryItem(
+            Long id, Long reporterId, String reason, String status, LocalDateTime createdAt
+    ) {
+        public static ReportHistoryItem from(AdminItemDetailResult.ReportHistoryItem r) {
+            return new ReportHistoryItem(r.id(), r.reporterId(), r.reason(), r.status(), r.createdAt());
+        }
+    }
+
+    public record TransactionHistoryItem(
+            Long id, Long buyerId, String buyerNickname, String status, long price, LocalDateTime completedAt
+    ) {
+        public static TransactionHistoryItem from(AdminItemDetailResult.TransactionHistoryItem t) {
+            return new TransactionHistoryItem(t.id(), t.buyerId(), t.buyerNickname(), t.status(), t.price(), t.completedAt());
+        }
+    }
+
+    public static AdminItemDetailResponse from(AdminItemDetailResult r) {
+        return new AdminItemDetailResponse(
+                r.item(), r.sellerNickname(), r.reportCount(),
+                r.reportHistory().stream().map(ReportHistoryItem::from).toList(),
+                r.transactionHistory().stream().map(TransactionHistoryItem::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/item/presentation/dto/AdminItemSummaryResponse.java
+++ b/src/main/java/com/sseulang/domain/item/presentation/dto/AdminItemSummaryResponse.java
@@ -1,0 +1,39 @@
+package com.sseulang.domain.item.presentation.dto;
+
+import com.sseulang.domain.item.application.dto.AdminItemSummaryResult;
+import com.sseulang.domain.item.domain.ItemStatus;
+import com.sseulang.domain.item.domain.TradeType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminItemSummaryResponse(
+        Long id,
+        Long sellerId,
+        String sellerNickname,
+        String title,
+        String thumbnailUrl,
+        Set<TradeType> tradeTypes,
+        Long salePrice,
+        Long rentalPrice,
+        TradeType tradeType,        // legacy
+        long price,                 // legacy
+        Long categoryId,
+        ItemStatus status,
+        String region,
+        int viewCount,
+        int wishlistCount,
+        long reportCount,
+        LocalDateTime createdAt
+) {
+    public static AdminItemSummaryResponse from(AdminItemSummaryResult r) {
+        return new AdminItemSummaryResponse(
+                r.id(), r.sellerId(), r.sellerNickname(),
+                r.title(), r.thumbnailUrl(),
+                r.tradeTypes(), r.salePrice(), r.rentalPrice(), r.tradeType(), r.price(),
+                r.categoryId(), r.status(), r.region(),
+                r.viewCount(), r.wishlistCount(), r.reportCount(),
+                r.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
+++ b/src/main/java/com/sseulang/domain/report/domain/UserReportRepository.java
@@ -26,4 +26,9 @@ public interface UserReportRepository {
 
     
     long countCreatedSince(java.time.LocalDateTime since);
+
+    // 라운드 12 — admin item 화면. itemId 별 신고 누적 카운트 + 이력 조회.
+    java.util.Map<Long, Long> countByItemIds(java.util.Collection<Long> itemIds);
+
+    java.util.List<UserReport> findByItemIdOrderByCreatedAtDesc(Long itemId);
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/ItemReportViewAdapter.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/ItemReportViewAdapter.java
@@ -1,0 +1,23 @@
+package com.sseulang.domain.report.infrastructure;
+
+import com.sseulang.domain.item.domain.ItemReportView;
+import com.sseulang.domain.report.domain.UserReportRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Component
+public class ItemReportViewAdapter implements ItemReportView {
+
+    private final UserReportRepository repository;
+
+    public ItemReportViewAdapter(UserReportRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Map<Long, Long> countByItemIds(Collection<Long> itemIds) {
+        return repository.countByItemIds(itemIds);
+    }
+}

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportJpaRepository.java
@@ -41,4 +41,19 @@ interface UserReportJpaRepository extends JpaRepository<UserReport, Long> {
     
     @Query("SELECT COUNT(r) FROM UserReport r WHERE r.createdAt >= :since")
     long countCreatedSince(@org.springframework.data.repository.query.Param("since") java.time.LocalDateTime since);
+
+    // 라운드 12 — admin item 화면. itemId 별 신고 누적 카운트.
+    @Query("""
+            SELECT r.itemId AS itemId, COUNT(r) AS cnt FROM UserReport r
+             WHERE r.itemId IN :ids
+             GROUP BY r.itemId
+            """)
+    java.util.List<ItemCountRow> countByItemIdsRaw(@Param("ids") java.util.Collection<Long> ids);
+
+    interface ItemCountRow {
+        Long getItemId();
+        Long getCnt();
+    }
+
+    java.util.List<UserReport> findByItemIdOrderByCreatedAtDesc(Long itemId);
 }

--- a/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/report/infrastructure/persistence/UserReportRepositoryImpl.java
@@ -59,4 +59,22 @@ public class UserReportRepositoryImpl implements UserReportRepository {
     public long countCreatedSince(java.time.LocalDateTime since) {
         return jpa.countCreatedSince(since);
     }
+
+    @Override
+    public java.util.Map<Long, Long> countByItemIds(java.util.Collection<Long> itemIds) {
+        if (itemIds == null || itemIds.isEmpty()) {
+            return java.util.Collections.emptyMap();
+        }
+        java.util.Map<Long, Long> result = new java.util.HashMap<>();
+        for (UserReportJpaRepository.ItemCountRow row : jpa.countByItemIdsRaw(itemIds)) {
+            result.put(row.getItemId(), row.getCnt());
+        }
+        return result;
+    }
+
+    @Override
+    public java.util.List<UserReport> findByItemIdOrderByCreatedAtDesc(Long itemId) {
+        if (itemId == null) return java.util.List.of();
+        return jpa.findByItemIdOrderByCreatedAtDesc(itemId);
+    }
 }

--- a/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/domain/TransactionRepository.java
@@ -22,6 +22,9 @@ public interface TransactionRepository {
 
     boolean existsActiveByChatRoomId(Long chatRoomId);
 
+    // 라운드 12 — admin item 상세에서 거래 이력 조회 (최신순).
+    java.util.List<Transaction> findByItemIdOrderByIdDesc(Long itemId);
+
     // 라운드 12 — 거래대행 paired 매핑 (1:1, UNIQUE).
     Optional<Transaction> findByEscrowApplicationId(Long escrowApplicationId);
 

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionJpaRepository.java
@@ -33,6 +33,9 @@ interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
             """)
     boolean existsActiveByChatRoomIdJpql(@Param("chatRoomId") Long chatRoomId);
 
+    // 라운드 12 — admin item 상세 거래 이력.
+    List<Transaction> findByItemIdOrderByIdDesc(Long itemId);
+
     // 라운드 12 — 거래대행 paired Transaction (1:1).
     Optional<Transaction> findByEscrowApplicationId(Long escrowApplicationId);
 

--- a/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/transaction/infrastructure/persistence/TransactionRepositoryImpl.java
@@ -46,6 +46,12 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     }
 
     @Override
+    public java.util.List<Transaction> findByItemIdOrderByIdDesc(Long itemId) {
+        if (itemId == null) return java.util.List.of();
+        return jpa.findByItemIdOrderByIdDesc(itemId);
+    }
+
+    @Override
     public Optional<Transaction> findByEscrowApplicationId(Long escrowApplicationId) {
         if (escrowApplicationId == null) return Optional.empty();
         return jpa.findByEscrowApplicationId(escrowApplicationId);

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -323,6 +323,19 @@ public class UserApplicationService {
         return userRepository.findIdsByKeywordLike(keyword, limit);
     }
 
+    // 라운드 12 — admin 화면용 nickname/profile 배치 조회.
+    public java.util.Map<Long, UserProjection> findProjectionsByIds(java.util.Collection<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) return java.util.Map.of();
+        java.util.Map<Long, UserProjection> map = new java.util.HashMap<>();
+        for (Long id : userIds) {
+            userRepository.findById(id).ifPresent(u ->
+                    map.put(u.getId(), new UserProjection(u.getId(), u.getNickname(), u.getProfileImage())));
+        }
+        return map;
+    }
+
+    public record UserProjection(Long id, String nickname, String profileImage) { }
+
     
     @Transactional
     public void recordLogin(Long userId) {

--- a/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/chat/application/ChatRoomApplicationServiceTest.java
@@ -34,7 +34,7 @@ class ChatRoomApplicationServiceTest {
         roomRepo = new InMemoryFakeChatRoomRepository();
         itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView(), new com.sseulang.domain.item.application.NoOpItemReportView());
         service = new ChatRoomApplicationService(roomRepo, new com.sseulang.domain.chat.application.InMemoryFakeChatRoomCardRepository(), itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView(), new com.sseulang.domain.chat.application.NoOpTransactionView(), new com.sseulang.domain.chat.application.NoOpEscrowApplicationView());
 
         Item item = itemRepo.save(Item.create(

--- a/src/test/java/com/sseulang/domain/delivery/application/InMemoryFakeDeliveryRepository.java
+++ b/src/test/java/com/sseulang/domain/delivery/application/InMemoryFakeDeliveryRepository.java
@@ -114,4 +114,30 @@ public class InMemoryFakeDeliveryRepository implements DeliveryRepository {
                 .filter(d -> d.getEscrowApplicationId() != null && escrowApplicationIds.contains(d.getEscrowApplicationId()))
                 .toList();
     }
+
+    @Override
+    public Page<DeliveryRequest> adminSearch(
+            DeliveryStatus status, Long riderId, Long requesterId,
+            LocalDateTime createdAfter, LocalDateTime createdBefore,
+            String sort, Pageable pageable
+    ) {
+        java.util.Comparator<DeliveryRequest> cmp = "picked_up_desc".equals(sort)
+                ? java.util.Comparator.comparing(DeliveryRequest::getPickedUpAt,
+                        java.util.Comparator.nullsLast(java.util.Comparator.reverseOrder()))
+                : java.util.Comparator.comparing(DeliveryRequest::getRequestedAt).reversed();
+        java.util.List<DeliveryRequest> filtered = store.values().stream()
+                .filter(d -> status == null || d.getStatus() == status)
+                .filter(d -> riderId == null || riderId.equals(d.getRiderId()))
+                .filter(d -> requesterId == null || requesterId.equals(d.getRequesterId()))
+                .filter(d -> createdAfter == null || !d.getRequestedAt().isBefore(createdAfter))
+                .filter(d -> createdBefore == null || d.getRequestedAt().isBefore(createdBefore))
+                .sorted(cmp)
+                .toList();
+        return new PageImpl<>(filtered, pageable, filtered.size());
+    }
+
+    @Override
+    public long countCreatedSince(LocalDateTime since) {
+        return store.values().stream().filter(d -> !d.getRequestedAt().isBefore(since)).count();
+    }
 }

--- a/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
+++ b/src/test/java/com/sseulang/domain/item/application/InMemoryFakeItemRepository.java
@@ -121,6 +121,21 @@ public class InMemoryFakeItemRepository implements ItemRepository {
     }
 
     @Override
+    public Page<Item> adminSearch(
+            com.sseulang.domain.item.application.dto.AdminItemSearchCriteria criteria,
+            java.util.Collection<Long> matchedSellerIds,
+            Pageable pageable
+    ) {
+        // 라운드 12 — 테스트 단순화: criteria 무시하고 전체 정렬 후 페이징
+        List<Item> filtered = store.values().stream()
+                .sorted(Comparator.comparingLong(Item::getId).reversed())
+                .toList();
+        int start = Math.min((int) pageable.getOffset(), filtered.size());
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        return new PageImpl<>(filtered.subList(start, end), pageable, filtered.size());
+    }
+
+    @Override
     public Page<Item> findBySellerIdAndStatus(Long sellerId, ItemStatus status, Pageable pageable) {
         Stream<Item> stream = store.values().stream()
                 .filter(i -> sellerId.equals(i.getSellerId()));

--- a/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemApplicationServiceTest.java
@@ -37,7 +37,7 @@ class ItemApplicationServiceTest {
         categoryRepo = new InMemoryFakeCategoryRepository();
         CategoryApplicationService categoryService = new CategoryApplicationService(categoryRepo);
         // requireVerified 가드는 기본 통과 (mock void no-op) — 단위 테스트는 비즈니스 로직 검증.
-        service = new ItemApplicationService(itemRepo, categoryService, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
+        service = new ItemApplicationService(itemRepo, categoryService, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView(), new com.sseulang.domain.item.application.NoOpItemReportView());
         categoryId = categoryRepo.insert(Category.createRoot("디지털/가전", 1)).getId();
     }
 

--- a/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
+++ b/src/test/java/com/sseulang/domain/item/application/ItemSearchTest.java
@@ -36,7 +36,7 @@ class ItemSearchTest {
         InMemoryFakeCategoryRepository categoryRepo = new InMemoryFakeCategoryRepository();
         com.sseulang.domain.category.application.CategoryApplicationService catSvc =
                 new com.sseulang.domain.category.application.CategoryApplicationService(categoryRepo);
-        service = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
+        service = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView(), new com.sseulang.domain.item.application.NoOpItemReportView());
         catA = categoryRepo.insert(Category.createRoot("A", 1)).getId();
         catB = categoryRepo.insert(Category.createRoot("B", 2)).getId();
     }

--- a/src/test/java/com/sseulang/domain/item/application/NoOpItemReportView.java
+++ b/src/test/java/com/sseulang/domain/item/application/NoOpItemReportView.java
@@ -1,0 +1,13 @@
+package com.sseulang.domain.item.application;
+
+import com.sseulang.domain.item.domain.ItemReportView;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class NoOpItemReportView implements ItemReportView {
+    @Override
+    public Map<Long, Long> countByItemIds(Collection<Long> itemIds) {
+        return Map.of();
+    }
+}

--- a/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/message/application/MessageApplicationServiceTest.java
@@ -47,7 +47,7 @@ class MessageApplicationServiceTest {
         publisher = new FakeRealtimePublisher();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView(), new com.sseulang.domain.item.application.NoOpItemReportView());
         ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, new com.sseulang.domain.chat.application.InMemoryFakeChatRoomCardRepository(), itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView(), new com.sseulang.domain.chat.application.NoOpTransactionView(), new com.sseulang.domain.chat.application.NoOpEscrowApplicationView());
         NotificationApplicationService notifSvc = new NotificationApplicationService(notifRepo, new com.sseulang.domain.user.application.InMemoryFakeUserRepository());
         // 단위 테스트에선 트랜잭션 컨텍스트 X — AFTER_COMMIT listener 직접 호출하는 fake event publisher.

--- a/src/test/java/com/sseulang/domain/report/application/InMemoryFakeUserReportRepository.java
+++ b/src/test/java/com/sseulang/domain/report/application/InMemoryFakeUserReportRepository.java
@@ -77,4 +77,24 @@ public class InMemoryFakeUserReportRepository implements UserReportRepository {
                 .filter(r -> r.getCreatedAt() != null && !r.getCreatedAt().isBefore(since))
                 .count();
     }
+
+    @Override
+    public Map<Long, Long> countByItemIds(java.util.Collection<Long> itemIds) {
+        if (itemIds == null || itemIds.isEmpty()) return Map.of();
+        java.util.Map<Long, Long> map = new java.util.HashMap<>();
+        store.values().stream()
+                .filter(r -> r.getItemId() != null && itemIds.contains(r.getItemId()))
+                .forEach(r -> map.merge(r.getItemId(), 1L, Long::sum));
+        return map;
+    }
+
+    @Override
+    public java.util.List<com.sseulang.domain.report.domain.UserReport> findByItemIdOrderByCreatedAtDesc(Long itemId) {
+        if (itemId == null) return java.util.List.of();
+        return store.values().stream()
+                .filter(r -> itemId.equals(r.getItemId()))
+                .sorted(java.util.Comparator.comparing(com.sseulang.domain.report.domain.UserReport::getCreatedAt,
+                        java.util.Comparator.nullsLast(java.util.Comparator.reverseOrder())))
+                .toList();
+    }
 }

--- a/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/review/application/ReviewApplicationServiceTest.java
@@ -47,7 +47,7 @@ class ReviewApplicationServiceTest {
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
         UserApplicationService userSvc = new UserApplicationService(userRepo, new com.sseulang.domain.transaction.application.InMemoryFakeTransactionRepository(), new com.sseulang.domain.report.application.InMemoryFakeUserReportRepository(), new com.sseulang.domain.auth.application.NoOpRefreshTokenStore(), new com.sseulang.domain.auth.application.NoOpEmailSender(), java.time.Clock.systemDefaultZone());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, userSvc, new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView(), new com.sseulang.domain.item.application.NoOpItemReportView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, new InMemoryFakePointHistoryRepository());
         com.sseulang.domain.chat.application.ChatRoomApplicationService chatSvc =
                 new com.sseulang.domain.chat.application.ChatRoomApplicationService(

--- a/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/InMemoryFakeTransactionRepository.java
@@ -55,6 +55,15 @@ public class InMemoryFakeTransactionRepository implements TransactionRepository 
     }
 
     @Override
+    public java.util.List<Transaction> findByItemIdOrderByIdDesc(Long itemId) {
+        if (itemId == null) return java.util.List.of();
+        return store.values().stream()
+                .filter(t -> itemId.equals(t.getItemId()))
+                .sorted(java.util.Comparator.comparing(Transaction::getId).reversed())
+                .toList();
+    }
+
+    @Override
     public java.util.Optional<Transaction> findByEscrowApplicationId(Long escrowApplicationId) {
         if (escrowApplicationId == null) return java.util.Optional.empty();
         return store.values().stream()

--- a/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/transaction/application/TransactionApplicationServiceTest.java
@@ -66,7 +66,8 @@ class TransactionApplicationServiceTest {
         itemSvc = new ItemApplicationService(
                 itemRepo, catSvc, userSvc,
                 new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(),
-                new com.sseulang.domain.item.application.NoOpWishlistView());
+                new com.sseulang.domain.item.application.NoOpWishlistView(),
+                new com.sseulang.domain.item.application.NoOpItemReportView());
         PointApplicationService pointSvc = new PointApplicationService(userSvc, pointHistoryRepo);
         chatRoomRepo = new com.sseulang.domain.chat.application.InMemoryFakeChatRoomRepository();
         com.sseulang.domain.chat.application.ChatRoomApplicationService chatSvc =

--- a/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/SettlementRollbackIT.java
@@ -99,8 +99,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         // 라운드 12 PR-C #6 — ChatRoomApplicationService 가 ChatRoomCardRepository 의존 추가 (Mongo). DataJpaTest 라 NoOp 주입.
         com.sseulang.domain.chat.application.NoOpChatRoomCardRepository.class,
         // 라운드 12 — ChatRoom card 의 활성 거래/거래대행 동적 룩업용 View 포트. IT 컨텍스트에서 NoOp 사용.
+
         com.sseulang.domain.chat.application.NoOpTransactionView.class,
-        com.sseulang.domain.chat.application.NoOpEscrowApplicationView.class
+        com.sseulang.domain.chat.application.NoOpEscrowApplicationView.class,
+        com.sseulang.domain.report.infrastructure.ItemReportViewAdapter.class
 })
 @Testcontainers
 @Transactional(propagation = Propagation.NOT_SUPPORTED)

--- a/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
+++ b/src/test/java/com/sseulang/domain/transaction/integration/TransactionConcurrencyIT.java
@@ -89,7 +89,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         // 라운드 12 PR-C #6 — ChatRoomCardRepository 의존 (Mongo, DataJpaTest 라 NoOp).
         com.sseulang.domain.chat.application.NoOpChatRoomCardRepository.class,
         com.sseulang.domain.chat.application.NoOpTransactionView.class,
-        com.sseulang.domain.chat.application.NoOpEscrowApplicationView.class
+        com.sseulang.domain.chat.application.NoOpEscrowApplicationView.class,
+        com.sseulang.domain.report.infrastructure.ItemReportViewAdapter.class
 })
 @Testcontainers
 @Transactional(propagation = Propagation.NOT_SUPPORTED)

--- a/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/wishlist/application/WishlistApplicationServiceTest.java
@@ -29,7 +29,7 @@ class WishlistApplicationServiceTest {
         wishRepo = new InMemoryFakeWishlistRepository();
         itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView(), new com.sseulang.domain.item.application.NoOpItemReportView());
         service = new WishlistApplicationService(wishRepo, itemSvc);
 
         Item item = itemRepo.save(Item.create(

--- a/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/sseulang/global/websocket/StompAuthChannelInterceptorTest.java
@@ -53,7 +53,7 @@ class StompAuthChannelInterceptorTest {
         InMemoryFakeChatRoomRepository roomRepo = new InMemoryFakeChatRoomRepository();
         InMemoryFakeItemRepository itemRepo = new InMemoryFakeItemRepository();
         CategoryApplicationService catSvc = new CategoryApplicationService(new InMemoryFakeCategoryRepository());
-        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView());
+        ItemApplicationService itemSvc = new ItemApplicationService(itemRepo, catSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.file.application.NoOpPresignedUrlGenerator(), new com.sseulang.domain.item.application.NoOpWishlistView(), new com.sseulang.domain.item.application.NoOpItemReportView());
         ChatRoomApplicationService roomSvc = new ChatRoomApplicationService(roomRepo, new com.sseulang.domain.chat.application.InMemoryFakeChatRoomCardRepository(), itemSvc, org.mockito.Mockito.mock(com.sseulang.domain.user.application.UserApplicationService.class), new com.sseulang.domain.chat.application.NoOpUserView(), new com.sseulang.domain.chat.application.NoOpItemView(), new com.sseulang.domain.chat.application.NoOpTransactionView(), new com.sseulang.domain.chat.application.NoOpEscrowApplicationView());
 
         validTokens.clear();


### PR DESCRIPTION
## Summary
프론트 admin 페이지 작성용 신규 endpoint 4종.

## Endpoints
- GET /api/v1/admin/items — 페이징 + q/status/tradeType/category/createdAt 필터 + sort(latest/view_desc/report_desc) + reportCount 노출
- GET /api/v1/admin/items/{id} — ItemDetail + reportHistory + transactionHistory + sellerNickname
- GET /api/v1/admin/deliveries — status/riderId/requesterId/createdAfter/Before/sort 필터, requesterNickname/riderNickname/escrowApplicationId 노출
- GET /api/v1/admin/deliveries/stats — byStatus map + total + todayNew

## Test plan
- [x] \`./gradlew test\` 전체 통과
- [ ] prod 배포 후 admin 4건 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)