### PR TITLE
[codex] feat(overdue): 대여 연체 도메인 PR1+PR2

### DIFF
--- a/docs/OVERDUE_SYSTEM_DESIGN.md
+++ b/docs/OVERDUE_SYSTEM_DESIGN.md
@@ -1,0 +1,563 @@
+# 쓸랭 대여 연체 시스템 설계안
+
+라운드 14 escrow 대여 lifecycle 위에 얹는 후속 도메인입니다. Phase 1~4 정책 자동화와 관리자 운영 화면을 목표로 합니다.
+
+## 1. 도메인 위치 / 구조
+
+신규 도메인:
+
+```text
+com.sseulang.domain.overdue/
+├── application/
+│   ├── OverdueApplicationService
+│   ├── OverdueDetectionScheduler
+│   └── dto/
+│       └── OverdueChargeQueryResult
+├── domain/
+│   ├── OverdueRecord
+│   ├── OverdueRecordRepository
+│   ├── OverduePhase
+│   ├── OverdueStatus
+│   ├── LateFeeCalculator
+│   ├── OverdueLegalAction
+│   └── event/
+│       ├── OverdueStartedEvent
+│       ├── OverduePhaseChangedEvent
+│       └── OverdueAccountSuspendedEvent
+├── infrastructure/
+│   └── persistence/OverdueRecordJpaRepository
+└── presentation/
+    ├── AdminOverdueController
+    └── dto/AdminOverdueResponse, OverdueLegalActionRequest
+```
+
+`overdue` 도메인은 `escrow`, `point`, `user` 도메인의 `ApplicationService`만 호출합니다. 다른 도메인의 Repository를 직접 참조하지 않습니다.
+
+## 2. 도메인 모델
+
+### 2.1 OverdueRecord
+
+`OverdueRecord`는 1개 `EscrowApplication`에 1개만 존재하는 Aggregate Root입니다.
+
+```java
+class OverdueRecord {
+    Long id;
+    Long escrowApplicationId;
+    Long buyerId;
+    Long sellerId;
+    Long depositAmount;
+    LocalDateTime rentalEndAt;
+    LocalDateTime overdueStartedAt;
+    int overdueDays;
+    OverduePhase phase;
+    OverdueStatus status;
+    long depositForfeitedAmount;
+    long extraDebtAmount;
+    LocalDateTime accountSuspendedAt;
+    OverdueLegalAction legalAction;
+    LocalDateTime resolvedAt;
+    String resolutionNote;
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
+
+    void advanceDay(LocalDateTime now, OverdueThresholds thresholds);
+
+    void markResolved(LocalDateTime now, String note);
+
+    void markLegalAction(OverdueLegalAction action);
+}
+```
+
+도메인 메서드만 외부에 노출하고 setter는 열지 않습니다.
+
+### 2.2 OverduePhase
+
+| 값 | 의미 |
+|---|---|
+| `PHASE_1` | 보증금 차감, 1~7일 |
+| `PHASE_2` | 보증금 초과 채무 누적, 8일차부터 |
+| `PHASE_3` | 계정 정지 발동 |
+| `PHASE_4` | 법적 조치 단계 |
+
+### 2.3 OverdueStatus
+
+| 값 | 의미 |
+|---|---|
+| `진행중` | 활성 상태. 매일 `advanceDay` 대상 |
+| `정산완료` | 반납 완료. 잔여 보증금 환불, 채무는 남을 수 있음 |
+| `법적조치중` | Phase 4 진입, 운영팀 처리 대기 |
+| `종료` | 모든 채무 해소 |
+
+### 2.4 OverdueLegalAction
+
+| 값 | 의미 |
+|---|---|
+| `NONE` | 법적 조치 없음 |
+| `내용증명` | 내용증명 단계 |
+| `분쟁조정` | 분쟁조정 단계 |
+| `소송제기` | 소송 제기 단계 |
+
+### 2.5 정책값
+
+```java
+@ConfigurationProperties("app.overdue")
+record OverdueThresholds(
+    int phase3AmountKrw,
+    int phase3DaysThreshold,
+    int phase4DaysAfterSuspend,
+    int phase2DailyRatePercent
+) {
+}
+```
+
+기본값:
+
+| 설정 | 기본값 | 의미 |
+|---|---:|---|
+| `phase3AmountKrw` | `50_000` | Phase 3 계정 정지 금액 기준 |
+| `phase3DaysThreshold` | `14` | Phase 3 계정 정지 일수 기준 |
+| `phase4DaysAfterSuspend` | `7` | 정지 후 Phase 4 진입까지의 일수 |
+| `phase2DailyRatePercent` | `20` | Phase 2 일별 추가 채무율 |
+
+`application.yml`에 가시화합니다. 운영 중 변경은 재배포로 처리합니다.
+
+## 3. 마이그레이션
+
+### 3.1 V39__overdue_records.sql
+
+```sql
+CREATE TABLE overdue_records (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    escrow_application_id BIGINT NOT NULL UNIQUE,
+    buyer_id BIGINT NOT NULL,
+    seller_id BIGINT NOT NULL,
+    deposit_amount BIGINT NOT NULL,
+    rental_end_at DATETIME NOT NULL,
+    overdue_started_at DATETIME NOT NULL,
+    overdue_days INT NOT NULL DEFAULT 0,
+    phase VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    deposit_forfeited_amount BIGINT NOT NULL DEFAULT 0,
+    extra_debt_amount BIGINT NOT NULL DEFAULT 0,
+    account_suspended_at DATETIME NULL,
+    legal_action VARCHAR(30) NOT NULL DEFAULT 'NONE',
+    resolved_at DATETIME NULL,
+    resolution_note VARCHAR(1000) NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    INDEX idx_overdue_buyer (buyer_id, status),
+    INDEX idx_overdue_status_phase (status, phase),
+    INDEX idx_overdue_active (status, overdue_days),
+    CONSTRAINT fk_overdue_escrow FOREIGN KEY (escrow_application_id)
+        REFERENCES escrow_applications(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_overdue_buyer FOREIGN KEY (buyer_id) REFERENCES users(id),
+    CONSTRAINT fk_overdue_seller FOREIGN KEY (seller_id) REFERENCES users(id)
+);
+```
+
+### 3.2 V40__user_overdue_debt.sql
+
+구매자의 누적 채무 표시와 다음 결제 시 우선 차감 hook에서 사용합니다.
+
+```sql
+ALTER TABLE users
+    ADD COLUMN overdue_debt_balance BIGINT NOT NULL DEFAULT 0
+    COMMENT '연체로 인한 누적 채무 (Phase 2). 다음 충전/결제 시 우선 차감';
+
+CREATE INDEX idx_users_overdue_debt ON users (overdue_debt_balance);
+```
+
+### 3.3 V41__overdue_audit_columns.sql
+
+```sql
+ALTER TABLE point_histories
+    ADD COLUMN overdue_record_id BIGINT NULL
+    COMMENT '연체 정산 관련 history 인 경우 OverdueRecord ID';
+```
+
+`PointReferenceType` enum에 `OVERDUE` 값을 추가합니다.
+
+## 4. 핵심 알고리즘
+
+`LateFeeCalculator`는 Spring 의존성이 없는 순수 도메인 로직입니다.
+
+```java
+record DailyForfeit(int day, int rate) {
+}
+
+class LateFeeCalculator {
+    private static final List<DailyForfeit> PHASE1_TABLE = List.of(
+        new DailyForfeit(1, 30),
+        new DailyForfeit(2, 10),
+        new DailyForfeit(3, 10),
+        new DailyForfeit(4, 10),
+        new DailyForfeit(5, 10),
+        new DailyForfeit(6, 10),
+        new DailyForfeit(7, 10)
+    );
+
+    static LateFeeResult calculate(long deposit, int overdueDays, int phase2RatePercent) {
+        if (overdueDays <= 0) {
+            return LateFeeResult.zero(deposit);
+        }
+
+        int forfeitPercent = 0;
+        for (int i = 0; i < Math.min(overdueDays, 7); i++) {
+            forfeitPercent += PHASE1_TABLE.get(i).rate();
+        }
+
+        long forfeited = deposit * forfeitPercent / 100;
+        long remainingDeposit = deposit - forfeited;
+
+        long extraDebt = 0;
+        if (overdueDays > 7) {
+            int phase2Days = overdueDays - 7;
+            extraDebt = deposit * phase2RatePercent / 100 * phase2Days;
+        }
+
+        return new LateFeeResult(forfeited, remainingDeposit, extraDebt);
+    }
+}
+
+record LateFeeResult(long forfeited, long remainingDeposit, long extraDebt) {
+    static LateFeeResult zero(long deposit) {
+        return new LateFeeResult(0, deposit, 0);
+    }
+}
+```
+
+돈 산정 로직이므로 단위 테스트는 필수입니다. `0`, `1`, `7`, `8`, `30`일 boundary와 큰 값 overflow를 검증합니다.
+
+## 5. 스케줄러
+
+`OverdueDetectionScheduler`는 매일 새벽 2시 KST에 실행합니다. `AutoWithdrawalScheduler`의 1시 실행과 시간을 분리합니다.
+
+```java
+@Component
+class OverdueDetectionScheduler {
+    @Scheduled(cron = "0 0 2 * * *", zone = "Asia/Seoul")
+    public void run() {
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        List<EscrowApplication> targets = escrowService.findOverdueCandidates(now.minusHours(24));
+        for (var escrow : targets) {
+            try {
+                overdueService.startOverdue(escrow.getId(), now);
+            } catch (Exception ex) {
+                log.error("failed to start overdue. escrowApplicationId={}", escrow.getId(), ex);
+            }
+        }
+
+        List<Long> activeIds = overdueService.findActiveRecordIds(BATCH_LIMIT);
+        for (Long id : activeIds) {
+            try {
+                overdueService.advanceDay(id, now);
+            } catch (Exception ex) {
+                log.error("failed to advance overdue day. overdueRecordId={}", id, ex);
+            }
+        }
+    }
+}
+```
+
+### 5.1 startOverdue
+
+```java
+@Transactional
+void startOverdue(Long escrowAppId, LocalDateTime now) {
+    EscrowApplication escrow = escrowAppService.getForOverdue(escrowAppId);
+    if (overdueRepo.existsByEscrowApplicationId(escrowAppId)) {
+        return;
+    }
+
+    OverdueRecord record = OverdueRecord.create(
+        escrowAppId,
+        escrow.getBuyerId(),
+        escrow.getSellerId(),
+        escrow.getDepositAmount(),
+        escrow.getRentalEndAt(),
+        now
+    );
+    overdueRepo.save(record);
+
+    advanceDay(record.getId(), now);
+
+    notificationService.send(
+        record.getBuyerId(),
+        "[연체] 반납 기한 초과 — 1일차 보증금 30% 차감"
+    );
+}
+```
+
+### 5.2 advanceDay
+
+```java
+@Transactional
+void advanceDay(Long recordId, LocalDateTime now) {
+    OverdueRecord record = overdueRepo.findByIdForUpdate(recordId).orElseThrow();
+    if (record.status() != OverdueStatus.진행중) {
+        return;
+    }
+
+    int prevDays = record.overdueDays();
+    int newDays = (int) Duration.between(record.overdueStartedAt(), now).toDays() + 1;
+    if (newDays <= prevDays) {
+        return;
+    }
+
+    LateFeeResult prevFee = LateFeeCalculator.calculate(
+        record.depositAmount(),
+        prevDays,
+        threshold.phase2DailyRatePercent()
+    );
+    LateFeeResult newFee = LateFeeCalculator.calculate(
+        record.depositAmount(),
+        newDays,
+        threshold.phase2DailyRatePercent()
+    );
+
+    long deltaForfeit = newFee.forfeited() - prevFee.forfeited();
+    long deltaDebt = newFee.extraDebt() - prevFee.extraDebt();
+
+    if (deltaForfeit > 0) {
+        userService.releaseHold(record.buyerId(), deltaForfeit);
+        pointService.credit(
+            record.sellerId(),
+            deltaForfeit,
+            PointHistoryType.연체몰수,
+            PointReferenceType.OVERDUE,
+            recordId,
+            "연체 보증금 몰수 — " + newDays + "일차"
+        );
+    }
+
+    if (deltaDebt > 0) {
+        userService.incrementOverdueDebt(record.buyerId(), deltaDebt);
+    }
+
+    record.advanceDay(newDays, newFee.forfeited(), newFee.extraDebt(), now);
+
+    OverduePhase nextPhase = decidePhase(record, threshold);
+    if (nextPhase != record.phase()) {
+        record.setPhase(nextPhase);
+        eventPublisher.publish(new OverduePhaseChangedEvent(record.id(), nextPhase));
+    }
+
+    if (shouldSuspendAccount(record, threshold) && record.accountSuspendedAt() == null) {
+        userService.adminAutoSuspend(record.buyerId(), "연체 임계값 도달");
+        record.markAccountSuspended(now);
+        notificationService.sendToAdmin("연체 임계값 도달 — userId=" + record.buyerId());
+    }
+
+    if (shouldEnterLegalAction(record, threshold, now) && record.phase() != OverduePhase.PHASE_4) {
+        record.setPhase(OverduePhase.PHASE_4);
+        notificationService.sendToAdmin("연체 법적 조치 단계 진입 — recordId=" + record.id());
+    }
+}
+```
+
+### 5.3 Phase 결정
+
+```java
+OverduePhase decidePhase(OverdueRecord record, OverdueThresholds threshold) {
+    if (record.legalAction() != OverdueLegalAction.NONE) {
+        return OverduePhase.PHASE_4;
+    }
+    if (record.accountSuspendedAt() != null) {
+        return OverduePhase.PHASE_3;
+    }
+    if (record.overdueDays() > 7) {
+        return OverduePhase.PHASE_2;
+    }
+    return OverduePhase.PHASE_1;
+}
+
+boolean shouldSuspendAccount(OverdueRecord record, OverdueThresholds threshold) {
+    long totalDebt = record.depositForfeitedAmount() + record.extraDebtAmount();
+    return totalDebt >= threshold.phase3AmountKrw()
+        || record.overdueDays() >= threshold.phase3DaysThreshold();
+}
+
+boolean shouldEnterLegalAction(OverdueRecord record, OverdueThresholds threshold, LocalDateTime now) {
+    if (record.accountSuspendedAt() == null) {
+        return false;
+    }
+    return Duration.between(record.accountSuspendedAt(), now).toDays()
+        >= threshold.phase4DaysAfterSuspend();
+}
+```
+
+## 6. 정산 종료
+
+### 6.1 반납 완료
+
+`EscrowApplicationService.confirmReturn` 끝에 hook을 추가합니다.
+
+```java
+overdueService.markResolvedByReturn(escrowApp.id(), now);
+```
+
+`markResolvedByReturn` 처리:
+
+| 처리 | 정책 |
+|---|---|
+| 잔여 hold | Phase 1에서 살아남은 보증금은 구매자에게 환불 |
+| `extraDebtAmount` | `users.overdue_debt_balance`에 유지. 반납으로 자동 소멸하지 않음 |
+| record status | 기본 `정산완료`, 채무가 0이면 `종료` |
+
+### 6.2 채무 입금
+
+구매자가 토스로 충전하면 `PaymentApplicationService.handleChargeCompleted` 끝에서 채무를 우선 차감합니다.
+
+```java
+long debt = userService.findOverdueDebt(buyerId);
+if (debt > 0) {
+    long deduct = Math.min(charged, debt);
+    userService.decrementOverdueDebt(buyerId, deduct);
+    overdueService.recordDebtPayment(buyerId, deduct);
+}
+```
+
+## 7. 기존 도메인 통합 지점
+
+| 위치 | 변경 |
+|---|---|
+| `EscrowApplication.markRentalEnd` | 변경 없음. 기존 자동 반납 로직 유지 |
+| `EscrowApplicationService.confirmReturn` | 마지막에 `overdueService.markResolvedByReturn` 호출 |
+| `EscrowApplicationService` 신규 query | `findOverdueCandidates(LocalDateTime cutoff)` |
+| `UserApplicationService` 신규 메서드 | `incrementOverdueDebt`, `decrementOverdueDebt`, `findOverdueDebt`, `adminAutoSuspend(reason)` |
+| `PaymentApplicationService.handleChargeCompleted` | 마지막에 채무 우선 차감 hook |
+| `User` 엔티티 | `overdueDebtBalance` 필드와 도메인 메서드 |
+| `PointHistoryType` enum | `연체몰수`, `연체채무상환` 추가 |
+| `PointReferenceType` enum | `OVERDUE` 추가 |
+| `AdminUserResponse` | `overdueDebt`, `activeOverdueRecordId` 필드 추가 |
+
+## 8. API 엔드포인트
+
+### 8.1 관리자
+
+```http
+GET /api/v1/admin/overdue?status=진행중&phase=PHASE_2&page=&size=
+GET /api/v1/admin/overdue/{id}
+PATCH /api/v1/admin/overdue/{id}/legal-action
+PATCH /api/v1/admin/overdue/{id}/resolve
+POST /api/v1/admin/overdue/{id}/recompute
+```
+
+`PATCH /api/v1/admin/overdue/{id}/legal-action` 요청:
+
+```json
+{
+  "action": "내용증명"
+}
+```
+
+허용 값은 `내용증명`, `분쟁조정`, `소송제기`입니다. 처리 시 `legalAction`을 변경하고 `PHASE_4`로 강제 전이합니다.
+
+`PATCH /api/v1/admin/overdue/{id}/resolve` 요청:
+
+```json
+{
+  "note": "관리자 처리 메모"
+}
+```
+
+외부 합의 등 운영상 강제 종료가 필요한 경우 사용합니다.
+
+### 8.2 사용자
+
+```http
+GET /api/v1/users/me/overdue
+GET /api/v1/users/me/overdue-debt
+```
+
+## 9. 알림
+
+모든 알림은 `NotificationApplicationService`를 통해 생성하고 MongoDB에 저장합니다.
+
+| 트리거 | 수신자 | 내용 |
+|---|---|---|
+| Day 1 감지 | buyer | `[연체] 반납 1일 초과 — 보증금 30% 차감 시작` |
+| Phase 2 진입, Day 8 | buyer | `[연체] 보증금 초과 채무 누적 시작` |
+| Phase 3 정지 | buyer + admin | `[정지] 연체로 인한 계정 정지` |
+| Phase 4 진입 | admin | `[법적조치] recordId=X 검토 필요` |
+| 반납 완료 | buyer | `[정산완료] 잔여 보증금 X원 환불` |
+| 채무 입금 | buyer | `[채무상환] X원 차감 — 잔여 Y원` |
+
+## 10. 동시성 / 멱등성
+
+| 항목 | 정책 |
+|---|---|
+| 중복 생성 | `overdue_records.escrow_application_id` UNIQUE |
+| `advanceDay` 재실행 | `prevDays >= newDays`이면 no-op |
+| record race | `overdue_records` 행에 `PESSIMISTIC_WRITE` 락 |
+| 채무 잔액 | `UPDATE users SET overdue_debt_balance = overdue_debt_balance + ? WHERE id = ?` 원자 갱신 |
+| 스케줄러 중복 실행 | 현재 단일 인스턴스 가정. 다중 인스턴스 전환 시 ShedLock 도입 |
+
+## 11. 테스트 전략
+
+보증금 차감과 포인트 정산 영역이므로 TDD 강제 영역으로 봅니다.
+
+### 11.1 Domain 단위 테스트
+
+| 테스트 | 검증 |
+|---|---|
+| `LateFeeCalculatorTest` | 0/1/7/8/14/30일, boundary, 큰 값 overflow |
+| `OverdueRecordTest` | `advanceDay` 멱등, phase 전이, `markResolved` |
+| `UserTest` | `overdueDebtBalance` 증가/감소 |
+
+### 11.2 Application 단위 테스트
+
+| 테스트 | 검증 |
+|---|---|
+| `OverdueApplicationServiceTest` | `startOverdue` 신규/중복 가드 |
+| `OverdueApplicationServiceTest` | `advanceDay` phase 전이와 Phase 3 자동 정지 |
+| `OverdueApplicationServiceTest` | `markResolvedByReturn` 잔여 hold 환불 |
+| `OverdueApplicationServiceTest` | 채무 감소 음수 방지 |
+
+### 11.3 통합 테스트
+
+| 테스트 | 검증 |
+|---|---|
+| `OverdueLifecycleIT` | handover -> rentalEndAt 경과 -> scheduler -> 7일 advance -> Phase 2 -> Phase 3 -> 반납 -> 정산 |
+| `PaymentDebtHookIT` | buyer 충전 시 채무 우선 차감 |
+
+### 11.4 동시성 테스트
+
+| 테스트 | 검증 |
+|---|---|
+| `OverdueDebtConcurrencyTest` | 두 스케줄러 동시 실행 시 채무 중복 누적 방지 |
+
+## 12. 약관 / 운영 준비물
+
+코드 외 산출물:
+
+- `docs/POLICY_OVERDUE.md`: 연체 정책 정식 문서. FE 표시와 운영팀 SOP에 사용
+- 회원가입 약관: 연체 시 보증금 몰수, 추가 채무, 계정 정지, 법적조치 문구 추가
+- 관리자 화면 매뉴얼: Phase 4 진입 시 처리 절차, 내용증명 양식 등
+
+## 13. 작업 분할
+
+| PR | 내용 | 의존 |
+|---|---|---|
+| PR1 | 도메인 + 마이그레이션 + `LateFeeCalculator` + 단위테스트 | 없음 |
+| PR2 | `OverdueApplicationService` + Repository + escrow hook `markResolvedByReturn` | PR1 |
+| PR3 | `OverdueDetectionScheduler` + 알림 + Phase 3 자동 정지 | PR2 |
+| PR4 | Payment 채무 차감 hook + `AdminOverdueController` | PR3 |
+| PR5 | 사용자 본인 조회 endpoint + `AdminUserResponse` 필드 추가 | PR4 |
+| PR6 | 통합 테스트 IT + 약관/문서 | PR1~5 |
+
+예상 작업량은 집중 기준 1.5~2일입니다.
+
+## 14. 미정 영역
+
+구현 진입 전 정책 결정을 완료해야 합니다.
+
+| 항목 | 권장안 | 대안 |
+|---|---|---|
+| 연체 시작 기준 | `rentalEndAt + 24h` | `rentalEndAt` 즉시 |
+| Phase 1 몰수금 분배 | seller 100% | seller 70% + platform 20% |
+| Phase 2 채무 회수 | 채무 기록 + 다음 결제 우선 차감 | 외부 추심 강제 |
+| 반납 시 채무 처리 | 채무 유지 | 자동 소멸 |
+| Phase 3 제재 | 채무 해소까지 시한부 정지 | 영구 차단 |
+| 임계값 | 본 문서 기본값 사용 | PM 협의 후 조정 |

--- a/docs/POLICY_OVERDUE.md
+++ b/docs/POLICY_OVERDUE.md
@@ -1,0 +1,226 @@
+# 쓸랭 대여 연체 정책 (운영 SOP + 사용자 고지)
+
+> 거래대행 대여 (`escrow.rentalMode=true`) 의 반납 기한 (`rentalEndAt`) 초과 시 자동 적용되는 연체 처리 정책. FE 표시 + 운영팀 수동 처리 절차 통합.
+>
+> 마지막 갱신: 2026-05-14. 코드: `src/main/java/com/sseulang/domain/overdue/`.
+
+---
+
+## 1. 연체 발동 조건
+
+| 조건 | 값 |
+|---|---|
+| 대상 | `escrow.tradeMode=INTERNAL` + `escrow.rentalMode=true` + `escrow.status IN (사용중, 반납중)` |
+| 발동 시점 | `rentalEndAt + 24h ≤ now` (스케줄러 매일 02:00 KST) |
+| 1 escrow ↔ 1 record | `overdue_records.escrow_application_id` UNIQUE |
+
+스케줄러: `OverdueDetectionScheduler.run()` — cron `0 0 2 * * *` Asia/Seoul.
+
+---
+
+## 2. 차감 / 채무 산정 (LateFeeCalculator)
+
+### 2.1 Phase 1 — 보증금 차감 (1~7일)
+
+| 연체일 | 누적 차감률 | 잔여 보증금 |
+|---|---|---|
+| 1 | 30% | 70% |
+| 2 | 40% | 60% |
+| 3 | 50% | 50% |
+| 4 | 60% | 40% |
+| 5 | 70% | 30% |
+| 6 | 80% | 20% |
+| 7 | 90% | 10% |
+
+차감된 보증금 = **판매자 보상**. `pointBalance += deltaForfeit`, `PointHistoryType.연체몰수`.
+
+### 2.2 Phase 2 — 보증금 초과 채무 (8일차~)
+
+```
+일별 추가 채무 = 보증금 × phase2DailyRatePercent (default 20%)
+```
+
+예: 보증금 100,000원 + 8일차 → 90,000 (몰수 누적) + 20,000 (Day 8 추가) = **총 채무 110,000**.
+
+추가 채무는 `users.overdue_debt_balance` 에 누적 — 다음 충전 시 우선 차감 (§3.2).
+
+### 2.3 정책값 (`application.yml`)
+
+```yaml
+app:
+  overdue:
+    phase3-amount-krw: 50000        # 계정 정지 금액 임계
+    phase3-days-threshold: 14       # 계정 정지 일수 임계
+    phase4-days-after-suspend: 7    # 정지 후 법적 조치 검토까지 대기일
+    phase2-daily-rate-percent: 20   # Phase 2 일별 채무율
+```
+
+운영 중 변경은 재배포로.
+
+---
+
+## 3. Phase 3 / 4 — 자동 제재 + 수동 검토
+
+### 3.1 Phase 3 — 계정 자동 정지
+
+조건 (둘 중 하나):
+- `depositForfeitedAmount + extraDebtAmount ≥ phase3AmountKrw` (default 50,000원)
+- `overdueDays ≥ phase3DaysThreshold` (default 14일)
+
+동작:
+- `userApplicationService.adminAutoSuspend(buyerId, 30, "연체 임계값 도달")` — 30일 정지
+- Refresh Token 즉시 revoke
+- `record.markAccountSuspended(now)` + Phase 3 전이
+- buyer 알림 발송 ("연체로 인한 계정 정지")
+- `cumulativeSuspendDays` 누적 → 200일 도달 시 `AutoWithdrawalScheduler` 가 자동 탈퇴
+
+### 3.2 Phase 4 — 법적 조치 (관리자 수동)
+
+조건: `accountSuspendedAt + phase4DaysAfterSuspend ≤ now`.
+
+자동 동작: `log.warn("[overdue] Phase 4 — 법적 조치 검토 필요 ...")` 발송 (admin 알림 시스템 도입 후 자동 알림으로 대체 예정).
+
+운영팀 수동 절차:
+1. 관리자 화면에서 PHASE_4 후보 목록 확인 (`GET /api/v1/admin/overdue?phase=PHASE_3` + `accountSuspendedAt + 7일` 경과 필터)
+2. 사례 검토 (대상자 history, 채무 규모, 반납 가능성)
+3. 단계별 조치:
+   - 1단계: **내용증명** 발송 (법무팀 외부 발송 후 endpoint 호출)
+   - 2단계: **분쟁조정** 신청
+   - 3단계: **소송 / 형사고소**
+4. 각 단계마다 endpoint 호출:
+   ```
+   PATCH /api/v1/admin/overdue/{id}/legal-action
+   Body: { "action": "내용증명" }    # or "분쟁조정", "소송제기"
+   ```
+   → `record.markLegalAction(action)` → `status=법적조치중`, `phase=PHASE_4`
+5. 처리 종료 시:
+   ```
+   PATCH /api/v1/admin/overdue/{id}/resolve
+   Body: { "note": "외부 합의 종결" }
+   ```
+
+---
+
+## 4. 정산 종료 흐름
+
+### 4.1 정상 반납 (escrow.confirmReturn)
+
+`EscrowApplicationService.confirmReturn` 끝에서 `overdueService.markResolvedByReturn(escrowApplicationId)` 자동 호출.
+
+| 항목 | 처리 |
+|---|---|
+| 잔여 보증금 (Phase 1 잔여분) | buyer 환불 (`refundHold`) |
+| 누적 채무 (`extraDebtAmount`) | **삭감 X** — `users.overdue_debt_balance` 에 유지 |
+| record status | 채무 0 → `종료`, 채무 > 0 → `정산완료` |
+
+### 4.2 채무 입금 (charge hook)
+
+buyer 가 토스 충전 시 `PaymentApplicationService.applyPaymentConfirmedEffects` 끝에서:
+
+```
+debt = users.overdue_debt_balance
+if debt > 0:
+    deduct = min(charged, debt)
+    pointBalance -= deduct      (PointHistoryType.연체채무상환)
+    overdue_debt_balance -= deduct
+    notification: "[채무상환] X원 차감, 잔여 Y원"
+    if 채무 잔여 0:
+        모든 정산완료 record → 종료
+```
+
+### 4.3 관리자 강제 종료
+
+`PATCH /admin/overdue/{id}/resolve` — 외부 합의 등 운영상 종결.
+
+진행중 record 강제 종료 시 잔여 보증금 buyer 환불 + status 종료/정산완료.
+
+---
+
+## 5. 알림 매트릭스
+
+| 시점 | 수신자 | 제목 | 내용 |
+|---|---|---|---|
+| Day 1 신규 감지 | buyer | 연체 반납 기한 초과 | 1일차 보증금 30% 차감 |
+| Phase 1 → 2 (Day 8) | buyer | 보증금 초과 채무 누적 | 일 20% 추가 채무 적용 |
+| Phase 3 자동 정지 | buyer | 연체로 인한 계정 정지 | 30일 정지, 채무 해소 후 검토 |
+| Phase 4 진입 | admin | (log.warn) | 법적 조치 검토 필요 |
+| 반납 완료 | buyer | 정산완료 | 잔여 보증금 환불 + 잔여 채무 안내 |
+| 채무 입금 | buyer | 채무상환 | X원 차감, 잔여 Y원 |
+| 법적 조치 단계 전이 | buyer | 법적 조치 통보 | 내용증명/분쟁조정/소송제기 단계 명시 |
+
+---
+
+## 6. API 엔드포인트 요약
+
+### 관리자
+| Method | Path | 용도 |
+|---|---|---|
+| GET | `/api/v1/admin/overdue?status=&phase=&page=` | 목록 |
+| GET | `/api/v1/admin/overdue/{id}` | 단건 |
+| PATCH | `/api/v1/admin/overdue/{id}/legal-action` | 법적 조치 단계 전이 |
+| PATCH | `/api/v1/admin/overdue/{id}/resolve` | 강제 종료 |
+| POST | `/api/v1/admin/overdue/{id}/recompute` | 디버그 재계산 |
+
+### 본인
+| Method | Path | 용도 |
+|---|---|---|
+| GET | `/api/v1/users/me/overdue` | 진행중/정산완료/법적조치중 record |
+| GET | `/api/v1/users/me/overdue-debt` | 누적 채무 잔액 |
+
+### AdminUserResponse 신규 필드
+- `overdueDebt` — User.overdueDebtBalance
+- `activeOverdueRecordId` — MVP 에선 null
+
+---
+
+## 7. 약관 / 사용자 고지 문구 (FE 표시용 권장)
+
+대여 거래대행 신청 단계 (FE 약관 동의 또는 결제 직전 모달):
+
+> **연체 시 처리 안내**
+>
+> 반납 기한 (`rentalEndAt`) 경과 24시간 후부터 연체로 처리되며, 다음 정책이 자동 적용됩니다.
+>
+> 1. **1~7일차**: 보증금 일별 차감 (1일 30% / 2~7일 일 10%, 누적 90%까지). 차감된 보증금은 판매자에게 보상으로 지급됩니다.
+> 2. **8일차부터**: 보증금 외 추가 채무가 매일 누적됩니다 (보증금의 20%/일).
+> 3. **누적 채무 5만원 이상 또는 14일 경과** 시 계정이 30일간 자동 정지됩니다.
+> 4. 정지 후 7일 경과 시 **내용증명 / 분쟁조정 / 민사·형사 절차** 가 검토될 수 있습니다.
+> 5. 누적된 추가 채무는 다음 결제/충전 시 우선 차감됩니다.
+> 6. 신용평가기관 연동 시 신용등급 하락 가능성이 있으며, 쓸랭이 판매자에게 손해 보상 후 **구상권 행사** 를 통해 회수할 수 있습니다.
+
+---
+
+## 8. 운영 체크리스트
+
+| 주기 | 작업 | 위치 |
+|---|---|---|
+| 매일 | 스케줄러 정상 실행 로그 확인 | `[overdue-scheduler]` 키워드로 prod log grep |
+| 매일 | Phase 4 후보 (정지 + 7일 경과) 검토 | `GET /admin/overdue?phase=PHASE_3` |
+| 주간 | 신규 PHASE_4 진입 건 처리 | `GET /admin/overdue?phase=PHASE_4` |
+| 분기 | 임계값 (`app.overdue.*`) 정책 검토 | `application-prod.yml` |
+
+---
+
+## 9. 코드 참조
+
+| 파일 | 역할 |
+|---|---|
+| `domain/overdue/domain/OverdueRecord.java` | Aggregate Root + 상태 전이 |
+| `domain/overdue/domain/LateFeeCalculator.java` | 차감 / 채무 계산 (순수 도메인) |
+| `domain/overdue/application/OverdueApplicationService.java` | 트랜잭션 경계 |
+| `domain/overdue/application/OverdueDetectionScheduler.java` | 매일 02:00 cron |
+| `domain/overdue/presentation/AdminOverdueController.java` | 관리자 endpoint |
+| `domain/overdue/presentation/MyOverdueController.java` | 본인 endpoint |
+| `domain/escrow/application/EscrowApplicationService.java#confirmReturn` | 반납 정산 hook |
+| `domain/payment/application/PaymentApplicationService.java#applyOverdueDebtDeduction` | 충전 시 채무 차감 hook |
+
+---
+
+## 10. 미완 (후속)
+
+| 항목 | 비고 |
+|---|---|
+| Admin notification system | Phase 4 진입 시 admin 자동 알림 (현재 log.warn) |
+| 카카오 콘솔 외 자동 추심 | 외부 추심사 연동 시 endpoint 추가 |
+| 신용평가기관 연동 | 사업자 인증 + 데이터 공유 약정 후 |
+| ProviderId migration tool | 카카오/구글 앱 변경 시 social_id 일괄 갱신 (overdue 와 별개) |

--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowApplicationService.java
@@ -29,6 +29,7 @@ import com.sseulang.domain.escrow.domain.event.EscrowConfirmedEvent;
 import com.sseulang.domain.point.application.PointApplicationService;
 import com.sseulang.domain.point.domain.PointHistoryType;
 import com.sseulang.domain.point.domain.PointReferenceType;
+import com.sseulang.domain.overdue.application.OverdueApplicationService;
 import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.domain.user.domain.User;
 import com.sseulang.global.exception.BusinessException;
@@ -67,6 +68,7 @@ public class EscrowApplicationService {
     private final com.sseulang.domain.transaction.application.TransactionApplicationService transactionApplicationService;
     private final com.sseulang.domain.transaction.application.TransactionCascadeService transactionCascadeService;
     private final com.sseulang.domain.notification.application.NotificationApplicationService notificationApplicationService;
+    private final OverdueApplicationService overdueApplicationService;
     private final Clock clock;
     private final TransactionTemplate newTxTemplate;
     private final int linkExpiryHours;
@@ -84,6 +86,7 @@ public class EscrowApplicationService {
             com.sseulang.domain.transaction.application.TransactionApplicationService transactionApplicationService,
             com.sseulang.domain.transaction.application.TransactionCascadeService transactionCascadeService,
             com.sseulang.domain.notification.application.NotificationApplicationService notificationApplicationService,
+            OverdueApplicationService overdueApplicationService,
             PlatformTransactionManager transactionManager,
             Clock clock,
             @Value("${app.escrow.link.expiry-hours:24}") int linkExpiryHours
@@ -100,6 +103,7 @@ public class EscrowApplicationService {
         this.transactionApplicationService = transactionApplicationService;
         this.transactionCascadeService = transactionCascadeService;
         this.notificationApplicationService = notificationApplicationService;
+        this.overdueApplicationService = overdueApplicationService;
         this.clock = clock;
         this.newTxTemplate = new TransactionTemplate(transactionManager);
         this.newTxTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
@@ -998,9 +1002,12 @@ public class EscrowApplicationService {
                 paired, deposit, depositPct, null, null
         );
 
-        // PR8 — 보증금 환불 (point_hold → point_balance 복원). atomic UPDATE 한 번.
+        // PR8 — 보증금 환불. 연체 record 가 있으면 잔여 보증금만 overdue hook 에서 환불한다.
         if (app.getDepositAmount() != null && app.getDepositAmount() > 0) {
-            userApplicationService.refundHold(app.getBuyerId(), app.getDepositAmount());
+            boolean overdueHandled = overdueApplicationService.markResolvedByReturn(app.getId(), LocalDateTime.now(clock));
+            if (!overdueHandled) {
+                userApplicationService.refundHold(app.getBuyerId(), app.getDepositAmount());
+            }
         }
 
         // cascade — 같은 chatRoom 의 활성 직거래 자동 정리. 대여 직거래는 도메인 가드로 자동 스킵 (반납 흐름 보존).

--- a/src/main/java/com/sseulang/domain/escrow/application/EscrowOverdueQueryService.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/EscrowOverdueQueryService.java
@@ -1,0 +1,57 @@
+package com.sseulang.domain.escrow.application;
+
+import com.sseulang.domain.escrow.application.dto.EscrowOverdueSnapshot;
+import com.sseulang.domain.escrow.domain.EscrowApplication;
+import com.sseulang.domain.escrow.domain.EscrowApplicationRepository;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class EscrowOverdueQueryService {
+
+    private final EscrowApplicationRepository applicationRepository;
+
+    public EscrowOverdueQueryService(EscrowApplicationRepository applicationRepository) {
+        this.applicationRepository = applicationRepository;
+    }
+
+    @Transactional
+    public EscrowOverdueSnapshot getForOverdue(Long applicationId) {
+        EscrowApplication app = applicationRepository.findByIdForUpdate(applicationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESCROW_NOT_FOUND));
+        validateOverdueTarget(app);
+        return EscrowOverdueSnapshot.from(app);
+    }
+
+    public List<EscrowOverdueSnapshot> findOverdueCandidates(LocalDateTime cutoff) {
+        if (cutoff == null) {
+            throw new IllegalArgumentException("cutoff 은 필수입니다");
+        }
+        return applicationRepository.findOverdueCandidates(cutoff).stream()
+                .filter(this::isValidOverdueTarget)
+                .map(EscrowOverdueSnapshot::from)
+                .toList();
+    }
+
+    private void validateOverdueTarget(EscrowApplication app) {
+        if (!isValidOverdueTarget(app)) {
+            throw new BusinessException(ErrorCode.ESCROW_INVALID_STATE);
+        }
+    }
+
+    private boolean isValidOverdueTarget(EscrowApplication app) {
+        return app.isRentalMode()
+                && (app.getStatus() == EscrowApplicationStatus.사용중
+                    || app.getStatus() == EscrowApplicationStatus.반납중)
+                && app.getRentalEndAt() != null
+                && app.getDepositAmount() != null
+                && app.getDepositAmount() >= 0;
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowOverdueSnapshot.java
+++ b/src/main/java/com/sseulang/domain/escrow/application/dto/EscrowOverdueSnapshot.java
@@ -1,0 +1,28 @@
+package com.sseulang.domain.escrow.application.dto;
+
+import com.sseulang.domain.escrow.domain.EscrowApplication;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+
+import java.time.LocalDateTime;
+
+public record EscrowOverdueSnapshot(
+        Long id,
+        Long buyerId,
+        Long sellerId,
+        Long depositAmount,
+        LocalDateTime rentalEndAt,
+        EscrowApplicationStatus status,
+        boolean rentalMode
+) {
+    public static EscrowOverdueSnapshot from(EscrowApplication app) {
+        return new EscrowOverdueSnapshot(
+                app.getId(),
+                app.getBuyerId(),
+                app.getSellerId(),
+                app.getDepositAmount(),
+                app.getRentalEndAt(),
+                app.getStatus(),
+                app.isRentalMode()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/domain/EscrowApplicationRepository.java
@@ -34,6 +34,8 @@ public interface EscrowApplicationRepository {
 
     List<EscrowApplication> findOverdueRentalEndApplications(LocalDateTime threshold);
 
+    List<EscrowApplication> findOverdueCandidates(LocalDateTime cutoff);
+
     
     long countInProgress();
 

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationJpaRepository.java
@@ -48,6 +48,19 @@ public interface EscrowApplicationJpaRepository extends JpaRepository<EscrowAppl
     List<EscrowApplication> findOverdueRentalEndApplications(@Param("threshold") LocalDateTime threshold);
 
     @Query("""
+            SELECT a FROM EscrowApplication a
+            WHERE a.status IN (
+                com.sseulang.domain.escrow.domain.EscrowApplicationStatus.사용중,
+                com.sseulang.domain.escrow.domain.EscrowApplicationStatus.반납중
+            )
+              AND a.rentalMode = true
+              AND a.rentalEndAt IS NOT NULL
+              AND a.rentalEndAt <= :cutoff
+            ORDER BY a.rentalEndAt ASC
+            """)
+    List<EscrowApplication> findOverdueCandidates(@Param("cutoff") LocalDateTime cutoff);
+
+    @Query("""
             SELECT COUNT(a) FROM EscrowApplication a
             WHERE a.status IN (
                 com.sseulang.domain.escrow.domain.EscrowApplicationStatus.결제대기,

--- a/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/escrow/infrastructure/persistence/EscrowApplicationRepositoryImpl.java
@@ -66,6 +66,11 @@ public class EscrowApplicationRepositoryImpl implements EscrowApplicationReposit
     }
 
     @Override
+    public List<EscrowApplication> findOverdueCandidates(LocalDateTime cutoff) {
+        return jpa.findOverdueCandidates(cutoff);
+    }
+
+    @Override
     public long countInProgress() {
         return jpa.countInProgress();
     }

--- a/src/main/java/com/sseulang/domain/overdue/application/OverdueApplicationService.java
+++ b/src/main/java/com/sseulang/domain/overdue/application/OverdueApplicationService.java
@@ -1,0 +1,176 @@
+package com.sseulang.domain.overdue.application;
+
+import com.sseulang.domain.escrow.application.EscrowOverdueQueryService;
+import com.sseulang.domain.escrow.application.dto.EscrowOverdueSnapshot;
+import com.sseulang.domain.overdue.domain.OverdueRecord;
+import com.sseulang.domain.overdue.domain.OverdueRecordRepository;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+import com.sseulang.domain.overdue.domain.OverdueThresholds;
+import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.point.domain.PointHistoryType;
+import com.sseulang.domain.point.domain.PointReferenceType;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.global.exception.BusinessException;
+import com.sseulang.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class OverdueApplicationService {
+
+    private final OverdueRecordRepository overdueRecordRepository;
+    private final EscrowOverdueQueryService escrowOverdueQueryService;
+    private final UserApplicationService userApplicationService;
+    private final PointApplicationService pointApplicationService;
+    private final Clock clock;
+    private final OverdueThresholds thresholds;
+
+    public OverdueApplicationService(
+            OverdueRecordRepository overdueRecordRepository,
+            EscrowOverdueQueryService escrowOverdueQueryService,
+            UserApplicationService userApplicationService,
+            PointApplicationService pointApplicationService,
+            Clock clock,
+            @Value("${app.overdue.phase3-amount-krw:50000}") int phase3AmountKrw,
+            @Value("${app.overdue.phase3-days-threshold:14}") int phase3DaysThreshold,
+            @Value("${app.overdue.phase4-days-after-suspend:7}") int phase4DaysAfterSuspend,
+            @Value("${app.overdue.phase2-daily-rate-percent:20}") int phase2DailyRatePercent
+    ) {
+        this.overdueRecordRepository = overdueRecordRepository;
+        this.escrowOverdueQueryService = escrowOverdueQueryService;
+        this.userApplicationService = userApplicationService;
+        this.pointApplicationService = pointApplicationService;
+        this.clock = clock;
+        this.thresholds = new OverdueThresholds(
+                phase3AmountKrw,
+                phase3DaysThreshold,
+                phase4DaysAfterSuspend,
+                phase2DailyRatePercent
+        );
+    }
+
+    public List<Long> findOverdueCandidateEscrowIds(LocalDateTime cutoff) {
+        return escrowOverdueQueryService.findOverdueCandidates(cutoff).stream()
+                .filter(s -> !overdueRecordRepository.existsByEscrowApplicationId(s.id()))
+                .map(EscrowOverdueSnapshot::id)
+                .toList();
+    }
+
+    public List<Long> findActiveRecordIds(int limit) {
+        return overdueRecordRepository.findActiveIds(limit);
+    }
+
+    @Transactional
+    public boolean startOverdue(Long escrowApplicationId) {
+        return startOverdue(escrowApplicationId, LocalDateTime.now(clock));
+    }
+
+    @Transactional
+    public boolean startOverdue(Long escrowApplicationId, LocalDateTime now) {
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+        if (overdueRecordRepository.existsByEscrowApplicationId(escrowApplicationId)) {
+            return false;
+        }
+
+        EscrowOverdueSnapshot escrow = escrowOverdueQueryService.getForOverdue(escrowApplicationId);
+        OverdueRecord record = OverdueRecord.create(
+                escrow.id(),
+                escrow.buyerId(),
+                escrow.sellerId(),
+                escrow.depositAmount(),
+                escrow.rentalEndAt(),
+                now
+        );
+        OverdueRecord saved = overdueRecordRepository.save(record);
+        advanceDay(saved, now);
+        return true;
+    }
+
+    @Transactional
+    public boolean advanceDay(Long recordId) {
+        return advanceDay(recordId, LocalDateTime.now(clock));
+    }
+
+    @Transactional
+    public boolean advanceDay(Long recordId, LocalDateTime now) {
+        OverdueRecord record = overdueRecordRepository.findByIdForUpdate(recordId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.OVERDUE_NOT_FOUND));
+        return advanceDay(record, now);
+    }
+
+    @Transactional
+    public boolean markResolvedByReturn(Long escrowApplicationId) {
+        return markResolvedByReturn(escrowApplicationId, LocalDateTime.now(clock));
+    }
+
+    @Transactional
+    public boolean markResolvedByReturn(Long escrowApplicationId, LocalDateTime now) {
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+        return overdueRecordRepository.findByEscrowApplicationIdForUpdate(escrowApplicationId)
+                .map(record -> {
+                    if (record.getStatus() == OverdueStatus.진행중
+                            || record.getStatus() == OverdueStatus.법적조치중) {
+                        long remainingDeposit = record.remainingDepositAmount();
+                        if (remainingDeposit > 0) {
+                            userApplicationService.refundHold(
+                                    record.getBuyerId(),
+                                    remainingDeposit
+                            );
+                        }
+                        record.markResolved(now, "반납 완료");
+                    }
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    private boolean advanceDay(OverdueRecord record, LocalDateTime now) {
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+        if (record.getStatus() != OverdueStatus.진행중) {
+            return false;
+        }
+
+        int prevDays = record.getOverdueDays();
+        long prevForfeited = record.getDepositForfeitedAmount();
+        long prevDebt = record.getExtraDebtAmount();
+
+        record.advanceDay(now, thresholds);
+
+        if (record.getOverdueDays() <= prevDays) {
+            return false;
+        }
+
+        long deltaForfeit = record.getDepositForfeitedAmount() - prevForfeited;
+        long deltaDebt = record.getExtraDebtAmount() - prevDebt;
+
+        if (deltaForfeit > 0) {
+            userApplicationService.releaseHold(record.getBuyerId(), deltaForfeit);
+            pointApplicationService.credit(
+                    record.getSellerId(),
+                    deltaForfeit,
+                    PointHistoryType.연체몰수,
+                    PointReferenceType.OVERDUE,
+                    record.getId(),
+                    "연체 보증금 몰수 — " + record.getOverdueDays() + "일차"
+            );
+        }
+
+        if (deltaDebt > 0) {
+            userApplicationService.incrementOverdueDebt(record.getBuyerId(), deltaDebt);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/sseulang/domain/overdue/application/OverdueApplicationService.java
+++ b/src/main/java/com/sseulang/domain/overdue/application/OverdueApplicationService.java
@@ -4,6 +4,7 @@ import com.sseulang.domain.escrow.application.EscrowOverdueQueryService;
 import com.sseulang.domain.escrow.application.dto.EscrowOverdueSnapshot;
 import com.sseulang.domain.notification.application.NotificationApplicationService;
 import com.sseulang.domain.notification.domain.NotificationType;
+import com.sseulang.domain.overdue.domain.OverdueLegalAction;
 import com.sseulang.domain.overdue.domain.OverduePhase;
 import com.sseulang.domain.overdue.domain.OverdueRecord;
 import com.sseulang.domain.overdue.domain.OverdueRecordRepository;
@@ -18,6 +19,8 @@ import com.sseulang.global.exception.ErrorCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -245,6 +248,84 @@ public class OverdueApplicationService {
             log.error("[overdue] 알림 발송 실패 recordId={} buyerId={} title={} reason={}",
                     record.getId(), record.getBuyerId(), title, e.getMessage(), e);
         }
+    }
+
+    public Page<OverdueRecord> adminSearch(OverdueStatus status, OverduePhase phase, Pageable pageable) {
+        return overdueRecordRepository.searchAdmin(status, phase, pageable);
+    }
+
+    public OverdueRecord adminGet(Long recordId) {
+        return overdueRecordRepository.findById(recordId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.OVERDUE_NOT_FOUND));
+    }
+
+    public List<OverdueRecord> findByBuyer(Long buyerId, List<OverdueStatus> statuses) {
+        return overdueRecordRepository.findByBuyerIdAndStatusIn(buyerId, statuses);
+    }
+
+    @Transactional
+    public void adminMarkLegalAction(Long recordId, OverdueLegalAction action) {
+        OverdueRecord record = overdueRecordRepository.findByIdForUpdate(recordId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.OVERDUE_NOT_FOUND));
+        record.markLegalAction(action);
+        log.warn("[overdue] 관리자 법적 조치 수동 전이 recordId={} action={}", recordId, action);
+        notifyBuyer(record,
+                "[법적조치] 연체 관련 법적 조치 통보",
+                "연체 미해소로 다음 단계의 법적 조치가 진행됩니다 (" + action + ").");
+    }
+
+    @Transactional
+    public void adminResolve(Long recordId, String note) {
+        OverdueRecord record = overdueRecordRepository.findByIdForUpdate(recordId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.OVERDUE_NOT_FOUND));
+        if (record.getStatus() == OverdueStatus.종료) {
+            throw new BusinessException(ErrorCode.OVERDUE_ALREADY_RESOLVED);
+        }
+        long remainingDeposit = record.remainingDepositAmount();
+        if (remainingDeposit > 0 && record.getStatus() == OverdueStatus.진행중) {
+            // 진행중 상태에서 admin 강제 종료 시 잔여 hold 환불
+            userApplicationService.refundHold(record.getBuyerId(), remainingDeposit);
+        }
+        record.markResolved(LocalDateTime.now(clock), note);
+        notifyBuyer(record,
+                "[정산완료] 관리자 처리",
+                "관리자에 의해 연체 건이 정리되었습니다." + (note == null ? "" : " 메모: " + note));
+    }
+
+    @Transactional
+    public boolean recompute(Long recordId) {
+        return advanceDay(recordId, LocalDateTime.now(clock));
+    }
+
+    @Transactional
+    public long recordDebtPayment(Long buyerId, long amount) {
+        if (buyerId == null || amount <= 0) {
+            return 0L;
+        }
+        long remaining = userApplicationService.findOverdueDebt(buyerId);
+        if (remaining < 0) remaining = 0;
+        log.info("[overdue] 채무 차감 buyerId={} amount={} 잔여={}", buyerId, amount, remaining);
+
+        // 활성/정산완료 record 들에 대해 buyer 알림 (대표 1건만, 가장 최근)
+        List<OverdueRecord> records = overdueRecordRepository.findByBuyerIdAndStatusIn(
+                buyerId,
+                List.of(OverdueStatus.진행중, OverdueStatus.정산완료, OverdueStatus.법적조치중)
+        );
+        if (!records.isEmpty()) {
+            OverdueRecord representative = records.get(0);
+            String content = "충전 금액에서 연체 채무 " + amount + "원이 차감되었습니다. 잔여 채무: " + remaining + "원.";
+            notifyBuyer(representative, "[채무상환] 연체 채무 차감", content);
+
+            // 잔여 0 도달 + 정산완료 record 들 자동 종료
+            if (remaining == 0) {
+                for (OverdueRecord r : records) {
+                    if (r.getStatus() == OverdueStatus.정산완료) {
+                        r.markResolved(LocalDateTime.now(clock), "채무 전액 상환으로 자동 종료");
+                    }
+                }
+            }
+        }
+        return remaining;
     }
 
     private void notifyResolvedByReturn(OverdueRecord record, long remainingDeposit) {

--- a/src/main/java/com/sseulang/domain/overdue/application/OverdueApplicationService.java
+++ b/src/main/java/com/sseulang/domain/overdue/application/OverdueApplicationService.java
@@ -2,6 +2,9 @@ package com.sseulang.domain.overdue.application;
 
 import com.sseulang.domain.escrow.application.EscrowOverdueQueryService;
 import com.sseulang.domain.escrow.application.dto.EscrowOverdueSnapshot;
+import com.sseulang.domain.notification.application.NotificationApplicationService;
+import com.sseulang.domain.notification.domain.NotificationType;
+import com.sseulang.domain.overdue.domain.OverduePhase;
 import com.sseulang.domain.overdue.domain.OverdueRecord;
 import com.sseulang.domain.overdue.domain.OverdueRecordRepository;
 import com.sseulang.domain.overdue.domain.OverdueStatus;
@@ -12,6 +15,8 @@ import com.sseulang.domain.point.domain.PointReferenceType;
 import com.sseulang.domain.user.application.UserApplicationService;
 import com.sseulang.global.exception.BusinessException;
 import com.sseulang.global.exception.ErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,10 +29,17 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class OverdueApplicationService {
 
+    private static final Logger log = LoggerFactory.getLogger(OverdueApplicationService.class);
+
+    // Phase 3 자동 정지 시 부여 일수. 이 값 동안 채무 미해소면 cumulativeSuspendDays 누적되어
+    // 자연스럽게 200일 자동 탈퇴 트리거에 합류 (AutoWithdrawalScheduler).
+    private static final int PHASE3_AUTO_SUSPEND_DAYS = 30;
+
     private final OverdueRecordRepository overdueRecordRepository;
     private final EscrowOverdueQueryService escrowOverdueQueryService;
     private final UserApplicationService userApplicationService;
     private final PointApplicationService pointApplicationService;
+    private final NotificationApplicationService notificationApplicationService;
     private final Clock clock;
     private final OverdueThresholds thresholds;
 
@@ -36,6 +48,7 @@ public class OverdueApplicationService {
             EscrowOverdueQueryService escrowOverdueQueryService,
             UserApplicationService userApplicationService,
             PointApplicationService pointApplicationService,
+            NotificationApplicationService notificationApplicationService,
             Clock clock,
             @Value("${app.overdue.phase3-amount-krw:50000}") int phase3AmountKrw,
             @Value("${app.overdue.phase3-days-threshold:14}") int phase3DaysThreshold,
@@ -46,6 +59,7 @@ public class OverdueApplicationService {
         this.escrowOverdueQueryService = escrowOverdueQueryService;
         this.userApplicationService = userApplicationService;
         this.pointApplicationService = pointApplicationService;
+        this.notificationApplicationService = notificationApplicationService;
         this.clock = clock;
         this.thresholds = new OverdueThresholds(
                 phase3AmountKrw,
@@ -128,6 +142,7 @@ public class OverdueApplicationService {
                             );
                         }
                         record.markResolved(now, "반납 완료");
+                        notifyResolvedByReturn(record, remainingDeposit);
                     }
                     return true;
                 })
@@ -145,6 +160,7 @@ public class OverdueApplicationService {
         int prevDays = record.getOverdueDays();
         long prevForfeited = record.getDepositForfeitedAmount();
         long prevDebt = record.getExtraDebtAmount();
+        OverduePhase prevPhase = record.getPhase();
 
         record.advanceDay(now, thresholds);
 
@@ -171,6 +187,74 @@ public class OverdueApplicationService {
             userApplicationService.incrementOverdueDebt(record.getBuyerId(), deltaDebt);
         }
 
+        // Day 1 신규 감지 알림
+        if (prevDays == 0 && record.getOverdueDays() >= 1) {
+            notifyBuyer(record,
+                    "[연체] 반납 기한 초과",
+                    "반납 기한이 지났습니다. 1일차 보증금 30% 차감이 적용되었습니다.");
+        }
+
+        // Phase 1 → Phase 2 전이 알림 (Day 8)
+        if (prevPhase == OverduePhase.PHASE_1 && record.getPhase() == OverduePhase.PHASE_2) {
+            notifyBuyer(record,
+                    "[연체] 보증금 초과 채무 누적",
+                    "보증금이 모두 차감되었습니다. 8일차부터 보증금의 "
+                            + thresholds.phase2DailyRatePercent() + "%씩 추가 채무가 매일 누적됩니다.");
+        }
+
+        // Phase 3 자동 정지 트리거
+        if (record.shouldSuspendAccount(thresholds) && record.getAccountSuspendedAt() == null) {
+            userApplicationService.adminAutoSuspend(
+                    record.getBuyerId(),
+                    PHASE3_AUTO_SUSPEND_DAYS,
+                    "연체 임계값 도달 (recordId=" + record.getId() + ")"
+            );
+            record.markAccountSuspended(now);
+            notifyBuyer(record,
+                    "[정지] 연체로 인한 계정 정지",
+                    "연체 임계값 초과로 계정이 " + PHASE3_AUTO_SUSPEND_DAYS
+                            + "일 정지되었습니다. 채무 해소 후 관리자 검토를 요청하세요.");
+            log.warn("[overdue] Phase 3 — 계정 자동 정지 recordId={} buyerId={} totalDebt={}",
+                    record.getId(), record.getBuyerId(),
+                    record.getDepositForfeitedAmount() + record.getExtraDebtAmount());
+        }
+
+        // Phase 4 진입 (Phase 3 정지 후 N일 경과)
+        if (record.shouldEnterLegalAction(thresholds, now) && record.getPhase() != OverduePhase.PHASE_4) {
+            // Note: PHASE_4 전이는 record.markLegalAction(NONE 외) 또는 admin endpoint 로 발동.
+            // 자동 트리거 시점에서는 admin 알림만 보내고 운영팀이 legal-action 결정.
+            log.warn("[overdue] Phase 4 — 법적 조치 검토 필요 recordId={} buyerId={} suspendedAt={}",
+                    record.getId(), record.getBuyerId(), record.getAccountSuspendedAt());
+            // TODO: admin notification system 도입 시 여기서 admin 들에게 알림 broadcast.
+        }
+
         return true;
+    }
+
+    private void notifyBuyer(OverdueRecord record, String title, String content) {
+        try {
+            notificationApplicationService.notify(
+                    record.getBuyerId(),
+                    NotificationType.시스템,
+                    title,
+                    content,
+                    "OVERDUE",
+                    record.getId()
+            );
+        } catch (RuntimeException e) {
+            log.error("[overdue] 알림 발송 실패 recordId={} buyerId={} title={} reason={}",
+                    record.getId(), record.getBuyerId(), title, e.getMessage(), e);
+        }
+    }
+
+    private void notifyResolvedByReturn(OverdueRecord record, long remainingDeposit) {
+        String content = remainingDeposit > 0
+                ? "반납이 완료되었습니다. 잔여 보증금 " + remainingDeposit + "원이 환불되었습니다."
+                : "반납이 완료되었습니다. 잔여 보증금이 없어 환불은 발생하지 않았습니다.";
+        if (record.getExtraDebtAmount() > 0) {
+            content += " 누적 채무 " + record.getExtraDebtAmount()
+                    + "원은 다음 결제 시 우선 차감됩니다.";
+        }
+        notifyBuyer(record, "[정산완료] 연체 반납 처리", content);
     }
 }

--- a/src/main/java/com/sseulang/domain/overdue/application/OverdueDetectionScheduler.java
+++ b/src/main/java/com/sseulang/domain/overdue/application/OverdueDetectionScheduler.java
@@ -1,0 +1,76 @@
+package com.sseulang.domain.overdue.application;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 매일 새벽 2시 KST — 신규 연체 감지 + 진행중 record advance.
+ * AutoWithdrawalScheduler(1시) 와 시간 분리.
+ */
+@Component
+public class OverdueDetectionScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(OverdueDetectionScheduler.class);
+
+    private static final int BATCH_LIMIT = 200;
+    private static final int OVERDUE_TRIGGER_HOURS = 24;
+
+    private final OverdueApplicationService overdueApplicationService;
+    private final Clock clock;
+
+    public OverdueDetectionScheduler(
+            OverdueApplicationService overdueApplicationService,
+            Clock clock
+    ) {
+        this.overdueApplicationService = overdueApplicationService;
+        this.clock = clock;
+    }
+
+    @Scheduled(cron = "0 0 2 * * *", zone = "Asia/Seoul")
+    public void run() {
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime cutoff = now.minusHours(OVERDUE_TRIGGER_HOURS);
+
+        // Step 1 — 신규 연체 감지
+        List<Long> candidates = overdueApplicationService.findOverdueCandidateEscrowIds(cutoff);
+        if (!candidates.isEmpty()) {
+            log.info("[overdue-scheduler] 신규 연체 후보 {} 건", candidates.size());
+        }
+        int started = 0;
+        for (Long escrowId : candidates) {
+            try {
+                if (overdueApplicationService.startOverdue(escrowId, now)) {
+                    started++;
+                }
+            } catch (Exception e) {
+                log.error("[overdue-scheduler] startOverdue 실패 escrowApplicationId={}", escrowId, e);
+            }
+        }
+
+        // Step 2 — 진행중 record 매일 +1
+        List<Long> activeIds = overdueApplicationService.findActiveRecordIds(BATCH_LIMIT);
+        if (!activeIds.isEmpty()) {
+            log.info("[overdue-scheduler] 진행중 record {} 건 advance", activeIds.size());
+        }
+        int advanced = 0;
+        for (Long recordId : activeIds) {
+            try {
+                if (overdueApplicationService.advanceDay(recordId, now)) {
+                    advanced++;
+                }
+            } catch (Exception e) {
+                log.error("[overdue-scheduler] advanceDay 실패 overdueRecordId={}", recordId, e);
+            }
+        }
+
+        if (started > 0 || advanced > 0) {
+            log.info("[overdue-scheduler] 완료 — 신규 {} 건 / 진행 {} 건", started, advanced);
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/overdue/application/dto/OverdueChargeQueryResult.java
+++ b/src/main/java/com/sseulang/domain/overdue/application/dto/OverdueChargeQueryResult.java
@@ -1,0 +1,18 @@
+package com.sseulang.domain.overdue.application.dto;
+
+import com.sseulang.domain.overdue.domain.OverduePhase;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+
+public record OverdueChargeQueryResult(
+        Long overdueRecordId,
+        Long escrowApplicationId,
+        Long buyerId,
+        long depositAmount,
+        int overdueDays,
+        OverduePhase phase,
+        OverdueStatus status,
+        long depositForfeitedAmount,
+        long remainingDepositAmount,
+        long extraDebtAmount
+) {
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/LateFeeCalculator.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/LateFeeCalculator.java
@@ -1,0 +1,56 @@
+package com.sseulang.domain.overdue.domain;
+
+import java.util.List;
+
+public final class LateFeeCalculator {
+
+    private static final List<DailyForfeit> PHASE1_TABLE = List.of(
+            new DailyForfeit(1, 30),
+            new DailyForfeit(2, 10),
+            new DailyForfeit(3, 10),
+            new DailyForfeit(4, 10),
+            new DailyForfeit(5, 10),
+            new DailyForfeit(6, 10),
+            new DailyForfeit(7, 10)
+    );
+
+    private LateFeeCalculator() {
+    }
+
+    public static LateFeeResult calculate(long deposit, int overdueDays, int phase2RatePercent) {
+        if (deposit < 0) {
+            throw new IllegalArgumentException("deposit 은 음수가 될 수 없습니다");
+        }
+        if (phase2RatePercent < 0) {
+            throw new IllegalArgumentException("phase2RatePercent 는 음수가 될 수 없습니다");
+        }
+        if (overdueDays <= 0) {
+            return LateFeeResult.zero(deposit);
+        }
+
+        int forfeitPercent = 0;
+        int phase1Days = Math.min(overdueDays, PHASE1_TABLE.size());
+        for (int i = 0; i < phase1Days; i++) {
+            forfeitPercent += PHASE1_TABLE.get(i).rate();
+        }
+
+        long forfeited = percentageOf(deposit, forfeitPercent);
+        long remainingDeposit = deposit - forfeited;
+
+        long extraDebt = 0;
+        if (overdueDays > PHASE1_TABLE.size()) {
+            int phase2Days = overdueDays - PHASE1_TABLE.size();
+            long dailyDebt = percentageOf(deposit, phase2RatePercent);
+            extraDebt = Math.multiplyExact(dailyDebt, phase2Days);
+        }
+
+        return new LateFeeResult(forfeited, remainingDeposit, extraDebt);
+    }
+
+    private static long percentageOf(long amount, int percent) {
+        return Math.multiplyExact(amount, percent) / 100;
+    }
+
+    private record DailyForfeit(int day, int rate) {
+    }
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/LateFeeResult.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/LateFeeResult.java
@@ -1,0 +1,13 @@
+package com.sseulang.domain.overdue.domain;
+
+public record LateFeeResult(long forfeited, long remainingDeposit, long extraDebt) {
+    public LateFeeResult {
+        if (forfeited < 0 || remainingDeposit < 0 || extraDebt < 0) {
+            throw new IllegalArgumentException("연체 산정 금액은 음수가 될 수 없습니다");
+        }
+    }
+
+    public static LateFeeResult zero(long deposit) {
+        return new LateFeeResult(0, deposit, 0);
+    }
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/OverdueLegalAction.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/OverdueLegalAction.java
@@ -1,0 +1,8 @@
+package com.sseulang.domain.overdue.domain;
+
+public enum OverdueLegalAction {
+    NONE,
+    내용증명,
+    분쟁조정,
+    소송제기
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/OverduePhase.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/OverduePhase.java
@@ -1,0 +1,8 @@
+package com.sseulang.domain.overdue.domain;
+
+public enum OverduePhase {
+    PHASE_1,
+    PHASE_2,
+    PHASE_3,
+    PHASE_4
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/OverdueRecord.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/OverdueRecord.java
@@ -1,0 +1,225 @@
+package com.sseulang.domain.overdue.domain;
+
+import com.sseulang.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "overdue_records")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OverdueRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "escrow_application_id", nullable = false, unique = true)
+    private Long escrowApplicationId;
+
+    @Column(name = "buyer_id", nullable = false)
+    private Long buyerId;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "deposit_amount", nullable = false)
+    private long depositAmount;
+
+    @Column(name = "rental_end_at", nullable = false)
+    private LocalDateTime rentalEndAt;
+
+    @Column(name = "overdue_started_at", nullable = false)
+    private LocalDateTime overdueStartedAt;
+
+    @Column(name = "overdue_days", nullable = false)
+    private int overdueDays;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "phase", nullable = false, length = 20)
+    private OverduePhase phase;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private OverdueStatus status;
+
+    @Column(name = "deposit_forfeited_amount", nullable = false)
+    private long depositForfeitedAmount;
+
+    @Column(name = "extra_debt_amount", nullable = false)
+    private long extraDebtAmount;
+
+    @Column(name = "account_suspended_at")
+    private LocalDateTime accountSuspendedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "legal_action", nullable = false, length = 30)
+    private OverdueLegalAction legalAction;
+
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+
+    @Column(name = "resolution_note", length = 1000)
+    private String resolutionNote;
+
+    public static OverdueRecord create(
+            Long escrowApplicationId,
+            Long buyerId,
+            Long sellerId,
+            long depositAmount,
+            LocalDateTime rentalEndAt,
+            LocalDateTime overdueStartedAt
+    ) {
+        validatePositiveId(escrowApplicationId, "escrowApplicationId");
+        validatePositiveId(buyerId, "buyerId");
+        validatePositiveId(sellerId, "sellerId");
+        if (buyerId.equals(sellerId)) {
+            throw new IllegalArgumentException("buyerId 와 sellerId 는 달라야 합니다");
+        }
+        if (depositAmount < 0) {
+            throw new IllegalArgumentException("depositAmount 는 음수가 될 수 없습니다");
+        }
+        if (rentalEndAt == null) {
+            throw new IllegalArgumentException("rentalEndAt 은 필수입니다");
+        }
+        if (overdueStartedAt == null) {
+            throw new IllegalArgumentException("overdueStartedAt 은 필수입니다");
+        }
+        if (overdueStartedAt.isBefore(rentalEndAt)) {
+            throw new IllegalArgumentException("overdueStartedAt 은 rentalEndAt 이후여야 합니다");
+        }
+
+        OverdueRecord record = new OverdueRecord();
+        record.escrowApplicationId = escrowApplicationId;
+        record.buyerId = buyerId;
+        record.sellerId = sellerId;
+        record.depositAmount = depositAmount;
+        record.rentalEndAt = rentalEndAt;
+        record.overdueStartedAt = overdueStartedAt;
+        record.overdueDays = 0;
+        record.phase = OverduePhase.PHASE_1;
+        record.status = OverdueStatus.진행중;
+        record.depositForfeitedAmount = 0;
+        record.extraDebtAmount = 0;
+        record.legalAction = OverdueLegalAction.NONE;
+        return record;
+    }
+
+    public void advanceDay(LocalDateTime now, OverdueThresholds thresholds) {
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+        if (thresholds == null) {
+            throw new IllegalArgumentException("thresholds 는 필수입니다");
+        }
+        if (status != OverdueStatus.진행중) {
+            return;
+        }
+
+        int newDays = (int) Duration.between(overdueStartedAt, now).toDays() + 1;
+        if (newDays <= overdueDays) {
+            return;
+        }
+
+        LateFeeResult fee = LateFeeCalculator.calculate(
+                depositAmount,
+                newDays,
+                thresholds.phase2DailyRatePercent()
+        );
+        this.overdueDays = newDays;
+        this.depositForfeitedAmount = fee.forfeited();
+        this.extraDebtAmount = fee.extraDebt();
+        this.phase = decidePhase(thresholds);
+    }
+
+    public void markAccountSuspended(LocalDateTime now) {
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+        if (status != OverdueStatus.진행중) {
+            return;
+        }
+        if (this.accountSuspendedAt == null) {
+            this.accountSuspendedAt = now;
+        }
+        this.phase = OverduePhase.PHASE_3;
+    }
+
+    public void markLegalAction(OverdueLegalAction action) {
+        if (action == null || action == OverdueLegalAction.NONE) {
+            throw new IllegalArgumentException("법적 조치 action 은 NONE 이 될 수 없습니다");
+        }
+        this.legalAction = action;
+        this.phase = OverduePhase.PHASE_4;
+        this.status = OverdueStatus.법적조치중;
+    }
+
+    public void markResolved(LocalDateTime now, String note) {
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+        if (note != null && note.length() > 1000) {
+            throw new IllegalArgumentException("resolutionNote 는 1000자를 초과할 수 없습니다");
+        }
+        this.resolvedAt = now;
+        this.resolutionNote = note;
+        this.status = extraDebtAmount == 0 ? OverdueStatus.종료 : OverdueStatus.정산완료;
+    }
+
+    public long remainingDepositAmount() {
+        return depositAmount - depositForfeitedAmount;
+    }
+
+    public boolean shouldSuspendAccount(OverdueThresholds thresholds) {
+        if (thresholds == null) {
+            throw new IllegalArgumentException("thresholds 는 필수입니다");
+        }
+        long totalDebt = Math.addExact(depositForfeitedAmount, extraDebtAmount);
+        return totalDebt >= thresholds.phase3AmountKrw()
+                || overdueDays >= thresholds.phase3DaysThreshold();
+    }
+
+    public boolean shouldEnterLegalAction(OverdueThresholds thresholds, LocalDateTime now) {
+        if (thresholds == null) {
+            throw new IllegalArgumentException("thresholds 는 필수입니다");
+        }
+        if (now == null) {
+            throw new IllegalArgumentException("now 는 필수입니다");
+        }
+        if (accountSuspendedAt == null) {
+            return false;
+        }
+        return Duration.between(accountSuspendedAt, now).toDays() >= thresholds.phase4DaysAfterSuspend();
+    }
+
+    private OverduePhase decidePhase(OverdueThresholds thresholds) {
+        if (legalAction != OverdueLegalAction.NONE) {
+            return OverduePhase.PHASE_4;
+        }
+        if (accountSuspendedAt != null) {
+            return OverduePhase.PHASE_3;
+        }
+        if (overdueDays > 7) {
+            return OverduePhase.PHASE_2;
+        }
+        return OverduePhase.PHASE_1;
+    }
+
+    private static void validatePositiveId(Long id, String name) {
+        if (id == null || id <= 0) {
+            throw new IllegalArgumentException(name + " 는 양수여야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/OverdueRecordRepository.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/OverdueRecordRepository.java
@@ -1,0 +1,14 @@
+package com.sseulang.domain.overdue.domain;
+
+import java.util.Optional;
+
+public interface OverdueRecordRepository {
+
+    boolean existsByEscrowApplicationId(Long escrowApplicationId);
+
+    Optional<OverdueRecord> findById(Long id);
+
+    Optional<OverdueRecord> findByEscrowApplicationId(Long escrowApplicationId);
+
+    OverdueRecord save(OverdueRecord record);
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/OverdueRecordRepository.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/OverdueRecordRepository.java
@@ -1,5 +1,9 @@
 package com.sseulang.domain.overdue.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface OverdueRecordRepository {
@@ -14,7 +18,11 @@ public interface OverdueRecordRepository {
 
     Optional<OverdueRecord> findByEscrowApplicationIdForUpdate(Long escrowApplicationId);
 
-    java.util.List<Long> findActiveIds(int limit);
+    List<Long> findActiveIds(int limit);
+
+    Page<OverdueRecord> searchAdmin(OverdueStatus status, OverduePhase phase, Pageable pageable);
+
+    List<OverdueRecord> findByBuyerIdAndStatusIn(Long buyerId, List<OverdueStatus> statuses);
 
     OverdueRecord save(OverdueRecord record);
 }

--- a/src/main/java/com/sseulang/domain/overdue/domain/OverdueRecordRepository.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/OverdueRecordRepository.java
@@ -8,7 +8,13 @@ public interface OverdueRecordRepository {
 
     Optional<OverdueRecord> findById(Long id);
 
+    Optional<OverdueRecord> findByIdForUpdate(Long id);
+
     Optional<OverdueRecord> findByEscrowApplicationId(Long escrowApplicationId);
+
+    Optional<OverdueRecord> findByEscrowApplicationIdForUpdate(Long escrowApplicationId);
+
+    java.util.List<Long> findActiveIds(int limit);
 
     OverdueRecord save(OverdueRecord record);
 }

--- a/src/main/java/com/sseulang/domain/overdue/domain/OverdueStatus.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/OverdueStatus.java
@@ -1,0 +1,8 @@
+package com.sseulang.domain.overdue.domain;
+
+public enum OverdueStatus {
+    진행중,
+    정산완료,
+    법적조치중,
+    종료
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/OverdueThresholds.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/OverdueThresholds.java
@@ -1,0 +1,27 @@
+package com.sseulang.domain.overdue.domain;
+
+public record OverdueThresholds(
+        int phase3AmountKrw,
+        int phase3DaysThreshold,
+        int phase4DaysAfterSuspend,
+        int phase2DailyRatePercent
+) {
+    public static OverdueThresholds defaults() {
+        return new OverdueThresholds(50_000, 14, 7, 20);
+    }
+
+    public OverdueThresholds {
+        if (phase3AmountKrw <= 0) {
+            throw new IllegalArgumentException("phase3AmountKrw 는 양수여야 합니다");
+        }
+        if (phase3DaysThreshold <= 0) {
+            throw new IllegalArgumentException("phase3DaysThreshold 는 양수여야 합니다");
+        }
+        if (phase4DaysAfterSuspend <= 0) {
+            throw new IllegalArgumentException("phase4DaysAfterSuspend 는 양수여야 합니다");
+        }
+        if (phase2DailyRatePercent < 0) {
+            throw new IllegalArgumentException("phase2DailyRatePercent 는 음수가 될 수 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/event/OverdueAccountSuspendedEvent.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/event/OverdueAccountSuspendedEvent.java
@@ -1,0 +1,6 @@
+package com.sseulang.domain.overdue.domain.event;
+
+import java.time.LocalDateTime;
+
+public record OverdueAccountSuspendedEvent(Long overdueRecordId, Long buyerId, LocalDateTime occurredAt) {
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/event/OverduePhaseChangedEvent.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/event/OverduePhaseChangedEvent.java
@@ -1,0 +1,8 @@
+package com.sseulang.domain.overdue.domain.event;
+
+import com.sseulang.domain.overdue.domain.OverduePhase;
+
+import java.time.LocalDateTime;
+
+public record OverduePhaseChangedEvent(Long overdueRecordId, OverduePhase phase, LocalDateTime occurredAt) {
+}

--- a/src/main/java/com/sseulang/domain/overdue/domain/event/OverdueStartedEvent.java
+++ b/src/main/java/com/sseulang/domain/overdue/domain/event/OverdueStartedEvent.java
@@ -1,0 +1,6 @@
+package com.sseulang.domain.overdue.domain.event;
+
+import java.time.LocalDateTime;
+
+public record OverdueStartedEvent(Long overdueRecordId, Long escrowApplicationId, Long buyerId, LocalDateTime occurredAt) {
+}

--- a/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordJpaRepository.java
@@ -1,12 +1,14 @@
 package com.sseulang.domain.overdue.infrastructure.persistence;
 
+import com.sseulang.domain.overdue.domain.OverduePhase;
 import com.sseulang.domain.overdue.domain.OverdueRecord;
 import com.sseulang.domain.overdue.domain.OverdueStatus;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -32,4 +34,21 @@ public interface OverdueRecordJpaRepository extends JpaRepository<OverdueRecord,
              ORDER BY r.id ASC
             """)
     List<Long> findActiveIds(@Param("status") OverdueStatus status, Pageable pageable);
+
+    @Query("""
+            SELECT r FROM OverdueRecord r
+             WHERE (:status IS NULL OR r.status = :status)
+               AND (:phase IS NULL OR r.phase = :phase)
+             ORDER BY r.id DESC
+            """)
+    Page<OverdueRecord> searchAdmin(
+            @Param("status") OverdueStatus status,
+            @Param("phase") OverduePhase phase,
+            Pageable pageable
+    );
+
+    List<OverdueRecord> findByBuyerIdAndStatusInOrderByIdDesc(
+            Long buyerId,
+            List<OverdueStatus> statuses
+    );
 }

--- a/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordJpaRepository.java
@@ -1,0 +1,13 @@
+package com.sseulang.domain.overdue.infrastructure.persistence;
+
+import com.sseulang.domain.overdue.domain.OverdueRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OverdueRecordJpaRepository extends JpaRepository<OverdueRecord, Long> {
+
+    boolean existsByEscrowApplicationId(Long escrowApplicationId);
+
+    Optional<OverdueRecord> findByEscrowApplicationId(Long escrowApplicationId);
+}

--- a/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordJpaRepository.java
@@ -1,8 +1,15 @@
 package com.sseulang.domain.overdue.infrastructure.persistence;
 
 import com.sseulang.domain.overdue.domain.OverdueRecord;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OverdueRecordJpaRepository extends JpaRepository<OverdueRecord, Long> {
@@ -10,4 +17,19 @@ public interface OverdueRecordJpaRepository extends JpaRepository<OverdueRecord,
     boolean existsByEscrowApplicationId(Long escrowApplicationId);
 
     Optional<OverdueRecord> findByEscrowApplicationId(Long escrowApplicationId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM OverdueRecord r WHERE r.id = :id")
+    Optional<OverdueRecord> findByIdForUpdate(@Param("id") Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM OverdueRecord r WHERE r.escrowApplicationId = :escrowApplicationId")
+    Optional<OverdueRecord> findByEscrowApplicationIdForUpdate(@Param("escrowApplicationId") Long escrowApplicationId);
+
+    @Query("""
+            SELECT r.id FROM OverdueRecord r
+             WHERE r.status = :status
+             ORDER BY r.id ASC
+            """)
+    List<Long> findActiveIds(@Param("status") OverdueStatus status, Pageable pageable);
 }

--- a/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordRepositoryImpl.java
@@ -2,8 +2,11 @@ package com.sseulang.domain.overdue.infrastructure.persistence;
 
 import com.sseulang.domain.overdue.domain.OverdueRecord;
 import com.sseulang.domain.overdue.domain.OverdueRecordRepository;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -26,8 +29,26 @@ public class OverdueRecordRepositoryImpl implements OverdueRecordRepository {
     }
 
     @Override
+    public Optional<OverdueRecord> findByIdForUpdate(Long id) {
+        return jpa.findByIdForUpdate(id);
+    }
+
+    @Override
     public Optional<OverdueRecord> findByEscrowApplicationId(Long escrowApplicationId) {
         return jpa.findByEscrowApplicationId(escrowApplicationId);
+    }
+
+    @Override
+    public Optional<OverdueRecord> findByEscrowApplicationIdForUpdate(Long escrowApplicationId) {
+        return jpa.findByEscrowApplicationIdForUpdate(escrowApplicationId);
+    }
+
+    @Override
+    public List<Long> findActiveIds(int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        return jpa.findActiveIds(OverdueStatus.진행중, PageRequest.of(0, limit));
     }
 
     @Override

--- a/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.sseulang.domain.overdue.infrastructure.persistence;
+
+import com.sseulang.domain.overdue.domain.OverdueRecord;
+import com.sseulang.domain.overdue.domain.OverdueRecordRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class OverdueRecordRepositoryImpl implements OverdueRecordRepository {
+
+    private final OverdueRecordJpaRepository jpa;
+
+    public OverdueRecordRepositoryImpl(OverdueRecordJpaRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public boolean existsByEscrowApplicationId(Long escrowApplicationId) {
+        return jpa.existsByEscrowApplicationId(escrowApplicationId);
+    }
+
+    @Override
+    public Optional<OverdueRecord> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Optional<OverdueRecord> findByEscrowApplicationId(Long escrowApplicationId) {
+        return jpa.findByEscrowApplicationId(escrowApplicationId);
+    }
+
+    @Override
+    public OverdueRecord save(OverdueRecord record) {
+        return jpa.save(record);
+    }
+}

--- a/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/overdue/infrastructure/persistence/OverdueRecordRepositoryImpl.java
@@ -1,9 +1,12 @@
 package com.sseulang.domain.overdue.infrastructure.persistence;
 
+import com.sseulang.domain.overdue.domain.OverduePhase;
 import com.sseulang.domain.overdue.domain.OverdueRecord;
 import com.sseulang.domain.overdue.domain.OverdueRecordRepository;
 import com.sseulang.domain.overdue.domain.OverdueStatus;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -49,6 +52,19 @@ public class OverdueRecordRepositoryImpl implements OverdueRecordRepository {
             return List.of();
         }
         return jpa.findActiveIds(OverdueStatus.진행중, PageRequest.of(0, limit));
+    }
+
+    @Override
+    public Page<OverdueRecord> searchAdmin(OverdueStatus status, OverduePhase phase, Pageable pageable) {
+        return jpa.searchAdmin(status, phase, pageable);
+    }
+
+    @Override
+    public List<OverdueRecord> findByBuyerIdAndStatusIn(Long buyerId, List<OverdueStatus> statuses) {
+        if (buyerId == null || statuses == null || statuses.isEmpty()) {
+            return List.of();
+        }
+        return jpa.findByBuyerIdAndStatusInOrderByIdDesc(buyerId, statuses);
     }
 
     @Override

--- a/src/main/java/com/sseulang/domain/overdue/presentation/AdminOverdueController.java
+++ b/src/main/java/com/sseulang/domain/overdue/presentation/AdminOverdueController.java
@@ -1,0 +1,83 @@
+package com.sseulang.domain.overdue.presentation;
+
+import com.sseulang.domain.overdue.application.OverdueApplicationService;
+import com.sseulang.domain.overdue.domain.OverduePhase;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+import com.sseulang.domain.overdue.presentation.dto.AdminOverdueResponse;
+import com.sseulang.domain.overdue.presentation.dto.OverdueLegalActionRequest;
+import com.sseulang.domain.overdue.presentation.dto.OverdueResolveRequest;
+import com.sseulang.global.common.ApiResponse;
+import com.sseulang.global.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "AdminOverdue", description = "관리자 — 연체 관리")
+@RestController
+@RequestMapping("/api/v1/admin/overdue")
+public class AdminOverdueController {
+
+    private final OverdueApplicationService overdueService;
+
+    public AdminOverdueController(OverdueApplicationService overdueService) {
+        this.overdueService = overdueService;
+    }
+
+    @Operation(summary = "[관리자] 연체 목록",
+            description = "status (진행중/정산완료/법적조치중/종료) + phase (PHASE_1~4) 필터, 페이징.")
+    @GetMapping
+    public ApiResponse<PageResponse<AdminOverdueResponse>> list(
+            @RequestParam(value = "status", required = false) OverdueStatus status,
+            @RequestParam(value = "phase", required = false) OverduePhase phase,
+            Pageable pageable
+    ) {
+        return ApiResponse.ok(PageResponse.from(
+                overdueService.adminSearch(status, phase, pageable).map(AdminOverdueResponse::from)
+        ));
+    }
+
+    @Operation(summary = "[관리자] 연체 단건 조회")
+    @GetMapping("/{id}")
+    public ApiResponse<AdminOverdueResponse> getOne(@PathVariable("id") Long id) {
+        return ApiResponse.ok(AdminOverdueResponse.from(overdueService.adminGet(id)));
+    }
+
+    @Operation(summary = "[관리자] 법적 조치 단계 전이",
+            description = "내용증명/분쟁조정/소송제기 중 하나로 status=법적조치중, phase=PHASE_4 강제 전이.")
+    @PatchMapping("/{id}/legal-action")
+    public ApiResponse<Void> markLegalAction(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody OverdueLegalActionRequest request
+    ) {
+        overdueService.adminMarkLegalAction(id, request.action());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "[관리자] 강제 종료",
+            description = "외부 합의 등으로 운영상 강제 종료. 진행중이면 잔여 보증금 환불, status=종료/정산완료.")
+    @PatchMapping("/{id}/resolve")
+    public ApiResponse<Void> resolve(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody(required = false) OverdueResolveRequest request
+    ) {
+        overdueService.adminResolve(id, request == null ? null : request.note());
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "[관리자] 강제 재계산 (디버그용)",
+            description = "스케줄러 실행 외 임의 시점에서 advanceDay 호출. 연체일 / 차감 / phase 재산정.")
+    @PostMapping("/{id}/recompute")
+    public ApiResponse<Void> recompute(@PathVariable("id") Long id) {
+        overdueService.recompute(id);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/sseulang/domain/overdue/presentation/MyOverdueController.java
+++ b/src/main/java/com/sseulang/domain/overdue/presentation/MyOverdueController.java
@@ -1,0 +1,57 @@
+package com.sseulang.domain.overdue.presentation;
+
+import com.sseulang.domain.overdue.application.OverdueApplicationService;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+import com.sseulang.domain.overdue.presentation.dto.UserOverdueDebtResponse;
+import com.sseulang.domain.overdue.presentation.dto.UserOverdueResponse;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "MyOverdue", description = "본인 연체 정보 조회")
+@RestController
+@RequestMapping("/api/v1/users/me")
+public class MyOverdueController {
+
+    private final OverdueApplicationService overdueService;
+    private final UserApplicationService userApplicationService;
+
+    public MyOverdueController(
+            OverdueApplicationService overdueService,
+            UserApplicationService userApplicationService
+    ) {
+        this.overdueService = overdueService;
+        this.userApplicationService = userApplicationService;
+    }
+
+    @Operation(summary = "[본인] 진행/정산완료/법적조치중 연체 record 목록",
+            description = "종료 상태는 제외. 최근순. buyer 본인만 조회.")
+    @GetMapping("/overdue")
+    public ApiResponse<List<UserOverdueResponse>> myOverdue(@AuthenticationPrincipal Long userId) {
+        List<OverdueStatus> active = List.of(
+                OverdueStatus.진행중,
+                OverdueStatus.정산완료,
+                OverdueStatus.법적조치중
+        );
+        return ApiResponse.ok(
+                overdueService.findByBuyer(userId, active).stream()
+                        .map(UserOverdueResponse::from)
+                        .toList()
+        );
+    }
+
+    @Operation(summary = "[본인] 누적 연체 채무 잔액",
+            description = "users.overdue_debt_balance 단순 조회. 다음 충전 시 우선 차감.")
+    @GetMapping("/overdue-debt")
+    public ApiResponse<UserOverdueDebtResponse> myOverdueDebt(@AuthenticationPrincipal Long userId) {
+        long debt = userApplicationService.findOverdueDebt(userId);
+        return ApiResponse.ok(new UserOverdueDebtResponse(debt));
+    }
+}

--- a/src/main/java/com/sseulang/domain/overdue/presentation/dto/AdminOverdueResponse.java
+++ b/src/main/java/com/sseulang/domain/overdue/presentation/dto/AdminOverdueResponse.java
@@ -1,0 +1,56 @@
+package com.sseulang.domain.overdue.presentation.dto;
+
+import com.sseulang.domain.overdue.domain.OverdueLegalAction;
+import com.sseulang.domain.overdue.domain.OverduePhase;
+import com.sseulang.domain.overdue.domain.OverdueRecord;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "관리자 — 연체 단건 응답.")
+public record AdminOverdueResponse(
+        @Schema(example = "12") Long id,
+        @Schema(example = "100") Long escrowApplicationId,
+        @Schema(example = "11") Long buyerId,
+        @Schema(example = "20") Long sellerId,
+        @Schema(example = "100000") long depositAmount,
+        @Schema(example = "30000") long depositForfeitedAmount,
+        @Schema(example = "20000") long extraDebtAmount,
+        @Schema(description = "잔여 보증금 = depositAmount - depositForfeitedAmount") long remainingDeposit,
+        @Schema(example = "8") int overdueDays,
+        OverduePhase phase,
+        OverdueStatus status,
+        OverdueLegalAction legalAction,
+        LocalDateTime rentalEndAt,
+        LocalDateTime overdueStartedAt,
+        @Schema(nullable = true) LocalDateTime accountSuspendedAt,
+        @Schema(nullable = true) LocalDateTime resolvedAt,
+        @Schema(nullable = true) String resolutionNote,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static AdminOverdueResponse from(OverdueRecord r) {
+        return new AdminOverdueResponse(
+                r.getId(),
+                r.getEscrowApplicationId(),
+                r.getBuyerId(),
+                r.getSellerId(),
+                r.getDepositAmount(),
+                r.getDepositForfeitedAmount(),
+                r.getExtraDebtAmount(),
+                r.remainingDepositAmount(),
+                r.getOverdueDays(),
+                r.getPhase(),
+                r.getStatus(),
+                r.getLegalAction(),
+                r.getRentalEndAt(),
+                r.getOverdueStartedAt(),
+                r.getAccountSuspendedAt(),
+                r.getResolvedAt(),
+                r.getResolutionNote(),
+                r.getCreatedAt(),
+                r.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/overdue/presentation/dto/OverdueLegalActionRequest.java
+++ b/src/main/java/com/sseulang/domain/overdue/presentation/dto/OverdueLegalActionRequest.java
@@ -1,0 +1,12 @@
+package com.sseulang.domain.overdue.presentation.dto;
+
+import com.sseulang.domain.overdue.domain.OverdueLegalAction;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "관리자 법적 조치 단계 전이 요청. NONE 은 허용 X.")
+public record OverdueLegalActionRequest(
+        @Schema(description = "법적 조치 액션", example = "내용증명",
+                allowableValues = {"내용증명", "분쟁조정", "소송제기"})
+        @NotNull OverdueLegalAction action
+) { }

--- a/src/main/java/com/sseulang/domain/overdue/presentation/dto/OverdueResolveRequest.java
+++ b/src/main/java/com/sseulang/domain/overdue/presentation/dto/OverdueResolveRequest.java
@@ -1,0 +1,11 @@
+package com.sseulang.domain.overdue.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "관리자 강제 종료 요청 — 외부 합의 등.")
+public record OverdueResolveRequest(
+        @Schema(description = "처리 메모 (선택)", example = "buyer 와 seller 외부 합의 종결",
+                maxLength = 1000, nullable = true)
+        @Size(max = 1000) String note
+) { }

--- a/src/main/java/com/sseulang/domain/overdue/presentation/dto/UserOverdueDebtResponse.java
+++ b/src/main/java/com/sseulang/domain/overdue/presentation/dto/UserOverdueDebtResponse.java
@@ -1,0 +1,9 @@
+package com.sseulang.domain.overdue.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "본인 누적 연체 채무 잔액. 다음 충전 시 우선 차감.")
+public record UserOverdueDebtResponse(
+        @Schema(example = "23000", description = "현재 누적 채무 (원). 0 이면 채무 없음.")
+        long debt
+) { }

--- a/src/main/java/com/sseulang/domain/overdue/presentation/dto/UserOverdueResponse.java
+++ b/src/main/java/com/sseulang/domain/overdue/presentation/dto/UserOverdueResponse.java
@@ -1,0 +1,45 @@
+package com.sseulang.domain.overdue.presentation.dto;
+
+import com.sseulang.domain.overdue.domain.OverduePhase;
+import com.sseulang.domain.overdue.domain.OverdueRecord;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "본인용 — 연체 record 단건 (민감 정보 제외).")
+public record UserOverdueResponse(
+        @Schema(example = "12") Long id,
+        @Schema(example = "100") Long escrowApplicationId,
+        @Schema(example = "100000") long depositAmount,
+        @Schema(example = "30000") long depositForfeitedAmount,
+        @Schema(example = "20000") long extraDebtAmount,
+        @Schema(description = "잔여 보증금 = depositAmount - depositForfeitedAmount") long remainingDeposit,
+        @Schema(example = "8") int overdueDays,
+        OverduePhase phase,
+        OverdueStatus status,
+        LocalDateTime rentalEndAt,
+        LocalDateTime overdueStartedAt,
+        @Schema(nullable = true) LocalDateTime accountSuspendedAt,
+        @Schema(nullable = true) LocalDateTime resolvedAt,
+        LocalDateTime createdAt
+) {
+    public static UserOverdueResponse from(OverdueRecord r) {
+        return new UserOverdueResponse(
+                r.getId(),
+                r.getEscrowApplicationId(),
+                r.getDepositAmount(),
+                r.getDepositForfeitedAmount(),
+                r.getExtraDebtAmount(),
+                r.remainingDepositAmount(),
+                r.getOverdueDays(),
+                r.getPhase(),
+                r.getStatus(),
+                r.getRentalEndAt(),
+                r.getOverdueStartedAt(),
+                r.getAccountSuspendedAt(),
+                r.getResolvedAt(),
+                r.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
+++ b/src/main/java/com/sseulang/domain/payment/application/PaymentApplicationService.java
@@ -48,6 +48,7 @@ public class PaymentApplicationService {
     private final ObjectMapper objectMapper;
     private final WebhookPendingRateLimiter pendingRateLimiter;
     private final com.sseulang.domain.escrow.application.EscrowApplicationService escrowApplicationService;
+    private final com.sseulang.domain.overdue.application.OverdueApplicationService overdueApplicationService;
 
     public PaymentApplicationService(
             PaymentRepository paymentRepository,
@@ -59,7 +60,9 @@ public class PaymentApplicationService {
             TossWebhookSignatureVerifier webhookVerifier,
             ObjectMapper objectMapper,
             WebhookPendingRateLimiter pendingRateLimiter,
-            com.sseulang.domain.escrow.application.EscrowApplicationService escrowApplicationService
+            com.sseulang.domain.escrow.application.EscrowApplicationService escrowApplicationService,
+            @org.springframework.beans.factory.annotation.Autowired(required = false)
+            com.sseulang.domain.overdue.application.OverdueApplicationService overdueApplicationService
     ) {
         this.paymentRepository = paymentRepository;
         this.paymentGateway = paymentGateway;
@@ -71,6 +74,7 @@ public class PaymentApplicationService {
         this.objectMapper = objectMapper;
         this.pendingRateLimiter = pendingRateLimiter;
         this.escrowApplicationService = escrowApplicationService;
+        this.overdueApplicationService = overdueApplicationService;
     }
 
     
@@ -197,13 +201,13 @@ public class PaymentApplicationService {
 
     private void applyPaymentConfirmedEffects(Payment payment, String chargeDescription) {
         if (payment.getEscrowApplicationId() != null) {
-            
+
             escrowApplicationService.recordPaymentConfirmed(
                     payment.getEscrowApplicationId(),
                     payment.getUserId()
             );
         } else {
-            
+
             pointApplicationService.credit(
                     payment.getUserId(),
                     payment.getAmount(),
@@ -212,6 +216,34 @@ public class PaymentApplicationService {
                     payment.getId(),
                     chargeDescription
             );
+            // 충전 직후 buyer 의 연체 채무 우선 차감 (PR4 hook). overdueApplicationService 미주입 시 skip.
+            applyOverdueDebtDeduction(payment);
+        }
+    }
+
+    private void applyOverdueDebtDeduction(Payment payment) {
+        if (overdueApplicationService == null) {
+            return;
+        }
+        long debt = userApplicationService.findOverdueDebt(payment.getUserId());
+        if (debt <= 0) {
+            return;
+        }
+        long deduct = Math.min(payment.getAmount(), debt);
+        try {
+            pointApplicationService.deduct(
+                    payment.getUserId(),
+                    deduct,
+                    PointHistoryType.연체채무상환,
+                    PointReferenceType.OVERDUE,
+                    payment.getId(),
+                    "연체 채무 우선 차감"
+            );
+            userApplicationService.decrementOverdueDebt(payment.getUserId(), deduct);
+            overdueApplicationService.recordDebtPayment(payment.getUserId(), deduct);
+        } catch (RuntimeException e) {
+            log.error("[overdue-debt-deduct] 채무 차감 실패 — 충전은 적용됨. paymentId={} userId={} debt={} deduct={} reason={}",
+                    payment.getId(), payment.getUserId(), debt, deduct, e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/sseulang/domain/point/domain/PointHistory.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointHistory.java
@@ -45,6 +45,9 @@ public class PointHistory {
     @Column(name = "reference_id")
     private Long referenceId;
 
+    @Column(name = "overdue_record_id")
+    private Long overdueRecordId;
+
     @Column(name = "description", length = 255)
     private String description;
 
@@ -130,9 +133,10 @@ public class PointHistory {
                 && type != PointHistoryType.판매정산
                 && type != PointHistoryType.환불
                 && type != PointHistoryType.배달정산
-                && type != PointHistoryType.거래환불) {
+                && type != PointHistoryType.거래환불
+                && type != PointHistoryType.연체몰수) {
             throw new IllegalArgumentException(
-                    "recordCredit 은 충전 / 판매정산 / 환불 / 배달정산 / 거래환불 type 만 허용: " + type);
+                    "recordCredit 은 충전 / 판매정산 / 환불 / 배달정산 / 거래환불 / 연체몰수 type 만 허용: " + type);
         }
     }
 
@@ -141,9 +145,10 @@ public class PointHistory {
                 && type != PointHistoryType.출금
                 && type != PointHistoryType.환불
                 && type != PointHistoryType.배달결제
-                && type != PointHistoryType.거래보관) {
+                && type != PointHistoryType.거래보관
+                && type != PointHistoryType.연체채무상환) {
             throw new IllegalArgumentException(
-                    "recordDebit 은 결제 / 출금 / 환불 / 배달결제 / 거래보관 type 만 허용: " + type);
+                    "recordDebit 은 결제 / 출금 / 환불 / 배달결제 / 거래보관 / 연체채무상환 type 만 허용: " + type);
         }
     }
 }

--- a/src/main/java/com/sseulang/domain/point/domain/PointHistory.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointHistory.java
@@ -117,6 +117,7 @@ public class PointHistory {
         h.balanceAfter = balanceAfter;
         h.referenceType = referenceType;
         h.referenceId = referenceId;
+        h.overdueRecordId = referenceType == PointReferenceType.OVERDUE ? referenceId : null;
         h.description = description;
         h.createdAt = now;
         return h;

--- a/src/main/java/com/sseulang/domain/point/domain/PointHistoryType.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointHistoryType.java
@@ -9,5 +9,7 @@ public enum PointHistoryType {
     배달결제,
     배달정산,
     거래보관,
-    거래환불
+    거래환불,
+    연체몰수,
+    연체채무상환
 }

--- a/src/main/java/com/sseulang/domain/point/domain/PointReferenceType.java
+++ b/src/main/java/com/sseulang/domain/point/domain/PointReferenceType.java
@@ -5,5 +5,6 @@ public enum PointReferenceType {
     TRANSACTION,
     WITHDRAWAL,
     DELIVERY,
-    ESCROW
+    ESCROW,
+    OVERDUE
 }

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -238,6 +238,36 @@ public class UserApplicationService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
+    @Transactional
+    public void incrementOverdueDebt(Long userId, long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        int affected = userRepository.incrementOverdueDebt(userId, amount);
+        if (affected != 1) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Transactional
+    public void decrementOverdueDebt(Long userId, long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        int affected = userRepository.decrementOverdueDebt(userId, amount);
+        if (affected != 1) {
+            throw new BusinessException(ErrorCode.INSUFFICIENT_POINT);
+        }
+    }
+
+    public long findOverdueDebt(Long userId) {
+        Long debt = userRepository.findOverdueDebtBalance(userId);
+        if (debt == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        return debt;
+    }
+
     
 
     public Page<User> adminFindAll(Pageable pageable) {

--- a/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
+++ b/src/main/java/com/sseulang/domain/user/application/UserApplicationService.java
@@ -349,6 +349,18 @@ public class UserApplicationService {
         u.unsuspend();
     }
 
+    @Transactional
+    public void adminAutoSuspend(Long userId, int days, String reason) {
+        User u = getById(userId);
+        u.suspend(days, java.time.LocalDateTime.now(clock));
+        refreshTokenStore.revokeAll(USER_ROLE, userId);
+        log.warn("[admin-auto-suspend] userId={} days={} reason={}", userId, days, reason);
+        if (u.isAutoWithdrawTarget()) {
+            u.markWithdrawn();
+            sendAutoWithdrawnNotice(u);
+        }
+    }
+
     
 
     public java.util.List<Long> findAutoWithdrawTargetIds(int limit) {

--- a/src/main/java/com/sseulang/domain/user/application/dto/AdminUserResult.java
+++ b/src/main/java/com/sseulang/domain/user/application/dto/AdminUserResult.java
@@ -26,6 +26,8 @@ public record AdminUserResult(
         UserStatus status,
         long tradeCount,
         long reportCount,
+        long overdueDebt,
+        Long activeOverdueRecordId,
         LocalDateTime createdAt
 ) {
     public static AdminUserResult from(
@@ -34,6 +36,17 @@ public record AdminUserResult(
             int dormantThresholdDays,
             long tradeCount,
             long reportCount
+    ) {
+        return from(u, now, dormantThresholdDays, tradeCount, reportCount, null);
+    }
+
+    public static AdminUserResult from(
+            User u,
+            LocalDateTime now,
+            int dormantThresholdDays,
+            long tradeCount,
+            long reportCount,
+            Long activeOverdueRecordId
     ) {
         LocalDateTime suspendedUntil = (u.getSuspendedAt() != null && u.getSuspendDays() != null && u.getSuspendDays() > 0)
                 ? u.getSuspendedAt().plusDays(u.getSuspendDays())
@@ -57,6 +70,8 @@ public record AdminUserResult(
                 u.derivedStatus(now, dormantThresholdDays),
                 tradeCount,
                 reportCount,
+                u.getOverdueDebtBalance(),
+                activeOverdueRecordId,
                 u.getCreatedAt()
         );
     }

--- a/src/main/java/com/sseulang/domain/user/domain/User.java
+++ b/src/main/java/com/sseulang/domain/user/domain/User.java
@@ -103,6 +103,9 @@ public class User extends BaseEntity {
     @Column(name = "point_hold", nullable = false)
     private long pointHold;
 
+    @Column(name = "overdue_debt_balance", nullable = false)
+    private long overdueDebtBalance;
+
     
 
     @Version
@@ -301,5 +304,22 @@ public class User extends BaseEntity {
 
     public boolean isAccessibleAt(LocalDateTime now) {
         return !blocked && !deleted && !isSuspendedAt(now);
+    }
+
+    public void increaseOverdueDebt(long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        this.overdueDebtBalance = Math.addExact(this.overdueDebtBalance, amount);
+    }
+
+    public void decreaseOverdueDebt(long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount 는 양수여야 합니다");
+        }
+        if (this.overdueDebtBalance < amount) {
+            throw new IllegalStateException("연체 채무 잔액보다 큰 금액은 차감할 수 없습니다");
+        }
+        this.overdueDebtBalance -= amount;
     }
 }

--- a/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/sseulang/domain/user/domain/UserRepository.java
@@ -65,6 +65,12 @@ public interface UserRepository {
 
     record PointSnapshot(long balance, long hold) { }
 
+    int incrementOverdueDebt(Long userId, long amount);
+
+    int decrementOverdueDebt(Long userId, long amount);
+
+    Long findOverdueDebtBalance(Long userId);
+
     
 
     

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserJpaRepository.java
@@ -92,6 +92,22 @@ interface UserJpaRepository extends JpaRepository<User, Long> {
         long getHold();
     }
 
+    @Modifying
+    @Query("UPDATE User u SET u.overdueDebtBalance = u.overdueDebtBalance + :amount WHERE u.id = :userId")
+    int incrementOverdueDebt(@Param("userId") Long userId, @Param("amount") long amount);
+
+    @Modifying
+    @Query("""
+            UPDATE User u
+               SET u.overdueDebtBalance = u.overdueDebtBalance - :amount
+             WHERE u.id = :userId
+               AND u.overdueDebtBalance >= :amount
+            """)
+    int decrementOverdueDebt(@Param("userId") Long userId, @Param("amount") long amount);
+
+    @Query("SELECT u.overdueDebtBalance FROM User u WHERE u.id = :userId")
+    Long findOverdueDebtBalanceById(@Param("userId") Long userId);
+
     Page<User> findAllByOrderByIdDesc(Pageable pageable);
 
     

--- a/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/sseulang/domain/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -113,6 +113,21 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public int incrementOverdueDebt(Long userId, long amount) {
+        return jpa.incrementOverdueDebt(userId, amount);
+    }
+
+    @Override
+    public int decrementOverdueDebt(Long userId, long amount) {
+        return jpa.decrementOverdueDebt(userId, amount);
+    }
+
+    @Override
+    public Long findOverdueDebtBalance(Long userId) {
+        return jpa.findOverdueDebtBalanceById(userId);
+    }
+
+    @Override
     public long countAll() {
         return jpa.count();
     }

--- a/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
+++ b/src/main/java/com/sseulang/domain/user/presentation/dto/AdminUserResponse.java
@@ -29,6 +29,8 @@ public record AdminUserResponse(
         @Schema(description = "회원 상태 (derived). WITHDRAWN > SUSPENDED > DORMANT > ACTIVE 우선순위.") UserStatus status,
         @Schema(example = "5", description = "이 회원이 buyer 또는 seller 로 참여한 거래 횟수") long tradeCount,
         @Schema(example = "0", description = "이 회원이 신고당한 횟수") long reportCount,
+        @Schema(example = "0", description = "현재 누적 연체 채무 (원). 0 이면 채무 없음.") long overdueDebt,
+        @Schema(description = "진행중/법적조치중 연체 record id. 없으면 null.", nullable = true) Long activeOverdueRecordId,
         LocalDateTime createdAt
 ) {
     public static AdminUserResponse from(AdminUserResult r) {
@@ -38,11 +40,12 @@ public record AdminUserResponse(
                 r.lastLoginAt(), r.suspendedAt(), r.suspendDays(), r.suspendedUntil(),
                 r.dormant(), r.status(),
                 r.tradeCount(), r.reportCount(),
+                r.overdueDebt(), r.activeOverdueRecordId(),
                 r.createdAt()
         );
     }
 
-    
+
 
     @Deprecated
     public static AdminUserResponse from(User u) {
@@ -52,6 +55,7 @@ public record AdminUserResponse(
                 u.getLastLoginAt(), u.getSuspendedAt(), u.getSuspendDays(), null,
                 false, UserStatus.ACTIVE,
                 0L, 0L,
+                0L, null,
                 u.getCreatedAt()
         );
     }

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -137,6 +137,9 @@ public enum ErrorCode {
     ESCROW_TX_CHATROOM_MISMATCH(HttpStatus.BAD_REQUEST, "쓸랭 거래의 채팅방과 거래대행 신청 채팅방이 다릅니다."),
     ESCROW_SELLER_ONLY(HttpStatus.FORBIDDEN, "거래대행 신청은 판매자만 가능합니다."),
 
+    // 연체
+    OVERDUE_NOT_FOUND(HttpStatus.NOT_FOUND, "연체 기록을 찾을 수 없습니다."),
+
     PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "요청 본문 크기가 한도를 초과합니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/sseulang/global/exception/ErrorCode.java
+++ b/src/main/java/com/sseulang/global/exception/ErrorCode.java
@@ -139,6 +139,7 @@ public enum ErrorCode {
 
     // 연체
     OVERDUE_NOT_FOUND(HttpStatus.NOT_FOUND, "연체 기록을 찾을 수 없습니다."),
+    OVERDUE_ALREADY_RESOLVED(HttpStatus.CONFLICT, "이미 종료된 연체 기록입니다."),
 
     PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "요청 본문 크기가 한도를 초과합니다.");
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -100,3 +100,8 @@ app:
     enabled: true
   delivery:
     auto-accept-rider-id: ${APP_DELIVERY_AUTO_ACCEPT_RIDER_ID:0}
+  overdue:
+    phase3-amount-krw: ${APP_OVERDUE_PHASE3_AMOUNT_KRW:50000}
+    phase3-days-threshold: ${APP_OVERDUE_PHASE3_DAYS_THRESHOLD:14}
+    phase4-days-after-suspend: ${APP_OVERDUE_PHASE4_DAYS_AFTER_SUSPEND:7}
+    phase2-daily-rate-percent: ${APP_OVERDUE_PHASE2_DAILY_RATE_PERCENT:20}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -94,6 +94,11 @@ app:
   delivery:
     # 시연/QA 용 — 0 이거나 미설정이면 자동 매칭 X. 양수면 EscrowConfirmedEvent 발행 시 그 user 로 즉시 accept.
     auto-accept-rider-id: ${APP_DELIVERY_AUTO_ACCEPT_RIDER_ID:0}
+  overdue:
+    phase3-amount-krw: ${APP_OVERDUE_PHASE3_AMOUNT_KRW:50000}
+    phase3-days-threshold: ${APP_OVERDUE_PHASE3_DAYS_THRESHOLD:14}
+    phase4-days-after-suspend: ${APP_OVERDUE_PHASE4_DAYS_AFTER_SUSPEND:7}
+    phase2-daily-rate-percent: ${APP_OVERDUE_PHASE2_DAILY_RATE_PERCENT:20}
 
 # Swagger prod 노출 정책 — default 비활성. 외부 API 검수 / 응급 디버그 시에만 일시 true 로.
 # false 시 /swagger-ui.html, /v3/api-docs/** 가 404. Spring Security PUBLIC chain 도 막혀

--- a/src/main/resources/db/migration/V39__overdue_records.sql
+++ b/src/main/resources/db/migration/V39__overdue_records.sql
@@ -1,0 +1,27 @@
+CREATE TABLE overdue_records (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    escrow_application_id BIGINT NOT NULL UNIQUE,
+    buyer_id BIGINT NOT NULL,
+    seller_id BIGINT NOT NULL,
+    deposit_amount BIGINT NOT NULL,
+    rental_end_at DATETIME NOT NULL,
+    overdue_started_at DATETIME NOT NULL,
+    overdue_days INT NOT NULL DEFAULT 0,
+    phase VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    deposit_forfeited_amount BIGINT NOT NULL DEFAULT 0,
+    extra_debt_amount BIGINT NOT NULL DEFAULT 0,
+    account_suspended_at DATETIME NULL,
+    legal_action VARCHAR(30) NOT NULL DEFAULT 'NONE',
+    resolved_at DATETIME NULL,
+    resolution_note VARCHAR(1000) NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    INDEX idx_overdue_buyer (buyer_id, status),
+    INDEX idx_overdue_status_phase (status, phase),
+    INDEX idx_overdue_active (status, overdue_days),
+    CONSTRAINT fk_overdue_escrow FOREIGN KEY (escrow_application_id)
+        REFERENCES escrow_applications(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_overdue_buyer FOREIGN KEY (buyer_id) REFERENCES users(id),
+    CONSTRAINT fk_overdue_seller FOREIGN KEY (seller_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V40__user_overdue_debt.sql
+++ b/src/main/resources/db/migration/V40__user_overdue_debt.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users
+    ADD COLUMN overdue_debt_balance BIGINT NOT NULL DEFAULT 0
+        COMMENT '연체로 인한 누적 채무 (Phase 2). 다음 충전/결제 시 우선 차감';
+
+CREATE INDEX idx_users_overdue_debt ON users (overdue_debt_balance);

--- a/src/main/resources/db/migration/V41__overdue_audit_columns.sql
+++ b/src/main/resources/db/migration/V41__overdue_audit_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE point_histories
+    ADD COLUMN overdue_record_id BIGINT NULL
+        COMMENT '연체 정산 관련 history 인 경우 OverdueRecord ID';

--- a/src/main/resources/db/migration/V42__point_histories_overdue_types.sql
+++ b/src/main/resources/db/migration/V42__point_histories_overdue_types.sql
@@ -1,0 +1,9 @@
+-- V42: point_histories.point_type ENUM 확장 — 연체 시스템 (Codex PR1+PR2 누락 fix).
+-- PointHistoryType 에 연체몰수, 연체채무상환 추가됐지만 컬럼 ENUM 미확장 → INSERT 시 'Data truncated'.
+
+ALTER TABLE point_histories
+    MODIFY COLUMN point_type ENUM(
+        '충전','결제','판매정산','출금','환불',
+        '배달결제','배달정산',
+        '연체몰수','연체채무상환'
+    ) NOT NULL;

--- a/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/EscrowApplicationServiceTest.java
@@ -54,6 +54,7 @@ class EscrowApplicationServiceTest {
     private UserApplicationService userService;
     private PointApplicationService pointService;
     private PlatformTransactionManager transactionManager;
+    private com.sseulang.domain.overdue.application.OverdueApplicationService overdueService;
     private Clock clock;
     private List<Object> publishedEvents;
     private ApplicationEventPublisher eventPublisher;
@@ -90,6 +91,7 @@ class EscrowApplicationServiceTest {
                 mock(com.sseulang.domain.transaction.application.TransactionCascadeService.class);
         com.sseulang.domain.notification.application.NotificationApplicationService notifService =
                 mock(com.sseulang.domain.notification.application.NotificationApplicationService.class);
+        overdueService = mock(com.sseulang.domain.overdue.application.OverdueApplicationService.class);
         when(transactionManager.getTransaction(any(TransactionDefinition.class)))
                 .thenReturn(new SimpleTransactionStatus());
         doNothing().when(transactionManager).commit(any(TransactionStatus.class));
@@ -98,6 +100,7 @@ class EscrowApplicationServiceTest {
                 linkRepo, appRepo, settingsRepo,
                 userService, pointService, deliveryRepo, eventPublisher,
                 chatRoomService, itemAppService, txAppService, txCascadeService, notifService,
+                overdueService,
                 transactionManager, clock, 24
         );
     }
@@ -572,6 +575,20 @@ class EscrowApplicationServiceTest {
     }
 
     @Test
+    @DisplayName("confirmReturn_연체record_있으면_OverdueService가_보증금환불_처리하고_전액환불_skip")
+    void confirmReturn_overdue_record_delegates_deposit_refund() {
+        EscrowApplication app = rentalApplication(LocalDateTime.of(2026, 5, 13, 8, 0));
+        app.requestReturnByBuyer(app.getBuyerId());
+        appRepo.save(app);
+        when(overdueService.markResolvedByReturn(eq(app.getId()), any(LocalDateTime.class))).thenReturn(true);
+
+        service.confirmReturn(app.getId(), app.getSellerId());
+
+        verify(overdueService).markResolvedByReturn(eq(app.getId()), any(LocalDateTime.class));
+        verify(userService, never()).refundHold(eq(app.getBuyerId()), eq(36_000L));
+    }
+
+    @Test
     @DisplayName("autoTriggerReturn_사용중아님_BUSINESS_EXCEPTION")
     void autoTriggerReturn_invalid_state_throws() {
         EscrowApplication app = rentalDraftApplication(LocalDateTime.of(2026, 5, 13, 8, 0));
@@ -589,6 +606,7 @@ class EscrowApplicationServiceTest {
                 1_000_000L, 1_062_000L, 0L);
         app.markAsRental();
         app.markRentalEnd(rentalEndAt);
+        app.setRentalDeposit(36_000L, 30);
         app.markInitiatorPaid();
         app.markInProgress();
         app.enterUsing();

--- a/src/test/java/com/sseulang/domain/escrow/application/InMemoryFakeEscrowApplicationRepository.java
+++ b/src/test/java/com/sseulang/domain/escrow/application/InMemoryFakeEscrowApplicationRepository.java
@@ -86,6 +86,17 @@ public class InMemoryFakeEscrowApplicationRepository implements EscrowApplicatio
     }
 
     @Override
+    public List<EscrowApplication> findOverdueCandidates(LocalDateTime cutoff) {
+        return store.values().stream()
+                .filter(EscrowApplication::isRentalMode)
+                .filter(a -> a.getStatus() == EscrowApplicationStatus.사용중
+                        || a.getStatus() == EscrowApplicationStatus.반납중)
+                .filter(a -> a.getRentalEndAt() != null && !a.getRentalEndAt().isAfter(cutoff))
+                .sorted(java.util.Comparator.comparing(EscrowApplication::getRentalEndAt))
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public long countInProgress() {
         return store.values().stream()
                 .filter(a -> a.getStatus() != EscrowApplicationStatus.완료 && a.getStatus() != EscrowApplicationStatus.취소)

--- a/src/test/java/com/sseulang/domain/overdue/application/InMemoryFakeOverdueRecordRepository.java
+++ b/src/test/java/com/sseulang/domain/overdue/application/InMemoryFakeOverdueRecordRepository.java
@@ -1,8 +1,12 @@
 package com.sseulang.domain.overdue.application;
 
+import com.sseulang.domain.overdue.domain.OverduePhase;
 import com.sseulang.domain.overdue.domain.OverdueRecord;
 import com.sseulang.domain.overdue.domain.OverdueRecordRepository;
 import com.sseulang.domain.overdue.domain.OverdueStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Comparator;
@@ -54,6 +58,30 @@ class InMemoryFakeOverdueRecordRepository implements OverdueRecordRepository {
                 .map(OverdueRecord::getId)
                 .sorted()
                 .limit(limit)
+                .toList();
+    }
+
+    @Override
+    public Page<OverdueRecord> searchAdmin(OverdueStatus status, OverduePhase phase, Pageable pageable) {
+        List<OverdueRecord> matched = store.values().stream()
+                .filter(r -> status == null || r.getStatus() == status)
+                .filter(r -> phase == null || r.getPhase() == phase)
+                .sorted(Comparator.comparing(OverdueRecord::getId).reversed())
+                .toList();
+        int from = (int) Math.min(pageable.getOffset(), matched.size());
+        int to = Math.min(from + pageable.getPageSize(), matched.size());
+        return new PageImpl<>(matched.subList(from, to), pageable, matched.size());
+    }
+
+    @Override
+    public List<OverdueRecord> findByBuyerIdAndStatusIn(Long buyerId, List<OverdueStatus> statuses) {
+        if (buyerId == null || statuses == null || statuses.isEmpty()) {
+            return List.of();
+        }
+        return store.values().stream()
+                .filter(r -> buyerId.equals(r.getBuyerId()))
+                .filter(r -> statuses.contains(r.getStatus()))
+                .sorted(Comparator.comparing(OverdueRecord::getId).reversed())
                 .toList();
     }
 

--- a/src/test/java/com/sseulang/domain/overdue/application/InMemoryFakeOverdueRecordRepository.java
+++ b/src/test/java/com/sseulang/domain/overdue/application/InMemoryFakeOverdueRecordRepository.java
@@ -1,0 +1,74 @@
+package com.sseulang.domain.overdue.application;
+
+import com.sseulang.domain.overdue.domain.OverdueRecord;
+import com.sseulang.domain.overdue.domain.OverdueRecordRepository;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+class InMemoryFakeOverdueRecordRepository implements OverdueRecordRepository {
+
+    private final Map<Long, OverdueRecord> store = new LinkedHashMap<>();
+    private long sequence = 0;
+
+    @Override
+    public boolean existsByEscrowApplicationId(Long escrowApplicationId) {
+        return store.values().stream()
+                .anyMatch(r -> escrowApplicationId.equals(r.getEscrowApplicationId()));
+    }
+
+    @Override
+    public Optional<OverdueRecord> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<OverdueRecord> findByIdForUpdate(Long id) {
+        return findById(id);
+    }
+
+    @Override
+    public Optional<OverdueRecord> findByEscrowApplicationId(Long escrowApplicationId) {
+        return store.values().stream()
+                .filter(r -> escrowApplicationId.equals(r.getEscrowApplicationId()))
+                .findFirst();
+    }
+
+    @Override
+    public Optional<OverdueRecord> findByEscrowApplicationIdForUpdate(Long escrowApplicationId) {
+        return findByEscrowApplicationId(escrowApplicationId);
+    }
+
+    @Override
+    public List<Long> findActiveIds(int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        return store.values().stream()
+                .filter(r -> r.getStatus() == OverdueStatus.진행중)
+                .map(OverdueRecord::getId)
+                .sorted()
+                .limit(limit)
+                .toList();
+    }
+
+    @Override
+    public OverdueRecord save(OverdueRecord record) {
+        if (record.getId() == null) {
+            ReflectionTestUtils.setField(record, "id", ++sequence);
+        }
+        store.put(record.getId(), record);
+        return record;
+    }
+
+    List<OverdueRecord> all() {
+        return store.values().stream()
+                .sorted(Comparator.comparing(OverdueRecord::getId))
+                .toList();
+    }
+}

--- a/src/test/java/com/sseulang/domain/overdue/application/OverdueApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/overdue/application/OverdueApplicationServiceTest.java
@@ -3,6 +3,8 @@ package com.sseulang.domain.overdue.application;
 import com.sseulang.domain.escrow.application.EscrowOverdueQueryService;
 import com.sseulang.domain.escrow.application.dto.EscrowOverdueSnapshot;
 import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import com.sseulang.domain.notification.application.NotificationApplicationService;
+import com.sseulang.domain.notification.domain.NotificationType;
 import com.sseulang.domain.overdue.domain.OverduePhase;
 import com.sseulang.domain.overdue.domain.OverdueRecord;
 import com.sseulang.domain.overdue.domain.OverdueStatus;
@@ -33,6 +35,7 @@ class OverdueApplicationServiceTest {
     private EscrowOverdueQueryService escrowQueryService;
     private UserApplicationService userService;
     private PointApplicationService pointService;
+    private NotificationApplicationService notificationService;
     private OverdueApplicationService service;
 
     @BeforeEach
@@ -41,12 +44,14 @@ class OverdueApplicationServiceTest {
         escrowQueryService = mock(EscrowOverdueQueryService.class);
         userService = mock(UserApplicationService.class);
         pointService = mock(PointApplicationService.class);
+        notificationService = mock(NotificationApplicationService.class);
         Clock clock = Clock.fixed(Instant.parse("2026-05-02T10:00:00Z"), ZoneOffset.UTC);
         service = new OverdueApplicationService(
                 overdueRepo,
                 escrowQueryService,
                 userService,
                 pointService,
+                notificationService,
                 clock,
                 50_000,
                 14,
@@ -87,7 +92,7 @@ class OverdueApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("advanceDay_8일차_증분_몰수와_추가채무만_처리")
+    @DisplayName("advanceDay_8일차_증분_몰수와_추가채무_처리_+_phase3_임계_초과시_자동정지")
     void advanceDay_applies_delta_only() {
         when(escrowQueryService.getForOverdue(100L)).thenReturn(snapshot(100_000L));
         service.startOverdue(100L, STARTED);
@@ -98,7 +103,9 @@ class OverdueApplicationServiceTest {
 
         assertThat(advanced).isTrue();
         assertThat(record.getOverdueDays()).isEqualTo(8);
-        assertThat(record.getPhase()).isEqualTo(OverduePhase.PHASE_2);
+        // Day 8 totalDebt = 90k(몰수) + 20k(추가채무) = 110k ≥ phase3AmountKrw(50k) → 즉시 PHASE_3 트리거
+        assertThat(record.getPhase()).isEqualTo(OverduePhase.PHASE_3);
+        assertThat(record.getAccountSuspendedAt()).isNotNull();
         assertThat(record.getDepositForfeitedAmount()).isEqualTo(90_000L);
         assertThat(record.getExtraDebtAmount()).isEqualTo(20_000L);
         verify(userService).releaseHold(11L, 60_000L);
@@ -108,6 +115,7 @@ class OverdueApplicationServiceTest {
                 contains("8일차")
         );
         verify(userService).incrementOverdueDebt(11L, 20_000L);
+        verify(userService).adminAutoSuspend(eq(11L), anyInt(), contains("연체 임계값"));
     }
 
     @Test
@@ -159,6 +167,103 @@ class OverdueApplicationServiceTest {
         List<Long> ids = service.findOverdueCandidateEscrowIds(STARTED);
 
         assertThat(ids).containsExactly(101L);
+    }
+
+    @Test
+    @DisplayName("startOverdue_Day1_buyer_알림_발송")
+    void startOverdue_sends_day1_notification() {
+        when(escrowQueryService.getForOverdue(100L)).thenReturn(snapshot(100_000L));
+
+        service.startOverdue(100L, STARTED);
+
+        verify(notificationService).notify(
+                eq(11L),
+                eq(NotificationType.시스템),
+                contains("반납 기한 초과"),
+                anyString(),
+                eq("OVERDUE"),
+                anyLong()
+        );
+    }
+
+    @Test
+    @DisplayName("advanceDay_Phase1_to_Phase2_전이시_알림_발송")
+    void advanceDay_phase2_transition_notifies() {
+        when(escrowQueryService.getForOverdue(100L)).thenReturn(snapshot(100_000L));
+        service.startOverdue(100L, STARTED);
+        OverdueRecord record = overdueRepo.all().get(0);
+        clearInvocations(notificationService);
+
+        service.advanceDay(record.getId(), STARTED.plusDays(7));
+
+        verify(notificationService).notify(
+                eq(11L),
+                eq(NotificationType.시스템),
+                contains("보증금 초과 채무"),
+                anyString(),
+                eq("OVERDUE"),
+                eq(record.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("advanceDay_phase3_threshold_도달시_자동정지_+_알림")
+    void advanceDay_phase3_auto_suspends() {
+        when(escrowQueryService.getForOverdue(100L)).thenReturn(snapshot(100_000L));
+        service.startOverdue(100L, STARTED);
+        OverdueRecord record = overdueRepo.all().get(0);
+        clearInvocations(userService, notificationService);
+
+        // Day 14 도달 — phase3DaysThreshold=14 트리거
+        service.advanceDay(record.getId(), STARTED.plusDays(13));
+
+        assertThat(record.getOverdueDays()).isEqualTo(14);
+        assertThat(record.getAccountSuspendedAt()).isNotNull();
+        assertThat(record.getPhase()).isEqualTo(OverduePhase.PHASE_3);
+
+        verify(userService).adminAutoSuspend(eq(11L), eq(30), contains("연체 임계값"));
+        verify(notificationService).notify(
+                eq(11L),
+                eq(NotificationType.시스템),
+                contains("계정 정지"),
+                anyString(),
+                eq("OVERDUE"),
+                eq(record.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("advanceDay_이미_정지된_record는_재정지_안함_(idempotent)")
+    void advanceDay_already_suspended_no_resuspend() {
+        when(escrowQueryService.getForOverdue(100L)).thenReturn(snapshot(100_000L));
+        service.startOverdue(100L, STARTED);
+        OverdueRecord record = overdueRepo.all().get(0);
+        service.advanceDay(record.getId(), STARTED.plusDays(13));  // Day 14 → suspend
+        clearInvocations(userService, notificationService);
+
+        service.advanceDay(record.getId(), STARTED.plusDays(14));  // Day 15
+
+        verify(userService, never()).adminAutoSuspend(anyLong(), anyInt(), anyString());
+    }
+
+    @Test
+    @DisplayName("markResolvedByReturn_buyer_정산완료_알림_발송")
+    void markResolvedByReturn_sends_settlement_notification() {
+        when(escrowQueryService.getForOverdue(100L)).thenReturn(snapshot(100_000L));
+        service.startOverdue(100L, STARTED);
+        OverdueRecord record = overdueRepo.all().get(0);
+        clearInvocations(notificationService);
+
+        service.markResolvedByReturn(100L, STARTED.plusDays(1));
+
+        verify(notificationService).notify(
+                eq(11L),
+                eq(NotificationType.시스템),
+                contains("정산완료"),
+                anyString(),
+                eq("OVERDUE"),
+                eq(record.getId())
+        );
     }
 
     private static EscrowOverdueSnapshot snapshot(long depositAmount) {

--- a/src/test/java/com/sseulang/domain/overdue/application/OverdueApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/overdue/application/OverdueApplicationServiceTest.java
@@ -1,0 +1,179 @@
+package com.sseulang.domain.overdue.application;
+
+import com.sseulang.domain.escrow.application.EscrowOverdueQueryService;
+import com.sseulang.domain.escrow.application.dto.EscrowOverdueSnapshot;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import com.sseulang.domain.overdue.domain.OverduePhase;
+import com.sseulang.domain.overdue.domain.OverdueRecord;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+import com.sseulang.domain.point.application.PointApplicationService;
+import com.sseulang.domain.point.domain.PointHistoryType;
+import com.sseulang.domain.point.domain.PointReferenceType;
+import com.sseulang.domain.user.application.UserApplicationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class OverdueApplicationServiceTest {
+
+    private static final LocalDateTime RENTAL_END = LocalDateTime.of(2026, 5, 1, 10, 0);
+    private static final LocalDateTime STARTED = RENTAL_END.plusHours(24);
+
+    private InMemoryFakeOverdueRecordRepository overdueRepo;
+    private EscrowOverdueQueryService escrowQueryService;
+    private UserApplicationService userService;
+    private PointApplicationService pointService;
+    private OverdueApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        overdueRepo = new InMemoryFakeOverdueRecordRepository();
+        escrowQueryService = mock(EscrowOverdueQueryService.class);
+        userService = mock(UserApplicationService.class);
+        pointService = mock(PointApplicationService.class);
+        Clock clock = Clock.fixed(Instant.parse("2026-05-02T10:00:00Z"), ZoneOffset.UTC);
+        service = new OverdueApplicationService(
+                overdueRepo,
+                escrowQueryService,
+                userService,
+                pointService,
+                clock,
+                50_000,
+                14,
+                7,
+                20
+        );
+    }
+
+    @Test
+    @DisplayName("startOverdue_신규_record_생성하고_1일차_보증금몰수_처리")
+    void startOverdue_creates_record_and_forfeits_day_1() {
+        when(escrowQueryService.getForOverdue(100L)).thenReturn(snapshot(100_000L));
+
+        boolean started = service.startOverdue(100L, STARTED);
+
+        assertThat(started).isTrue();
+        OverdueRecord record = overdueRepo.all().get(0);
+        assertThat(record.getEscrowApplicationId()).isEqualTo(100L);
+        assertThat(record.getOverdueDays()).isEqualTo(1);
+        assertThat(record.getDepositForfeitedAmount()).isEqualTo(30_000L);
+        verify(userService).releaseHold(11L, 30_000L);
+        verify(pointService).credit(
+                eq(20L), eq(30_000L),
+                eq(PointHistoryType.연체몰수), eq(PointReferenceType.OVERDUE), eq(record.getId()),
+                contains("1일차")
+        );
+    }
+
+    @Test
+    @DisplayName("startOverdue_중복_record_있으면_noop")
+    void startOverdue_duplicate_noop() {
+        overdueRepo.save(OverdueRecord.create(100L, 11L, 20L, 100_000L, RENTAL_END, STARTED));
+
+        boolean started = service.startOverdue(100L, STARTED);
+
+        assertThat(started).isFalse();
+        verifyNoInteractions(escrowQueryService, userService, pointService);
+    }
+
+    @Test
+    @DisplayName("advanceDay_8일차_증분_몰수와_추가채무만_처리")
+    void advanceDay_applies_delta_only() {
+        when(escrowQueryService.getForOverdue(100L)).thenReturn(snapshot(100_000L));
+        service.startOverdue(100L, STARTED);
+        OverdueRecord record = overdueRepo.all().get(0);
+        clearInvocations(userService, pointService);
+
+        boolean advanced = service.advanceDay(record.getId(), STARTED.plusDays(7));
+
+        assertThat(advanced).isTrue();
+        assertThat(record.getOverdueDays()).isEqualTo(8);
+        assertThat(record.getPhase()).isEqualTo(OverduePhase.PHASE_2);
+        assertThat(record.getDepositForfeitedAmount()).isEqualTo(90_000L);
+        assertThat(record.getExtraDebtAmount()).isEqualTo(20_000L);
+        verify(userService).releaseHold(11L, 60_000L);
+        verify(pointService).credit(
+                eq(20L), eq(60_000L),
+                eq(PointHistoryType.연체몰수), eq(PointReferenceType.OVERDUE), eq(record.getId()),
+                contains("8일차")
+        );
+        verify(userService).incrementOverdueDebt(11L, 20_000L);
+    }
+
+    @Test
+    @DisplayName("advanceDay_같은날_재실행은_noop")
+    void advanceDay_same_day_noop() {
+        when(escrowQueryService.getForOverdue(100L)).thenReturn(snapshot(100_000L));
+        service.startOverdue(100L, STARTED);
+        OverdueRecord record = overdueRepo.all().get(0);
+        clearInvocations(userService, pointService);
+
+        boolean advanced = service.advanceDay(record.getId(), STARTED);
+
+        assertThat(advanced).isFalse();
+        verifyNoInteractions(userService, pointService);
+    }
+
+    @Test
+    @DisplayName("markResolvedByReturn_연체record_없으면_false")
+    void markResolvedByReturn_absent_false() {
+        assertThat(service.markResolvedByReturn(100L, STARTED)).isFalse();
+    }
+
+    @Test
+    @DisplayName("markResolvedByReturn_잔여보증금만_환불하고_추가채무_있으면_정산완료")
+    void markResolvedByReturn_refunds_remaining_deposit() {
+        when(escrowQueryService.getForOverdue(100L)).thenReturn(snapshot(100_000L));
+        service.startOverdue(100L, STARTED);
+        OverdueRecord record = overdueRepo.all().get(0);
+        service.advanceDay(record.getId(), STARTED.plusDays(7));
+        clearInvocations(userService, pointService);
+
+        boolean handled = service.markResolvedByReturn(100L, STARTED.plusDays(8));
+
+        assertThat(handled).isTrue();
+        assertThat(record.getStatus()).isEqualTo(OverdueStatus.정산완료);
+        verify(userService).refundHold(11L, 10_000L);
+        verifyNoInteractions(pointService);
+    }
+
+    @Test
+    @DisplayName("findOverdueCandidateEscrowIds_이미_record_있는_escrow는_제외")
+    void findOverdueCandidateEscrowIds_excludes_existing_records() {
+        overdueRepo.save(OverdueRecord.create(100L, 11L, 20L, 100_000L, RENTAL_END, STARTED));
+        when(escrowQueryService.findOverdueCandidates(STARTED)).thenReturn(List.of(
+                snapshot(100L, 100_000L),
+                snapshot(101L, 50_000L)
+        ));
+
+        List<Long> ids = service.findOverdueCandidateEscrowIds(STARTED);
+
+        assertThat(ids).containsExactly(101L);
+    }
+
+    private static EscrowOverdueSnapshot snapshot(long depositAmount) {
+        return snapshot(100L, depositAmount);
+    }
+
+    private static EscrowOverdueSnapshot snapshot(Long id, long depositAmount) {
+        return new EscrowOverdueSnapshot(
+                id,
+                11L,
+                20L,
+                depositAmount,
+                RENTAL_END,
+                EscrowApplicationStatus.사용중,
+                true
+        );
+    }
+}

--- a/src/test/java/com/sseulang/domain/overdue/application/OverdueDetectionSchedulerTest.java
+++ b/src/test/java/com/sseulang/domain/overdue/application/OverdueDetectionSchedulerTest.java
@@ -1,0 +1,82 @@
+package com.sseulang.domain.overdue.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OverdueDetectionSchedulerTest {
+
+    private OverdueApplicationService overdueService;
+    private OverdueDetectionScheduler scheduler;
+    private LocalDateTime fixedNow;
+
+    @BeforeEach
+    void setUp() {
+        overdueService = mock(OverdueApplicationService.class);
+        Clock clock = Clock.fixed(Instant.parse("2026-05-15T02:00:00Z"), ZoneOffset.UTC);
+        fixedNow = LocalDateTime.now(clock);
+        scheduler = new OverdueDetectionScheduler(overdueService, clock);
+    }
+
+    @Test
+    @DisplayName("run_신규감지_+_active_advance_둘다_호출")
+    void run_invokes_both_phases() {
+        when(overdueService.findOverdueCandidateEscrowIds(fixedNow.minusHours(24)))
+                .thenReturn(List.of(100L, 101L));
+        when(overdueService.findActiveRecordIds(200))
+                .thenReturn(List.of(7L, 8L));
+        when(overdueService.startOverdue(any(), any())).thenReturn(true);
+        when(overdueService.advanceDay(any(), any())).thenReturn(true);
+
+        scheduler.run();
+
+        verify(overdueService).startOverdue(eq(100L), eq(fixedNow));
+        verify(overdueService).startOverdue(eq(101L), eq(fixedNow));
+        verify(overdueService).advanceDay(eq(7L), eq(fixedNow));
+        verify(overdueService).advanceDay(eq(8L), eq(fixedNow));
+    }
+
+    @Test
+    @DisplayName("run_startOverdue_예외나도_나머지_계속_처리")
+    void run_continues_on_individual_failure() {
+        when(overdueService.findOverdueCandidateEscrowIds(any()))
+                .thenReturn(List.of(100L, 101L, 102L));
+        when(overdueService.findActiveRecordIds(200)).thenReturn(List.of());
+        when(overdueService.startOverdue(eq(100L), any())).thenReturn(true);
+        when(overdueService.startOverdue(eq(101L), any())).thenThrow(new RuntimeException("boom"));
+        when(overdueService.startOverdue(eq(102L), any())).thenReturn(true);
+
+        scheduler.run();
+
+        verify(overdueService).startOverdue(eq(100L), any());
+        verify(overdueService).startOverdue(eq(101L), any());
+        verify(overdueService).startOverdue(eq(102L), any());
+    }
+
+    @Test
+    @DisplayName("run_빈_후보_빈_active_면_no-op")
+    void run_no_targets() {
+        when(overdueService.findOverdueCandidateEscrowIds(any())).thenReturn(List.of());
+        when(overdueService.findActiveRecordIds(200)).thenReturn(List.of());
+
+        scheduler.run();
+
+        verify(overdueService, never()).startOverdue(any(), any());
+        verify(overdueService, never()).advanceDay(any(), any());
+        assertThat(true).isTrue();
+    }
+}

--- a/src/test/java/com/sseulang/domain/overdue/domain/LateFeeCalculatorTest.java
+++ b/src/test/java/com/sseulang/domain/overdue/domain/LateFeeCalculatorTest.java
@@ -1,0 +1,76 @@
+package com.sseulang.domain.overdue.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LateFeeCalculatorTest {
+
+    @Test
+    @DisplayName("calculate_0일차는_보증금_전액_잔여")
+    void calculate_zero_days() {
+        LateFeeResult result = LateFeeCalculator.calculate(100_000L, 0, 20);
+
+        assertThat(result.forfeited()).isZero();
+        assertThat(result.remainingDeposit()).isEqualTo(100_000L);
+        assertThat(result.extraDebt()).isZero();
+    }
+
+    @Test
+    @DisplayName("calculate_1일차는_보증금_30퍼센트_몰수")
+    void calculate_day_1() {
+        LateFeeResult result = LateFeeCalculator.calculate(100_000L, 1, 20);
+
+        assertThat(result.forfeited()).isEqualTo(30_000L);
+        assertThat(result.remainingDeposit()).isEqualTo(70_000L);
+        assertThat(result.extraDebt()).isZero();
+    }
+
+    @Test
+    @DisplayName("calculate_7일차는_보증금_90퍼센트_몰수")
+    void calculate_day_7() {
+        LateFeeResult result = LateFeeCalculator.calculate(100_000L, 7, 20);
+
+        assertThat(result.forfeited()).isEqualTo(90_000L);
+        assertThat(result.remainingDeposit()).isEqualTo(10_000L);
+        assertThat(result.extraDebt()).isZero();
+    }
+
+    @Test
+    @DisplayName("calculate_8일차부터_Phase2_추가채무_1일분_발생")
+    void calculate_day_8() {
+        LateFeeResult result = LateFeeCalculator.calculate(100_000L, 8, 20);
+
+        assertThat(result.forfeited()).isEqualTo(90_000L);
+        assertThat(result.remainingDeposit()).isEqualTo(10_000L);
+        assertThat(result.extraDebt()).isEqualTo(20_000L);
+    }
+
+    @Test
+    @DisplayName("calculate_30일차는_Phase2_23일분_추가채무_발생")
+    void calculate_day_30() {
+        LateFeeResult result = LateFeeCalculator.calculate(100_000L, 30, 20);
+
+        assertThat(result.forfeited()).isEqualTo(90_000L);
+        assertThat(result.remainingDeposit()).isEqualTo(10_000L);
+        assertThat(result.extraDebt()).isEqualTo(460_000L);
+    }
+
+    @Test
+    @DisplayName("calculate_큰_금액_overflow는_예외")
+    void calculate_overflow_guard() {
+        assertThatThrownBy(() -> LateFeeCalculator.calculate(Long.MAX_VALUE, 8, 100))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    @DisplayName("calculate_음수_입력_거부")
+    void calculate_negative_input_rejected() {
+        assertThatThrownBy(() -> LateFeeCalculator.calculate(-1L, 1, 20))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> LateFeeCalculator.calculate(100_000L, 1, -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/sseulang/domain/overdue/domain/OverdueRecordTest.java
+++ b/src/test/java/com/sseulang/domain/overdue/domain/OverdueRecordTest.java
@@ -1,0 +1,156 @@
+package com.sseulang.domain.overdue.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OverdueRecordTest {
+
+    private static final LocalDateTime RENTAL_END = LocalDateTime.of(2026, 5, 1, 10, 0);
+    private static final LocalDateTime STARTED = RENTAL_END.plusHours(24);
+    private static final OverdueThresholds THRESHOLDS = new OverdueThresholds(50_000, 14, 7, 20);
+
+    private static OverdueRecord record(long depositAmount) {
+        return OverdueRecord.create(
+                100L,
+                11L,
+                20L,
+                depositAmount,
+                RENTAL_END,
+                STARTED
+        );
+    }
+
+    @Test
+    @DisplayName("create_초기상태는_진행중_Phase1_0일차")
+    void create_initial_state() {
+        OverdueRecord record = record(100_000L);
+
+        assertThat(record.getStatus()).isEqualTo(OverdueStatus.진행중);
+        assertThat(record.getPhase()).isEqualTo(OverduePhase.PHASE_1);
+        assertThat(record.getLegalAction()).isEqualTo(OverdueLegalAction.NONE);
+        assertThat(record.getOverdueDays()).isZero();
+        assertThat(record.getDepositForfeitedAmount()).isZero();
+        assertThat(record.getExtraDebtAmount()).isZero();
+        assertThat(record.remainingDepositAmount()).isEqualTo(100_000L);
+    }
+
+    @Test
+    @DisplayName("advanceDay_1일차_보증금_30퍼센트_몰수")
+    void advanceDay_day_1() {
+        OverdueRecord record = record(100_000L);
+
+        record.advanceDay(STARTED, THRESHOLDS);
+
+        assertThat(record.getOverdueDays()).isEqualTo(1);
+        assertThat(record.getPhase()).isEqualTo(OverduePhase.PHASE_1);
+        assertThat(record.getDepositForfeitedAmount()).isEqualTo(30_000L);
+        assertThat(record.remainingDepositAmount()).isEqualTo(70_000L);
+    }
+
+    @Test
+    @DisplayName("advanceDay_같은날_재실행은_멱등")
+    void advanceDay_idempotent_same_day() {
+        OverdueRecord record = record(100_000L);
+
+        record.advanceDay(STARTED.plusDays(2), THRESHOLDS);
+        record.advanceDay(STARTED.plusDays(2), THRESHOLDS);
+
+        assertThat(record.getOverdueDays()).isEqualTo(3);
+        assertThat(record.getDepositForfeitedAmount()).isEqualTo(50_000L);
+        assertThat(record.getExtraDebtAmount()).isZero();
+    }
+
+    @Test
+    @DisplayName("advanceDay_8일차_Phase2_추가채무_발생")
+    void advanceDay_phase_2() {
+        OverdueRecord record = record(100_000L);
+
+        record.advanceDay(STARTED.plusDays(7), THRESHOLDS);
+
+        assertThat(record.getOverdueDays()).isEqualTo(8);
+        assertThat(record.getPhase()).isEqualTo(OverduePhase.PHASE_2);
+        assertThat(record.getDepositForfeitedAmount()).isEqualTo(90_000L);
+        assertThat(record.getExtraDebtAmount()).isEqualTo(20_000L);
+    }
+
+    @Test
+    @DisplayName("shouldSuspendAccount_금액_또는_일수_임계값_도달")
+    void shouldSuspendAccount_threshold() {
+        OverdueRecord byAmount = record(100_000L);
+        byAmount.advanceDay(STARTED, THRESHOLDS);
+
+        OverdueRecord byDays = record(1_000L);
+        byDays.advanceDay(STARTED.plusDays(13), THRESHOLDS);
+
+        assertThat(byAmount.shouldSuspendAccount(new OverdueThresholds(30_000, 14, 7, 20))).isTrue();
+        assertThat(byDays.shouldSuspendAccount(THRESHOLDS)).isTrue();
+    }
+
+    @Test
+    @DisplayName("markAccountSuspended_Phase3_전이")
+    void markAccountSuspended() {
+        OverdueRecord record = record(100_000L);
+        LocalDateTime suspendedAt = STARTED.plusDays(14);
+
+        record.markAccountSuspended(suspendedAt);
+
+        assertThat(record.getPhase()).isEqualTo(OverduePhase.PHASE_3);
+        assertThat(record.getAccountSuspendedAt()).isEqualTo(suspendedAt);
+        assertThat(record.shouldEnterLegalAction(THRESHOLDS, suspendedAt.plusDays(7))).isTrue();
+    }
+
+    @Test
+    @DisplayName("markLegalAction_Phase4_및_법적조치중_전이")
+    void markLegalAction() {
+        OverdueRecord record = record(100_000L);
+
+        record.markLegalAction(OverdueLegalAction.내용증명);
+
+        assertThat(record.getLegalAction()).isEqualTo(OverdueLegalAction.내용증명);
+        assertThat(record.getPhase()).isEqualTo(OverduePhase.PHASE_4);
+        assertThat(record.getStatus()).isEqualTo(OverdueStatus.법적조치중);
+    }
+
+    @Test
+    @DisplayName("markResolved_채무_0이면_종료")
+    void markResolved_without_debt() {
+        OverdueRecord record = record(100_000L);
+        record.advanceDay(STARTED, THRESHOLDS);
+
+        record.markResolved(STARTED.plusDays(1), "반납 완료");
+
+        assertThat(record.getStatus()).isEqualTo(OverdueStatus.종료);
+        assertThat(record.getResolvedAt()).isEqualTo(STARTED.plusDays(1));
+        assertThat(record.getResolutionNote()).isEqualTo("반납 완료");
+    }
+
+    @Test
+    @DisplayName("markResolved_추가채무_있으면_정산완료")
+    void markResolved_with_debt() {
+        OverdueRecord record = record(100_000L);
+        record.advanceDay(STARTED.plusDays(7), THRESHOLDS);
+
+        record.markResolved(STARTED.plusDays(8), "반납 완료");
+
+        assertThat(record.getStatus()).isEqualTo(OverdueStatus.정산완료);
+        assertThat(record.getExtraDebtAmount()).isEqualTo(20_000L);
+    }
+
+    @Test
+    @DisplayName("create_invalid_입력_거부")
+    void create_invalid() {
+        assertThatThrownBy(() -> OverdueRecord.create(null, 11L, 20L, 100L, RENTAL_END, STARTED))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> OverdueRecord.create(100L, 11L, 11L, 100L, RENTAL_END, STARTED))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> OverdueRecord.create(100L, 11L, 20L, -1L, RENTAL_END, STARTED))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> OverdueRecord.create(100L, 11L, 20L, 100L, RENTAL_END, RENTAL_END.minusSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/sseulang/domain/overdue/integration/OverdueLifecycleIT.java
+++ b/src/test/java/com/sseulang/domain/overdue/integration/OverdueLifecycleIT.java
@@ -1,0 +1,232 @@
+package com.sseulang.domain.overdue.integration;
+
+import com.sseulang.domain.escrow.application.EscrowOverdueQueryService;
+import com.sseulang.domain.escrow.application.dto.EscrowOverdueSnapshot;
+import com.sseulang.domain.escrow.domain.EscrowApplicationStatus;
+import com.sseulang.domain.overdue.application.OverdueApplicationService;
+import com.sseulang.domain.overdue.domain.OverduePhase;
+import com.sseulang.domain.overdue.domain.OverdueRecord;
+import com.sseulang.domain.overdue.domain.OverdueRecordRepository;
+import com.sseulang.domain.overdue.domain.OverdueStatus;
+import com.sseulang.domain.user.application.UserApplicationService;
+import com.sseulang.domain.user.domain.Email;
+import com.sseulang.domain.user.domain.SocialProvider;
+import com.sseulang.domain.user.domain.User;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * 연체 lifecycle e2e — 실 DB 위에서 OverdueApplicationService 동작 검증.
+ * EscrowOverdueQueryService 는 mock — escrow 실 흐름 우회 (overdue 도메인 격리).
+ *
+ * 검증:
+ *  1. startOverdue → Day 1 보증금 30% 차감 + seller 정산
+ *  2. advanceDay 14일 도달 → Phase 3 자동 정지 (suspend 14일 누적)
+ *  3. markResolvedByReturn → 잔여 보증금 환불
+ */
+@SpringBootTest
+@Testcontainers
+class OverdueLifecycleIT {
+
+    @Container
+    static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+                    .withDatabaseName("sseulang").withUsername("test").withPassword("test")
+                    .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci",
+                            "--ngram_token_size=2");
+
+    @Container
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+
+    @Container
+    static final MongoDBContainer MONGO =
+            new MongoDBContainer(DockerImageName.parse("mongo:7"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        r.add("spring.datasource.username", MYSQL::getUsername);
+        r.add("spring.datasource.password", MYSQL::getPassword);
+        r.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        r.add("spring.flyway.enabled", () -> "true");
+        r.add("spring.data.redis.host", REDIS::getHost);
+        r.add("spring.data.redis.port", REDIS::getFirstMappedPort);
+        r.add("spring.data.mongodb.uri", MONGO::getReplicaSetUrl);
+        r.add("app.dev-auth.enabled", () -> "false");
+    }
+
+    @Autowired private OverdueApplicationService overdueService;
+    @Autowired private OverdueRecordRepository overdueRecordRepository;
+    @Autowired private UserApplicationService userService;
+    @Autowired private EntityManager em;
+    @Autowired private PlatformTransactionManager txManager;
+
+    @MockBean
+    private EscrowOverdueQueryService escrowOverdueQueryService;
+
+    private static final long DEPOSIT = 100_000L;
+    private static final LocalDateTime RENTAL_END = LocalDateTime.of(2026, 5, 1, 10, 0);
+    private static final LocalDateTime DAY1 = RENTAL_END.plusHours(24);
+
+    private Long buyerId;
+    private Long sellerId;
+    private Long escrowAppId;
+
+    @BeforeEach
+    void setUp() {
+        TransactionTemplate tx = new TransactionTemplate(txManager);
+        tx.execute(s -> {
+            em.createNativeQuery("DELETE FROM point_histories").executeUpdate();
+            em.createNativeQuery("DELETE FROM overdue_records").executeUpdate();
+            em.createNativeQuery("DELETE FROM users").executeUpdate();
+            return null;
+        });
+
+        buyerId = createUser("buyer");
+        sellerId = createUser("seller");
+
+        // 보증금 hold 시뮬레이션 — buyer.point_balance 채운 후 hold 로 이동.
+        tx.execute(s -> {
+            em.createNativeQuery("UPDATE users SET point_balance = :amt WHERE id = :id")
+                    .setParameter("amt", DEPOSIT).setParameter("id", buyerId).executeUpdate();
+            return null;
+        });
+        userService.holdForEscrow(buyerId, DEPOSIT);
+
+        // escrow_application FK 우회 — 임의 id 사용 + mock query service 가 snapshot 반환.
+        escrowAppId = 9_999L;
+        when(escrowOverdueQueryService.getForOverdue(escrowAppId)).thenReturn(snapshot());
+    }
+
+    private Long createUser(String suffix) {
+        User u = userService.findOrCreateBySocial(
+                SocialProvider.KAKAO, "social-" + suffix + "-" + UUID.randomUUID(),
+                new Email(suffix + "@x.com"), suffix, null
+        );
+        return u.getId();
+    }
+
+    private EscrowOverdueSnapshot snapshot() {
+        return new EscrowOverdueSnapshot(
+                escrowAppId, buyerId, sellerId, DEPOSIT, RENTAL_END,
+                EscrowApplicationStatus.사용중, true
+        );
+    }
+
+    private long balance(Long userId) {
+        return ((Number) em.createNativeQuery("SELECT point_balance FROM users WHERE id = :id")
+                .setParameter("id", userId).getSingleResult()).longValue();
+    }
+
+    private long hold(Long userId) {
+        return ((Number) em.createNativeQuery("SELECT point_hold FROM users WHERE id = :id")
+                .setParameter("id", userId).getSingleResult()).longValue();
+    }
+
+    @Test
+    @DisplayName("startOverdue_Day1_보증금_30%_차감_+_seller_정산")
+    void startOverdue_day1() {
+        // FK constraint 우회 — escrow_application_id 없는 record 저장 위해 임시로 FK off.
+        disableFk();
+        try {
+            boolean started = overdueService.startOverdue(escrowAppId, DAY1);
+            assertThat(started).isTrue();
+
+            // buyer hold: 100,000 → 70,000 (30% 차감)
+            assertThat(hold(buyerId)).isEqualTo(70_000L);
+            assertThat(balance(buyerId)).isZero();
+            // seller balance: 0 → 30,000
+            assertThat(balance(sellerId)).isEqualTo(30_000L);
+        } finally {
+            enableFk();
+        }
+    }
+
+    @Test
+    @DisplayName("advanceDay_14일_도달_Phase3_자동_정지")
+    void advanceDay_phase3_auto_suspend() {
+        disableFk();
+        try {
+            overdueService.startOverdue(escrowAppId, DAY1);
+            OverdueRecord record = overdueRecordRepository.findByEscrowApplicationId(escrowAppId)
+                    .orElseThrow();
+
+            // Day 14 도달 — phase3DaysThreshold(14) 또는 totalDebt 임계 어느 쪽이든 트리거
+            overdueService.advanceDay(record.getId(), DAY1.plusDays(13));
+
+            OverdueRecord refreshed = overdueRecordRepository.findById(record.getId()).orElseThrow();
+            assertThat(refreshed.getOverdueDays()).isEqualTo(14);
+            assertThat(refreshed.getPhase()).isEqualTo(OverduePhase.PHASE_3);
+            assertThat(refreshed.getAccountSuspendedAt()).isNotNull();
+
+            // buyer 가 자동 정지됐는지 — suspended_at not null
+            Object suspendedAt = em.createNativeQuery(
+                    "SELECT suspended_at FROM users WHERE id = :id"
+            ).setParameter("id", buyerId).getSingleResult();
+            assertThat(suspendedAt).isNotNull();
+        } finally {
+            enableFk();
+        }
+    }
+
+    @Test
+    @DisplayName("markResolvedByReturn_잔여_보증금_환불_+_상태_정산완료")
+    void markResolvedByReturn() {
+        disableFk();
+        try {
+            overdueService.startOverdue(escrowAppId, DAY1);
+            // Day 1 후 hold 70,000 잔여
+            assertThat(hold(buyerId)).isEqualTo(70_000L);
+
+            overdueService.markResolvedByReturn(escrowAppId, DAY1.plusDays(1));
+
+            // 잔여 hold (70,000) → balance 환불
+            assertThat(hold(buyerId)).isZero();
+            assertThat(balance(buyerId)).isEqualTo(70_000L);
+
+            OverdueRecord record = overdueRecordRepository.findByEscrowApplicationId(escrowAppId)
+                    .orElseThrow();
+            // extraDebt 없음 → 종료
+            assertThat(record.getStatus()).isEqualTo(OverdueStatus.종료);
+        } finally {
+            enableFk();
+        }
+    }
+
+    private void disableFk() {
+        new TransactionTemplate(txManager).execute(s -> {
+            em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+            return null;
+        });
+    }
+
+    private void enableFk() {
+        new TransactionTemplate(txManager).execute(s -> {
+            em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+            return null;
+        });
+    }
+}

--- a/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
+++ b/src/test/java/com/sseulang/domain/payment/application/PaymentApplicationServiceTest.java
@@ -61,7 +61,8 @@ class PaymentApplicationServiceTest {
                 new TossWebhookSignatureVerifier(tossProps),
                 new ObjectMapper(),
                 new WebhookPendingRateLimiter(),
-                null  // EscrowApplicationService — Payment 단위 테스트에선 escrow 흐름 호출 X
+                null,  // EscrowApplicationService — Payment 단위 테스트에선 escrow 흐름 호출 X
+                null   // OverdueApplicationService — 미주입 시 skip
         );
         userId = userRepo.save(User.createSocialUser(
                 SocialProvider.KAKAO, "kakao-1", new Email("u1@x.com"), "u1", null
@@ -710,6 +711,7 @@ class PaymentApplicationServiceTest {
                 new TossWebhookSignatureVerifier(signedProps),
                 new ObjectMapper(),
                 new WebhookPendingRateLimiter(),
+                null,
                 null
         );
     }

--- a/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
+++ b/src/test/java/com/sseulang/domain/user/application/InMemoryFakeUserRepository.java
@@ -127,6 +127,29 @@ public class InMemoryFakeUserRepository implements UserRepository {
     }
 
     @Override
+    public synchronized int incrementOverdueDebt(Long userId, long amount) {
+        User user = store.get(userId);
+        if (user == null) return 0;
+        ReflectionTestUtils.setField(user, "overdueDebtBalance", user.getOverdueDebtBalance() + amount);
+        return 1;
+    }
+
+    @Override
+    public synchronized int decrementOverdueDebt(Long userId, long amount) {
+        User user = store.get(userId);
+        if (user == null) return 0;
+        if (user.getOverdueDebtBalance() < amount) return 0;
+        ReflectionTestUtils.setField(user, "overdueDebtBalance", user.getOverdueDebtBalance() - amount);
+        return 1;
+    }
+
+    @Override
+    public Long findOverdueDebtBalance(Long userId) {
+        User user = store.get(userId);
+        return user == null ? null : user.getOverdueDebtBalance();
+    }
+
+    @Override
     public Page<User> findAllForAdmin(Pageable pageable) {
         List<User> all = store.values().stream()
                 .sorted(Comparator.comparing(User::getId).reversed())

--- a/src/test/java/com/sseulang/domain/user/domain/UserTest.java
+++ b/src/test/java/com/sseulang/domain/user/domain/UserTest.java
@@ -171,4 +171,47 @@ class UserTest {
                 .as("WITHDRAWN 이 BLOCKED 보다 우선")
                 .isEqualTo(com.sseulang.domain.user.domain.UserStatus.WITHDRAWN);
     }
+
+    @Test
+    @DisplayName("increaseOverdueDebt_정상_누적")
+    void increaseOverdueDebt_정상() {
+        User u = User.createSocialUser(SocialProvider.KAKAO, "k-overdue-1", EMAIL, "n", null);
+
+        u.increaseOverdueDebt(10_000L);
+        u.increaseOverdueDebt(5_000L);
+
+        assertThat(u.getOverdueDebtBalance()).isEqualTo(15_000L);
+    }
+
+    @Test
+    @DisplayName("decreaseOverdueDebt_정상_차감")
+    void decreaseOverdueDebt_정상() {
+        User u = User.createSocialUser(SocialProvider.KAKAO, "k-overdue-2", EMAIL, "n", null);
+        u.increaseOverdueDebt(15_000L);
+
+        u.decreaseOverdueDebt(10_000L);
+
+        assertThat(u.getOverdueDebtBalance()).isEqualTo(5_000L);
+    }
+
+    @Test
+    @DisplayName("overdueDebt_0이하_금액_거부")
+    void overdueDebt_invalid_amount() {
+        User u = User.createSocialUser(SocialProvider.KAKAO, "k-overdue-3", EMAIL, "n", null);
+
+        assertThatThrownBy(() -> u.increaseOverdueDebt(0L))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> u.decreaseOverdueDebt(0L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("decreaseOverdueDebt_잔액초과_거부")
+    void decreaseOverdueDebt_over_balance() {
+        User u = User.createSocialUser(SocialProvider.KAKAO, "k-overdue-4", EMAIL, "n", null);
+        u.increaseOverdueDebt(5_000L);
+
+        assertThatThrownBy(() -> u.decreaseOverdueDebt(5_001L))
+                .isInstanceOf(IllegalStateException.class);
+    }
 }


### PR DESCRIPTION
## Summary
- Add rental overdue system design documentation.
- Add overdue domain PR1: aggregate, enums, calculator, repository adapter, migrations, and unit tests.
- Add overdue PR2: OverdueApplicationService, escrow overdue snapshot query service, record lock/query methods, user overdue debt operations, and escrow confirmReturn hook.
- Prevent overdue rental deposit over-refund: if an overdue record exists, markResolvedByReturn refunds only the remaining deposit and skips the old full-deposit refund path.

## Validation
- ./gradlew compileJava compileTestJava
- ./gradlew test --tests "com.sseulang.domain.overdue.*" --tests "com.sseulang.domain.escrow.application.EscrowApplicationServiceTest" --tests "com.sseulang.domain.user.application.UserApplicationServiceTest" --tests "com.sseulang.domain.point.*"
- git diff --check

## Deferred
- OverdueDetectionScheduler
- notifications
- Phase 3 automatic suspension
- payment debt repayment hook
- admin/user overdue APIs
- integration/concurrency tests
